### PR TITLE
CI 빌드 속도 개선 (Gradle 네이티브 빌드 분리)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up JDK 25
+        uses: actions/setup-java@v4
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+
+      - name: Build JAR
+        run: ./gradlew bootJar --no-daemon
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -30,6 +39,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          file: Dockerfile.ci
           push: true
           platforms: linux/arm64
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/team3-server:latest

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,0 +1,26 @@
+# CI 전용 Dockerfile — Gradle 빌드는 GitHub Actions에서 네이티브로 실행 후 JAR만 넘겨받음
+# ────────────────────────────────────────────
+# Stage 1: extractor — Layered JAR 분리
+# ────────────────────────────────────────────
+FROM eclipse-temurin:25-jdk AS extractor
+WORKDIR /workspace
+COPY build/libs/*.jar app.jar
+RUN java -Djarmode=layertools -jar app.jar extract
+
+# ────────────────────────────────────────────
+# Stage 2: runtime — 최소 실행 이미지
+# ────────────────────────────────────────────
+FROM eclipse-temurin:25-jre AS runtime
+WORKDIR /app
+
+RUN groupadd --system appgroup && useradd --system --gid appgroup appuser
+
+COPY --from=extractor /workspace/dependencies/ ./
+COPY --from=extractor /workspace/spring-boot-loader/ ./
+COPY --from=extractor /workspace/snapshot-dependencies/ ./
+COPY --from=extractor /workspace/application/ ./
+
+USER appuser
+
+EXPOSE 8080
+ENTRYPOINT ["java", "org.springframework.boot.loader.launch.JarLauncher"]


### PR DESCRIPTION
## Situation
- EC2가 arm64(t4g)라 GitHub Actions에서 QEMU로 크로스 빌드 시
  Gradle 컴파일까지 ARM64 에뮬레이션 위에서 돌아 빌드가 10~15분 소요됨
- 다른 서비스 레퍼런스를 참고해 개선 방법 검토

## Task
- QEMU가 처리하는 작업을 최소화해 빌드 시간 단축

## Action
- `Dockerfile.ci` 추가: pre-built JAR을 COPY만 하는 CI 전용 Dockerfile
- deploy.yml에 JDK 25 셋업 + `./gradlew bootJar` 스텝 추가 (x86_64 네이티브 실행)
- Docker 빌드 시 `Dockerfile.ci` 사용, QEMU는 JAR COPY/추출만 처리
- 기존 `Dockerfile`은 로컬 빌드용으로 그대로 유지

## Result
- Gradle 컴파일은 빠른 x86_64에서 네이티브로, QEMU는 가벼운 작업만 처리
- 예상 빌드 시간 15분 → 5분 내외로 단축