### PR TITLE
토너먼트 마이그레이션 파일 추가 및 테스트 오류 수정

### DIFF
--- a/src/main/resources/db/migration/V3__create_tournaments.sql
+++ b/src/main/resources/db/migration/V3__create_tournaments.sql
@@ -1,0 +1,36 @@
+CREATE TABLE tournament
+(
+    id                        BIGINT       NOT NULL AUTO_INCREMENT,
+    user_id                   BINARY(16) NOT NULL,
+    name                      VARCHAR(255) NOT NULL,
+    round                     INT          NOT NULL,
+    final_winner_wish_item_id BIGINT NULL,
+    status                    VARCHAR(50)  NOT NULL DEFAULT 'IN_PROGRESS',
+    created_at                DATETIME(6) NOT NULL,
+    updated_at                DATETIME(6) NOT NULL,
+    deleted_at                DATETIME(6) NULL,
+    PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE tournament_wish_item
+(
+    tournament_id BIGINT NOT NULL,
+    wish_item_id  BIGINT NOT NULL,
+    position      INT    NOT NULL,
+    PRIMARY KEY (tournament_id, position),
+    CONSTRAINT fk_twi_tournament FOREIGN KEY (tournament_id) REFERENCES tournament (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE tournament_history
+(
+    id                  BIGINT NOT NULL AUTO_INCREMENT,
+    tournament_id       BIGINT NOT NULL,
+    current_round       INT    NOT NULL,
+    first_wish_item_id  BIGINT NOT NULL,
+    second_wish_item_id BIGINT NOT NULL,
+    winner_wish_item_id BIGINT NOT NULL,
+    created_at          DATETIME(6) NOT NULL,
+    updated_at          DATETIME(6) NOT NULL,
+    deleted_at          DATETIME(6) NULL,
+    PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/src/test/kotlin/com/depromeet/team3/tournament/service/TournamentServiceTest.kt
+++ b/src/test/kotlin/com/depromeet/team3/tournament/service/TournamentServiceTest.kt
@@ -10,6 +10,7 @@ import com.depromeet.team3.tournament.service.dto.RecordMatch
 import com.depromeet.team3.tournament.service.dto.StartTournament
 import com.depromeet.team3.wishlist.domain.Wish
 import com.depromeet.team3.wishlist.repository.WishRepository
+import com.depromeet.team3.wishlist.service.WishException
 import org.junit.jupiter.api.Test
 import java.util.UUID
 import kotlin.test.assertEquals
@@ -220,7 +221,7 @@ class TournamentServiceTest {
     fun `start 에서 위시 아이템이 요청자의 것이 아니면 예외가 발생한다`() {
         val serviceWithNoOwnership = TournamentService(repository, TestWishRepository(allOwned = false))
 
-        assertFailsWith<TournamentException> {
+        assertFailsWith<WishException> {
             serviceWithNoOwnership.start(userId, StartTournament("토너먼트", round = 4, wishItemIds = (1L..4L).toList()))
         }
     }


### PR DESCRIPTION
## Situation
- 토너먼트 API 추가 후 DB 마이그레이션 파일이 누락되어 배포 시 테이블이 생성되지 않는 상태
- `TournamentServiceTest`에서 위시 아이템 소유권 위반 시 `TournamentException`을 기대했으나, 실제 구현은 `WishException`을 던져 테스트 실패

## Task
- Flyway 마이그레이션 파일(V3) 추가로 배포 환경에서 토너먼트 테이블 자동 생성
- 테스트의 예외 타입 단언 수정

## Action
- `V3__create_tournaments.sql`에 `tournament`, `tournament_wish_item`, `tournament_history` 테이블 DDL 추가
- `TournamentServiceTest`의 소유권 검증 케이스에서 `assertFailsWith<TournamentException>` → `assertFailsWith<WishException>`으로 수정

## Result
- 배포 시 Flyway가 토너먼트 관련 테이블을 자동 생성
- 테스트 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 토너먼트 기능 추가: 토너먼트 생성, 매치 결과 기록, 토너먼트 상세 조회 가능
  * 헬스 체크 엔드포인트 추가
  * CORS 설정으로 프론트엔드 통신 지원

* **버그 수정**
  * 입력값 검증 강화
  * 보안 개선 (SSRF 방지)
  * 오류 처리 개선

* **개선 사항**
  * API 응답 형식 표준화
  * 더 명확한 유효성 검사 에러 메시지
  * 데이터베이스 마이그레이션 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->