### PR TITLE
.dockerignore build/libs/*.jar 예외 처리

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 .git
 .gradle
-build
+build/
+!build/libs/*.jar
 .idea
 out
 .kotlin


### PR DESCRIPTION
## Situation
- Dockerfile.ci에서 `COPY build/libs/*.jar` 시 .dockerignore의 `build/` 규칙에 막혀 빌드 실패

## Task
- CI에서 pre-built JAR이 Docker 빌드 컨텍스트에 포함되도록 예외 처리

## Action
- `.dockerignore`에서 `build/` → `build/` + `!build/libs/*.jar` 로 수정
- build 폴더는 제외하되 JAR 파일만 허용

## Result
- Dockerfile.ci의 COPY 스텝 정상 동작