### PR TITLE
IntelliJ Kotlin 코드 스타일 및 인스펙션 설정 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
-# IDE
-.idea/
+# IDE - 개인 설정 제외
+.idea/*
+!.idea/codeStyles/
+!.idea/inspectionProfiles/
+!.idea/misc.xml
+.idea/workspace.xml
+.idea/tasks.xml
+.idea/shelf/
 *.iml

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,130 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+
+    <!-- =============================== -->
+    <!--  전역 설정                       -->
+    <!-- =============================== -->
+
+    <!-- Kotlin 공식 컨벤션: 최대 줄 길이 120자 -->
+    <option name="RIGHT_MARGIN" value="120" />
+
+    <!-- 줄 끝 개행 문자: Unix 스타일 (LF) -->
+    <option name="LINE_SEPARATOR" value="&#10;" />
+
+    <!-- =============================== -->
+    <!--  Kotlin 전용 설정                -->
+    <!-- =============================== -->
+
+    <KotlinCodeStyleSettings>
+
+      <!-- import 정렬: 공식 컨벤션 순서 -->
+      <!-- 1. 모든 import를 알파벳 순 정렬 -->
+      <!-- 2. 와일드카드 import 금지 -->
+      <option name="PACKAGES_TO_USE_STAR_IMPORTS">
+        <value />
+      </option>
+      <option name="PACKAGES_IMPORT_LAYOUT">
+        <value>
+          <package name="" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="java" withSubpackages="true" static="false" />
+          <package name="javax" withSubpackages="true" static="false" />
+          <package name="kotlin" withSubpackages="true" static="false" />
+          <emptyLine />
+        </value>
+      </option>
+
+      <!-- Trailing comma: 멀티라인 시 마지막 요소 뒤 쉼표 자동 추가 -->
+      <option name="TRAILING_COMMA" value="true" />
+
+      <!-- 람다 화살표 앞뒤 공백 -->
+      <option name="SPACE_AROUND_LAMBDA_ARROW" value="true" />
+
+      <!-- when 화살표 앞뒤 공백 -->
+      <option name="SPACE_BEFORE_WHEN_PARENTHESES" value="true" />
+
+    </KotlinCodeStyleSettings>
+
+    <!-- =============================== -->
+    <!--  Kotlin 언어 코드 스타일         -->
+    <!-- =============================== -->
+
+    <codeStyleSettings language="kotlin">
+
+      <!-- 들여쓰기: 4 스페이스 (Kotlin 공식) -->
+      <option name="INDENT_SIZE" value="4" />
+      <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      <option name="TAB_SIZE" value="4" />
+      <option name="USE_TAB_CHARACTER" value="false" />
+
+      <!-- ============================= -->
+      <!--  파라미터 줄바꿈 (핵심 설정)   -->
+      <!-- ============================= -->
+
+      <!--
+        WRAP 값 의미:
+          0 = 줄바꿈 안 함
+          1 = 길면 줄바꿈
+          2 = 길면 각 항목 줄바꿈 (Chop down if long)
+          5 = 항상 각 항목 줄바꿈 (Wrap always) ← 팀 요청
+      -->
+
+      <!-- 함수 선언부 파라미터: 항상 개행 -->
+      <option name="METHOD_PARAMETERS_WRAP" value="5" />
+      <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
+
+      <!-- 함수 호출부 인자: 항상 개행 -->
+      <option name="CALL_PARAMETERS_WRAP" value="5" />
+      <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="false" />
+
+      <!-- 닫는 괄호를 새 줄에 (파라미터 개행 시) -->
+      <option name="METHOD_PARAMETERS_LPAREN_ON_NEXT_LINE" value="false" />
+      <option name="METHOD_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />
+      <option name="CALL_PARAMETERS_LPAREN_ON_NEXT_LINE" value="false" />
+      <option name="CALL_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />
+
+      <!-- ============================= -->
+      <!--  기타 줄바꿈 설정              -->
+      <!-- ============================= -->
+
+      <!-- 체이닝 메서드: 길면 줄바꿈 -->
+      <option name="METHOD_CALL_CHAIN_WRAP" value="2" />
+      <option name="WRAP_FIRST_METHOD_IN_CALL_CHAIN" value="true" />
+
+      <!-- when 조건: 길면 줄바꿈 -->
+      <option name="ASSIGNMENT_WRAP" value="1" />
+
+      <!-- 이진 연산자: 길면 줄바꿈 -->
+      <option name="BINARY_OPERATION_WRAP" value="1" />
+      <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
+
+      <!-- ============================= -->
+      <!--  공백 설정                     -->
+      <!-- ============================= -->
+
+      <!-- 제어문 키워드 뒤 공백: if (, for (, while ( -->
+      <option name="SPACE_BEFORE_IF_PARENTHESES" value="true" />
+      <option name="SPACE_BEFORE_FOR_PARENTHESES" value="true" />
+      <option name="SPACE_BEFORE_WHILE_PARENTHESES" value="true" />
+      <option name="SPACE_BEFORE_WHEN_PARENTHESES" value="true" />
+
+      <!-- 단항 연산자 앞뒤 공백 없음 -->
+      <option name="SPACE_AROUND_UNARY_OPERATOR" value="false" />
+
+      <!-- ============================= -->
+      <!--  빈 줄 설정                    -->
+      <!-- ============================= -->
+
+      <!-- 클래스 내 최대 연속 빈 줄: 1 -->
+      <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
+
+      <!-- 코드 내 최대 연속 빈 줄: 1 -->
+      <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+
+      <!-- 닫는 중괄호 앞 빈 줄 제거 -->
+      <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0" />
+
+    </codeStyleSettings>
+
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,117 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+
+    <!-- ======================== -->
+    <!--  Java 기본 인스펙션       -->
+    <!-- ======================== -->
+
+    <!-- 지역 변수를 final(val)로 선언 가능한 경우 경고 -->
+    <inspection_tool class="LocalCanBeFinal" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="REPORT_VARIABLES" value="true" />
+      <option name="REPORT_PARAMETERS" value="false" />
+    </inspection_tool>
+
+    <!-- ======================== -->
+    <!--  Kotlin 코드 품질         -->
+    <!-- ======================== -->
+
+    <!-- 사용하지 않는 import 제거 -->
+    <inspection_tool class="KotlinUnusedImport" enabled="true" level="WARNING" enabled_by_default="true" />
+
+    <!-- var 대신 val 사용 권장 -->
+    <inspection_tool class="KotlinValUsedAsVar" enabled="true" level="WARNING" enabled_by_default="true" />
+
+    <!-- Deprecated API 사용 경고 -->
+    <inspection_tool class="DEPRECATION" enabled="true" level="WARNING" enabled_by_default="true" />
+
+    <!-- 도달 불가능한 코드 -->
+    <inspection_tool class="KotlinUnreachableCode" enabled="true" level="WARNING" enabled_by_default="true" />
+
+    <!-- 항상 true/false인 조건식 -->
+    <inspection_tool class="KotlinConstantConditions" enabled="true" level="WARNING" enabled_by_default="true" />
+
+    <!-- 불필요한 non-null 단언 (!!) -->
+    <inspection_tool class="KotlinUnnecessaryNotNullOperator" enabled="true" level="WARNING" enabled_by_default="true" />
+
+    <!-- 불필요한 safe call (?.) -->
+    <inspection_tool class="KotlinUnnecessarySafeCall" enabled="true" level="WARNING" enabled_by_default="true" />
+
+    <!-- 불필요한 엘비스 연산자 -->
+    <inspection_tool class="KotlinUnnecessaryElvis" enabled="true" level="WARNING" enabled_by_default="true" />
+
+    <!-- null 비교를 safe call로 대체 가능한 경우 -->
+    <inspection_tool class="KotlinReplaceNullCheck" enabled="true" level="INFORMATION" enabled_by_default="true" />
+
+    <!-- ======================== -->
+    <!--  Kotlin 관용 표현         -->
+    <!-- ======================== -->
+
+    <!-- object literal을 lambda로 변환 가능한 경우 -->
+    <inspection_tool class="KotlinObjectLiteralToLambda" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
+
+    <!-- for 루프를 forEach로 대체 가능 -->
+    <inspection_tool class="KotlinRangeUntilVsRangeTo" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
+
+    <!-- when 표현식에서 불필요한 else 분기 -->
+    <inspection_tool class="KotlinRedundantElseInWhen" enabled="true" level="WARNING" enabled_by_default="true" />
+
+    <!-- 불필요한 visibility modifier (public은 기본값) -->
+    <inspection_tool class="KotlinRedundantVisibilityModifier" enabled="true" level="WARNING" enabled_by_default="true" />
+
+    <!-- 불필요한 override (변경 없이 super 호출만 하는 경우) -->
+    <inspection_tool class="KotlinRedundantOverride" enabled="true" level="WARNING" enabled_by_default="true" />
+
+    <!-- companion object 내 const 가능한 val -->
+    <inspection_tool class="KotlinMayBeConstant" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
+
+    <!-- 불필요한 Unit 반환 타입 명시 -->
+    <inspection_tool class="KotlinRedundantUnitReturnType" enabled="true" level="WARNING" enabled_by_default="true" />
+
+    <!-- Nullable 반환 타입이 불필요한 경우 -->
+    <inspection_tool class="KotlinRedundantNullableReturnType" enabled="true" level="WARNING" enabled_by_default="true" />
+
+    <!-- arrayOf() 대신 [] 리터럴 사용 권장 -->
+    <inspection_tool class="KotlinReplaceArrayOfWithLiteral" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
+
+    <!-- ======================== -->
+    <!--  Kotlin 잠재적 버그       -->
+    <!-- ======================== -->
+
+    <!-- Java와의 상호운용에서 nullable 처리 누락 -->
+    <inspection_tool class="KotlinNullableBooleanElvis" enabled="true" level="WARNING" enabled_by_default="true" />
+
+    <!-- equals() 구현 없이 hashCode() 구현 (또는 반대) -->
+    <inspection_tool class="KotlinHashCodeMissing" enabled="true" level="WARNING" enabled_by_default="true" />
+
+    <!-- data class에서 equals/hashCode 커스텀 구현 경고 -->
+    <inspection_tool class="KotlinDataClassPrivateConstructor" enabled="true" level="WARNING" enabled_by_default="true" />
+
+    <!-- 예외를 catch한 후 아무것도 안 하는 경우 -->
+    <inspection_tool class="EmptyCatchBlock" enabled="true" level="WARNING" enabled_by_default="true" />
+
+    <!-- 불필요한 try-finally -->
+    <inspection_tool class="EmptyFinallyBlock" enabled="true" level="WARNING" enabled_by_default="true" />
+
+    <!-- ======================== -->
+    <!--  코드 스타일 / 명명       -->
+    <!-- ======================== -->
+
+    <!-- 클래스/함수명이 컨벤션에 맞지 않는 경우 -->
+    <inspection_tool class="KotlinClassName" enabled="true" level="WARNING" enabled_by_default="true" />
+
+    <!-- 함수명 컨벤션 (camelCase) -->
+    <inspection_tool class="KotlinFunctionName" enabled="true" level="WARNING" enabled_by_default="true" />
+
+    <!-- 패키지명 컨벤션 (소문자) -->
+    <inspection_tool class="KotlinPackageName" enabled="true" level="WARNING" enabled_by_default="true" />
+
+    <!-- ======================== -->
+    <!--  비활성화 (팀 컨벤션 우선) -->
+    <!-- ======================== -->
+
+    <!-- trailing comma 스타일은 팀마다 다르므로 비활성화 -->
+    <inspection_tool class="KotlinWildcardImport" enabled="false" level="WARNING" enabled_by_default="false" />
+
+  </profile>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_25" default="true" project-jdk-name="openjdk-25" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>


### PR DESCRIPTION
## Situation
팀 프로젝트에서 IntelliJ 코드 스타일이 팀원마다 달라 포맷팅 불일치 문제 발생 가능성 존재                                                                                                                                                                                                                            
                                                                    
## Task
Kotlin 공식 컨벤션 기반으로 팀 공통 IntelliJ 설정을 git으로 관리하는 환경 구축                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                          
## Action
- 기존 .idea/ 전체 제외에서 팀 공유 파일(codeStyles/, inspectionProfiles/, misc.xml)만 추적 허용으로 .gitignore 변경
- codeStyles/Project.xml(포맷팅)·inspectionProfiles/Project_Default.xml(린터) 작성                                            
                                                                   
                                                            
## Result
팀원이 프로젝트를 열면 자동으로 동일한 코드 스타일(줄 길이 120자, 파라미터 항상 개행 등)과 인스펙션(null safety, 관용 표현 등) 적용    