### PR TITLE
commit attribution 설정 추가 및 스킬 정리

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -27,7 +27,7 @@
 
 1. `git status`와 `git diff --cached --stat`으로 staged 변경 내역 확인
 2. 변경 내역을 바탕으로 적절한 타입 선택 후 커밋 메시지 작성
-3. `Co-Authored-By` 없이 커밋 실행
+3. 커밋 실행
 4. 커밋 완료 확인
 
 $ARGUMENTS

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,8 @@
 {
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  },
   "hooks": {
     "SessionStart": [
       {


### PR DESCRIPTION
## S 
커밋/PR에 Generated with Claude Code 문구가 자동으로 붙는 문제

## T 
스킬 지시문(Co-Authored-By 없이)만으론 Claude가 무시할 수 있어 확실한 차단 필요

## A 
attribution: { commit: "", pr: "" } 설정으로 Claude Code 자체에서 문구 삽입을 막음

## R 
스킬 지시문 의존 없이 설정 레벨에서 보장, 모든 팀원에게 자동 적용

## 관련 PR
- #4 