### PR TITLE
chore: CodeRabbit 리뷰 완료 후 팀원 리뷰어 자동 지정

### DIFF
--- a/.github/workflows/auto-reviewer.yml
+++ b/.github/workflows/auto-reviewer.yml
@@ -1,0 +1,45 @@
+name: Auto Assign Reviewers
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  assign-reviewers:
+    runs-on: ubuntu-latest
+    # CodeRabbit 리뷰 제출 시에만 실행
+    if: github.event.review.user.login == 'coderabbitai[bot]'
+    steps:
+      - name: Request Review from Team Members
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          TEAM=("sevineleven" "1o18z" "m-a-king")
+
+          # PR 작성자 제외한 리뷰어 목록 구성
+          REVIEWERS=()
+          for member in "${TEAM[@]}"; do
+            if [[ "$member" != "$PR_AUTHOR" ]]; then
+              REVIEWERS+=("$member")
+            fi
+          done
+
+          # 이미 리뷰어가 지정되어 있으면 스킵 (중복 방지)
+          EXISTING=$(gh pr view "$PR_NUMBER" \
+            --repo depromeet/18th-team3-server \
+            --json reviewRequests \
+            --jq '.reviewRequests | length')
+
+          if [[ "$EXISTING" -gt 0 ]]; then
+            echo "Reviewers already assigned, skipping"
+            exit 0
+          fi
+
+          REVIEWER_STR=$(IFS=,; echo "${REVIEWERS[*]}")
+          gh pr edit "$PR_NUMBER" \
+            --add-reviewer "$REVIEWER_STR" \
+            --repo depromeet/18th-team3-server
+
+          echo "Assigned reviewers: $REVIEWER_STR"


### PR DESCRIPTION
## Situation

- CODEOWNERS로 PR 생성 즉시 리뷰어가 지정되어 CodeRabbit 리뷰 전에 불필요한 알림이 발생했음

## Task
> Slack PR 알림의「작업 요약」에 표시되는 섹터입니다.
- CodeRabbit 리뷰 완료 후 PR 작성자를 제외한 팀원 2명을 리뷰어로 자동 지정

## Action

- `auto-reviewer.yml` Action 추가
  - `coderabbitai[bot]` 리뷰 제출 이벤트 트리거
  - 팀원 3명(`sevineleven`, `1o18z`, `m-a-king`) 중 PR 작성자 제외한 2명 자동 지정
  - 이미 리뷰어가 지정된 경우 중복 방지 처리

## Result

- CodeRabbit AI 리뷰가 끝난 시점에 팀원 리뷰가 시작되어 리뷰 흐름이 자연스러워짐

---
## 연관 이슈

close #37