### PR TITLE
SpringDoc + Stoplight Elements API 문서 자동화 도입

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,9 @@ dependencies {
 	implementation("org.flywaydb:flyway-mysql")
 	runtimeOnly("com.mysql:mysql-connector-j")
 
+	// Spring Boot 4.0.5 / Jackson 3 호환 라인. Swagger UI 없이 /v3/api-docs 만 제공 (UI는 Stoplight Elements 사용)
+	implementation("org.springdoc:springdoc-openapi-starter-webmvc-api:3.0.3")
+
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.springframework.boot:spring-boot-testcontainers")
 	testImplementation("org.testcontainers:junit-jupiter")

--- a/src/main/kotlin/com/depromeet/team3/common/config/OpenApiConfig.kt
+++ b/src/main/kotlin/com/depromeet/team3/common/config/OpenApiConfig.kt
@@ -1,0 +1,35 @@
+package com.depromeet.team3.common.config
+
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Contact
+import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.info.License
+import io.swagger.v3.oas.models.servers.Server
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class OpenApiConfig {
+
+    @Bean
+    fun openAPI(
+        @Value("\${spring.application.name:team3}") applicationName: String,
+    ): OpenAPI = OpenAPI()
+        .info(
+            Info()
+                .title("$applicationName API")
+                .version("v1")
+                .description(
+                    """
+                    Depromeet 18기 3팀 위시리스트 서비스 API 문서.
+
+                    - 모든 응답의 에러 포맷은 RFC 7807 `application/problem+json` 을 따른다.
+                    - 게스트 식별자는 클라이언트가 발급받아 보관하며, 위시리스트 등록 시 함께 전달한다.
+                    """.trimIndent(),
+                )
+                .contact(Contact().name("team3").url("https://github.com/depromeet/18th-team3-server"))
+                .license(License().name("Apache-2.0").url("https://www.apache.org/licenses/LICENSE-2.0")),
+        )
+        .addServersItem(Server().url("/").description("Current host"))
+}

--- a/src/main/kotlin/com/depromeet/team3/common/config/OpenApiConfig.kt
+++ b/src/main/kotlin/com/depromeet/team3/common/config/OpenApiConfig.kt
@@ -19,6 +19,8 @@ class OpenApiConfig {
         .info(
             Info()
                 .title("$applicationName API")
+                // API 버전은 빌드 버전(0.0.1-SNAPSHOT)과 별개의 public 계약 버전이므로 별도 관리
+                // project.version은 Gradle 컨텍스트 전용이라 Spring Bean에서 직접 참조 불가
                 .version("v1")
                 .description(
                     """

--- a/src/main/kotlin/com/depromeet/team3/guest/controller/GuestController.kt
+++ b/src/main/kotlin/com/depromeet/team3/guest/controller/GuestController.kt
@@ -2,15 +2,44 @@ package com.depromeet.team3.guest.controller
 
 import com.depromeet.team3.guest.controller.dto.GuestResponse
 import com.depromeet.team3.guest.service.GuestService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
+@Tag(name = "Guest", description = "게스트 식별자 발급 API")
 @RestController
 @RequestMapping("/api/v1/guests")
 class GuestController(
     private val guestService: GuestService,
 ) {
+    @Operation(
+        summary = "게스트 ID 발급",
+        description = """
+            로그인 없이 위시리스트를 사용하는 게스트에게 영속 식별자(UUID v4)를 발급한다.
+            클라이언트는 발급받은 값을 안전하게 보관하고, 이후 위시리스트 API 호출 시 함께 전달한다.
+        """,
+    )
+    @ApiResponse(
+        responseCode = "200",
+        description = "게스트 ID 발급 성공",
+        content = [
+            Content(
+                schema = Schema(implementation = GuestResponse::class),
+                examples = [
+                    ExampleObject(
+                        name = "발급 성공",
+                        value = """{ "guestId": "8f1a3c2b-9d44-4e2a-9b12-1a2b3c4d5e6f" }""",
+                    ),
+                ],
+            ),
+        ],
+    )
     @PostMapping
     fun issueGuestId(): GuestResponse = GuestResponse(guestService.issueGuestId())
 }

--- a/src/main/kotlin/com/depromeet/team3/guest/controller/dto/GuestResponse.kt
+++ b/src/main/kotlin/com/depromeet/team3/guest/controller/dto/GuestResponse.kt
@@ -1,7 +1,14 @@
 package com.depromeet.team3.guest.controller.dto
 
+import io.swagger.v3.oas.annotations.media.Schema
 import java.util.UUID
 
+@Schema(description = "게스트 ID 발급 응답")
 data class GuestResponse(
+    @field:Schema(
+        description = "발급된 게스트 식별자 (UUID v4)",
+        example = "8f1a3c2b-9d44-4e2a-9b12-1a2b3c4d5e6f",
+        format = "uuid",
+    )
     val guestId: UUID,
 )

--- a/src/main/kotlin/com/depromeet/team3/wishlist/controller/WishlistController.kt
+++ b/src/main/kotlin/com/depromeet/team3/wishlist/controller/WishlistController.kt
@@ -3,18 +3,113 @@ package com.depromeet.team3.wishlist.controller
 import com.depromeet.team3.wishlist.controller.dto.WishlistRegisterRequest
 import com.depromeet.team3.wishlist.controller.dto.WishlistRegisterResponse
 import com.depromeet.team3.wishlist.service.WishlistService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.http.ProblemDetail
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
+@Tag(name = "Wishlist", description = "위시리스트 등록/조회 API")
 @RestController
 @RequestMapping("/api/v1/wishlists")
 class WishlistController(
     private val wishlistService: WishlistService,
 ) {
+    @Operation(
+        summary = "위시리스트 등록",
+        description = """
+            상품 페이지 URL 을 받아 메타데이터(이름/가격/이미지 등)를 추출한 뒤 게스트의 위시리스트에 등록한다.
+            동일 게스트가 동일 상품 링크를 중복 등록하는 경우 409 가 반환된다.
+        """,
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "201",
+                description = "위시리스트 등록 성공",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = WishlistRegisterResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "등록 성공",
+                                value = """
+                                    {
+                                      "wishId": 1024,
+                                      "name": "에어 조던 1 미드",
+                                      "regularPrice": 159000,
+                                      "discountedPrice": 119000,
+                                      "discountRate": 25,
+                                      "currency": "KRW",
+                                      "imageUrl": "https://cdn.example.com/p/1024.jpg"
+                                    }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청 (URL 형식 오류 등)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+                        schema = Schema(implementation = ProblemDetail::class),
+                        examples = [
+                            ExampleObject(
+                                name = "URL 형식 오류",
+                                value = """
+                                    {
+                                      "type": "about:blank",
+                                      "title": "Bad Request",
+                                      "status": 400,
+                                      "detail": "지원하지 않는 URL 형식입니다.",
+                                      "category": "INVALID_INPUT"
+                                    }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "409",
+                description = "이미 위시리스트에 등록된 상품",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+                        schema = Schema(implementation = ProblemDetail::class),
+                        examples = [
+                            ExampleObject(
+                                name = "중복 등록",
+                                value = """
+                                    {
+                                      "type": "about:blank",
+                                      "title": "Conflict",
+                                      "status": 409,
+                                      "detail": "입력 오류 — 요청을 수정하여 재시도",
+                                      "category": "INVALID_INPUT"
+                                    }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     fun register(@RequestBody request: WishlistRegisterRequest): WishlistRegisterResponse {

--- a/src/main/kotlin/com/depromeet/team3/wishlist/controller/dto/WishlistRegisterRequest.kt
+++ b/src/main/kotlin/com/depromeet/team3/wishlist/controller/dto/WishlistRegisterRequest.kt
@@ -1,8 +1,22 @@
 package com.depromeet.team3.wishlist.controller.dto
 
+import io.swagger.v3.oas.annotations.media.Schema
 import java.util.UUID
 
+@Schema(description = "위시리스트 등록 요청")
 data class WishlistRegisterRequest(
+    @field:Schema(
+        description = "등록할 상품 페이지 URL",
+        example = "https://www.example-shop.com/products/12345",
+        requiredMode = Schema.RequiredMode.REQUIRED,
+    )
     val url: String,
+
+    @field:Schema(
+        description = "게스트 식별자 (게스트 발급 API로 받은 UUID)",
+        example = "8f1a3c2b-9d44-4e2a-9b12-1a2b3c4d5e6f",
+        format = "uuid",
+        requiredMode = Schema.RequiredMode.REQUIRED,
+    )
     val guestId: UUID,
 )

--- a/src/main/kotlin/com/depromeet/team3/wishlist/controller/dto/WishlistRegisterResponse.kt
+++ b/src/main/kotlin/com/depromeet/team3/wishlist/controller/dto/WishlistRegisterResponse.kt
@@ -1,14 +1,33 @@
 package com.depromeet.team3.wishlist.controller.dto
 
 import com.depromeet.team3.wishlist.domain.Wish
+import io.swagger.v3.oas.annotations.media.Schema
 
+@Schema(description = "위시리스트 등록 응답")
 data class WishlistRegisterResponse(
+    @field:Schema(description = "위시리스트 항목 ID", example = "1024")
     val wishId: Long,
+
+    @field:Schema(description = "상품명 (추출 실패 시 null)", example = "에어 조던 1 미드", nullable = true)
     val name: String?,
+
+    @field:Schema(description = "정가 (할인 전 가격)", example = "159000", nullable = true)
     val regularPrice: Int?,
+
+    @field:Schema(description = "할인가", example = "119000", nullable = true)
     val discountedPrice: Int?,
+
+    @field:Schema(description = "할인율 (%)", example = "25", nullable = true)
     val discountRate: Int?,
+
+    @field:Schema(description = "통화 코드 (ISO 4217)", example = "KRW", nullable = true)
     val currency: String?,
+
+    @field:Schema(
+        description = "상품 대표 이미지 URL",
+        example = "https://cdn.example.com/p/1024.jpg",
+        nullable = true,
+    )
     val imageUrl: String?,
 ) {
     companion object {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,3 +27,8 @@ spring:
 gemini:
   api-key: ${GEMINI_API_KEY}
   model: gemini-3-flash-preview
+
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+  default-produces-media-type: application/json

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -4,8 +4,21 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <title>team3 API Docs</title>
-    <script src="https://unpkg.com/@stoplight/elements/web-components.min.js"></script>
-    <link rel="stylesheet" href="https://unpkg.com/@stoplight/elements/styles.min.css" />
+    <!--
+      v9.x: React Router v6 업그레이드로 hash 라우팅 회귀 버그 발생 (URL 해시는 변경되나 콘텐츠 미갱신)
+      v8.5.2 고정: hash router 정상 동작이 확인된 마지막 v8 버전
+    -->
+    <script
+      src="https://unpkg.com/@stoplight/elements@8.5.2/web-components.min.js"
+      integrity="sha384-Wy+FsmLS9ZgiQK/ODulQPSA9zg+xHduMLnVEy+vZeGqwi1FKQ8/dKmsE38c0ovx/"
+      crossorigin="anonymous"
+    ></script>
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/@stoplight/elements@8.5.2/styles.min.css"
+      integrity="sha384-oYu9Au1JU1Sd5Za5LYSepn+Sofm8uvVdUCxLWbJYesNAS72Y7G/gQ0pjiB6wyf1Z"
+      crossorigin="anonymous"
+    />
   </head>
   <body style="margin: 0;">
     <elements-api

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <title>team3 API Docs</title>
+    <script src="https://unpkg.com/@stoplight/elements/web-components.min.js"></script>
+    <link rel="stylesheet" href="https://unpkg.com/@stoplight/elements/styles.min.css" />
+  </head>
+  <body style="margin: 0;">
+    <elements-api
+      apiDescriptionUrl="/v3/api-docs"
+      router="hash"
+      layout="sidebar"
+    />
+  </body>
+</html>


### PR DESCRIPTION
## Situation
- API 문서가 없어 프론트엔드 팀과의 명세 공유 수단이 필요한 상황
- Swagger UI, Stoplight Platform(SaaS), Stoplight Elements 중 어떤 방식을 선택할지 검토
- 직접 OpenAPI YAML을 작성하는 방식은 관리 비용이 크다는 점에서 배제

## Task
- 코드 변경 시 API 문서가 자동으로 반영되는 문서 자동화 구축
- 렌더러는 Swagger UI보다 UI/UX가 우수한 Stoplight Elements 채택

## Action
- `springdoc-openapi-starter-webmvc-api:3.0.3` 의존성 추가
  - `-webmvc-ui`(Swagger UI 번들) 대신 `-webmvc-api`(API 엔드포인트만) 사용 — Stoplight Elements가 UI 역할을 하므로 Swagger UI 불필요
- `OpenApiConfig`: API 제목, 설명, 연락처 등 메타데이터 설정
- `GuestController`, `WishlistController`의 `@Tag`, `@Operation`, `@ApiResponse` 어노테이션은 @m-a-king 의 `chore/swagger-openapi` 브랜치 작업을 cherry-pick
- `/docs/index.html`: Stoplight Elements CDN 로드 후 `/v3/api-docs` 를 읽어 렌더링

## Result
- 컨트롤러 코드 배포 시 `/docs/index.html` 문서 자동 반영
- 어노테이션 없어도 `@RestController` 만 있으면 기본 문서 생성, 어노테이션으로 설명 보강 가능

---
## 연관 이슈

- close #59