### PR TITLE
Vercel 프론트엔드 CORS 허용 설정 추가

### DIFF
--- a/src/main/kotlin/com/depromeet/team3/common/config/CorsConfig.kt
+++ b/src/main/kotlin/com/depromeet/team3/common/config/CorsConfig.kt
@@ -1,0 +1,17 @@
+package com.depromeet.team3.common.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.CorsRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class CorsConfig : WebMvcConfigurer {
+
+    override fun addCorsMappings(registry: CorsRegistry) {
+        registry.addMapping("/**")
+            .allowedOrigins("https://depromeet.vercel.app")
+            .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
+            .allowedHeaders("*")
+            .allowCredentials(true)
+    }
+}


### PR DESCRIPTION
## Situation
- Vercel 프론트(https://depromeet.vercel.app)에서 백엔드 API 호출 시 CORS 에러 발생
- Vercel은 HTTPS, 백엔드는 HTTP IP였던 문제로 도메인 + Nginx + SSL도 함께 구성

## Task
- Vercel → 백엔드 API 호출 허용

## Action
- `CorsConfig` 추가: `https://depromeet.vercel.app` 허용
- 백엔드 도메인: `api.depromeet18team3.cloud` (가비아 구매 + Let's Encrypt SSL)

## Result
- Vercel 프론트에서 `https://api.depromeet18team3.cloud` 로 API 호출 가능