### PR TITLE
게스트 UUID 발급 API 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
 	kotlin("jvm") version "2.3.20"
 	kotlin("plugin.spring") version "2.3.20"
+	kotlin("plugin.jpa") version "2.3.20"
 	id("org.springframework.boot") version "4.0.5"
 	id("io.spring.dependency-management") version "1.1.7"
 }
@@ -20,8 +21,11 @@ repositories {
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-webmvc")
+	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
 	implementation("tools.jackson.module:jackson-module-kotlin")
+	runtimeOnly("com.h2database:h2")
+	runtimeOnly("com.mysql:mysql-connector-j")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/src/main/kotlin/com/depromeet/team3/common/config/JpaAuditingConfig.kt
+++ b/src/main/kotlin/com/depromeet/team3/common/config/JpaAuditingConfig.kt
@@ -1,0 +1,8 @@
+package com.depromeet.team3.common.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+
+@Configuration
+@EnableJpaAuditing
+class JpaAuditingConfig

--- a/src/main/kotlin/com/depromeet/team3/common/domain/BaseEntity.kt
+++ b/src/main/kotlin/com/depromeet/team3/common/domain/BaseEntity.kt
@@ -1,0 +1,41 @@
+package com.depromeet.team3.common.domain
+
+import jakarta.persistence.Column
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.MappedSuperclass
+import org.hibernate.Hibernate
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener::class)
+abstract class BaseEntity<ID : Any> {
+
+    abstract fun getId(): ID
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    var createdAt: LocalDateTime? = null
+        protected set
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: LocalDateTime? = null
+        protected set
+
+    @Column(name = "deleted_at")
+    var deletedAt: LocalDateTime? = null
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is BaseEntity<*>) return false
+        if (Hibernate.getClass(this) != Hibernate.getClass(other)) return false
+        return getId() == other.getId()
+    }
+
+    override fun hashCode(): Int = Hibernate
+        .getClass(this)
+        .hashCode() * 31 + getId().hashCode()
+}

--- a/src/main/kotlin/com/depromeet/team3/common/domain/BaseEntity.kt
+++ b/src/main/kotlin/com/depromeet/team3/common/domain/BaseEntity.kt
@@ -8,6 +8,7 @@ import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import java.time.LocalDateTime
+import java.util.Objects
 
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener::class)
@@ -35,7 +36,4 @@ abstract class BaseEntity<ID : Any> {
         return getId() == other.getId()
     }
 
-    override fun hashCode(): Int = Hibernate
-        .getClass(this)
-        .hashCode() * 31 + getId().hashCode()
-}
+    override fun hashCode(): Int = Objects.hash(getId()) }

--- a/src/main/kotlin/com/depromeet/team3/common/domain/BaseEntity.kt
+++ b/src/main/kotlin/com/depromeet/team3/common/domain/BaseEntity.kt
@@ -17,12 +17,12 @@ abstract class BaseEntity<ID : Any> {
 
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
-    var createdAt: LocalDateTime? = null
+    var createdAt: LocalDateTime = LocalDateTime.now()
         protected set
 
     @LastModifiedDate
     @Column(name = "updated_at", nullable = false)
-    var updatedAt: LocalDateTime? = null
+    var updatedAt: LocalDateTime = LocalDateTime.now()
         protected set
 
     @Column(name = "deleted_at")

--- a/src/main/kotlin/com/depromeet/team3/guest/controller/GuestController.kt
+++ b/src/main/kotlin/com/depromeet/team3/guest/controller/GuestController.kt
@@ -1,0 +1,16 @@
+package com.depromeet.team3.guest.controller
+
+import com.depromeet.team3.guest.controller.dto.GuestResponse
+import com.depromeet.team3.guest.service.GuestService
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/guests")
+class GuestController(
+    private val guestService: GuestService,
+) {
+    @PostMapping
+    fun issueGuestUuid(): GuestResponse = GuestResponse(guestService.issueGuestUuid())
+}

--- a/src/main/kotlin/com/depromeet/team3/guest/controller/GuestController.kt
+++ b/src/main/kotlin/com/depromeet/team3/guest/controller/GuestController.kt
@@ -12,5 +12,5 @@ class GuestController(
     private val guestService: GuestService,
 ) {
     @PostMapping
-    fun issueGuestUuid(): GuestResponse = GuestResponse(guestService.issueGuestUuid())
+    fun issueGuestUuid(): GuestResponse = GuestResponse(guestService.issueGuestId())
 }

--- a/src/main/kotlin/com/depromeet/team3/guest/controller/GuestController.kt
+++ b/src/main/kotlin/com/depromeet/team3/guest/controller/GuestController.kt
@@ -12,5 +12,5 @@ class GuestController(
     private val guestService: GuestService,
 ) {
     @PostMapping
-    fun issueGuestUuid(): GuestResponse = GuestResponse(guestService.issueGuestId())
+    fun issueGuestId(): GuestResponse = GuestResponse(guestService.issueGuestId())
 }

--- a/src/main/kotlin/com/depromeet/team3/guest/controller/dto/GuestResponse.kt
+++ b/src/main/kotlin/com/depromeet/team3/guest/controller/dto/GuestResponse.kt
@@ -1,5 +1,7 @@
 package com.depromeet.team3.guest.controller.dto
 
+import java.util.UUID
+
 data class GuestResponse(
-    val guestUUID: String,
+    val guestId: UUID,
 )

--- a/src/main/kotlin/com/depromeet/team3/guest/controller/dto/GuestResponse.kt
+++ b/src/main/kotlin/com/depromeet/team3/guest/controller/dto/GuestResponse.kt
@@ -1,0 +1,5 @@
+package com.depromeet.team3.guest.controller.dto
+
+data class GuestResponse(
+    val guestUUID: String,
+)

--- a/src/main/kotlin/com/depromeet/team3/guest/domain/Guest.kt
+++ b/src/main/kotlin/com/depromeet/team3/guest/domain/Guest.kt
@@ -1,0 +1,12 @@
+package com.depromeet.team3.guest.domain
+
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "guests")
+class Guest(
+    @Id
+    val uuid: String,
+)

