### PR TITLE
Issue Automation 완화 — 상위 Epic 강제 제거 및 best-effort 화

### DIFF
--- a/.github/workflows/issue-project-sync.yml
+++ b/.github/workflows/issue-project-sync.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   add-to-project-and-sync-dates:
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - name: Add to Project & Set Dates
         env:
@@ -91,36 +92,14 @@ jobs:
           update_field "$DUE_FIELD"          "date"                   "$DUE_DATE"            "Date"
           update_field "$PRIORITY_FIELD_ID"  "singleSelectOptionId"   "$PRIORITY_OPTION_ID"  "String"
 
-          # bash -e 환경에서 [[ ]] && echo 패턴은 조건이 false일 때 exit 1을 유발하므로 if/fi 사용
+          # bash -e 환경에서 `[[ ]] && echo` 는 조건이 false 일 때 exit 1 을 유발하므로 if/fi 사용
           if [[ -n "$START_DATE" ]];        then echo "Start date set: $START_DATE"; fi
           if [[ -n "$DUE_DATE" ]];          then echo "Due date set: $DUE_DATE"; fi
           if [[ -n "$PRIORITY_OPTION_ID" ]]; then echo "Priority set: $PRIORITY_LABEL"; fi
 
-  check-parent-epic:
-    runs-on: ubuntu-latest
-    # task 라벨 이슈에만 적용
-    if: contains(toJson(github.event.issue.labels.*.name), 'task')
-    steps:
-      - name: Warn if No Parent Epic
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ISSUE_BODY: ${{ github.event.issue.body }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
-        run: |
-          PARENT=$(echo "$ISSUE_BODY" | grep -A3 "^### 상위 Epic" | grep -E "^#[0-9]+" | head -1)
-
-          if [[ -z "$PARENT" ]]; then
-            gh issue edit "$ISSUE_NUMBER" \
-              --add-label "needs-parent" \
-              --repo depromeet/18th-team3-server
-
-            gh issue comment "$ISSUE_NUMBER" \
-              --body "⚠️ 상위 Epic이 연결되지 않았습니다. 관련 Epic이 있다면 이슈 본문의 **상위 Epic** 항목에 \`#번호\` 형태로 추가해주세요." \
-              --repo depromeet/18th-team3-server
-          fi
-
   check-assignee:
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - name: Auto-assign creator if no assignee
         env:


### PR DESCRIPTION
## Situation
- 이슈 자동화 워크플로우가 너무 빡빡해 task 이슈 생성마다 실패 메일·경고 댓글 노이즈가 쌓이고 있었다.
- `add-to-project-and-sync-dates` job 의 마지막 `[[ ]] && echo` 라인이 `bash -e` 와 충돌해 날짜·우선순위 미입력 케이스에서 exit 1 → CI 실패 → 실패 메일.
- `check-parent-epic` job 이 task 라벨 이슈마다 상위 Epic 미연결 시 `needs-parent` 라벨 + 경고 댓글을 자동으로 달아 알림 노이즈를 양산.

## Task
- 자동화 실패가 메일 알림으로 이어지지 않도록 완화.
- 상위 Epic 연결을 강제하지 않고 라벨/댓글도 남기지 않도록 정리.

## Action
- `check-parent-epic` job 통째 제거 — 상위 Epic 강제 정책 폐기. 라벨 추가도, 댓글도 남기지 않는다.
- 모든 job 에 `continue-on-error: true` — 자동화는 best-effort 이므로 부수적 실패가 워크플로우 실패로 집계되어 메일을 발생시키지 않게 한다.
- `[[ ]] && echo` → `if/fi` 로 교체 — `bash -e` 환경에서 마지막 식의 false 가 exit 1 로 떨어지던 회귀를 차단.

## Result
- task 이슈 생성 시 상위 Epic 미연결로 라벨·경고 댓글이 더 이상 자동으로 달리지 않는다.
- 자동화 내부 버그가 발생해도 CI 실패 메일이 오지 않는다 (`continue-on-error` 안전망).
- 같은 파일을 수정하는 chore/78-migrate-tfstate-to-s3 (auto-assign 추가 등) 와 충돌 가능 — 이 PR 이 먼저 들어가면 chore/78 rebase 시 해당 영역을 정리해야 함.

---
## 연관 이슈

- 