### PR TITLE
코드 일관성 및 잠재적 오류 개선

### DIFF
--- a/src/main/kotlin/com/depromeet/team3/common/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/depromeet/team3/common/exception/GlobalExceptionHandler.kt
@@ -42,7 +42,7 @@ class GlobalExceptionHandler {
         log.warn("[IllegalArgumentException] {}", e.message)
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
-            .body(ApiResponseBody.fail(ErrorCategory.INVALID_INPUT, HttpStatus.BAD_REQUEST))
+            .body(ApiResponseBody.fail(ErrorCategory.INVALID_INPUT, HttpStatus.BAD_REQUEST, e.message))
     }
 
     @ExceptionHandler(Exception::class)

--- a/src/main/kotlin/com/depromeet/team3/guest/controller/GuestController.kt
+++ b/src/main/kotlin/com/depromeet/team3/guest/controller/GuestController.kt
@@ -3,8 +3,10 @@ package com.depromeet.team3.guest.controller
 import com.depromeet.team3.common.response.ApiResponseBody
 import com.depromeet.team3.guest.controller.dto.GuestResponse
 import com.depromeet.team3.guest.service.GuestService
+import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -13,5 +15,7 @@ class GuestController(
     private val guestService: GuestService,
 ) : GuestApi {
     @PostMapping
-    override fun issueGuestId(): ApiResponseBody<GuestResponse> = ApiResponseBody.ok(GuestResponse(guestService.issueGuestId()))
+    @ResponseStatus(HttpStatus.CREATED)
+    override fun issueGuestId(): ApiResponseBody<GuestResponse> =
+        ApiResponseBody.created(GuestResponse(guestService.issueGuestId()))
 }

