### PR TITLE
terraform 실제 AWS 계정 연결 및 Free Plan 제약 대응

### DIFF
--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -12,19 +12,12 @@ terraform {
 # -----------------------------------------------------------------------------
 # AWS Provider
 #
-# 현재는 AWS 계정이 없어서 mock 자격증명으로 로컬 validate/plan 만 수행한다.
-# 실제 계정이 준비되면 아래 3개의 skip_* 옵션과 mock key 를 제거하고
-# `aws configure` 또는 환경변수(AWS_PROFILE, AWS_ACCESS_KEY_ID 등)로 교체한다.
+# 자격증명은 환경변수(AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY)로 주입한다.
+# 로컬 ~/.aws/credentials 에 영구 저장하지 않는 정책.
+# 키는 작업 시점에 콘솔에서 생성 → export → 작업 종료 후 삭제.
 # -----------------------------------------------------------------------------
 provider "aws" {
   region = var.aws_region
-
-  # TODO: 실제 계정 준비 시 아래 블록 전체 삭제
-  access_key                  = "mock_access_key"
-  secret_key                  = "mock_secret_key"
-  skip_credentials_validation = true
-  skip_requesting_account_id  = true
-  skip_metadata_api_check     = true
 
   default_tags {
     tags = {

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -38,8 +38,10 @@ resource "aws_db_instance" "mysql" {
   # DB Subnet Group 은 2개 AZ 가 필요하지만 실제 인스턴스는 여기 한 곳만 사용.
   availability_zone = var.azs[0]
 
-  backup_retention_period = 7
-  backup_window           = "17:00-18:00" # KST 02:00-03:00
+  # AWS 신규 Free Plan(2025-07-15 이후 가입) 은 retention > 0 을 거부한다(FreeTierRestrictionError).
+  # Paid plan 승격 시 7 로 복구할 것.
+  backup_retention_period = 0
+  backup_window           = "17:00-18:00" # KST 02:00-03:00, retention=0 이면 무시됨
   maintenance_window      = "sun:18:00-sun:19:00"
 
   auto_minor_version_upgrade = true


### PR DESCRIPTION
## Situation
- 그동안 terraform 은 AWS 계정이 없어 mock 자격증명(skip_* + 가짜 key)으로 로컬 validate/plan 만 수행해왔음
- team3 AWS 계정(250758375457) 이 준비되어 첫 apply 를 하려 했더니 두 가지 지점에서 막힘

## Task
- AWS 자격증명을 mock 대신 실계정으로 전환하되, 키를 레포·로컬(`~/.aws/credentials`)에 영구 저장하지 않는 정책 유지
- 신규 Free Plan(2025-07-15 이후) 의 FreeTierRestrictionError 로 인한 apply 실패 해소

## Action
- `providers.tf` — mock access_key/secret_key 및 skip_credentials_validation / skip_requesting_account_id / skip_metadata_api_check 전부 제거. 자격증명은 `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` 환경변수로 주입 (작업 시 export, 종료 후 삭제)
- `rds.tf` — `backup_retention_period` 7 → 0. 신규 Free Plan 은 자동 백업을 유료 피처로 분류해서 retention > 0 이면 plan/apply 가 막힘

## Result
- 실계정 환경에서 terraform plan/apply 가 정상 동작
- 트레이드오프: retention=0 이면 자동 스냅샷·Point-in-Time Recovery 불가 → 장애 시 복구 수단 없음. Paid plan 승격 시 7 로 복구 필요 (`rds.tf` 에 TODO 주석 박아둠)

---
## 연관 이슈
- 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **Chores**
  * AWS 프로바이더 자격증명 처리 방식 업데이트
  * RDS 데이터베이스 백업 보관 설정 변경

<!-- end of auto-generated comment: release notes by coderabbit.ai -->