### PR TITLE
chore: direct-push 경고문구 추가(protect 전 까지만 운용)

### DIFF
--- a/.github/workflows/slack-pr-bot.yml
+++ b/.github/workflows/slack-pr-bot.yml
@@ -559,9 +559,9 @@ jobs:
           PR_LIST=$(curl -s \
             -H "Authorization: Bearer $GH_TOKEN" \
             -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${{ github.repository }}/commits/${{ github.sha }}/pulls")
+            "https://api.github.com/repos/${{ github.repository }}/pulls?state=closed&base=main&sort=updated&direction=desc&per_page=20")
 
-          PR_COUNT=$(echo "$PR_LIST" | jq 'length')
+          PR_COUNT=$(echo "$PR_LIST" | jq --arg sha "${{ github.sha }}" '[.[] | select(.merge_commit_sha == $sha)] | length')
           echo "pr_count=$PR_COUNT" >> "$GITHUB_OUTPUT"
 
       - name: Send Slack alert
@@ -582,8 +582,12 @@ jobs:
           SHORT_SHA="${SHORT_SHA:0:7}"
           COMMIT_URL="https://github.com/${{ github.repository }}/commit/${{ github.sha }}"
 
-          TEXT=$(printf '<!channel> 🚨🚨🚨 %s 님이 main에 *직접 푸시*했어요!!\n비상비상 애옹애옹\n\n• *커밋*: <%s|%s>\n• *메시지*: %s' \
+          SOUNDS=("비상비상 애옹애옹 🐱" "비상비상 멍멍멍멍 🐶" "비상비상 크르르릉~~~!!! 🐯" "비상비상 꽥꽥꽥꽥 🦆" "비상비상 어흥어흥!!! 🦁" "비상비상 뀨뀨뀨뀨 🐹" "비상비상 히이이잉~~~ 🐴")
+          SOUND="${SOUNDS[$RANDOM % ${#SOUNDS[@]}]}"
+
+          TEXT=$(printf '<!channel> 🚨🚨🚨 %s 님이 main에 *직접 푸시*했어요!!\n%s\n\n• *커밋*: <%s|%s>\n• *메시지*: %s' \
             "$PUSHER_MENTION" \
+            "$SOUND" \
             "$COMMIT_URL" \
             "$SHORT_SHA" \
             "$COMMIT_MSG")


### PR DESCRIPTION
---

## Situation

- 경고문구 추가 요구사항
## Task 
> Slack PR 알림의「작업 요약」에 표시됩니다.
- direct-push 경고문구 추가 
- PR-Merger 로 인한 Push 도 전역으로 잡히는 문제 commit-hash 유무로 분기

## Action

- 

## Result

- 
---
## 연관 이슈

close #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * Slack 알림 메시지에 무작위로 선택된 동물 소리/이모지가 추가되었습니다.

* **Chores**
  * 최근 업데이트된 PR을 대상으로 GitHub API 쿼리 필터링이 개선되었습니다.
  * PR 카운팅 로직이 보다 정확한 일치 감지를 위해 최적화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->