--- a/src/main/kotlin/com/depromeet/team3/guest/domain/Guest.kt
+++ b/src/main/kotlin/com/depromeet/team3/guest/domain/Guest.kt
@@ -1,17 +1,18 @@
 package com.depromeet.team3.guest.domain
 
+import com.depromeet.team3.common.domain.BaseEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
-import org.springframework.data.domain.Persistable
 import java.util.UUID
 
 @Entity
 class Guest(
     @Id
     @Column(name = "id")
-    private val guestId: UUID,
-) : Persistable<String> {
-    override fun getId(): String = guestId.toString()
-    override fun isNew(): Boolean = true
+    private val id: UUID = UUID.randomUUID(),
+) : BaseEntity<UUID>() {
+    override fun getId(): UUID {
+        return id
+    }
 }

--- a/src/main/kotlin/com/depromeet/team3/guest/domain/Guest.kt
+++ b/src/main/kotlin/com/depromeet/team3/guest/domain/Guest.kt
@@ -2,11 +2,9 @@ package com.depromeet.team3.guest.domain
 
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
-import jakarta.persistence.Table
 
 @Entity
-@Table(name = "guests")
 class Guest(
     @Id
-    val uuid: String,
+    val id: String,
 )

--- a/src/main/kotlin/com/depromeet/team3/guest/domain/Guest.kt
+++ b/src/main/kotlin/com/depromeet/team3/guest/domain/Guest.kt
@@ -1,10 +1,16 @@
 package com.depromeet.team3.guest.domain
 
+import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
+import org.springframework.data.domain.Persistable
 
 @Entity
 class Guest(
     @Id
-    val id: String,
-)
+    @Column(name = "id")
+    private val guestId: String,
+) : Persistable<String> {
+    override fun getId(): String = guestId
+    override fun isNew(): Boolean = true
+}

--- a/src/main/kotlin/com/depromeet/team3/guest/domain/Guest.kt
+++ b/src/main/kotlin/com/depromeet/team3/guest/domain/Guest.kt
@@ -4,13 +4,14 @@ import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import org.springframework.data.domain.Persistable
+import java.util.UUID
 
 @Entity
 class Guest(
     @Id
     @Column(name = "id")
-    private val guestId: String,
+    private val guestId: UUID,
 ) : Persistable<String> {
-    override fun getId(): String = guestId
+    override fun getId(): String = guestId.toString()
     override fun isNew(): Boolean = true
 }

--- a/src/main/kotlin/com/depromeet/team3/guest/repository/GuestJpaRepository.kt
+++ b/src/main/kotlin/com/depromeet/team3/guest/repository/GuestJpaRepository.kt
@@ -2,5 +2,6 @@ package com.depromeet.team3.guest.repository
 
 import com.depromeet.team3.guest.domain.Guest
 import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
 
-interface GuestJpaRepository : JpaRepository<Guest, String>
+interface GuestJpaRepository : JpaRepository<Guest, UUID>

