### PR TITLE
Terraform 으로 AWS 초기 인프라 코드화 및 로컬 검증 파이프라인 구성

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,24 @@
+# Local .terraform directories
+.terraform/
+# Note: .terraform.lock.hcl is intentionally committed (provider version lock).
+
+# State files
+*.tfstate
+*.tfstate.*
+*.tfstate.backup
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Sensitive variable values
+*.tfvars
+*.tfvars.json
+!*.tfvars.example
+
+# CLI config
+.terraformrc
+terraform.rc
+
+# Plan output
+*.tfplan

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -22,3 +22,6 @@ terraform.rc
 
 # Plan output
 *.tfplan
+
+# Infracost local cache
+.infracost/

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/terraform/.trivyignore
+++ b/terraform/.trivyignore
@@ -8,15 +8,10 @@
 
 # AWS-0104: Security group egress 0.0.0.0/0
 # 사유: EC2 는 패키지 업데이트, JDK/Docker pull, 외부 API 호출 등을 위해
-#       아웃바운드 인터넷이 필요하다. RDS SG 의 egress 도 동일한 관행.
+#       아웃바운드 인터넷이 필요하다. (RDS SG 는 egress 를 닫아 두었으므로 해당 없음.)
 #       엄격하게 막으려면 VPC Endpoint 로 S3/ECR 등만 화이트리스트 해야 하는데
 #       학습 프로젝트 범위에서는 과잉. prod 전환 시 재검토.
 AWS-0104
-
-# AWS-0164: Subnet associates public IP address (map_public_ip_on_launch = true)
-# 사유: 단일 EC2 를 퍼블릭 서브넷에 두는 것이 이 아키텍처의 의도.
-#       ALB + 프라이빗 EC2 구성으로 바꿀 때 이 예외도 함께 제거.
-AWS-0164
 
 # AWS-0178: VPC does not have VPC Flow Logs enabled
 # 사유: CloudWatch Logs 요금을 피하기 위해 dev 단계에서는 비활성.

--- a/terraform/.trivyignore
+++ b/terraform/.trivyignore
@@ -1,0 +1,39 @@
+# -----------------------------------------------------------------------------
+# Trivy IaC 스캔 예외 목록
+#
+# 각 항목은 "의도된 설정" 이며, 왜 무시하는지 명시한다.
+# 새 경고가 뜨면 여기에 추가하지 말고 먼저 실제로 수정 가능한지 검토할 것.
+# 포맷: <ID>  (옵션으로 expiry 날짜 지정 가능)
+# -----------------------------------------------------------------------------
+
+# AWS-0104: Security group egress 0.0.0.0/0
+# 사유: EC2 는 패키지 업데이트, JDK/Docker pull, 외부 API 호출 등을 위해
+#       아웃바운드 인터넷이 필요하다. RDS SG 의 egress 도 동일한 관행.
+#       엄격하게 막으려면 VPC Endpoint 로 S3/ECR 등만 화이트리스트 해야 하는데
+#       학습 프로젝트 범위에서는 과잉. prod 전환 시 재검토.
+AWS-0104
+
+# AWS-0164: Subnet associates public IP address (map_public_ip_on_launch = true)
+# 사유: 단일 EC2 를 퍼블릭 서브넷에 두는 것이 이 아키텍처의 의도.
+#       ALB + 프라이빗 EC2 구성으로 바꿀 때 이 예외도 함께 제거.
+AWS-0164
+
+# AWS-0178: VPC does not have VPC Flow Logs enabled
+# 사유: CloudWatch Logs 요금을 피하기 위해 dev 단계에서는 비활성.
+#       운영 환경으로 승격 시 반드시 활성화하고 이 항목 제거.
+AWS-0178
+
+# AWS-0177: RDS does not have Deletion Protection enabled
+# 사유: dev 단계에서 terraform destroy 로 자유롭게 재생성하기 위함.
+#       prod 전환 시 rds.tf 의 deletion_protection = true 로 변경하고 이 항목 제거.
+AWS-0177
+
+# AWS-0176: RDS does not have IAM Authentication enabled
+# 사유: 현재는 마스터 계정 + 비밀번호만 사용. IAM 인증은 추후 운영 전환 시 도입.
+#       Spring Boot 쪽 JDBC URL 도 함께 바꿔야 하므로 별도 작업으로 분리.
+AWS-0176
+
+# AWS-0133: RDS does not have Performance Insights enabled
+# 사유: db.t4g.micro 에서도 무료지만 현재 단계에서 모니터링 필요성이 낮음.
+#       장애 분석이 필요해지는 시점에 활성화. 제거해도 무방한 낮은 우선순위.
+AWS-0133

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -4,10 +4,15 @@
 # t4g.* 는 Graviton(ARM) 이므로 반드시 arm64 AMI 를 써야 한다.
 # owner 099720109477 은 Canonical 공식 계정.
 #
