### PR TITLE
health check 엔드포인트 추가

### DIFF
--- a/src/main/kotlin/com/depromeet/team3/common/controller/HealthController.kt
+++ b/src/main/kotlin/com/depromeet/team3/common/controller/HealthController.kt
@@ -1,0 +1,13 @@
+package com.depromeet.team3.common.controller
+
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class HealthController {
+
+    @GetMapping("/health")
+    fun health(): ResponseEntity<Map<String, String>> =
+        ResponseEntity.ok(mapOf("status" to "ok"))
+}


### PR DESCRIPTION
## Situation
- 배포 후 서버가 정상 동작하는지 브라우저에서 바로 확인할 방법이 없었음

## Task
- GET 요청 한 번으로 서버 상태를 확인할 수 있는 엔드포인트 추가

## Action
- `GET /health` → `{"status": "ok"}` 응답 반환
- `HealthController` 추가 (`common/controller` 패키지)

## Result
- `http://3.37.172.220:8080/health` 로 서버 생존 여부 즉시 확인 가능