### PR TITLE
chore: Slack PR 봇 environment 제거 및 repo secrets 사용 및 slack bot 파싱 변경 방식

### DIFF
--- a/.github/workflows/slack-pr-bot.yml
+++ b/.github/workflows/slack-pr-bot.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     types:
       - opened
-      - ready_for_review
       - review_requested
       - review_request_removed
       - edited
@@ -16,10 +15,14 @@ permissions:
   pull-requests: write
   issues: write
 
+# 레이스 방지용 concurrency
+concurrency:
+  group: slack-pr-bot-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
 jobs:
   notify-slack:
     runs-on: ubuntu-latest
-    environment: PR-Bot
     env:
       SLACK_USER_MAP: '{"m-a-king":"U0AKAEF2K9U","1o18z":"U0AKQ6G8BT3","sevin98":"U0AK6U2J62F"}'
 
@@ -89,12 +92,7 @@ jobs:
           echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
 
       - name: Post parent message
-        if: |
-          steps.find_ts.outputs.ts == '' &&
-          (
-            (github.event.action == 'opened' && github.event.pull_request.draft == false) ||
-            github.event.action == 'ready_for_review'
-          )
+        if: steps.find_ts.outputs.ts == '' && github.event.action == 'opened' && github.event.pull_request.draft == false
         id: post_parent
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -194,11 +192,35 @@ jobs:
 
           build_summary() {
             local pr_body="$1"
-            local summary
-
-            summary=$(echo "$pr_body" | grep -E '^- ' | head -n 1 | sed 's/^- //')
-            [ -z "$summary" ] && summary="요약 없음"
-            echo "$summary"
+            printf '%s\n' "$pr_body" | awk '
+              BEGIN { in_task=0; n=0; out="" }
+              /^##/ {
+                if (in_task == 1) exit
+                r = $0
+                sub(/^##[[:space:]]+/, "", r)
+                ok = (match(r, /^[Tt][Aa][Ss][Kk]([^A-Za-z]|$)/) || match(r, /[[:space:]][Tt][Aa][Ss][Kk]([^A-Za-z]|$)/))
+                if (ok) { in_task=1; next }
+                next
+              }
+              in_task == 1 && /^##/ { exit }
+              in_task == 1 {
+                s = $0
+                sub(/^[[:space:]]+/, "", s)
+                if (s ~ /^>/) next
+                if (s ~ /^-[[:space:]]*\[[[:space:]xX]\]/) next
+                if (s ~ /^-[[:space:]]+/) {
+                  sub(/^-[[:space:]]+/, "", s)
+                  if (length(s) > 0) {
+                    if (n++ > 0) out = out "\n"
+                    out = out "• " s
+                  }
+                }
+              }
+              END {
+                if (n > 0) print out
+                else print "요약 없음"
+              }
+            '
           }
 
           PR_BODY=$(jq -r '.pull_request.body // ""' "$GITHUB_EVENT_PATH")
@@ -366,11 +388,35 @@ jobs:
 
           build_summary() {
             local pr_body="$1"
-            local summary
-
-            summary=$(echo "$pr_body" | grep -E '^- ' | head -n 1 | sed 's/^- //')
-            [ -z "$summary" ] && summary="요약 없음"
-            echo "$summary"
+            printf '%s\n' "$pr_body" | awk '
+              BEGIN { in_task=0; n=0; out="" }
+              /^##/ {
+                if (in_task == 1) exit
+                r = $0
+                sub(/^##[[:space:]]+/, "", r)
+                ok = (match(r, /^[Tt][Aa][Ss][Kk]([^A-Za-z]|$)/) || match(r, /[[:space:]][Tt][Aa][Ss][Kk]([^A-Za-z]|$)/))
+                if (ok) { in_task=1; next }
+                next
+              }
+              in_task == 1 && /^##/ { exit }
+              in_task == 1 {
+                s = $0
+                sub(/^[[:space:]]+/, "", s)
+                if (s ~ /^>/) next
+                if (s ~ /^-[[:space:]]*\[[[:space:]xX]\]/) next
+                if (s ~ /^-[[:space:]]+/) {
+                  sub(/^-[[:space:]]+/, "", s)
+                  if (length(s) > 0) {
+                    if (n++ > 0) out = out "\n"
+                    out = out "• " s
+                  }
+                }
+              }
+              END {
+                if (n > 0) print out
+                else print "요약 없음"
+              }
+            '
           }
 
           CHANNEL_ID="${{ steps.find_ts.outputs.channel }}"
@@ -446,9 +492,7 @@ jobs:
 
           TEXT=""
 
-          if [ "$ACTION" = "ready_for_review" ]; then
-            TEXT="👀 Draft 해제됨. 리뷰 가능한 상태입니다."
-          elif [ "$ACTION" = "review_requested" ]; then
+          if [ "$ACTION" = "review_requested" ]; then
             REQUESTED_REVIEWER=$(jq -r '.requested_reviewer.login // ""' "$GITHUB_EVENT_PATH")
             if [ -n "$REQUESTED_REVIEWER" ]; then
               TEXT="🙋 리뷰 요청됨: $(mention_slack_user "$REQUESTED_REVIEWER")"


### PR DESCRIPTION
---

## Situation

- PR Template 을 STAR 구조로 변경하면서 slack bot 의 파싱 방식 변경 필요
- repo.environment 에 secret 을 등록하면, 모든 job 을 deploy로 인식해 PR-deploy가 noise되는 이슈 발견
## Task 
> Slack PR 알림의「작업 요약」에 표시됩니다. 한 줄로 작성해 주세요.
- #11 에 맞게끔 slack-bot 의 pasring 양식 변경
- repo.envrionment 의 slack 관련 secret 을 repo.secret 으로 이관 (노이즈 제거)

## Action

- `##Task` 의 모든 bullet 을 요약으로 파싱 및 slack에 전송하고, 개발자에겐 안내 문구로 템플릿에 맞는 작성 유도

## Result

- 
---
## 연관 이슈

close #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * Slack PR 알림 워크플로우 트리거 로직을 최적화하였습니다
  * 작업 요약 추출 기능을 강화하여 더 정확한 정보를 제공합니다
  * PR당 동시 실행 제어 메커니즘을 도입하였습니다

<!-- end of auto-generated comment: release notes by coderabbit.ai -->