--- a/src/main/kotlin/com/depromeet/team3/tournament/controller/TournamentApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/team3/tournament/controller/TournamentApiExamples.kt
@@ -41,6 +41,7 @@ class TournamentApiExamples(private val openApiObjectMapper: OpenApiObjectMapper
                     payload = ApiResponseBody.ok(
                         TournamentInfoResponse(
                             tournamentId = 1,
+                            round = 4,
                             finalWinnerWishItemId = 3,
                             history = listOf(
                                 TournamentHistoryInfoResponse(

--- a/src/main/kotlin/com/depromeet/team3/tournament/controller/dto/TournamentInfoResponse.kt
+++ b/src/main/kotlin/com/depromeet/team3/tournament/controller/dto/TournamentInfoResponse.kt
@@ -5,6 +5,7 @@ import com.depromeet.team3.tournament.service.dto.TournamentInfo
 
 data class TournamentInfoResponse(
     val tournamentId: Long,
+    val round: Int,
     val finalWinnerWishItemId: Long?,
     val history: List<TournamentHistoryInfoResponse>,
 ) {
@@ -12,6 +13,7 @@ data class TournamentInfoResponse(
         fun from(tournamentInfo: TournamentInfo): TournamentInfoResponse {
             return TournamentInfoResponse(
                 tournamentId = tournamentInfo.tournamentId,
+                round = tournamentInfo.round,
                 finalWinnerWishItemId = tournamentInfo.finalWinnerWishItemId,
                 history = tournamentInfo.history.map { TournamentHistoryInfoResponse.from(it) },
             )

--- a/src/main/kotlin/com/depromeet/team3/tournament/domain/Tournament.kt
+++ b/src/main/kotlin/com/depromeet/team3/tournament/domain/Tournament.kt
@@ -27,9 +27,15 @@ class Tournament(
     @Column(columnDefinition = "varchar(50)")
     var status: TournamentStatus = TournamentStatus.IN_PROGRESS,
 ) : LongBaseEntity() {
+
+    init {
+        require(wishItemIds.size == round) {
+            "토너먼트 참가 아이템 수(${wishItemIds.size})가 라운드 수($round)와 다릅니다."
+        }
+    }
+
     fun complete(winnerWishItemId: Long) {
         check(!isCompleted()) { "이미 완료된 토너먼트입니다." }
-        require(winnerWishItemId in wishItemIds) { "우승자는 토너먼트 참가 아이템 중 하나여야 합니다." }
         this.finalWinnerWishItemId = winnerWishItemId
         this.status = TournamentStatus.COMPLETED
     }

--- a/src/main/kotlin/com/depromeet/team3/tournament/domain/Tournament.kt
+++ b/src/main/kotlin/com/depromeet/team3/tournament/domain/Tournament.kt
@@ -36,6 +36,7 @@ class Tournament(
 
     fun complete(winnerWishItemId: Long) {
         check(!isCompleted()) { "이미 완료된 토너먼트입니다." }
+        require(winnerWishItemId in wishItemIds) { "우승자는 토너먼트 참가 아이템 중 하나여야 합니다." }
         this.finalWinnerWishItemId = winnerWishItemId
         this.status = TournamentStatus.COMPLETED
     }

--- a/src/main/kotlin/com/depromeet/team3/tournament/service/dto/TournamentInfo.kt
+++ b/src/main/kotlin/com/depromeet/team3/tournament/service/dto/TournamentInfo.kt
@@ -5,12 +5,14 @@ import com.depromeet.team3.tournament.domain.TournamentHistory
 
 data class TournamentInfo(
     val tournamentId: Long,
+    val round: Int,
     val finalWinnerWishItemId: Long?,
     val history: List<TournamentHistoryInfo>,
 ) {
     companion object {
         fun of(tournament: Tournament, histories: List<TournamentHistory>): TournamentInfo = TournamentInfo(
             tournamentId = tournament.getId(),
+            round = tournament.round,
             finalWinnerWishItemId = tournament.finalWinnerWishItemId,
             history = histories.map(TournamentHistoryInfo::from),
         )

--- a/src/main/kotlin/com/depromeet/team3/wishlist/domain/Wish.kt
+++ b/src/main/kotlin/com/depromeet/team3/wishlist/domain/Wish.kt
@@ -15,10 +15,10 @@ import java.util.UUID
 @Table(name = "wishes")
 class Wish(
     @Column(name = "guest_id", nullable = false, columnDefinition = "BINARY(16)")
-    var guestId: UUID,
+    val guestId: UUID,
 
     @Embedded
-    var product: Product,
+    val product: Product,
 ) : BaseEntity<Long>() {
 
     @Id

--- a/src/test/kotlin/com/depromeet/team3/guest/controller/GuestControllerTest.kt
+++ b/src/test/kotlin/com/depromeet/team3/guest/controller/GuestControllerTest.kt
@@ -27,7 +27,7 @@ class GuestControllerTest : IntegrationTestSupport() {
         val mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build()
 
         val response = mockMvc.perform(post("/api/v1/guests"))
-            .andExpect(status().isOk)
+            .andExpect(status().isCreated)
             .andExpect(jsonPath("$.data.guestId").exists())
             .andReturn().response.contentAsString
 
@@ -40,12 +40,12 @@ class GuestControllerTest : IntegrationTestSupport() {
         val mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build()
 
         val first = mockMvc.perform(post("/api/v1/guests"))
-            .andExpect(status().isOk)
+            .andExpect(status().isCreated)
             .andReturn().response.contentAsString
             .let { objectMapper.readTree(it).path("data").path("guestId").asString() }
 
         val second = mockMvc.perform(post("/api/v1/guests"))
-            .andExpect(status().isOk)
+            .andExpect(status().isCreated)
             .andReturn().response.contentAsString
             .let { objectMapper.readTree(it).path("data").path("guestId").asString() }
 

--- a/src/test/kotlin/com/depromeet/team3/tournament/controller/TournamentControllerTest.kt
+++ b/src/test/kotlin/com/depromeet/team3/tournament/controller/TournamentControllerTest.kt
@@ -84,6 +84,7 @@ class TournamentControllerTest {
     fun `GET tournaments id 는 토너먼트 정보를 반환한다`() {
         val tournamentInfo = TournamentInfo(
             tournamentId = 1L,
+            round = 4,
             finalWinnerWishItemId = 10L,
             history = listOf(
                 TournamentHistoryInfo(
@@ -102,6 +103,7 @@ class TournamentControllerTest {
         )
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.data.tournamentId").value(1))
+            .andExpect(jsonPath("$.data.round").value(4))
             .andExpect(jsonPath("$.data.finalWinnerWishItemId").value(10))
             .andExpect(jsonPath("$.data.history[0].currentRound").value(2))
             .andExpect(jsonPath("$.data.history[0].winnerWishItemId").value(10))

--- a/src/test/kotlin/com/depromeet/team3/tournament/service/TournamentServiceTest.kt
+++ b/src/test/kotlin/com/depromeet/team3/tournament/service/TournamentServiceTest.kt
@@ -64,7 +64,7 @@ class TournamentServiceTest {
 
     @Test
     fun `start 는 저장된 토너먼트 ID 를 반환한다`() {
-        val id = service.start(userId, StartTournament("내 토너먼트", round = 8, wishItemIds = (1L..16L).toList()))
+        val id = service.start(userId, StartTournament("내 토너먼트", round = 16, wishItemIds = (1L..16L).toList()))
 
         assertEquals(1L, id)
         assertEquals(1, repository.tournaments.size)
@@ -224,5 +224,21 @@ class TournamentServiceTest {
         assertFailsWith<WishException> {
             serviceWithNoOwnership.start(userId, StartTournament("토너먼트", round = 4, wishItemIds = (1L..4L).toList()))
         }
+    }
+
+    @Test
+    fun `start 에서 round 와 wishItemIds 크기가 다르면 IllegalArgumentException 이 발생한다`() {
+        assertFailsWith<IllegalArgumentException> {
+            service.start(userId, StartTournament("토너먼트", round = 8, wishItemIds = (1L..4L).toList()))
+        }
+    }
+
+    @Test
+    fun `getTournamentById 는 응답에 round 를 포함한다`() {
+        val tournamentId = service.start(userId, StartTournament("조회 토너먼트", round = 4, wishItemIds = (1L..4L).toList()))
+
+        val info = service.getTournamentById(tournamentId, userId)
+
+        assertEquals(4, info.round)
     }
 }


### PR DESCRIPTION
## Situation
- 코드 전체를 리뷰하던 중 도메인 검증 불일치, 응답 상태코드 혼용,
  불필요한 가변성, 예외 메시지 비노출 등 잠재적 버그와 컨벤션 위반이 산발적으로 발견됨
- 각각 크리티컬하진 않지만 방치 시 디버깅 비용 증가 및 API 계약 불일치로 이어질 수 있음

## Task
- 발견된 5가지 문제를 개별 커밋으로 분리해 독립적으로 수정
- 단순 스타일 정리가 아니라 각각 실제 동작·계약·안전성에 영향을 주는 변경

## Action

### 도메인 정합성
- `Tournament.init`에 `require(wishItemIds.size == round)` 추가
  — `round=8`, `wishItemIds` 4개처럼 불일치하는 요청이 DB에 그대로 저장되는 버그 차단
- `TournamentInfo` / `TournamentInfoResponse`에 `round` 필드 노출
  — 저장은 됐지만 조회 응답에 포함되지 않아 클라이언트가 참조할 수 없었던 dead field 해소

### API 계약 일관성
- `GuestController.issueGuestId()` → `@ResponseStatus(CREATED)` + `ApiResponseBody.created()`
  — `WishlistController`, `TournamentController`는 생성 시 201을 반환하는데 Guest만 200을 반환해 일관성 깨짐
- `GlobalExceptionHandler.handleIllegalArgument()` → `e.message` 노출
  — `ProductLink.parse()`가 던지는 "https URL만 허용합니다" 같은 명확한 메시지가 버려지고
    `MethodArgumentNotValidException` 핸들러는 메시지를 노출하는데 이쪽만 숨기는 불일치 해소

### 불변성
- `Wish.guestId`, `Wish.product` → `var → val`
  — 등록 후 재할당 로직이 없는 필드에 `var`를 쓰면 컴파일러가 불변 의도를 보장하지 못함

## Result
- `Tournament` 생성 시 `round ≠ wishItemIds.size`이면 400으로 즉시 거부
- Guest 발급 API가 201을 반환하고 응답 body의 `status` 필드와 HTTP 상태코드가 일치
- `IllegalArgumentException` 발생 시 클라이언트가 실제 거부 사유를 응답에서 확인 가능
- 기존 단위 테스트 보완: `TournamentServiceTest(+2)`, `TournamentControllerTest(+1)`, `GuestControllerTest` 상태코드 수정

---
## 연관 이슈

- close #81

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## 릴리스 노트

* **API 개선**
  * 게스트 ID 발급 엔드포인트가 HTTP 201(Created) 반환으로 변경
  * 잘못된 입력 오류 응답에 상세 예외 메시지 포함

* **기능 개선**
  * 토너먼트 정보 응답에 라운드(round) 값 추가
  * 토너먼트 생성 시 참가자 수와 라운드 수 일치 검증 강화

* **코드 품질**
  * 불변성 향상을 위한 일부 엔티티 프로퍼티를 mutable→immutable으로 변경
<!-- end of auto-generated comment: release notes by coderabbit.ai -->