### PR TITLE
API 응답 포맷 ApiResponse로 통일

### DIFF
--- a/src/main/kotlin/com/depromeet/team3/common/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/depromeet/team3/common/exception/GlobalExceptionHandler.kt
@@ -1,8 +1,9 @@
 package com.depromeet.team3.common.exception
 
+import com.depromeet.team3.common.response.ApiResponse
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
-import org.springframework.http.ProblemDetail
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 
@@ -12,28 +13,28 @@ class GlobalExceptionHandler {
     private val log = LoggerFactory.getLogger(javaClass)
 
     @ExceptionHandler(BaseException::class)
-    fun handleBaseException(e: BaseException): ProblemDetail {
+    fun handleBaseException(e: BaseException): ResponseEntity<ApiResponse<Nothing>> {
         log.warn("[{}] {}", e.javaClass.simpleName, e.message, e)
         val status = if (e is HttpMappable) e.httpStatus else HttpStatus.INTERNAL_SERVER_ERROR
         val category = if (e is HttpMappable) e.category else ErrorCategory.SERVER_ERROR
-        return ProblemDetail.forStatusAndDetail(status, category.description).apply {
-            setProperty("category", category)
-        }
+        return ResponseEntity
+            .status(status)
+            .body(ApiResponse.fail(category, status, e.message))
     }
 
     @ExceptionHandler(IllegalArgumentException::class)
-    fun handleIllegalArgument(e: IllegalArgumentException): ProblemDetail {
+    fun handleIllegalArgument(e: IllegalArgumentException): ResponseEntity<ApiResponse<Nothing>> {
         log.warn("[IllegalArgumentException] {}", e.message)
-        return ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, e.message ?: "잘못된 요청입니다.").apply {
-            setProperty("category", ErrorCategory.INVALID_INPUT)
-        }
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ApiResponse.fail(ErrorCategory.INVALID_INPUT, HttpStatus.BAD_REQUEST))
     }
 
     @ExceptionHandler(Exception::class)
-    fun handleUnexpected(e: Exception): ProblemDetail {
+    fun handleUnexpected(e: Exception): ResponseEntity<ApiResponse<Nothing>> {
         log.error("[UnexpectedException] {}", e.message, e)
-        return ProblemDetail.forStatusAndDetail(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCategory.SERVER_ERROR.description).apply {
-            setProperty("category", ErrorCategory.SERVER_ERROR)
-        }
+        return ResponseEntity
+            .status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(ApiResponse.fail(ErrorCategory.SERVER_ERROR, HttpStatus.INTERNAL_SERVER_ERROR))
     }
 }

--- a/src/main/kotlin/com/depromeet/team3/common/response/ApiResponse.kt
+++ b/src/main/kotlin/com/depromeet/team3/common/response/ApiResponse.kt
@@ -21,13 +21,10 @@ data class ApiResponse<T>(
             code = "COMMON_SUCCESS",
         )
 
-        fun <T> created(
-            data: T,
-            detail: String?,
-        ): ApiResponse<T> = ApiResponse(
+        fun <T> created(data: T? = null): ApiResponse<T> = ApiResponse(
             status = HttpStatus.CREATED.value(),
             data = data,
-            detail = detail ?: "생성되었습니다.",
+            detail = "정상적으로 생성되었습니다.",
             code = "CREATED",
         )
 

--- a/src/main/kotlin/com/depromeet/team3/common/response/ApiResponse.kt
+++ b/src/main/kotlin/com/depromeet/team3/common/response/ApiResponse.kt
@@ -1,0 +1,45 @@
+package com.depromeet.team3.common.response
+
+import com.depromeet.team3.common.exception.ErrorCategory
+import com.fasterxml.jackson.annotation.JsonInclude
+import org.springframework.http.HttpStatus
+
+data class ApiResponse<T>(
+    val status: Int,
+    val data: T?,
+    val detail: String,
+    val code: String,
+    @field:JsonInclude(JsonInclude.Include.NON_NULL)
+    val pageResponse: PageResponse? = null,
+) {
+    companion object {
+
+        fun <T> ok(data: T? = null): ApiResponse<T> = ApiResponse(
+            status = HttpStatus.OK.value(),
+            data = data,
+            detail = "요청이 정상적으로 처리되었습니다.",
+            code = "COMMON_SUCCESS",
+        )
+
+        fun <T> created(
+            data: T,
+            detail: String?,
+        ): ApiResponse<T> = ApiResponse(
+            status = HttpStatus.CREATED.value(),
+            data = data,
+            detail = detail ?: "생성되었습니다.",
+            code = "CREATED",
+        )
+
+        fun <T> fail(
+            category: ErrorCategory,
+            status: HttpStatus,
+            detail: String? = null,
+        ): ApiResponse<T> = ApiResponse(
+            status = status.value(),
+            data = null,
+            detail = detail ?: category.description,
+            code = status.name,
+        )
+    }
+}

--- a/src/main/kotlin/com/depromeet/team3/common/response/PageResponse.kt
+++ b/src/main/kotlin/com/depromeet/team3/common/response/PageResponse.kt
@@ -1,0 +1,6 @@
+package com.depromeet.team3.common.response
+
+data class PageResponse(
+    val nextCursor: String?,
+    val hasNext: Boolean,
+)

--- a/src/main/kotlin/com/depromeet/team3/guest/controller/GuestController.kt
+++ b/src/main/kotlin/com/depromeet/team3/guest/controller/GuestController.kt
@@ -1,12 +1,13 @@
 package com.depromeet.team3.guest.controller
 
+import com.depromeet.team3.common.response.ApiResponse
 import com.depromeet.team3.guest.controller.dto.GuestResponse
 import com.depromeet.team3.guest.service.GuestService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.ExampleObject
 import io.swagger.v3.oas.annotations.media.Schema
-import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -25,7 +26,7 @@ class GuestController(
             클라이언트는 발급받은 값을 안전하게 보관하고, 이후 위시리스트 API 호출 시 함께 전달한다.
         """,
     )
-    @ApiResponse(
+    @SwaggerApiResponse(
         responseCode = "200",
         description = "게스트 ID 발급 성공",
         content = [
@@ -34,12 +35,19 @@ class GuestController(
                 examples = [
                     ExampleObject(
                         name = "발급 성공",
-                        value = """{ "guestId": "8f1a3c2b-9d44-4e2a-9b12-1a2b3c4d5e6f" }""",
+                        value = """
+                            {
+                              "status": 200,
+                              "data": { "guestId": "8f1a3c2b-9d44-4e2a-9b12-1a2b3c4d5e6f" },
+                              "detail": "성공",
+                              "code": "COMMON_SUCCESS"
+                            }
+                        """,
                     ),
                 ],
             ),
         ],
     )
     @PostMapping
-    fun issueGuestId(): GuestResponse = GuestResponse(guestService.issueGuestId())
+    fun issueGuestId(): ApiResponse<GuestResponse> = ApiResponse.ok(GuestResponse(guestService.issueGuestId()))
 }

--- a/src/main/kotlin/com/depromeet/team3/wishlist/controller/WishlistController.kt
+++ b/src/main/kotlin/com/depromeet/team3/wishlist/controller/WishlistController.kt
@@ -1,5 +1,6 @@
 package com.depromeet.team3.wishlist.controller
 
+import com.depromeet.team3.common.response.ApiResponse
 import com.depromeet.team3.wishlist.controller.dto.WishlistRegisterRequest
 import com.depromeet.team3.wishlist.controller.dto.WishlistRegisterResponse
 import com.depromeet.team3.wishlist.service.WishlistService
@@ -7,7 +8,6 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.ExampleObject
 import io.swagger.v3.oas.annotations.media.Schema
-import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
+import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
 
 @Tag(name = "Wishlist", description = "위시리스트 등록/조회 API")
 @RestController
@@ -33,13 +34,13 @@ class WishlistController(
     )
     @ApiResponses(
         value = [
-            ApiResponse(
+            SwaggerApiResponse(
                 responseCode = "201",
                 description = "위시리스트 등록 성공",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,
-                        schema = Schema(implementation = ApiResponse::class),
+                        schema = Schema(implementation = SwaggerApiResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "등록 성공",
@@ -64,13 +65,13 @@ class WishlistController(
                     ),
                 ],
             ),
-            ApiResponse(
+            SwaggerApiResponse(
                 responseCode = "400",
                 description = "잘못된 요청 (URL 형식 오류 등)",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,
-                        schema = Schema(implementation = ApiResponse::class),
+                        schema = Schema(implementation = SwaggerApiResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "URL 형식 오류",
@@ -87,13 +88,13 @@ class WishlistController(
                     ),
                 ],
             ),
-            ApiResponse(
+            SwaggerApiResponse(
                 responseCode = "409",
                 description = "이미 위시리스트에 등록된 상품",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,
-                        schema = Schema(implementation = ApiResponse::class),
+                        schema = Schema(implementation = SwaggerApiResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "중복 등록",
@@ -114,11 +115,8 @@ class WishlistController(
     )
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    fun register(@RequestBody request: WishlistRegisterRequest): com.depromeet.team3.common.response.ApiResponse<WishlistRegisterResponse> {
+    fun register(@RequestBody request: WishlistRegisterRequest): ApiResponse<WishlistRegisterResponse> {
         val result = wishlistService.register(rawUrl = request.url, guestId = request.guestId)
-        return com.depromeet.team3.common.response.ApiResponse.created(
-            data = WishlistRegisterResponse.from(result.wish),
-            detail = "위시가 등록되었습니다.",
-        )
+        return ApiResponse.created(WishlistRegisterResponse.from(result.wish))
     }
 }

--- a/src/main/kotlin/com/depromeet/team3/wishlist/controller/WishlistController.kt
+++ b/src/main/kotlin/com/depromeet/team3/wishlist/controller/WishlistController.kt
@@ -12,7 +12,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
-import org.springframework.http.ProblemDetail
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -40,19 +39,24 @@ class WishlistController(
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,
-                        schema = Schema(implementation = WishlistRegisterResponse::class),
+                        schema = Schema(implementation = ApiResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "등록 성공",
                                 value = """
                                     {
-                                      "wishId": 1024,
-                                      "name": "에어 조던 1 미드",
-                                      "regularPrice": 159000,
-                                      "discountedPrice": 119000,
-                                      "discountRate": 25,
-                                      "currency": "KRW",
-                                      "imageUrl": "https://cdn.example.com/p/1024.jpg"
+                                      "status": 201,
+                                      "data": {
+                                        "wishId": 1024,
+                                        "name": "에어 조던 1 미드",
+                                        "regularPrice": 159000,
+                                        "discountedPrice": 119000,
+                                        "discountRate": 25,
+                                        "currency": "KRW",
+                                        "imageUrl": "https://cdn.example.com/p/1024.jpg"
+                                      },
+                                      "detail": "위시가 등록되었습니다.",
+                                      "code": "WISH_CREATED"
                                     }
                                 """,
                             ),
@@ -65,18 +69,17 @@ class WishlistController(
                 description = "잘못된 요청 (URL 형식 오류 등)",
                 content = [
                     Content(
-                        mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
-                        schema = Schema(implementation = ProblemDetail::class),
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "URL 형식 오류",
                                 value = """
                                     {
-                                      "type": "about:blank",
-                                      "title": "Bad Request",
                                       "status": 400,
+                                      "data": null,
                                       "detail": "지원하지 않는 URL 형식입니다.",
-                                      "category": "INVALID_INPUT"
+                                      "code": "INVALID_INPUT"
                                     }
                                 """,
                             ),
@@ -89,18 +92,17 @@ class WishlistController(
                 description = "이미 위시리스트에 등록된 상품",
                 content = [
                     Content(
-                        mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
-                        schema = Schema(implementation = ProblemDetail::class),
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "중복 등록",
                                 value = """
                                     {
-                                      "type": "about:blank",
-                                      "title": "Conflict",
                                       "status": 409,
-                                      "detail": "입력 오류 — 요청을 수정하여 재시도",
-                                      "category": "INVALID_INPUT"
+                                      "data": null,
+                                      "detail": "이미 위시리스트에 등록된 상품입니다.",
+                                      "code": "WISH_DUPLICATED"
                                     }
                                 """,
                             ),
@@ -112,8 +114,11 @@ class WishlistController(
     )
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    fun register(@RequestBody request: WishlistRegisterRequest): WishlistRegisterResponse {
+    fun register(@RequestBody request: WishlistRegisterRequest): com.depromeet.team3.common.response.ApiResponse<WishlistRegisterResponse> {
         val result = wishlistService.register(rawUrl = request.url, guestId = request.guestId)
-        return WishlistRegisterResponse.from(result.wish)
+        return com.depromeet.team3.common.response.ApiResponse.created(
+            data = WishlistRegisterResponse.from(result.wish),
+            detail = "위시가 등록되었습니다.",
+        )
     }
 }

--- a/src/test/kotlin/com/depromeet/team3/guest/controller/GuestControllerTest.kt
+++ b/src/test/kotlin/com/depromeet/team3/guest/controller/GuestControllerTest.kt
@@ -38,7 +38,7 @@ class GuestControllerTest {
 
         mockMvc.perform(post("/api/v1/guests"))
             .andExpect(status().isOk)
-            .andExpect(jsonPath("$.guestId").value(expectedUuid.toString()))
+            .andExpect(jsonPath("$.data.guestId").value(expectedUuid.toString()))
     }
 
     @Test
@@ -49,10 +49,10 @@ class GuestControllerTest {
 
         mockMvc.perform(post("/api/v1/guests"))
             .andExpect(status().isOk)
-            .andExpect(jsonPath("$.guestId").value(first.toString()))
+            .andExpect(jsonPath("$.data.guestId").value(first.toString()))
 
         mockMvc.perform(post("/api/v1/guests"))
             .andExpect(status().isOk)
-            .andExpect(jsonPath("$.guestId").value(second.toString()))
+            .andExpect(jsonPath("$.data.guestId").value(second.toString()))
     }
 }


### PR DESCRIPTION
## Situation
- 기존 컨트롤러마다 응답 구조가 달랐고, 예외 응답은 Spring ProblemDetail 포맷을 사용해 성공/실패 응답을 클라이언트가 일관되게 처리하기 어려운 상황이었음
- 새로운 기능(토너먼트 등) 추가 시에도 응답 포맷이 제각각 늘어날 우려가 있었음

## Task
- 모든 API 응답을 `ApiResponse<T>` 단일 포맷으로 통일
- ProblemDetail 기반 예외 응답 제거 및 `ApiResponse.fail()` 형태로 일관화

## Action
- `ApiResponse<T>` 클래스 도입: `status`, `data`, `detail`, `code` 필드 구성, `ok()` / `created()` / `fail()` 팩토리 메서드 제공
- `PageResponse` 클래스 추가 (페이지네이션 응답용)
- `GlobalExceptionHandler`를 ProblemDetail 방식에서 `ApiResponse.fail()` 방식으로 전환
- `GuestController`, `WishlistController`에 ApiResponse 적용
- `GuestControllerTest`의 JSONPath를 `$.guestId` → `$.data.guestId`로 수정 (ApiResponse 래핑 반영)

## Result
- 성공/실패 모든 응답이 `{ status, data, detail, code }` 포맷으로 통일되어 클라이언트 파싱 일관성 확보
- 신규 컨트롤러는 `ApiResponse.ok(data)` / `ApiResponse.created(data, detail)` 만 사용하면 포맷이 자동으로 맞춰짐

---
## 연관 이슈

- close #25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * API 응답 구조를 표준화된 형식으로 통일하였습니다.
  * 예외 처리 응답 형식을 일관된 API 응답 포맷으로 변경하였습니다.

* **New Features**
  * 페이지네이션 메타데이터 지원이 추가되었습니다.

* **Tests**
  * API 응답 구조 변경에 따른 테스트를 업데이트하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->