--- a/src/main/kotlin/com/depromeet/team3/guest/repository/GuestJpaRepository.kt
+++ b/src/main/kotlin/com/depromeet/team3/guest/repository/GuestJpaRepository.kt
@@ -3,4 +3,4 @@ package com.depromeet.team3.guest.repository
 import com.depromeet.team3.guest.domain.Guest
 import org.springframework.data.jpa.repository.JpaRepository
 
-internal interface GuestJpaRepository : JpaRepository<Guest, String>
+interface GuestJpaRepository : JpaRepository<Guest, String>

--- a/src/main/kotlin/com/depromeet/team3/guest/repository/GuestJpaRepository.kt
+++ b/src/main/kotlin/com/depromeet/team3/guest/repository/GuestJpaRepository.kt
@@ -1,0 +1,6 @@
+package com.depromeet.team3.guest.repository
+
+import com.depromeet.team3.guest.domain.Guest
+import org.springframework.data.jpa.repository.JpaRepository
+
+internal interface GuestJpaRepository : JpaRepository<Guest, String>

--- a/src/main/kotlin/com/depromeet/team3/guest/repository/GuestRepository.kt
+++ b/src/main/kotlin/com/depromeet/team3/guest/repository/GuestRepository.kt
@@ -5,5 +5,5 @@ import com.depromeet.team3.guest.domain.Guest
 interface GuestRepository {
     fun existsByUuid(uuid: String): Boolean
 
-    fun save(guest: Guest): Guest
+    fun save(id: String): Guest
 }

--- a/src/main/kotlin/com/depromeet/team3/guest/repository/GuestRepository.kt
+++ b/src/main/kotlin/com/depromeet/team3/guest/repository/GuestRepository.kt
@@ -3,7 +3,5 @@ package com.depromeet.team3.guest.repository
 import com.depromeet.team3.guest.domain.Guest
 
 interface GuestRepository {
-    fun existsByUuid(uuid: String): Boolean
-
     fun save(id: String): Guest
 }

--- a/src/main/kotlin/com/depromeet/team3/guest/repository/GuestRepository.kt
+++ b/src/main/kotlin/com/depromeet/team3/guest/repository/GuestRepository.kt
@@ -1,0 +1,9 @@
+package com.depromeet.team3.guest.repository
+
+import com.depromeet.team3.guest.domain.Guest
+
+interface GuestRepository {
+    fun existsByUuid(uuid: String): Boolean
+
+    fun save(guest: Guest): Guest
+}

--- a/src/main/kotlin/com/depromeet/team3/guest/repository/GuestRepository.kt
+++ b/src/main/kotlin/com/depromeet/team3/guest/repository/GuestRepository.kt
@@ -1,7 +1,8 @@
 package com.depromeet.team3.guest.repository
 
 import com.depromeet.team3.guest.domain.Guest
+import java.util.UUID
 
 interface GuestRepository {
-    fun save(id: String): Guest
+    fun save(id: UUID): Guest
 }

--- a/src/main/kotlin/com/depromeet/team3/guest/repository/GuestRepositoryImpl.kt
+++ b/src/main/kotlin/com/depromeet/team3/guest/repository/GuestRepositoryImpl.kt
@@ -7,7 +7,5 @@ import org.springframework.stereotype.Repository
 class GuestRepositoryImpl(
     private val guestJpaRepository: GuestJpaRepository,
 ) : GuestRepository {
-    override fun existsByUuid(uuid: String): Boolean = guestJpaRepository.existsById(uuid)
-
     override fun save(id: String): Guest = guestJpaRepository.save(Guest(id))
 }

--- a/src/main/kotlin/com/depromeet/team3/guest/repository/GuestRepositoryImpl.kt
+++ b/src/main/kotlin/com/depromeet/team3/guest/repository/GuestRepositoryImpl.kt
@@ -4,7 +4,7 @@ import com.depromeet.team3.guest.domain.Guest
 import org.springframework.stereotype.Repository
 
 @Repository