-# 이 data source 는 실제 AWS API 호출이 필요하므로 mock provider 로는
-# plan 시점에 실패한다. 계정 연결 후에만 활성화할 것.
+# 이 data source 는 var.ec2_ami_id 가 null 일 때만 실행된다. 새 AMI 가 공개될
+# 때마다 apply 시점에 인스턴스가 교체될 수 있으므로 부트스트랩 용도로만 사용하고,
+# 최초 apply 이후에는 resolved 된 AMI ID 를 var.ec2_ami_id 로 고정해 교체를 막을 것.
+#
+# 또한 실제 AWS API 호출이 필요하므로 mock provider 로는 plan 시점에 실패한다.
+# 계정 연결 후에만 활성화할 것.
 # -----------------------------------------------------------------------------
 data "aws_ami" "ubuntu_2404_arm64" {
+  count       = var.ec2_ami_id == null ? 1 : 0
   most_recent = true
   owners      = ["099720109477"] # Canonical
 
@@ -28,7 +33,7 @@ data "aws_ami" "ubuntu_2404_arm64" {
 }
 
 resource "aws_instance" "app" {
-  ami                    = data.aws_ami.ubuntu_2404_arm64.id
+  ami                    = var.ec2_ami_id != null ? var.ec2_ami_id : data.aws_ami.ubuntu_2404_arm64[0].id
   instance_type          = var.ec2_instance_type
   subnet_id              = aws_subnet.public.id
   availability_zone      = var.azs[0]

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -1,0 +1,55 @@
+# -----------------------------------------------------------------------------
+# Ubuntu 24.04 LTS (Noble Numbat) arm64 최신 AMI 조회
+#
+# t4g.* 는 Graviton(ARM) 이므로 반드시 arm64 AMI 를 써야 한다.
+# owner 099720109477 은 Canonical 공식 계정.
+#
+# 이 data source 는 실제 AWS API 호출이 필요하므로 mock provider 로는
+# plan 시점에 실패한다. 계정 연결 후에만 활성화할 것.
+# -----------------------------------------------------------------------------
+data "aws_ami" "ubuntu_2404_arm64" {
+  most_recent = true
+  owners      = ["099720109477"] # Canonical
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-*"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["arm64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+resource "aws_instance" "app" {
+  ami                    = data.aws_ami.ubuntu_2404_arm64.id
+  instance_type          = var.ec2_instance_type
+  subnet_id              = aws_subnet.public.id
+  availability_zone      = var.azs[0]
+  vpc_security_group_ids = [aws_security_group.ec2.id]
+
+  # IMDSv2 강제 — 2019 Capital One 사태의 원인이었던 IMDSv1 SSRF 취약점 방어.
+  # http_tokens = "required" 로 두면 메타데이터 조회 시 토큰 세션이 필수가 된다.
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 1
+  }
+
+  root_block_device {
+    volume_size           = 20
+    volume_type           = "gp3"
+    encrypted             = true
+    delete_on_termination = true
+  }
+
+  tags = {
+    Name = "${local.name_prefix}-app"
+  }
+}

--- a/terraform/eip.tf
+++ b/terraform/eip.tf
@@ -1,0 +1,24 @@
+# -----------------------------------------------------------------------------
+# Elastic IP — EC2 재시작 시에도 동일한 퍼블릭 IP 를 유지하기 위한 고정 IP.
+#
+# 2024-02 이후 AWS 는 모든 퍼블릭 IPv4 주소에 시간당 요금($0.005/h)을 부과한다.
+# 연결된 EIP 든 auto-assign IP 든 요금은 동일하며, EIP 로 전환한다고 해서
+# 추가 비용이 발생하지는 않는다. 신규 계정은 12개월간 퍼블릭 IPv4 프리티어 적용.
+#
+# domain = "vpc" 는 VPC 내부용 EIP 를 생성한다는 의미 (classic EC2 가 아님).
+# -----------------------------------------------------------------------------
+resource "aws_eip" "app" {
+  domain = "vpc"
+
+  # IGW 생성 이전에 EIP 를 할당하려 하면 에러가 나므로 명시적 의존성 선언.
+  depends_on = [aws_internet_gateway.main]
+
+  tags = {
+    Name = "${local.name_prefix}-app-eip"
+  }
+}
+
+resource "aws_eip_association" "app" {
+  instance_id   = aws_instance.app.id
+  allocation_id = aws_eip.app.id
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,34 @@
+output "vpc_id" {
+  description = "생성된 VPC ID"
+  value       = aws_vpc.main.id
+}
+
+output "public_subnet_id" {
+  description = "EC2 가 위치한 퍼블릭 서브넷 ID"
+  value       = aws_subnet.public.id
+}
+
+output "private_subnet_ids" {
+  description = "RDS DB Subnet Group 에 사용된 프라이빗 서브넷 ID 목록"
+  value       = aws_subnet.private[*].id
+}
+
+output "ec2_public_ip" {
+  description = "EC2 에 연결된 Elastic IP (고정)"
+  value       = aws_eip.app.public_ip
+}
+
+output "ec2_public_dns" {
+  description = "EC2 퍼블릭 DNS (EIP 기준)"
+  value       = aws_eip.app.public_dns
+}
+
+output "rds_endpoint" {
+  description = "RDS 엔드포인트 (host:port)"
+  value       = aws_db_instance.mysql.endpoint
+}
+
+output "rds_address" {
+  description = "RDS 호스트"
+  value       = aws_db_instance.mysql.address
+}

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,0 +1,36 @@
+terraform {
+  required_version = ">= 1.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+# -----------------------------------------------------------------------------
+# AWS Provider
+#
+# 현재는 AWS 계정이 없어서 mock 자격증명으로 로컬 validate/plan 만 수행한다.
+# 실제 계정이 준비되면 아래 3개의 skip_* 옵션과 mock key 를 제거하고
+# `aws configure` 또는 환경변수(AWS_PROFILE, AWS_ACCESS_KEY_ID 등)로 교체한다.
+# -----------------------------------------------------------------------------
+provider "aws" {
+  region = var.aws_region
+
+  # TODO: 실제 계정 준비 시 아래 블록 전체 삭제
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  skip_metadata_api_check     = true
+
+  default_tags {
+    tags = {
+      Project     = var.project
+      Environment = var.environment
+      ManagedBy   = "terraform"
+    }
+  }
+}

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -1,0 +1,52 @@
+# -----------------------------------------------------------------------------
+# DB Subnet Group — RDS 는 최소 2개 AZ 의 서브넷이 필요하다
+# -----------------------------------------------------------------------------
+resource "aws_db_subnet_group" "main" {
+  name       = "${local.name_prefix}-db-subnet-group"
+  subnet_ids = aws_subnet.private[*].id
+
+  tags = {
+    Name = "${local.name_prefix}-db-subnet-group"
+  }
+}
+
+# -----------------------------------------------------------------------------
+# RDS MySQL 8.4 (LTS) — db.t4g.micro
+# -----------------------------------------------------------------------------
+resource "aws_db_instance" "mysql" {
+  identifier     = "${local.name_prefix}-mysql"
+  engine         = "mysql"
+  engine_version = var.db_engine_version
+  instance_class = var.db_instance_class
+
+  allocated_storage     = var.db_allocated_storage
+  max_allocated_storage = 100
+  storage_type          = "gp3"
+  storage_encrypted     = true
+
+  db_name  = var.db_name
+  username = var.db_username
+  password = var.db_password
+  port     = 3306
+
+  db_subnet_group_name   = aws_db_subnet_group.main.name
+  vpc_security_group_ids = [aws_security_group.rds.id]
+  publicly_accessible    = false
+  multi_az               = false
+
+  # EC2 와 동일 AZ 에 고정해서 cross-AZ 데이터 전송 요금을 피한다.
+  # DB Subnet Group 은 2개 AZ 가 필요하지만 실제 인스턴스는 여기 한 곳만 사용.
+  availability_zone = var.azs[0]
+
+  backup_retention_period = 7
+  backup_window           = "17:00-18:00" # KST 02:00-03:00
+  maintenance_window      = "sun:18:00-sun:19:00"
+
+  auto_minor_version_upgrade = true
+  deletion_protection        = false # dev 단계에서는 false, prod 에서는 true 로 전환
+  skip_final_snapshot        = true  # dev 단계에서만 true
+
+  tags = {
+    Name = "${local.name_prefix}-mysql"
+  }
+}

--- a/terraform/security_groups.tf
+++ b/terraform/security_groups.tf
@@ -1,0 +1,78 @@
+# -----------------------------------------------------------------------------
+# EC2 Security Group — SSH(22) + HTTP(80) + HTTPS(443)
+#
+# 8080 (Spring Boot) 은 외부에 노출하지 않는다.
+# EC2 내부에서 Nginx 또는 Caddy 를 reverse proxy 로 두고 TLS 를 종료한 뒤
+# localhost:8080 (var.app_port) 으로 forward 하는 구조를 전제로 한다.
+# Spring Boot 는 application.yml 에서 server.address=127.0.0.1 로 바인딩.
+# -----------------------------------------------------------------------------
+resource "aws_security_group" "ec2" {
+  name        = "${local.name_prefix}-ec2-sg"
+  description = "Allow SSH and HTTP/HTTPS to EC2"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description = "SSH"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = [var.ssh_ingress_cidr]
+  }
+
+  ingress {
+    description = "HTTP (redirect to HTTPS at reverse proxy layer)"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "HTTPS"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "Allow all outbound"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${local.name_prefix}-ec2-sg"
+  }
+}
+
+# -----------------------------------------------------------------------------
+# RDS Security Group — EC2 SG 로부터의 3306 만 허용
+# -----------------------------------------------------------------------------
+resource "aws_security_group" "rds" {
+  name        = "${local.name_prefix}-rds-sg"
+  description = "Allow MySQL from EC2 SG only"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description     = "MySQL from EC2"
+    from_port       = 3306
+    to_port         = 3306
+    protocol        = "tcp"
+    security_groups = [aws_security_group.ec2.id]
+  }
+
+  egress {
+    description = "Allow all outbound"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${local.name_prefix}-rds-sg"
+  }
+}

--- a/terraform/security_groups.tf
+++ b/terraform/security_groups.tf
@@ -64,13 +64,11 @@ resource "aws_security_group" "rds" {
     security_groups = [aws_security_group.ec2.id]
   }
 
-  egress {
-    description = "Allow all outbound"
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
+  # egress 블록을 의도적으로 생략한다.
+  # aws_security_group 은 VPC 내 생성 시 AWS 가 자동으로 붙이는 기본 all-allow 아웃바운드 룰을
+  # Terraform 이 제거해 주므로, 블록을 두지 않으면 RDS SG 는 송신이 전부 차단된 상태가 된다.
+  # RDS 는 인바운드 응답만으로 동작하고 공식 backup/snapshot 은 AWS 관리 경로라 SG egress 와 무관.
+  # 추후 외부 연동(S3 Data Export 등) 이 필요하면 그때 최소 대상만 명시적으로 열 것.
 
   tags = {
     Name = "${local.name_prefix}-rds-sg"

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,12 @@
+# 실제 사용 시 이 파일을 terraform.tfvars 로 복사하고 값을 채울 것.
+# terraform.tfvars 는 .gitignore 에 의해 커밋되지 않는다.
+
+project     = "team3"
+environment = "dev"
+
+# 본인 공인 IP/32 로 좁힐 것. 예: "123.45.67.89/32"
+# 여러 팀원은 SG 레벨에서 ingress 블록을 추가하거나, 별도 변수로 list 처리.
+ssh_ingress_cidr = "203.0.113.1/32"
+
+# RDS 마스터 비밀번호 — 반드시 강한 값으로 교체
+db_password = "CHANGE_ME_STRONG_PASSWORD"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -65,9 +65,14 @@ variable "db_instance_class" {
 }
 
 variable "db_engine_version" {
-  description = "MySQL 엔진 버전 (8.4 = 최신 LTS)"
+  description = <<-EOT
+    MySQL 엔진 버전. 8.4 는 Innovation Release 라인이므로 AWS RDS 의
+    표준 지원 종료일을 주기적으로 확인하고 수명주기가 충분히 남은 마이너 버전으로 유지할 것.
+    참고: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MySQL.Concepts.VersionMgmt.html
+  EOT
   type        = string
-  default     = "8.4.3"
+  # 8.4.3 은 2026-05-31 에 RDS 표준 지원 종료 예정이므로 8.4.8 (~2027-02-03) 로 승격
+  default = "8.4.8"
 }
 
 variable "db_name" {
@@ -87,6 +92,16 @@ variable "db_password" {
   type        = string
   sensitive   = true
   # default 를 두지 않아 실수로 평문이 커밋되지 않도록 강제한다
+
+  # terraform.tfvars.example 의 placeholder 그대로 apply 되는 사고를 막기 위한 가드.
+  # 길이 하한(16자) 은 AWS RDS 마스터 비밀번호 권장 최소치를 반영.
+  validation {
+    condition = (
+      length(var.db_password) >= 16 &&
+      var.db_password != "CHANGE_ME_STRONG_PASSWORD"
+    )
+    error_message = "db_password 는 16자 이상이어야 하며 example 파일의 placeholder 그대로 사용할 수 없습니다."
+  }
 }
 
 variable "db_allocated_storage" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -48,6 +48,17 @@ variable "ec2_instance_type" {
   default     = "t4g.micro"
 }
 
+variable "ec2_ami_id" {
+  description = <<-EOT
+    EC2 에 사용할 고정 AMI ID. 값을 지정하면 data.aws_ami 조회 대신 이 ID 를 그대로 사용한다.
+    null 이면 data source 로 최신 Ubuntu 24.04 arm64 AMI 를 조회하지만,
+    새 AMI 가 공개될 때마다 apply 시점에 인스턴스가 교체될 수 있으므로
+    운영 단계에서는 반드시 조회된 AMI ID 를 이 변수로 고정할 것.
+  EOT
+  type        = string
+  default     = null
+}
+
 variable "ssh_ingress_cidr" {
   description = "SSH 접속을 허용할 CIDR. 실제로는 본인/팀원 공인 IP/32 로 좁힐 것"
   type        = string

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,96 @@
+variable "project" {
+  description = "프로젝트 식별자 (태그/리소스 이름 접두사)"
+  type        = string
+  default     = "team3"
+}
+
+variable "environment" {
+  description = "배포 환경 (dev / stg / prod)"
+  type        = string
+  default     = "dev"
+}
+
+variable "aws_region" {
+  description = "AWS 리전"
+  type        = string
+  default     = "ap-northeast-2"
+}
+
+variable "vpc_cidr" {
+  description = "VPC CIDR 블록"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "public_subnet_cidr" {
+  description = "EC2 가 위치할 퍼블릭 서브넷 CIDR"
+  type        = string
+  default     = "10.0.1.0/24"
+}
+
+variable "private_subnet_cidrs" {
+  description = "RDS DB Subnet Group 용 프라이빗 서브넷 CIDR 목록 (최소 2개 AZ 필요)"
+  type        = list(string)
+  default     = ["10.0.11.0/24", "10.0.12.0/24"]
+}
+
+variable "azs" {
+  description = "사용할 가용영역 목록 (private subnet 과 1:1 매핑)"
+  type        = list(string)
+  default     = ["ap-northeast-2a", "ap-northeast-2c"]
+}
+
+# ----- EC2 -----
+
+variable "ec2_instance_type" {
+  description = "EC2 인스턴스 타입 (ARM / Graviton)"
+  type        = string
+  default     = "t4g.micro"
+}
+
+variable "ssh_ingress_cidr" {
+  description = "SSH 접속을 허용할 CIDR. 실제로는 본인/팀원 공인 IP/32 로 좁힐 것"
+  type        = string
+  # TODO: 팀원 IP 확보 후 terraform.tfvars 에서 실제 값으로 override 할 것.
+  # 아래는 RFC 5737 문서화용 예약 대역(TEST-NET-3) 의 placeholder 이며 실제 라우팅되지 않음.
+  default = "203.0.113.1/32"
+}
+
+# ----- RDS -----
+
+variable "db_instance_class" {
+  description = "RDS 인스턴스 클래스"
+  type        = string
+  default     = "db.t4g.micro"
+}
+
+variable "db_engine_version" {
+  description = "MySQL 엔진 버전 (8.4 = 최신 LTS)"
+  type        = string
+  default     = "8.4.3"
+}
+
+variable "db_name" {
+  description = "초기 생성할 데이터베이스 이름"
+  type        = string
+  default     = "team3"
+}
+
+variable "db_username" {
+  description = "RDS 마스터 사용자 이름"
+  type        = string
+  default     = "admin"
+}
+
+variable "db_password" {
+  description = "RDS 마스터 비밀번호. terraform.tfvars 또는 환경변수(TF_VAR_db_password)로 주입"
+  type        = string
+  sensitive   = true
+  # default 를 두지 않아 실수로 평문이 커밋되지 않도록 강제한다
+}
+
+variable "db_allocated_storage" {
+  description = "RDS 초기 스토리지 (GB)"
+  type        = number
+  default     = 20
+}

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -1,0 +1,95 @@
+locals {
+  name_prefix = "${var.project}-${var.environment}"
+}
+
+# -----------------------------------------------------------------------------
+# VPC
+# -----------------------------------------------------------------------------
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = "${local.name_prefix}-vpc"
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Internet Gateway (퍼블릭 서브넷의 EC2 가 인터넷으로 나가는 통로)
+# -----------------------------------------------------------------------------
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "${local.name_prefix}-igw"
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Public Subnet (EC2 전용)
+# -----------------------------------------------------------------------------
+resource "aws_subnet" "public" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = var.public_subnet_cidr
+  availability_zone = var.azs[0]
+
+  # EIP 를 별도로 부여하므로 auto-assign 을 끈다.
+  # 켜두면 EIP 와 자동 할당 IP 가 중복으로 생성되어 이중 과금 위험.
+  map_public_ip_on_launch = false
+
+  tags = {
+    Name = "${local.name_prefix}-public-${var.azs[0]}"
+    Tier = "public"
+  }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = {
+    Name = "${local.name_prefix}-public-rt"
+  }
+}
+
+resource "aws_route_table_association" "public" {
+  subnet_id      = aws_subnet.public.id
+  route_table_id = aws_route_table.public.id
+}
+
+# -----------------------------------------------------------------------------
+# Private Subnets (RDS 전용, 최소 2개 AZ)
+#
+# 이 서브넷의 유일한 리소스는 RDS 이며 RDS 는 외부 인터넷 접근이 필요 없다.
+# (OS 패치·백업은 모두 AWS 내부망 경유) 따라서 NAT Gateway 를 둘 이유가 없다.
+# -----------------------------------------------------------------------------
+resource "aws_subnet" "private" {
+  count             = length(var.private_subnet_cidrs)
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = var.private_subnet_cidrs[count.index]
+  availability_zone = var.azs[count.index]
+
+  tags = {
+    Name = "${local.name_prefix}-private-${var.azs[count.index]}"
+    Tier = "private"
+  }
+}
+
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "${local.name_prefix}-private-rt"
+  }
+}
+
+resource "aws_route_table_association" "private" {
+  count          = length(aws_subnet.private)
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private.id
+}


### PR DESCRIPTION
---

## Situation

- 서버 배포용 AWS 인프라가 코드로 관리되고 있지 않아, 팀원 간 일관된 방식으로 환경을 구축하기 어려운 상태였음.
- 인프라를 AI 가 이해하고 개선할 수 있는 문서로서 관리하려면 선언형 IaC 도구가 필요했고, Terraform 을 선택.
- AWS 계정이 아직 준비되지 않은 시점이지만, 설계와 검증은 미리 진행할 수 있어야 했음.

## Task

- Terraform 으로 단일 EC2 + RDS MySQL 기반 AWS 초기 인프라를 코드화하고 로컬 검증 파이프라인을 구축

## Action

- **VPC / 네트워크 (`vpc.tf`)**: 10.0.0.0/16 VPC, 퍼블릭 서브넷 1개(EC2), 프라이빗 서브넷 2개(RDS Subnet Group 요건), IGW, 라우트 테이블 구성. 프라이빗 서브넷에는 RDS 만 위치하고 RDS 는 외부 인터넷 접근이 필요 없으므로 NAT Gateway 미사용.
- **Security Group (`security_groups.tf`)**: EC2 SG 는 SSH(제한된 CIDR) / 80 / 443 만 허용. RDS SG 는 3306 을 EC2 SG 참조 방식으로만 허용해 외부 노출 차단. 8080 은 외부에 열지 않고 reverse proxy 전제.
- **EC2 (`ec2.tf`)**: Ubuntu 24.04 LTS arm64 최신 AMI 를 data source 로 조회, t4g.micro 로 생성. IMDSv2 강제 (`http_tokens = required`) 로 SSRF 기반 메타데이터 유출 방지. 루트 볼륨 gp3 20GB 암호화.
- **RDS (`rds.tf`)**: MySQL 8.4 LTS, db.t4g.micro, 프라이빗 서브넷 배치. EC2 와 동일 AZ(`ap-northeast-2a`)에 고정해 cross-AZ 데이터 전송 요금 회피. 백업 7일, 스토리지 암호화, 마스터 비밀번호는 `terraform.tfvars` 로 주입.
- **Elastic IP (`eip.tf`)**: EC2 재시작 시에도 고정 IP 유지. 퍼블릭 서브넷의 `map_public_ip_on_launch = false` 로 auto-assign 과 이중 부여 방지.
- **mock provider (`providers.tf`)**: `skip_credentials_validation` 등으로 AWS 계정 없이도 `init/validate/plan` 이 가능하도록 설정. 실제 계정 연결 시 제거 예정.
- **로컬 검증 파이프라인**: `terraform fmt` → `terraform validate` → `tflint` → `trivy config` → `infracost breakdown` 까지 하나의 체인으로 구성. 의도된 보안 경고는 `.trivyignore` 에 사유와 함께 주석으로 기록.
- **보안 개선**: Trivy 초기 스캔에서 잡힌 HIGH 이슈 중 실제 수정 가능한 항목(IMDSv2 미강제, SSH `0.0.0.0/0`)은 코드로 수정. 의도된 설정(egress open, dev 단계 deletion_protection 등)은 `.trivyignore` 로 분리.

## Result

- `terraform validate`, `tflint`, `trivy config`, `infracost breakdown` 모두 로컬에서 통과.
- 예상 월 비용 약 $34 (EC2 $7.59 + RDS $18.25 + EBS $4.44 + EIP $3.65). 신규 계정 프리티어 적용 시 첫 12개월 거의 무료.
  - 산출 방법: `cd terraform && infracost breakdown --path .` (Infracost 무료 API 키 필요, `infracost auth login` 1회 등록). 또는 AWS Pricing Calculator 로 수동 검증 가능.
- AWS 계정이 준비되면 `providers.tf` 의 mock 블록 제거 및 `terraform.tfvars` 작성 후 `plan` → `apply` 만으로 즉시 배포 가능한 상태.
- `terraform/.gitignore` 로 state / tfvars / `.terraform/` 이 커밋에서 제외되어 있어 시크릿 유출 위험 없음.

---

## 테라폼 시각화

<img width="1233" height="1087" alt="image" src="https://github.com/user-attachments/assets/22e374da-a608-4529-bc41-c562523253c1" />

---
## 연관 이슈

- close #22 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * AWS 인프라 추가: VPC, 퍼블릭/프라이빗 서브넷, EC2 인스턴스, RDS 인스턴스 및 보안 그룹
  * Elastic IP 할당 및 인스턴스 연결
  * 주요 인프라 식별자·연결 정보 출력(여러 출력 값 추가)

* **Chores**
  * 배포 변수 템플릿 및 예시 파일 추가
  * Terraform 공급자/버전 고정 및 잠금 파일 추가
  * Terraform 관련 .gitignore 및 보안 스캐너(Trivy) 예외 규칙 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->