### PR TITLE
Docker 빌드 플랫폼 arm64로 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,11 +20,18 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
+          platforms: linux/arm64
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/team3-server:latest
 
       - name: Deploy to EC2


### PR DESCRIPTION
## Situation
- EC2가 arm64 아키텍처(Ubuntu 24.04 arm64)인데 GitHub Actions는 amd64로 빌드해서
  컨테이너 실행 시 `exec format error`로 즉시 종료됨

## Task
- EC2 아키텍처에 맞는 arm64 이미지 빌드

## Action
- QEMU, Docker Buildx 추가
- `platforms: linux/arm64` 명시

## Result
- EC2에서 컨테이너 정상 실행
- 단, 크로스 빌드로 인해 빌드 시간 증가 (약 10~15분 예상)