-internal class GuestRepositoryImpl(
+class GuestRepositoryImpl(
     private val guestJpaRepository: GuestJpaRepository,
 ) : GuestRepository {
     override fun existsByUuid(uuid: String): Boolean = guestJpaRepository.existsById(uuid)

--- a/src/main/kotlin/com/depromeet/team3/guest/repository/GuestRepositoryImpl.kt
+++ b/src/main/kotlin/com/depromeet/team3/guest/repository/GuestRepositoryImpl.kt
@@ -1,0 +1,13 @@
+package com.depromeet.team3.guest.repository
+
+import com.depromeet.team3.guest.domain.Guest
+import org.springframework.stereotype.Repository
+
+@Repository
+internal class GuestRepositoryImpl(
+    private val guestJpaRepository: GuestJpaRepository,
+) : GuestRepository {
+    override fun existsByUuid(uuid: String): Boolean = guestJpaRepository.existsById(uuid)
+
+    override fun save(guest: Guest): Guest = guestJpaRepository.save(guest)
+}

--- a/src/main/kotlin/com/depromeet/team3/guest/repository/GuestRepositoryImpl.kt
+++ b/src/main/kotlin/com/depromeet/team3/guest/repository/GuestRepositoryImpl.kt
@@ -2,10 +2,11 @@ package com.depromeet.team3.guest.repository
 
 import com.depromeet.team3.guest.domain.Guest
 import org.springframework.stereotype.Repository
+import java.util.UUID
 
 @Repository
 class GuestRepositoryImpl(
     private val guestJpaRepository: GuestJpaRepository,
 ) : GuestRepository {
-    override fun save(id: String): Guest = guestJpaRepository.save(Guest(id))
+    override fun save(id: UUID): Guest = guestJpaRepository.save(Guest(id))
 }

--- a/src/main/kotlin/com/depromeet/team3/guest/repository/GuestRepositoryImpl.kt
+++ b/src/main/kotlin/com/depromeet/team3/guest/repository/GuestRepositoryImpl.kt
@@ -9,5 +9,5 @@ internal class GuestRepositoryImpl(
 ) : GuestRepository {
     override fun existsByUuid(uuid: String): Boolean = guestJpaRepository.existsById(uuid)
 
-    override fun save(guest: Guest): Guest = guestJpaRepository.save(guest)
+    override fun save(id: String): Guest = guestJpaRepository.save(Guest(id))
 }

--- a/src/main/kotlin/com/depromeet/team3/guest/service/GuestService.kt
+++ b/src/main/kotlin/com/depromeet/team3/guest/service/GuestService.kt
@@ -10,5 +10,5 @@ class GuestService(
     private val guestRepository: GuestRepository,
 ) {
     @Transactional
-    fun issueGuestUuid(): String = guestRepository.save(UUID.randomUUID().toString()).id
+    fun issueGuestId(): String = guestRepository.save(UUID.randomUUID()).id
 }

--- a/src/main/kotlin/com/depromeet/team3/guest/service/GuestService.kt
+++ b/src/main/kotlin/com/depromeet/team3/guest/service/GuestService.kt
@@ -10,5 +10,7 @@ class GuestService(
     private val guestRepository: GuestRepository,
 ) {
     @Transactional
-    fun issueGuestId(): String = guestRepository.save(UUID.randomUUID()).id
+    fun issueGuestId(): UUID = guestRepository
+        .save(UUID.randomUUID())
+        .getId()
 }

--- a/src/main/kotlin/com/depromeet/team3/guest/service/GuestService.kt
+++ b/src/main/kotlin/com/depromeet/team3/guest/service/GuestService.kt
@@ -12,12 +12,12 @@ class GuestService(
 ) {
     @Transactional
     fun issueGuestUuid(): String {
-        var uuid: String
+        var id: String
         do {
-            uuid = UUID.randomUUID().toString()
-        } while (guestRepository.existsByUuid(uuid))
+            id = UUID.randomUUID().toString()
+        } while (guestRepository.existsByUuid(id))
 
-        guestRepository.save(Guest(uuid))
-        return uuid
+        guestRepository.save(id)
+        return id
     }
 }

--- a/src/main/kotlin/com/depromeet/team3/guest/service/GuestService.kt
+++ b/src/main/kotlin/com/depromeet/team3/guest/service/GuestService.kt
@@ -1,0 +1,23 @@
+package com.depromeet.team3.guest.service
+
+import com.depromeet.team3.guest.domain.Guest
+import com.depromeet.team3.guest.repository.GuestRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Service
+class GuestService(
+    private val guestRepository: GuestRepository,
+) {
+    @Transactional
+    fun issueGuestUuid(): String {
+        var uuid: String
+        do {
+            uuid = UUID.randomUUID().toString()
+        } while (guestRepository.existsByUuid(uuid))
+
+        guestRepository.save(Guest(uuid))
+        return uuid
+    }
+}

--- a/src/main/kotlin/com/depromeet/team3/guest/service/GuestService.kt
+++ b/src/main/kotlin/com/depromeet/team3/guest/service/GuestService.kt
@@ -1,6 +1,5 @@
 package com.depromeet.team3.guest.service
 
-import com.depromeet.team3.guest.domain.Guest
 import com.depromeet.team3.guest.repository.GuestRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -11,13 +10,5 @@ class GuestService(
     private val guestRepository: GuestRepository,
 ) {
     @Transactional
-    fun issueGuestUuid(): String {
-        var id: String
-        do {
-            id = UUID.randomUUID().toString()
-        } while (guestRepository.existsByUuid(id))
-
-        guestRepository.save(id)
-        return id
-    }
+    fun issueGuestUuid(): String = guestRepository.save(UUID.randomUUID().toString()).id
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,7 +14,7 @@ spring:
     password: ${DB_PASSWORD:}
   jpa:
     hibernate:
-      ddl-auto: ${JPA_DDL_AUTO:create-drop}
+      ddl-auto: ${JPA_DDL_AUTO:validate}
     show-sql: false
 
 gemini:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,6 +7,15 @@ spring:
     multipart:
       max-file-size: 10MB
       max-request-size: 10MB
+  datasource:
+    url: ${DB_URL:jdbc:h2:mem:team3db;DB_CLOSE_DELAY=-1}
+    driver-class-name: ${DB_DRIVER:org.h2.Driver}
+    username: ${DB_USERNAME:sa}
+    password: ${DB_PASSWORD:}
+  jpa:
+    hibernate:
+      ddl-auto: ${JPA_DDL_AUTO:create-drop}
+    show-sql: false
 
 gemini:
   api-key: ${GEMINI_API_KEY:}

--- a/src/test/kotlin/com/depromeet/team3/guest/controller/GuestControllerTest.kt
+++ b/src/test/kotlin/com/depromeet/team3/guest/controller/GuestControllerTest.kt
@@ -1,0 +1,55 @@
+package com.depromeet.team3.guest.controller
+
+import com.depromeet.team3.guest.service.GuestService
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.BDDMockito.given
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+
+@ExtendWith(MockitoExtension::class)
+class GuestControllerTest {
+
+    @Mock
+    private lateinit var guestService: GuestService
+
+    @InjectMocks
+    private lateinit var guestController: GuestController
+
+    private lateinit var mockMvc: MockMvc
+
+    @BeforeEach
+    fun setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(guestController).build()
+    }
+
+    @Test
+    fun `POST api v1 guests 는 발급된 UUID 를 guestUUID 필드로 반환한다`() {
+        val expectedUuid = "11111111-2222-3333-4444-555555555555"
+        given(guestService.issueGuestUuid()).willReturn(expectedUuid)
+
+        mockMvc.perform(post("/api/v1/guests"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.guestUUID").value(expectedUuid))
+    }
+
+    @Test
+    fun `POST api v1 guests 는 매 요청마다 GuestService 를 호출해 새 UUID 를 받아온다`() {
+        given(guestService.issueGuestUuid()).willReturn("first-uuid", "second-uuid")
+
+        mockMvc.perform(post("/api/v1/guests"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.guestUUID").value("first-uuid"))
+
+        mockMvc.perform(post("/api/v1/guests"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.guestUUID").value("second-uuid"))
+    }
+}

--- a/src/test/kotlin/com/depromeet/team3/guest/controller/GuestControllerTest.kt
+++ b/src/test/kotlin/com/depromeet/team3/guest/controller/GuestControllerTest.kt
@@ -13,6 +13,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.util.UUID
 
 @ExtendWith(MockitoExtension::class)
 class GuestControllerTest {
@@ -31,25 +32,27 @@ class GuestControllerTest {
     }
 
     @Test
-    fun `POST api v1 guests 는 발급된 UUID 를 guestUUID 필드로 반환한다`() {
-        val expectedUuid = "11111111-2222-3333-4444-555555555555"
+    fun `POST api v1 guests 는 발급된 UUID 를 guestId 필드로 반환한다`() {
+        val expectedUuid = UUID.fromString("11111111-2222-3333-4444-555555555555")
         given(guestService.issueGuestId()).willReturn(expectedUuid)
 
         mockMvc.perform(post("/api/v1/guests"))
             .andExpect(status().isOk)
-            .andExpect(jsonPath("$.guestUUID").value(expectedUuid))
+            .andExpect(jsonPath("$.guestId").value(expectedUuid.toString()))
     }
 
     @Test
     fun `POST api v1 guests 는 매 요청마다 GuestService 를 호출해 새 UUID 를 받아온다`() {
-        given(guestService.issueGuestId()).willReturn("first-uuid", "second-uuid")
+        val first = UUID.randomUUID()
+        val second = UUID.randomUUID()
+        given(guestService.issueGuestId()).willReturn(first, second)
 
         mockMvc.perform(post("/api/v1/guests"))
             .andExpect(status().isOk)
-            .andExpect(jsonPath("$.guestUUID").value("first-uuid"))
+            .andExpect(jsonPath("$.guestId").value(first.toString()))
 
         mockMvc.perform(post("/api/v1/guests"))
             .andExpect(status().isOk)
-            .andExpect(jsonPath("$.guestUUID").value("second-uuid"))
+            .andExpect(jsonPath("$.guestId").value(second.toString()))
     }
 }

--- a/src/test/kotlin/com/depromeet/team3/guest/controller/GuestControllerTest.kt
+++ b/src/test/kotlin/com/depromeet/team3/guest/controller/GuestControllerTest.kt
@@ -33,7 +33,7 @@ class GuestControllerTest {
     @Test
     fun `POST api v1 guests 는 발급된 UUID 를 guestUUID 필드로 반환한다`() {
         val expectedUuid = "11111111-2222-3333-4444-555555555555"
-        given(guestService.issueGuestUuid()).willReturn(expectedUuid)
+        given(guestService.issueGuestId()).willReturn(expectedUuid)
 
         mockMvc.perform(post("/api/v1/guests"))
             .andExpect(status().isOk)
@@ -42,7 +42,7 @@ class GuestControllerTest {
 
     @Test
     fun `POST api v1 guests 는 매 요청마다 GuestService 를 호출해 새 UUID 를 받아온다`() {
-        given(guestService.issueGuestUuid()).willReturn("first-uuid", "second-uuid")
+        given(guestService.issueGuestId()).willReturn("first-uuid", "second-uuid")
 
         mockMvc.perform(post("/api/v1/guests"))
             .andExpect(status().isOk)

--- a/src/test/kotlin/com/depromeet/team3/guest/service/GuestServiceTest.kt
+++ b/src/test/kotlin/com/depromeet/team3/guest/service/GuestServiceTest.kt
@@ -1,0 +1,77 @@
+package com.depromeet.team3.guest.service
+
+import com.depromeet.team3.guest.domain.Guest
+import com.depromeet.team3.guest.repository.GuestRepository
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class GuestServiceTest {
+
+    private class StubGuestRepository : GuestRepository {
+        val saved = mutableListOf<Guest>()
+        var existsResults: ArrayDeque<Boolean> = ArrayDeque()
+        val existsCalledFor = mutableListOf<String>()
+
+        override fun existsByUuid(uuid: String): Boolean {
+            existsCalledFor.add(uuid)
+            return existsResults.removeFirstOrNull() ?: false
+        }
+
+        override fun save(guest: Guest): Guest {
+            saved.add(guest)
+            return guest
+        }
+    }
+
+    private val repository = StubGuestRepository()
+    private val guestService = GuestService(repository)
+
+    @Test
+    fun `issueGuestUuid 는 UUID 형식의 문자열을 반환한다`() {
+        val uuid = guestService.issueGuestUuid()
+
+        UUID.fromString(uuid)
+    }
+
+    @Test
+    fun `issueGuestUuid 는 발급한 UUID 를 저장소에 저장한다`() {
+        val uuid = guestService.issueGuestUuid()
+
+        assertEquals(1, repository.saved.size)
+        assertEquals(uuid, repository.saved[0].uuid)
+    }
+
+    @Test
+    fun `issueGuestUuid 를 여러 번 호출하면 매번 새로운 UUID 가 발급된다`() {
+        val first = guestService.issueGuestUuid()
+        val second = guestService.issueGuestUuid()
+        val third = guestService.issueGuestUuid()
+
+        val uuids = setOf(first, second, third)
+        assertEquals(3, uuids.size)
+        assertEquals(3, repository.saved.size)
+    }
+
+    @Test
+    fun `이미 존재하는 UUID 면 새 UUID 를 다시 발급한다`() {
+        repository.existsResults = ArrayDeque(listOf(true, false))
+
+        val issued = guestService.issueGuestUuid()
+
+        UUID.fromString(issued)
+        assertEquals(2, repository.existsCalledFor.size)
+        assertEquals(1, repository.saved.size)
+        assertEquals(issued, repository.saved[0].uuid)
+    }
+
+    @Test
+    fun `existsByUuid 가 false 일 때만 save 가 호출된다`() {
+        val uuid = guestService.issueGuestUuid()
+        val unrelated = UUID.randomUUID().toString()
+        assertNotEquals(uuid, unrelated)
+
+        assertEquals(listOf(uuid), repository.saved.map { it.uuid })
+    }
+}

--- a/src/test/kotlin/com/depromeet/team3/guest/service/GuestServiceTest.kt
+++ b/src/test/kotlin/com/depromeet/team3/guest/service/GuestServiceTest.kt
@@ -9,9 +9,9 @@ import kotlin.test.assertEquals
 class GuestServiceTest {
 
     private class StubGuestRepository : GuestRepository {
-        val saved = mutableListOf<String>()
+        val saved = mutableListOf<UUID>()
 
-        override fun save(id: String): Guest {
+        override fun save(id: UUID): Guest {
             saved.add(id)
             return Guest(id)
         }
@@ -21,27 +21,27 @@ class GuestServiceTest {
     private val guestService = GuestService(repository)
 
     @Test
-    fun `issueGuestUuid 는 UUID 형식의 문자열을 반환한다`() {
-        val uuid = guestService.issueGuestUuid()
+    fun `issueGuestId 는 UUID 형식의 문자열을 반환한다`() {
+        val id = guestService.issueGuestId()
 
-        UUID.fromString(uuid)
+        UUID.fromString(id)
     }
 
     @Test
-    fun `issueGuestUuid 는 발급한 UUID 를 저장소에 저장한다`() {
-        val uuid = guestService.issueGuestUuid()
+    fun `issueGuestId 는 발급한 UUID 를 저장소에 저장한다`() {
+        val id = guestService.issueGuestId()
 
-        assertEquals(listOf(uuid), repository.saved)
+        assertEquals(listOf(id), repository.saved.map { it.toString() })
     }
 
     @Test
-    fun `issueGuestUuid 를 여러 번 호출하면 매번 새로운 UUID 가 발급된다`() {
-        val first = guestService.issueGuestUuid()
-        val second = guestService.issueGuestUuid()
-        val third = guestService.issueGuestUuid()
+    fun `issueGuestId 를 여러 번 호출하면 매번 새로운 UUID 가 발급된다`() {
+        val first = guestService.issueGuestId()
+        val second = guestService.issueGuestId()
+        val third = guestService.issueGuestId()
 
-        val uuids = setOf(first, second, third)
-        assertEquals(3, uuids.size)
-        assertEquals(listOf(first, second, third), repository.saved)
+        val ids = setOf(first, second, third)
+        assertEquals(3, ids.size)
+        assertEquals(listOf(first, second, third), repository.saved.map { it.toString() })
     }
 }

--- a/src/test/kotlin/com/depromeet/team3/guest/service/GuestServiceTest.kt
+++ b/src/test/kotlin/com/depromeet/team3/guest/service/GuestServiceTest.kt
@@ -5,23 +5,15 @@ import com.depromeet.team3.guest.repository.GuestRepository
 import org.junit.jupiter.api.Test
 import java.util.UUID
 import kotlin.test.assertEquals
-import kotlin.test.assertNotEquals
 
 class GuestServiceTest {
 
     private class StubGuestRepository : GuestRepository {
-        val saved = mutableListOf<Guest>()
-        var existsResults: ArrayDeque<Boolean> = ArrayDeque()
-        val existsCalledFor = mutableListOf<String>()
+        val saved = mutableListOf<String>()
 
-        override fun existsByUuid(uuid: String): Boolean {
-            existsCalledFor.add(uuid)
-            return existsResults.removeFirstOrNull() ?: false
-        }
-
-        override fun save(guest: Guest): Guest {
-            saved.add(guest)
-            return guest
+        override fun save(id: String): Guest {
+            saved.add(id)
+            return Guest(id)
         }
     }
 
@@ -39,8 +31,7 @@ class GuestServiceTest {
     fun `issueGuestUuid 는 발급한 UUID 를 저장소에 저장한다`() {
         val uuid = guestService.issueGuestUuid()
 
-        assertEquals(1, repository.saved.size)
-        assertEquals(uuid, repository.saved[0].uuid)
+        assertEquals(listOf(uuid), repository.saved)
     }
 
     @Test
@@ -51,27 +42,6 @@ class GuestServiceTest {
 
         val uuids = setOf(first, second, third)
         assertEquals(3, uuids.size)
-        assertEquals(3, repository.saved.size)
-    }
-
-    @Test
-    fun `이미 존재하는 UUID 면 새 UUID 를 다시 발급한다`() {
-        repository.existsResults = ArrayDeque(listOf(true, false))
-
-        val issued = guestService.issueGuestUuid()
-
-        UUID.fromString(issued)
-        assertEquals(2, repository.existsCalledFor.size)
-        assertEquals(1, repository.saved.size)
-        assertEquals(issued, repository.saved[0].uuid)
-    }
-
-    @Test
-    fun `existsByUuid 가 false 일 때만 save 가 호출된다`() {
-        val uuid = guestService.issueGuestUuid()
-        val unrelated = UUID.randomUUID().toString()
-        assertNotEquals(uuid, unrelated)
-
-        assertEquals(listOf(uuid), repository.saved.map { it.uuid })
+        assertEquals(listOf(first, second, third), repository.saved)
     }
 }

--- a/src/test/kotlin/com/depromeet/team3/guest/service/GuestServiceTest.kt
+++ b/src/test/kotlin/com/depromeet/team3/guest/service/GuestServiceTest.kt
@@ -21,17 +21,10 @@ class GuestServiceTest {
     private val guestService = GuestService(repository)
 
     @Test
-    fun `issueGuestId 는 UUID 형식의 문자열을 반환한다`() {
+    fun `issueGuestId 는 UUID 를 반환한다`() {
         val id = guestService.issueGuestId()
 
-        UUID.fromString(id)
-    }
-
-    @Test
-    fun `issueGuestId 는 발급한 UUID 를 저장소에 저장한다`() {
-        val id = guestService.issueGuestId()
-
-        assertEquals(listOf(id), repository.saved.map { it.toString() })
+        assertEquals(listOf(id), repository.saved)
     }
 
     @Test
@@ -42,6 +35,6 @@ class GuestServiceTest {
 
         val ids = setOf(first, second, third)
         assertEquals(3, ids.size)
-        assertEquals(listOf(first, second, third), repository.saved.map { it.toString() })
+        assertEquals(listOf(first, second, third), repository.saved)
     }
 }


### PR DESCRIPTION
## Situation
- 게스트(비회원) 사용자를 식별하기 위한 별도의 식별자가 필요했음
- 기존 코드베이스에는 영속성(JPA/datasource) 설정이 없어 신규 도입이 필요했음

## Task
- 게스트 식별용 UUID를 발급·저장하고 클라이언트에 반환하는 API 추가
- 영속성 계층(JPA + datasource) 초기 설정

## Action
- `kotlin("plugin.jpa")` plugin과 `spring-boot-starter-data-jpa` 의존성 추가, 로컬/테스트용 H2와 운영용 MySQL 드라이버를 runtimeOnly로 등록
- `application.yml` 의 datasource/jpa 설정을 환경 변수 기반으로 분리해 로컬은 H2 인메모리, 운영은 `DB_URL` 등으로 주입하도록 구성
- `POST /api/v1/guests` 추가: UUID 생성 → `existsByUuid` 로 충돌 검사 → 충돌 시 재발급 → `guests` 테이블에 저장 후 `guestUUID` 필드로 반환
- repository를 `GuestRepository` 인터페이스와 `GuestRepositoryImpl`(+ `GuestJpaRepository`) 구현체로 분리해 service/domain 계층이 JPA에 직접 의존하지 않도록 처리
- MockMvc 기반 컨트롤러 테스트와 stub repository 기반 서비스 테스트로 응답 형식, 매 요청마다 신규 UUID 발급, 중복 시 재발급 동작을 검증

## Result
- 게스트가 `POST /api/v1/guests` 한 번으로 영구 보관되는 UUID를 발급받을 수 있음
- 환경 변수만 바꾸면 로컬(H2) ↔ 운영(MySQL) 전환 가능
- 주의: `JPA_DDL_AUTO` 기본값이 `create-drop` 이므로 운영 환경에서는 별도 값(`validate` 등)으로 덮어쓰는 운영 정책이 필요

---
## 연관 이슈

- close #45

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 게스트 식별자 발급 API 엔드포인트 추가
  * 도메인 및 영속성 계층 추가(게스트 엔티티, 저장소 및 서비스)
  * JPA 감사(auditing) 기반 베이스 엔티티 추가

* **설정**
  * 데이터베이스 지원 확대(H2, MySQL) 및 관련 데이터소스/JPA 설정 추가
  * 빌드에 JPA 관련 플러그인·의존성 추가

* **테스트**
  * API 엔드포인트 및 식별자 발급 로직 단위/통합 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->