### PR TITLE
CI/CD 파이프라인 구성 및 ktlint 도입

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  push:
+    branches: [ dev ]
+  pull_request:
+    types: [ opened, synchronize ]
+    branches: [ dev, main ]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle.kts', '**/gradle-wrapper.properties') }}
+          restore-keys: gradle-${{ runner.os }}-
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build & Test
+        run: ./gradlew check
+
+      - name: Report test results
+        if: always()
+        uses: dorny/test-reporter@v1
+        with:
+          name: Test Results
+          path: build/test-results/**/*.xml
+          reporter: java-junit
+          fail-on-error: false

--- a/.github/workflows/deploy-manual.yml
+++ b/.github/workflows/deploy-manual.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout

--- a/.github/workflows/deploy-manual.yml
+++ b/.github/workflows/deploy-manual.yml
@@ -1,22 +1,22 @@
-name: Deploy to EC2
+name: Deploy to Staging (Manual)
 
 on:
-  workflow_run:
-    workflows: [ CI ]
-    branches: [ dev ]
-    types: [ completed ]
   workflow_dispatch:
+    inputs:
+      branch:
+        description: '배포할 브랜치'
+        required: true
+        default: 'dev'
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          ref: ${{ github.event.inputs.branch }}
 
       - name: Set up JDK 25
         uses: actions/setup-java@v4
@@ -50,6 +50,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Sanitize branch name for Docker tag
+        id: tag
+        run: echo "value=staging-$(echo '${{ github.event.inputs.branch }}' | tr '/' '-')" >> $GITHUB_OUTPUT
+
       - name: Build and push Docker image
         id: docker_push
         uses: docker/build-push-action@v6
@@ -58,11 +62,9 @@ jobs:
           file: Dockerfile.ci
           push: true
           platforms: linux/arm64
-          tags: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/team3-server:latest
-            ${{ secrets.DOCKERHUB_USERNAME }}/team3-server:${{ github.event.workflow_run.head_sha || github.sha }}
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/team3-server:${{ steps.tag.outputs.value }}
 
-      - name: Deploy to EC2
+      - name: Deploy to Staging EC2
         id: deploy
         uses: appleboy/ssh-action@v1
         with:
@@ -70,7 +72,7 @@ jobs:
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
-            IMAGE="${{ secrets.DOCKERHUB_USERNAME }}/team3-server:${{ github.event.workflow_run.head_sha || github.sha }}"
+            IMAGE="${{ secrets.DOCKERHUB_USERNAME }}/team3-server:${{ steps.tag.outputs.value }}"
             docker pull "$IMAGE"
             docker stop team3-server || true
             docker rm team3-server || true
@@ -115,14 +117,10 @@ jobs:
           ACTOR_MENTION="${SLACK_ID:+<@$SLACK_ID>}"
           ACTOR_MENTION="${ACTOR_MENTION:-$ACTOR}"
 
-          SHORT_SHA="${{ github.event.workflow_run.head_sha || github.sha }}"
-          SHORT_SHA="${SHORT_SHA:0:7}"
-          COMMIT_URL="https://github.com/${{ github.repository }}/commit/${{ github.event.workflow_run.head_sha || github.sha }}"
-          COMMIT_MSG=$(jq -r '(.workflow_run.head_commit.message // .head_commit.message // "")' "$GITHUB_EVENT_PATH" | head -n 1)
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
-          TEXT=$(printf '✅ `${{ github.ref_name }}` 배포 성공!  ✅\n• 배포자: %s\n• 커밋: <%s|%s>  %s\n• <%s|워크플로우 로그>' \
-            "$ACTOR_MENTION" "$COMMIT_URL" "$SHORT_SHA" "$COMMIT_MSG" "$RUN_URL")
+          TEXT=$(printf '✅ `${{ github.event.inputs.branch }}` → staging 배포 성공! ✅\n• 배포자: %s\n• <%s|워크플로우 로그>' \
+            "$ACTOR_MENTION" "$RUN_URL")
 
           curl -s -X POST https://slack.com/api/chat.postMessage \
             -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
@@ -140,10 +138,6 @@ jobs:
           ACTOR_MENTION="${SLACK_ID:+<@$SLACK_ID>}"
           ACTOR_MENTION="${ACTOR_MENTION:-$ACTOR}"
 
-          SHORT_SHA="${{ github.event.workflow_run.head_sha || github.sha }}"
-          SHORT_SHA="${SHORT_SHA:0:7}"
-          COMMIT_URL="https://github.com/${{ github.repository }}/commit/${{ github.event.workflow_run.head_sha || github.sha }}"
-          COMMIT_MSG=$(jq -r '(.workflow_run.head_commit.message // .head_commit.message // "")' "$GITHUB_EVENT_PATH" | head -n 1)
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
           if [ "${{ steps.build.outcome }}" = "failure" ]; then
@@ -160,8 +154,8 @@ jobs:
             CAUSE="알 수 없음 (환경 설정 단계)"
           fi
 
-          TEXT=$(printf '❌ `${{ github.ref_name }}` 배포 실패!!!! ❌\n• 배포자: %s\n• 커밋: <%s|%s>  %s\n• 원인: %s\n• <%s|워크플로우 로그 확인>' \
-            "$ACTOR_MENTION" "$COMMIT_URL" "$SHORT_SHA" "$COMMIT_MSG" "$CAUSE" "$RUN_URL")
+          TEXT=$(printf '❌ `${{ github.event.inputs.branch }}` → staging 배포 실패! ❌\n• 배포자: %s\n• 원인: %s\n• <%s|워크플로우 로그 확인>' \
+            "$ACTOR_MENTION" "$CAUSE" "$RUN_URL")
 
           curl -s -X POST https://slack.com/api/chat.postMessage \
             -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,22 +1,27 @@
 plugins {
-	kotlin("jvm") version "2.3.20"
-	kotlin("plugin.spring") version "2.3.20"
-	kotlin("plugin.jpa") version "2.3.20"
-	id("org.springframework.boot") version "4.0.5"
-	id("io.spring.dependency-management") version "1.1.7"
+    kotlin("jvm") version "2.3.20"
+    kotlin("plugin.spring") version "2.3.20"
+    kotlin("plugin.jpa") version "2.3.20"
+    id("org.springframework.boot") version "4.0.5"
+    id("io.spring.dependency-management") version "1.1.7"
+    id("org.jlleitschuh.gradle.ktlint") version "12.1.2"
+}
+
+ktlint {
+    version.set("1.4.1")
 }
 
 group = "com.depromeet"
 version = "0.0.1-SNAPSHOT"
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(25)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 // Spring Boot 4.0.5 의 platform 은 testcontainers 코어 2.0.x 만 포함하고
@@ -25,41 +30,41 @@ repositories {
 val testcontainersVersion = "1.21.4"
 
 dependencyManagement {
-	imports {
-		mavenBom("org.testcontainers:testcontainers-bom:$testcontainersVersion")
-	}
+    imports {
+        mavenBom("org.testcontainers:testcontainers-bom:$testcontainersVersion")
+    }
 }
 
 dependencies {
-	implementation("org.springframework.boot:spring-boot-starter-webmvc")
-	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
-	implementation("org.springframework.boot:spring-boot-starter-validation")
-	implementation("org.jetbrains.kotlin:kotlin-reflect")
-	implementation("tools.jackson.module:jackson-module-kotlin")
+    implementation("org.springframework.boot:spring-boot-starter-webmvc")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-validation")
+    implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("tools.jackson.module:jackson-module-kotlin")
 
-	implementation("org.springframework.boot:spring-boot-starter-flyway")
-	implementation("org.flywaydb:flyway-mysql")
-	runtimeOnly("com.mysql:mysql-connector-j")
+    implementation("org.springframework.boot:spring-boot-starter-flyway")
+    implementation("org.flywaydb:flyway-mysql")
+    runtimeOnly("com.mysql:mysql-connector-j")
 
-	// Spring Boot 4.0.5 / Jackson 3 호환 라인. Swagger UI 없이 /v3/api-docs 만 제공 (UI는 Stoplight Elements 사용)
-	implementation("org.springdoc:springdoc-openapi-starter-webmvc-api:3.0.3")
+    // Spring Boot 4.0.5 / Jackson 3 호환 라인. Swagger UI 없이 /v3/api-docs 만 제공 (UI는 Stoplight Elements 사용)
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-api:3.0.3")
 
-	testImplementation("org.springframework.boot:spring-boot-starter-test")
-	testImplementation("org.springframework.boot:spring-boot-testcontainers")
-	testImplementation("org.testcontainers:junit-jupiter")
-	testImplementation("org.testcontainers:mysql")
-	testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
-	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.boot:spring-boot-testcontainers")
+    testImplementation("org.testcontainers:junit-jupiter")
+    testImplementation("org.testcontainers:mysql")
+    testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
 kotlin {
-	compilerOptions {
-		freeCompilerArgs.addAll("-Xjsr305=strict", "-Xannotation-default-target=param-property")
-	}
+    compilerOptions {
+        freeCompilerArgs.addAll("-Xjsr305=strict", "-Xannotation-default-target=param-property")
+    }
 }
 
 tasks.withType<Test> {
-	useJUnitPlatform()
-	// JDK 21+부터 동적 에이전트 로딩이 제한됨. Mockito(ByteBuddy)가 런타임에 에이전트를 붙이므로 명시적 허용 필요.
-	jvmArgs("-XX:+EnableDynamicAgentLoading")
+    useJUnitPlatform()
+    // JDK 21+부터 동적 에이전트 로딩이 제한됨. Mockito(ByteBuddy)가 런타임에 에이전트를 붙이므로 명시적 허용 필요.
+    jvmArgs("-XX:+EnableDynamicAgentLoading")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,4 +67,10 @@ tasks.withType<Test> {
     useJUnitPlatform()
     // JDK 21+부터 동적 에이전트 로딩이 제한됨. Mockito(ByteBuddy)가 런타임에 에이전트를 붙이므로 명시적 허용 필요.
     jvmArgs("-XX:+EnableDynamicAgentLoading")
+    testLogging {
+        events("failed")
+        exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+        showCauses = true
+        showStackTraces = true
+    }
 }

--- a/src/main/kotlin/com/depromeet/team3/common/config/CorsConfig.kt
+++ b/src/main/kotlin/com/depromeet/team3/common/config/CorsConfig.kt
@@ -6,9 +6,9 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
 @Configuration
 class CorsConfig : WebMvcConfigurer {
-
     override fun addCorsMappings(registry: CorsRegistry) {
-        registry.addMapping("/**")
+        registry
+            .addMapping("/**")
             .allowedOrigins("https://depromeet.vercel.app")
             .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
             .allowedHeaders("*")

--- a/src/main/kotlin/com/depromeet/team3/common/config/OpenApiConfig.kt
+++ b/src/main/kotlin/com/depromeet/team3/common/config/OpenApiConfig.kt
@@ -11,27 +11,25 @@ import org.springframework.context.annotation.Configuration
 
 @Configuration
 class OpenApiConfig {
-
     @Bean
     fun openAPI(
         @Value("\${spring.application.name:team3}") applicationName: String,
-    ): OpenAPI = OpenAPI()
-        .info(
-            Info()
-                .title("$applicationName API")
-                // API 버전은 빌드 버전(0.0.1-SNAPSHOT)과 별개의 public 계약 버전이므로 별도 관리
-                // project.version은 Gradle 컨텍스트 전용이라 Spring Bean에서 직접 참조 불가
-                .version("v1")
-                .description(
-                    """
-                    Depromeet 18기 3팀 위시리스트 서비스 API 문서.
+    ): OpenAPI =
+        OpenAPI()
+            .info(
+                Info()
+                    .title("$applicationName API")
+                    // API 버전은 빌드 버전(0.0.1-SNAPSHOT)과 별개의 public 계약 버전이므로 별도 관리
+                    // project.version은 Gradle 컨텍스트 전용이라 Spring Bean에서 직접 참조 불가
+                    .version("v1")
+                    .description(
+                        """
+                        Depromeet 18기 3팀 위시리스트 서비스 API 문서.
 
-                    - 모든 응답의 에러 포맷은 RFC 7807 `application/problem+json` 을 따른다.
-                    - 게스트 식별자는 클라이언트가 발급받아 보관하며, 위시리스트 등록 시 함께 전달한다.
-                    """.trimIndent(),
-                )
-                .contact(Contact().name("team3").url("https://github.com/depromeet/18th-team3-server"))
-                .license(License().name("Apache-2.0").url("https://www.apache.org/licenses/LICENSE-2.0")),
-        )
-        .addServersItem(Server().url("/").description("Current host"))
+                        - 모든 응답의 에러 포맷은 RFC 7807 `application/problem+json` 을 따른다.
+                        - 게스트 식별자는 클라이언트가 발급받아 보관하며, 위시리스트 등록 시 함께 전달한다.
+                        """.trimIndent(),
+                    ).contact(Contact().name("team3").url("https://github.com/depromeet/18th-team3-server"))
+                    .license(License().name("Apache-2.0").url("https://www.apache.org/licenses/LICENSE-2.0")),
+            ).addServersItem(Server().url("/").description("Current host"))
 }

--- a/src/main/kotlin/com/depromeet/team3/common/controller/HealthController.kt
+++ b/src/main/kotlin/com/depromeet/team3/common/controller/HealthController.kt
@@ -6,8 +6,6 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 class HealthController {
-
     @GetMapping("/health")
-    fun health(): ResponseEntity<Map<String, String>> =
-        ResponseEntity.ok(mapOf("status" to "ok"))
+    fun health(): ResponseEntity<Map<String, String>> = ResponseEntity.ok(mapOf("status" to "ok"))
 }

--- a/src/main/kotlin/com/depromeet/team3/common/domain/BaseEntity.kt
+++ b/src/main/kotlin/com/depromeet/team3/common/domain/BaseEntity.kt
@@ -13,7 +13,6 @@ import java.util.Objects
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener::class)
 abstract class BaseEntity<ID : Any> {
-
     // 영속화 후에만 채워지는 자동 생성 PK 등을 표현하기 위한 nullable getter.
     // 외부에서는 getId() 만 사용한다. 미영속 인스턴스는 엔티티가 아니므로 동등성 검사·해시
     // 시도 자체를 거부해 데이터 정합성이 사일런트로 깨지는 것을 막는다.

--- a/src/main/kotlin/com/depromeet/team3/common/exception/ErrorCategory.kt
+++ b/src/main/kotlin/com/depromeet/team3/common/exception/ErrorCategory.kt
@@ -1,6 +1,8 @@
 package com.depromeet.team3.common.exception
 
-enum class ErrorCategory(val description: String) {
+enum class ErrorCategory(
+    val description: String,
+) {
     INVALID_INPUT("입력 오류 — 요청을 수정하여 재시도"),
     UNAUTHORIZED("인증 필요 — 로그인 후 재시도"),
     FORBIDDEN("권한 없음 — 접근 불가"),

--- a/src/main/kotlin/com/depromeet/team3/common/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/depromeet/team3/common/exception/GlobalExceptionHandler.kt
@@ -10,7 +10,6 @@ import org.springframework.web.bind.annotation.RestControllerAdvice
 
 @RestControllerAdvice
 class GlobalExceptionHandler {
-
     private val log = LoggerFactory.getLogger(javaClass)
 
     @ExceptionHandler(BaseException::class)
@@ -28,9 +27,10 @@ class GlobalExceptionHandler {
         // 첫 번째 위반 필드만 사용자 메시지로 노출. 나머지는 로그로.
         // 응답 스키마는 다른 4xx 와 동일하게 ApiResponseBody 로 통일한다.
         val first = e.bindingResult.fieldErrors.firstOrNull()
-        val detail = first
-            ?.let { "${it.field}: ${it.defaultMessage ?: "유효하지 않은 값입니다."}" }
-            ?: "요청 본문 검증 실패"
+        val detail =
+            first
+                ?.let { "${it.field}: ${it.defaultMessage ?: "유효하지 않은 값입니다."}" }
+                ?: "요청 본문 검증 실패"
         log.warn("[ValidationException] {}", e.bindingResult.fieldErrors)
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)

--- a/src/main/kotlin/com/depromeet/team3/common/openapi/OpenApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/team3/common/openapi/OpenApiExamples.kt
@@ -1,6 +1,6 @@
 package com.depromeet.team3.common.openapi
 
-import com.fasterxml.jackson.databind.ObjectMapper
+import tools.jackson.databind.ObjectMapper
 import io.swagger.v3.oas.models.Operation
 import io.swagger.v3.oas.models.examples.Example
 import io.swagger.v3.oas.models.media.Content

--- a/src/main/kotlin/com/depromeet/team3/common/openapi/OpenApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/team3/common/openapi/OpenApiExamples.kt
@@ -18,16 +18,27 @@ fun HandlerMethod.binds(ref: KFunction<*>): Boolean {
         method.parameterTypes.contentEquals(target.parameterTypes)
 }
 
-fun Operation.examples(objectMapper: ObjectMapper, block: OperationExamples.() -> Unit) {
+fun Operation.examples(
+    objectMapper: ObjectMapper,
+    block: OperationExamples.() -> Unit,
+) {
     OperationExamples(this, objectMapper).block()
 }
 
-class OperationExamples(private val operation: Operation, private val objectMapper: ObjectMapper) {
-    fun add(status: HttpStatus, name: String, payload: Any) {
+class OperationExamples(
+    private val operation: Operation,
+    private val objectMapper: ObjectMapper,
+) {
+    fun add(
+        status: HttpStatus,
+        name: String,
+        payload: Any,
+    ) {
         val response = operation.responses?.get(status.value().toString()) ?: return
         val content = response.content ?: Content().also { response.content = it }
-        val mediaType = content[SpringMediaType.APPLICATION_JSON_VALUE]
-            ?: MediaType().also { content[SpringMediaType.APPLICATION_JSON_VALUE] = it }
+        val mediaType =
+            content[SpringMediaType.APPLICATION_JSON_VALUE]
+                ?: MediaType().also { content[SpringMediaType.APPLICATION_JSON_VALUE] = it }
         val example = Example().value(objectMapper.convertValue(payload, Any::class.java))
         mediaType.examples = (mediaType.examples ?: linkedMapOf()).apply { put(name, example) }
     }

--- a/src/main/kotlin/com/depromeet/team3/common/openapi/OpenApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/team3/common/openapi/OpenApiExamples.kt
@@ -1,12 +1,12 @@
 package com.depromeet.team3.common.openapi
 
-import tools.jackson.databind.ObjectMapper
 import io.swagger.v3.oas.models.Operation
 import io.swagger.v3.oas.models.examples.Example
 import io.swagger.v3.oas.models.media.Content
 import io.swagger.v3.oas.models.media.MediaType
 import org.springframework.http.HttpStatus
 import org.springframework.web.method.HandlerMethod
+import tools.jackson.databind.ObjectMapper
 import kotlin.reflect.KFunction
 import kotlin.reflect.jvm.javaMethod
 import org.springframework.http.MediaType as SpringMediaType

--- a/src/main/kotlin/com/depromeet/team3/common/openapi/OpenApiObjectMapper.kt
+++ b/src/main/kotlin/com/depromeet/team3/common/openapi/OpenApiObjectMapper.kt
@@ -1,6 +1,6 @@
 package com.depromeet.team3.common.openapi
 
-import com.fasterxml.jackson.databind.ObjectMapper
+import tools.jackson.databind.ObjectMapper
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 

--- a/src/main/kotlin/com/depromeet/team3/common/openapi/OpenApiObjectMapper.kt
+++ b/src/main/kotlin/com/depromeet/team3/common/openapi/OpenApiObjectMapper.kt
@@ -1,8 +1,8 @@
 package com.depromeet.team3.common.openapi
 
-import tools.jackson.databind.ObjectMapper
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import tools.jackson.databind.ObjectMapper
 
 class OpenApiObjectMapper(
     val delegate: ObjectMapper,

--- a/src/main/kotlin/com/depromeet/team3/common/openapi/OpenApiObjectMapper.kt
+++ b/src/main/kotlin/com/depromeet/team3/common/openapi/OpenApiObjectMapper.kt
@@ -4,15 +4,15 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
-class OpenApiObjectMapper(val delegate: ObjectMapper)
+class OpenApiObjectMapper(
+    val delegate: ObjectMapper,
+)
 
 @Configuration
 class OpenApiObjectMapperConfig {
-
     // IntelliJ Spring 플러그인이 JacksonAutoConfiguration이 등록한 ObjectMapper 빈을 인식 못해
     // false positive 경고를 띄운다. 런타임 주입은 정상이며, 회피 어노테이션은 이 한 지점에만 둔다.
     @Bean
     @Suppress("SpringJavaInjectionPointsAutowiringInspection")
-    fun openApiObjectMapper(objectMapper: ObjectMapper): OpenApiObjectMapper =
-        OpenApiObjectMapper(objectMapper)
+    fun openApiObjectMapper(objectMapper: ObjectMapper): OpenApiObjectMapper = OpenApiObjectMapper(objectMapper)
 }

--- a/src/main/kotlin/com/depromeet/team3/common/response/ApiResponseBody.kt
+++ b/src/main/kotlin/com/depromeet/team3/common/response/ApiResponseBody.kt
@@ -13,32 +13,31 @@ data class ApiResponseBody<T>(
     val pageResponse: PageResponse? = null,
 ) {
     companion object {
+        fun <T> ok(data: T? = null): ApiResponseBody<T> = success(HttpStatus.OK, data)
 
-        fun <T> ok(data: T? = null): ApiResponseBody<T> =
-            success(HttpStatus.OK, data)
-
-        fun <T> created(data: T? = null): ApiResponseBody<T> =
-            success(HttpStatus.CREATED, data)
+        fun <T> created(data: T? = null): ApiResponseBody<T> = success(HttpStatus.CREATED, data)
 
         fun <T> fail(
             category: ErrorCategory,
             status: HttpStatus,
             detail: String? = null,
-        ): ApiResponseBody<T> = ApiResponseBody(
-            status = status.value(),
-            data = null,
-            detail = detail ?: category.description,
-            code = status.name,
-        )
+        ): ApiResponseBody<T> =
+            ApiResponseBody(
+                status = status.value(),
+                data = null,
+                detail = detail ?: category.description,
+                code = status.name,
+            )
 
         private fun <T> success(
             status: HttpStatus,
             data: T?,
-        ): ApiResponseBody<T> = ApiResponseBody(
-            status = status.value(),
-            data = data,
-            detail = "정상적으로 처리되었습니다.",
-            code = status.name,
-        )
+        ): ApiResponseBody<T> =
+            ApiResponseBody(
+                status = status.value(),
+                data = data,
+                detail = "정상적으로 처리되었습니다.",
+                code = status.name,
+            )
     }
 }

--- a/src/main/kotlin/com/depromeet/team3/guest/controller/GuestApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/team3/guest/controller/GuestApiExamples.kt
@@ -12,21 +12,24 @@ import org.springframework.http.HttpStatus
 import java.util.UUID
 
 @Configuration
-class GuestApiExamples(private val openApiObjectMapper: OpenApiObjectMapper) {
-
+class GuestApiExamples(
+    private val openApiObjectMapper: OpenApiObjectMapper,
+) {
     @Bean
-    fun guestOpenApiExamples(): OperationCustomizer = OperationCustomizer { operation, handlerMethod ->
-        if (handlerMethod.binds(GuestController::issueGuestId)) {
-            operation.examples(openApiObjectMapper.delegate) {
-                add(
-                    status = HttpStatus.OK,
-                    name = "발급 성공",
-                    payload = ApiResponseBody.ok(
-                        GuestResponse(UUID.fromString("8f1a3c2b-9d44-4e2a-9b12-1a2b3c4d5e6f")),
-                    ),
-                )
+    fun guestOpenApiExamples(): OperationCustomizer =
+        OperationCustomizer { operation, handlerMethod ->
+            if (handlerMethod.binds(GuestController::issueGuestId)) {
+                operation.examples(openApiObjectMapper.delegate) {
+                    add(
+                        status = HttpStatus.OK,
+                        name = "발급 성공",
+                        payload =
+                            ApiResponseBody.ok(
+                                GuestResponse(UUID.fromString("8f1a3c2b-9d44-4e2a-9b12-1a2b3c4d5e6f")),
+                            ),
+                    )
+                }
             }
+            operation
         }
-        operation
-    }
 }

--- a/src/main/kotlin/com/depromeet/team3/guest/service/GuestService.kt
+++ b/src/main/kotlin/com/depromeet/team3/guest/service/GuestService.kt
@@ -10,7 +10,8 @@ class GuestService(
     private val guestRepository: GuestRepository,
 ) {
     @Transactional
-    fun issueGuestId(): UUID = guestRepository
-        .save(UUID.randomUUID())
-        .getId()
+    fun issueGuestId(): UUID =
+        guestRepository
+            .save(UUID.randomUUID())
+            .getId()
 }

--- a/src/main/kotlin/com/depromeet/team3/product/domain/Product.kt
+++ b/src/main/kotlin/com/depromeet/team3/product/domain/Product.kt
@@ -9,19 +9,14 @@ data class Product(
     @Convert(converter = ProductLinkConverter::class)
     @Column(name = "source_url", nullable = false, length = 2048)
     var link: ProductLink,
-
     @Column(name = "name", length = 512)
     var name: String? = null,
-
     @Column(name = "image_url", length = 2048)
     var imageUrl: String? = null,
-
     @Column(name = "regular_price")
     var regularPrice: Int? = null,
-
     @Column(name = "discounted_price")
     var discountedPrice: Int? = null,
-
     @Column(name = "currency", length = 8)
     var currency: String? = null,
 ) {

--- a/src/main/kotlin/com/depromeet/team3/product/domain/ProductLink.kt
+++ b/src/main/kotlin/com/depromeet/team3/product/domain/ProductLink.kt
@@ -2,7 +2,9 @@ package com.depromeet.team3.product.domain
 
 import java.net.URI
 
-class ProductLink private constructor(val value: URI) {
+class ProductLink private constructor(
+    val value: URI,
+) {
     override fun toString(): String = value.toString()
 
     // 로그/메트릭용. 쿼리스트링·fragment 에 토큰/세션이 섞일 수 있어 host+path 만 노출한다.
@@ -22,11 +24,12 @@ class ProductLink private constructor(val value: URI) {
         fun parse(raw: String): ProductLink {
             val trimmed = raw.trim()
             require(trimmed.isNotBlank()) { "URL이 비어 있습니다." }
-            val uri = try {
-                URI.create(trimmed)
-            } catch (e: IllegalArgumentException) {
-                throw IllegalArgumentException("유효한 URL 형식이 아닙니다: $trimmed", e)
-            }
+            val uri =
+                try {
+                    URI.create(trimmed)
+                } catch (e: IllegalArgumentException) {
+                    throw IllegalArgumentException("유효한 URL 형식이 아닙니다: $trimmed", e)
+                }
             // URI.create 는 스킴 없는 "example.com/product" 도 relative URI 로 통과시키므로 명시 검증.
             // RFC 3986 은 scheme 을 case-insensitive 로 정의하므로 비교 전에 lowercase 정규화한다.
             require(uri.scheme?.lowercase() in HTTP_SCHEMES) { "https URL만 허용합니다." }

--- a/src/main/kotlin/com/depromeet/team3/product/service/ProductExtractionException.kt
+++ b/src/main/kotlin/com/depromeet/team3/product/service/ProductExtractionException.kt
@@ -9,8 +9,8 @@ class ProductExtractionException private constructor(
     message: String,
     override val category: ErrorCategory,
     override val httpStatus: HttpStatus,
-) : BaseException(message), HttpMappable {
-
+) : BaseException(message),
+    HttpMappable {
     companion object {
         // LLM 이 "상품 페이지가 아님"으로 판정. 링크 재등록·재시도 모두 무의미.
         fun notProductPage(): ProductExtractionException =

--- a/src/main/kotlin/com/depromeet/team3/product/service/gemini/GeminiApiException.kt
+++ b/src/main/kotlin/com/depromeet/team3/product/service/gemini/GeminiApiException.kt
@@ -9,8 +9,8 @@ class GeminiApiException private constructor(
     message: String,
     override val category: ErrorCategory,
     cause: Throwable? = null,
-) : BaseException(message, cause), HttpMappable {
-
+) : BaseException(message, cause),
+    HttpMappable {
     override val httpStatus: HttpStatus = HttpStatus.BAD_GATEWAY
 
     companion object {
@@ -21,8 +21,7 @@ class GeminiApiException private constructor(
             GeminiApiException("Gemini 요청 오류", ErrorCategory.SERVER_ERROR, cause)
 
         // body 자체가 없음 (역직렬화 이전). transport/인프라 이슈로 일시적일 가능성이 크므로 RETRYABLE.
-        fun emptyResponse(): GeminiApiException =
-            GeminiApiException("Gemini 응답이 비어 있습니다.", ErrorCategory.RETRYABLE)
+        fun emptyResponse(): GeminiApiException = GeminiApiException("Gemini 응답이 비어 있습니다.", ErrorCategory.RETRYABLE)
 
         fun parseError(cause: Throwable): GeminiApiException =
             GeminiApiException("Gemini 응답 처리 실패", ErrorCategory.SERVER_ERROR, cause)

--- a/src/main/kotlin/com/depromeet/team3/product/service/gemini/GeminiExtractionRequest.kt
+++ b/src/main/kotlin/com/depromeet/team3/product/service/gemini/GeminiExtractionRequest.kt
@@ -36,7 +36,8 @@ data class GeminiExtractionRequest(
     companion object {
         // 서버에서 직접 fetch 한 HTML 을 in-context 로 받기 때문에 Gemini 의 url_context tool 을 쓰지 않는다.
         // CSR 페이지의 inline JSON-LD 등 정적 HTML 안의 정보를 LLM 이 직접 보고 추출하도록 유도.
-        private val SYSTEM_PROMPT = """
+        private val SYSTEM_PROMPT =
+            """
             You are a product information extractor. Given the URL and the HTML of a product page,
             extract information for the MAIN product of the page.
 
@@ -72,35 +73,43 @@ data class GeminiExtractionRequest(
             - Do NOT extract discount rate. The server computes it from regularPrice and discountedPrice.
 
             Respond with JSON only, matching the provided schema. Handle any language.
-        """.trimIndent()
+            """.trimIndent()
 
-        private val EXTRACTION_SCHEMA = JsonSchema(
-            type = "object",
-            properties = mapOf(
-                "isProductPage" to JsonSchema(type = "boolean"),
-                "name" to JsonSchema(type = "string", nullable = true),
-                "regularPrice" to JsonSchema(type = "integer", nullable = true),
-                "discountedPrice" to JsonSchema(type = "integer", nullable = true),
-                "currency" to JsonSchema(type = "string", nullable = true),
-                "imageUrl" to JsonSchema(type = "string", nullable = true),
-            ),
-            required = listOf("isProductPage"),
-        )
+        private val EXTRACTION_SCHEMA =
+            JsonSchema(
+                type = "object",
+                properties =
+                    mapOf(
+                        "isProductPage" to JsonSchema(type = "boolean"),
+                        "name" to JsonSchema(type = "string", nullable = true),
+                        "regularPrice" to JsonSchema(type = "integer", nullable = true),
+                        "discountedPrice" to JsonSchema(type = "integer", nullable = true),
+                        "currency" to JsonSchema(type = "string", nullable = true),
+                        "imageUrl" to JsonSchema(type = "string", nullable = true),
+                    ),
+                required = listOf("isProductPage"),
+            )
 
-        fun forHtmlExtraction(url: URI, html: String): GeminiExtractionRequest =
+        fun forHtmlExtraction(
+            url: URI,
+            html: String,
+        ): GeminiExtractionRequest =
             GeminiExtractionRequest(
-                generationConfig = GenerationConfig(
-                    responseMimeType = "application/json",
-                    responseJsonSchema = EXTRACTION_SCHEMA,
-                ),
-                contents = listOf(
-                    Content(
-                        parts = listOf(
-                            Part(text = SYSTEM_PROMPT),
-                            Part(text = "URL: $url\n\nHTML:\n$html"),
+                generationConfig =
+                    GenerationConfig(
+                        responseMimeType = "application/json",
+                        responseJsonSchema = EXTRACTION_SCHEMA,
+                    ),
+                contents =
+                    listOf(
+                        Content(
+                            parts =
+                                listOf(
+                                    Part(text = SYSTEM_PROMPT),
+                                    Part(text = "URL: $url\n\nHTML:\n$html"),
+                                ),
                         ),
                     ),
-                ),
             )
     }
 }

--- a/src/main/kotlin/com/depromeet/team3/product/service/gemini/GeminiExtractionResponse.kt
+++ b/src/main/kotlin/com/depromeet/team3/product/service/gemini/GeminiExtractionResponse.kt
@@ -7,12 +7,16 @@ data class GeminiExtractionResponse(
     val candidates: List<Candidate>,
 ) {
     fun extractText(): String =
-        candidates.firstOrNull()?.content?.parts?.firstOrNull()?.text
+        candidates
+            .firstOrNull()
+            ?.content
+            ?.parts
+            ?.firstOrNull()
+            ?.text
             ?: throw GeminiApiException.noTextPart()
 
     // url_context tool 결과의 fetch 상태를 관측용으로 노출한다. MVP 단계에선 로깅 용도.
-    fun urlContextMetadata(): UrlContextMetadata? =
-        candidates.firstOrNull()?.urlContextMetadata
+    fun urlContextMetadata(): UrlContextMetadata? = candidates.firstOrNull()?.urlContextMetadata
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     data class Candidate(

--- a/src/main/kotlin/com/depromeet/team3/product/service/gemini/GeminiProductExtractor.kt
+++ b/src/main/kotlin/com/depromeet/team3/product/service/gemini/GeminiProductExtractor.kt
@@ -23,16 +23,16 @@ class GeminiProductExtractor(
 ) : ProductExtractor {
     private val log = LoggerFactory.getLogger(javaClass)
 
-    private val restClient = RestClient
-        .builder()
-        .baseUrl("https://generativelanguage.googleapis.com")
-        .requestFactory(
-            SimpleClientHttpRequestFactory().apply {
-                setConnectTimeout(CONNECT_TIMEOUT_MS)
-                setReadTimeout(READ_TIMEOUT_MS)
-            },
-        )
-        .build()
+    private val restClient =
+        RestClient
+            .builder()
+            .baseUrl("https://generativelanguage.googleapis.com")
+            .requestFactory(
+                SimpleClientHttpRequestFactory().apply {
+                    setConnectTimeout(CONNECT_TIMEOUT_MS)
+                    setReadTimeout(READ_TIMEOUT_MS)
+                },
+            ).build()
 
     override fun extract(link: ProductLink): Product {
         val fetchStart = System.nanoTime()
@@ -44,27 +44,27 @@ class GeminiProductExtractor(
 
         val llmStart = System.nanoTime()
         // TODO: Gemini API 의 간헐적 5xx/타임아웃 대응 재시도 로직 필요. RETRYABLE 카테고리 예외 대상.
-        val response = try {
-            restClient
-                .post()
-                .uri {
-                    it
-                        .path("/v1beta/models/{model}:generateContent")
-                        .build(geminiProperties.model)
+        val response =
+            try {
+                restClient
+                    .post()
+                    .uri {
+                        it
+                            .path("/v1beta/models/{model}:generateContent")
+                            .build(geminiProperties.model)
+                    }.header(GEMINI_API_KEY_HEADER, geminiProperties.apiKey)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(request)
+                    .retrieve()
+                    .body<GeminiExtractionResponse>()
+            } catch (e: RestClientResponseException) {
+                throw when {
+                    e.statusCode.is5xxServerError -> GeminiApiException.upstreamError(e)
+                    else -> GeminiApiException.clientError(e)
                 }
-                .header(GEMINI_API_KEY_HEADER, geminiProperties.apiKey)
-                .contentType(MediaType.APPLICATION_JSON)
-                .body(request)
-                .retrieve()
-                .body<GeminiExtractionResponse>()
-        } catch (e: RestClientResponseException) {
-            throw when {
-                e.statusCode.is5xxServerError -> GeminiApiException.upstreamError(e)
-                else -> GeminiApiException.clientError(e)
-            }
-        } catch (e: ResourceAccessException) {
-            throw GeminiApiException.upstreamError(e)
-        } ?: throw GeminiApiException.emptyResponse()
+            } catch (e: ResourceAccessException) {
+                throw GeminiApiException.upstreamError(e)
+            } ?: throw GeminiApiException.emptyResponse()
         val llmMs = (System.nanoTime() - llmStart) / 1_000_000
 
         log.info(
@@ -76,20 +76,22 @@ class GeminiProductExtractor(
         )
 
         val text = response.extractText()
-        val result = try {
-            objectMapper.readValue<GeminiExtractionResult>(text)
-        } catch (e: Exception) {
-            throw GeminiApiException.parseError(e)
-        }
+        val result =
+            try {
+                objectMapper.readValue<GeminiExtractionResult>(text)
+            } catch (e: Exception) {
+                throw GeminiApiException.parseError(e)
+            }
         return result.toProduct(link)
     }
 
     // LLM 입력에서 <script>/<style>/주석을 제거해 토큰 낭비와 오판(스크립트 안의 가짜 가격 JSON 등)을 줄인다.
     // 단 <script type="application/ld+json"> 은 product schema 가 들어있을 가능성이 높아 보존한다.
-    private fun sanitize(html: String): String = html
-        .replace(NON_LDJSON_SCRIPT_PATTERN, "")
-        .replace(STYLE_PATTERN, "")
-        .replace(COMMENT_PATTERN, "")
+    private fun sanitize(html: String): String =
+        html
+            .replace(NON_LDJSON_SCRIPT_PATTERN, "")
+            .replace(STYLE_PATTERN, "")
+            .replace(COMMENT_PATTERN, "")
 
     companion object {
         private const val CONNECT_TIMEOUT_MS = 5_000
@@ -102,17 +104,20 @@ class GeminiProductExtractor(
         private const val GEMINI_API_KEY_HEADER = "x-goog-api-key"
 
         // application/ld+json 만 살리고 나머지 <script> 블록은 제거. (?!...) 는 negative lookahead.
-        private val NON_LDJSON_SCRIPT_PATTERN = Regex(
-            "<script\\b(?![^>]*type=[\"']application/ld\\+json[\"'])[^>]*>.*?</script>",
-            setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL),
-        )
-        private val STYLE_PATTERN = Regex(
-            "<style\\b[^>]*>.*?</style>",
-            setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL),
-        )
-        private val COMMENT_PATTERN = Regex(
-            "<!--.*?-->",
-            setOf(RegexOption.DOT_MATCHES_ALL),
-        )
+        private val NON_LDJSON_SCRIPT_PATTERN =
+            Regex(
+                "<script\\b(?![^>]*type=[\"']application/ld\\+json[\"'])[^>]*>.*?</script>",
+                setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL),
+            )
+        private val STYLE_PATTERN =
+            Regex(
+                "<style\\b[^>]*>.*?</style>",
+                setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL),
+            )
+        private val COMMENT_PATTERN =
+            Regex(
+                "<!--.*?-->",
+                setOf(RegexOption.DOT_MATCHES_ALL),
+            )
     }
 }

--- a/src/main/kotlin/com/depromeet/team3/product/service/http/HttpPageFetcher.kt
+++ b/src/main/kotlin/com/depromeet/team3/product/service/http/HttpPageFetcher.kt
@@ -19,47 +19,53 @@ class HttpPageFetcher : PageFetcher {
 
     // 외부 페이지 fetch 라 redirect 를 따라가지 않는다. 따라가면 1차 host 검증을
     // 통과해도 사설 IP 로 Location 점프하는 SSRF 우회가 가능하다.
-    private val requestFactory = object : SimpleClientHttpRequestFactory() {
-        override fun prepareConnection(connection: HttpURLConnection, httpMethod: String) {
-            super.prepareConnection(connection, httpMethod)
-            connection.instanceFollowRedirects = false
+    private val requestFactory =
+        object : SimpleClientHttpRequestFactory() {
+            override fun prepareConnection(
+                connection: HttpURLConnection,
+                httpMethod: String,
+            ) {
+                super.prepareConnection(connection, httpMethod)
+                connection.instanceFollowRedirects = false
+            }
+        }.apply {
+            setConnectTimeout(CONNECT_TIMEOUT_MS)
+            setReadTimeout(READ_TIMEOUT_MS)
         }
-    }.apply {
-        setConnectTimeout(CONNECT_TIMEOUT_MS)
-        setReadTimeout(READ_TIMEOUT_MS)
-    }
 
-    private val restClient = RestClient
-        .builder()
-        .requestFactory(requestFactory)
-        .defaultHeader(HttpHeaders.USER_AGENT, USER_AGENT)
-        .defaultHeader(HttpHeaders.ACCEPT, "text/html,application/xhtml+xml,*/*;q=0.8")
-        .defaultHeader(HttpHeaders.ACCEPT_LANGUAGE, "ko,en;q=0.9")
-        .build()
+    private val restClient =
+        RestClient
+            .builder()
+            .requestFactory(requestFactory)
+            .defaultHeader(HttpHeaders.USER_AGENT, USER_AGENT)
+            .defaultHeader(HttpHeaders.ACCEPT, "text/html,application/xhtml+xml,*/*;q=0.8")
+            .defaultHeader(HttpHeaders.ACCEPT_LANGUAGE, "ko,en;q=0.9")
+            .build()
 
     override fun fetch(link: ProductLink): PageContent {
         guardAgainstInternalHost(link)
 
         // String 오버로드는 URI 템플릿으로 해석되어 {q} 같은 쿼리가 변수로 치환될 수 있으므로 URI 로 명시 전달.
-        val body = try {
-            restClient
-                .get()
-                .uri(link.value)
-                .retrieve()
-                .body(String::class.java)
-        } catch (e: RestClientResponseException) {
-            log.warn("link fetch failed: status={} url={}", e.statusCode, link.safeLogString())
-            throw when {
-                e.statusCode.is5xxServerError -> PageFetchException.upstreamError(e)
-                else -> PageFetchException.clientError(e)
+        val body =
+            try {
+                restClient
+                    .get()
+                    .uri(link.value)
+                    .retrieve()
+                    .body(String::class.java)
+            } catch (e: RestClientResponseException) {
+                log.warn("link fetch failed: status={} url={}", e.statusCode, link.safeLogString())
+                throw when {
+                    e.statusCode.is5xxServerError -> PageFetchException.upstreamError(e)
+                    else -> PageFetchException.clientError(e)
+                }
+            } catch (e: ResourceAccessException) {
+                log.warn("link fetch upstream error url={}", link.safeLogString())
+                throw PageFetchException.upstreamError(e)
+            } ?: run {
+                log.warn("link fetch empty body url={}", link.safeLogString())
+                throw PageFetchException.emptyBody()
             }
-        } catch (e: ResourceAccessException) {
-            log.warn("link fetch upstream error url={}", link.safeLogString())
-            throw PageFetchException.upstreamError(e)
-        } ?: run {
-            log.warn("link fetch empty body url={}", link.safeLogString())
-            throw PageFetchException.emptyBody()
-        }
 
         val truncated = if (body.length > MAX_HTML_CHARS) body.substring(0, MAX_HTML_CHARS) else body
         return PageContent(link = link, html = truncated)
@@ -68,25 +74,28 @@ class HttpPageFetcher : PageFetcher {
     // host 가 loopback / 사설 / 링크로컬 / 메타데이터 IP 로 resolve 되면 SSRF 위험으로 차단.
     // 외부 쇼핑몰만 fetch 하는 것이 본 컴포넌트의 책임이라 외부 라우팅 가능 IP 만 허용한다.
     private fun guardAgainstInternalHost(link: ProductLink) {
-        val host = link.value.host ?: run {
-            log.warn("[SSRF] blocked: missing host url={}", link.safeLogString())
-            throw PageFetchException.blockedHost()
-        }
-        val addresses = try {
-            InetAddress.getAllByName(host)
-        } catch (e: java.net.UnknownHostException) {
-            log.warn("link fetch unknown host url={}", link.safeLogString())
-            throw PageFetchException.upstreamError(e)
-        }
-        val anyInternal = addresses.any { addr ->
-            addr.isLoopbackAddress ||
-                addr.isAnyLocalAddress ||
-                addr.isSiteLocalAddress ||
-                addr.isLinkLocalAddress ||
-                addr.isMulticastAddress ||
-                // AWS / GCP 인스턴스 메타데이터. site-local 범위에 속하지 않아 별도 차단.
-                addr.hostAddress == "169.254.169.254"
-        }
+        val host =
+            link.value.host ?: run {
+                log.warn("[SSRF] blocked: missing host url={}", link.safeLogString())
+                throw PageFetchException.blockedHost()
+            }
+        val addresses =
+            try {
+                InetAddress.getAllByName(host)
+            } catch (e: java.net.UnknownHostException) {
+                log.warn("link fetch unknown host url={}", link.safeLogString())
+                throw PageFetchException.upstreamError(e)
+            }
+        val anyInternal =
+            addresses.any { addr ->
+                addr.isLoopbackAddress ||
+                    addr.isAnyLocalAddress ||
+                    addr.isSiteLocalAddress ||
+                    addr.isLinkLocalAddress ||
+                    addr.isMulticastAddress ||
+                    // AWS / GCP 인스턴스 메타데이터. site-local 범위에 속하지 않아 별도 차단.
+                    addr.hostAddress == "169.254.169.254"
+            }
         if (anyInternal) {
             log.warn("[SSRF] blocked: internal address resolved url={}", link.safeLogString())
             throw PageFetchException.blockedHost()

--- a/src/main/kotlin/com/depromeet/team3/product/service/http/PageFetchException.kt
+++ b/src/main/kotlin/com/depromeet/team3/product/service/http/PageFetchException.kt
@@ -3,7 +3,6 @@ package com.depromeet.team3.product.service.http
 import com.depromeet.team3.common.exception.BaseException
 import com.depromeet.team3.common.exception.ErrorCategory
 import com.depromeet.team3.common.exception.HttpMappable
-import com.depromeet.team3.product.domain.ProductLink
 import org.springframework.http.HttpStatus
 
 class PageFetchException private constructor(
@@ -11,8 +10,8 @@ class PageFetchException private constructor(
     override val category: ErrorCategory,
     override val httpStatus: HttpStatus,
     cause: Throwable? = null,
-) : BaseException(message, cause), HttpMappable {
-
+) : BaseException(message, cause),
+    HttpMappable {
     companion object {
         // 사용자 입력 URL 의 query/fragment 에 토큰·세션이 박혀 있을 수 있어 어떤 메시지에도
         // link 자체를 노출하지 않는다. 디버깅용 식별자는 호출 지점에서

--- a/src/main/kotlin/com/depromeet/team3/tournament/controller/TournamentApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/team3/tournament/controller/TournamentApiExamples.kt
@@ -13,49 +13,56 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpStatus
 
 @Configuration
-class TournamentApiExamples(private val openApiObjectMapper: OpenApiObjectMapper) {
-
+class TournamentApiExamples(
+    private val openApiObjectMapper: OpenApiObjectMapper,
+) {
     @Bean
-    fun tournamentOpenApiExamples(): OperationCustomizer = OperationCustomizer { operation, handlerMethod ->
-        when {
-            handlerMethod.binds(TournamentController::start) -> operation.examples(openApiObjectMapper.delegate) {
-                add(
-                    status = HttpStatus.CREATED,
-                    name = "생성 성공",
-                    payload = ApiResponseBody.created(StartTournamentResponse(tournamentId = 1)),
-                )
-            }
+    fun tournamentOpenApiExamples(): OperationCustomizer =
+        OperationCustomizer { operation, handlerMethod ->
+            when {
+                handlerMethod.binds(TournamentController::start) ->
+                    operation.examples(openApiObjectMapper.delegate) {
+                        add(
+                            status = HttpStatus.CREATED,
+                            name = "생성 성공",
+                            payload = ApiResponseBody.created(StartTournamentResponse(tournamentId = 1)),
+                        )
+                    }
 
-            handlerMethod.binds(TournamentController::recordMatch) -> operation.examples(openApiObjectMapper.delegate) {
-                add(
-                    status = HttpStatus.OK,
-                    name = "기록 성공",
-                    payload = ApiResponseBody.ok<Unit>(),
-                )
-            }
+                handlerMethod.binds(TournamentController::recordMatch) ->
+                    operation.examples(openApiObjectMapper.delegate) {
+                        add(
+                            status = HttpStatus.OK,
+                            name = "기록 성공",
+                            payload = ApiResponseBody.ok<Unit>(),
+                        )
+                    }
 
-            handlerMethod.binds(TournamentController::getTournamentById) -> operation.examples(openApiObjectMapper.delegate) {
-                add(
-                    status = HttpStatus.OK,
-                    name = "조회 성공",
-                    payload = ApiResponseBody.ok(
-                        TournamentInfoResponse(
-                            tournamentId = 1,
-                            round = 4,
-                            finalWinnerWishItemId = 3,
-                            history = listOf(
-                                TournamentHistoryInfoResponse(
-                                    currentRound = 1,
-                                    firstWishItemId = 1,
-                                    secondWishItemId = 2,
-                                    winnerWishItemId = 1,
+                handlerMethod.binds(TournamentController::getTournamentById) ->
+                    operation.examples(openApiObjectMapper.delegate) {
+                        add(
+                            status = HttpStatus.OK,
+                            name = "조회 성공",
+                            payload =
+                                ApiResponseBody.ok(
+                                    TournamentInfoResponse(
+                                        tournamentId = 1,
+                                        round = 4,
+                                        finalWinnerWishItemId = 3,
+                                        history =
+                                            listOf(
+                                                TournamentHistoryInfoResponse(
+                                                    currentRound = 1,
+                                                    firstWishItemId = 1,
+                                                    secondWishItemId = 2,
+                                                    winnerWishItemId = 1,
+                                                ),
+                                            ),
+                                    ),
                                 ),
-                            ),
-                        ),
-                    ),
-                )
+                        )
+                    }
             }
+            operation
         }
-        operation
-    }
 }

--- a/src/main/kotlin/com/depromeet/team3/tournament/controller/dto/RecordMatchRequest.kt
+++ b/src/main/kotlin/com/depromeet/team3/tournament/controller/dto/RecordMatchRequest.kt
@@ -8,11 +8,12 @@ data class RecordMatchRequest(
     val secondWishItemId: Long,
     val winnerWishItemId: Long,
 ) {
-    fun toRecordMatch(tournamentId: Long): RecordMatch = RecordMatch(
-        tournamentId = tournamentId,
-        currentRound = currentRound,
-        firstWishItemId = firstWishItemId,
-        secondWishItemId = secondWishItemId,
-        winnerWishItemId = winnerWishItemId,
-    )
+    fun toRecordMatch(tournamentId: Long): RecordMatch =
+        RecordMatch(
+            tournamentId = tournamentId,
+            currentRound = currentRound,
+            firstWishItemId = firstWishItemId,
+            secondWishItemId = secondWishItemId,
+            winnerWishItemId = winnerWishItemId,
+        )
 }

--- a/src/main/kotlin/com/depromeet/team3/tournament/controller/dto/StartTournamentRequest.kt
+++ b/src/main/kotlin/com/depromeet/team3/tournament/controller/dto/StartTournamentRequest.kt
@@ -15,9 +15,10 @@ data class StartTournamentRequest(
     @field:Size(min = 2)
     val wishItemIds: List<Long>,
 ) {
-    fun toStartTournament(): StartTournament = StartTournament(
-        name = name,
-        round = round,
-        wishItemIds = wishItemIds,
-    )
+    fun toStartTournament(): StartTournament =
+        StartTournament(
+            name = name,
+            round = round,
+            wishItemIds = wishItemIds,
+        )
 }

--- a/src/main/kotlin/com/depromeet/team3/tournament/controller/dto/TournamentInfoResponse.kt
+++ b/src/main/kotlin/com/depromeet/team3/tournament/controller/dto/TournamentInfoResponse.kt
@@ -10,14 +10,13 @@ data class TournamentInfoResponse(
     val history: List<TournamentHistoryInfoResponse>,
 ) {
     companion object {
-        fun from(tournamentInfo: TournamentInfo): TournamentInfoResponse {
-            return TournamentInfoResponse(
+        fun from(tournamentInfo: TournamentInfo): TournamentInfoResponse =
+            TournamentInfoResponse(
                 tournamentId = tournamentInfo.tournamentId,
                 round = tournamentInfo.round,
                 finalWinnerWishItemId = tournamentInfo.finalWinnerWishItemId,
                 history = tournamentInfo.history.map { TournamentHistoryInfoResponse.from(it) },
             )
-        }
     }
 }
 
@@ -28,13 +27,12 @@ data class TournamentHistoryInfoResponse(
     val winnerWishItemId: Long,
 ) {
     companion object {
-        fun from(history: TournamentHistoryInfo): TournamentHistoryInfoResponse {
-            return TournamentHistoryInfoResponse(
+        fun from(history: TournamentHistoryInfo): TournamentHistoryInfoResponse =
+            TournamentHistoryInfoResponse(
                 currentRound = history.currentRound,
                 firstWishItemId = history.firstWishItemId,
                 secondWishItemId = history.secondWishItemId,
                 winnerWishItemId = history.winnerWishItemId,
             )
-        }
     }
 }

--- a/src/main/kotlin/com/depromeet/team3/tournament/domain/Tournament.kt
+++ b/src/main/kotlin/com/depromeet/team3/tournament/domain/Tournament.kt
@@ -27,7 +27,6 @@ class Tournament(
     @Column(columnDefinition = "varchar(50)")
     var status: TournamentStatus = TournamentStatus.IN_PROGRESS,
 ) : LongBaseEntity() {
-
     init {
         require(wishItemIds.size == round) {
             "토너먼트 참가 아이템 수(${wishItemIds.size})가 라운드 수($round)와 다릅니다."

--- a/src/main/kotlin/com/depromeet/team3/tournament/repository/TournamentJpaRepository.kt
+++ b/src/main/kotlin/com/depromeet/team3/tournament/repository/TournamentJpaRepository.kt
@@ -3,5 +3,4 @@ package com.depromeet.team3.tournament.repository
 import com.depromeet.team3.tournament.domain.Tournament
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface TournamentJpaRepository : JpaRepository<Tournament, Long> {
-}
+interface TournamentJpaRepository : JpaRepository<Tournament, Long>

--- a/src/main/kotlin/com/depromeet/team3/tournament/repository/TournamentRepository.kt
+++ b/src/main/kotlin/com/depromeet/team3/tournament/repository/TournamentRepository.kt
@@ -5,7 +5,10 @@ import com.depromeet.team3.tournament.domain.TournamentHistory
 
 interface TournamentRepository {
     fun saveTournament(tournament: Tournament): Long
+
     fun saveHistory(history: TournamentHistory)
+
     fun findTournamentById(tournamentId: Long): Tournament?
+
     fun findTournamentHistoriesByTournamentId(tournamentId: Long): List<TournamentHistory>
 }

--- a/src/main/kotlin/com/depromeet/team3/tournament/repository/TournamentRepositoryImpl.kt
+++ b/src/main/kotlin/com/depromeet/team3/tournament/repository/TournamentRepositoryImpl.kt
@@ -10,8 +10,7 @@ class TournamentRepositoryImpl(
     private val tournamentJpaRepository: TournamentJpaRepository,
     private val tournamentHistoryJpaRepository: TournamentHistoryJpaRepository,
 ) : TournamentRepository {
-    override fun saveTournament(tournament: Tournament): Long =
-        tournamentJpaRepository.save(tournament).getId()
+    override fun saveTournament(tournament: Tournament): Long = tournamentJpaRepository.save(tournament).getId()
 
     override fun saveHistory(history: TournamentHistory) {
         tournamentHistoryJpaRepository.save(history)

--- a/src/main/kotlin/com/depromeet/team3/tournament/service/TournamentException.kt
+++ b/src/main/kotlin/com/depromeet/team3/tournament/service/TournamentException.kt
@@ -9,8 +9,8 @@ class TournamentException private constructor(
     message: String,
     override val category: ErrorCategory,
     override val httpStatus: HttpStatus,
-) : BaseException(message), HttpMappable {
-
+) : BaseException(message),
+    HttpMappable {
     companion object {
         fun notFoundTournament(): TournamentException =
             TournamentException(
@@ -41,4 +41,3 @@ class TournamentException private constructor(
             )
     }
 }
-

--- a/src/main/kotlin/com/depromeet/team3/tournament/service/TournamentService.kt
+++ b/src/main/kotlin/com/depromeet/team3/tournament/service/TournamentService.kt
@@ -18,7 +18,10 @@ class TournamentService(
     private val wishRepository: WishRepository,
 ) {
     @Transactional
-    fun start(userId: UUID, command: StartTournament): Long {
+    fun start(
+        userId: UUID,
+        command: StartTournament,
+    ): Long {
         val ownedCount = wishRepository.countByIdsAndGuestId(command.wishItemIds, userId)
         if (ownedCount != command.wishItemIds.size.toLong()) throw WishException.forbiddenWishItems()
         return tournamentRepository.saveTournament(
@@ -32,18 +35,26 @@ class TournamentService(
     }
 
     @Transactional(readOnly = true)
-    fun getTournamentById(tournamentId: Long, userId: UUID): TournamentInfo {
-        val tournament = tournamentRepository.findTournamentById(tournamentId)
-            ?: throw TournamentException.notFoundTournament()
+    fun getTournamentById(
+        tournamentId: Long,
+        userId: UUID,
+    ): TournamentInfo {
+        val tournament =
+            tournamentRepository.findTournamentById(tournamentId)
+                ?: throw TournamentException.notFoundTournament()
         if (tournament.userId != userId) throw TournamentException.forbiddenTournament()
         val histories = tournamentRepository.findTournamentHistoriesByTournamentId(tournamentId)
         return TournamentInfo.of(tournament, histories)
     }
 
     @Transactional
-    fun recordMatch(userId: UUID, command: RecordMatch) {
-        val tournament = tournamentRepository.findTournamentById(command.tournamentId)
-            ?: throw TournamentException.notFoundTournament()
+    fun recordMatch(
+        userId: UUID,
+        command: RecordMatch,
+    ) {
+        val tournament =
+            tournamentRepository.findTournamentById(command.tournamentId)
+                ?: throw TournamentException.notFoundTournament()
 
         if (tournament.userId != userId) throw TournamentException.forbiddenTournament()
         if (tournament.isCompleted()) throw TournamentException.alreadyCompleted()

--- a/src/main/kotlin/com/depromeet/team3/tournament/service/dto/TournamentInfo.kt
+++ b/src/main/kotlin/com/depromeet/team3/tournament/service/dto/TournamentInfo.kt
@@ -10,12 +10,16 @@ data class TournamentInfo(
     val history: List<TournamentHistoryInfo>,
 ) {
     companion object {
-        fun of(tournament: Tournament, histories: List<TournamentHistory>): TournamentInfo = TournamentInfo(
-            tournamentId = tournament.getId(),
-            round = tournament.round,
-            finalWinnerWishItemId = tournament.finalWinnerWishItemId,
-            history = histories.map(TournamentHistoryInfo::from),
-        )
+        fun of(
+            tournament: Tournament,
+            histories: List<TournamentHistory>,
+        ): TournamentInfo =
+            TournamentInfo(
+                tournamentId = tournament.getId(),
+                round = tournament.round,
+                finalWinnerWishItemId = tournament.finalWinnerWishItemId,
+                history = histories.map(TournamentHistoryInfo::from),
+            )
     }
 }
 
@@ -26,11 +30,12 @@ data class TournamentHistoryInfo(
     val winnerWishItemId: Long,
 ) {
     companion object {
-        fun from(history: TournamentHistory): TournamentHistoryInfo = TournamentHistoryInfo(
-            currentRound = history.currentRound,
-            firstWishItemId = history.firstWishItemId,
-            secondWishItemId = history.secondWishItemId,
-            winnerWishItemId = history.winnerWishItemId,
-        )
+        fun from(history: TournamentHistory): TournamentHistoryInfo =
+            TournamentHistoryInfo(
+                currentRound = history.currentRound,
+                firstWishItemId = history.firstWishItemId,
+                secondWishItemId = history.secondWishItemId,
+                winnerWishItemId = history.winnerWishItemId,
+            )
     }
 }

--- a/src/main/kotlin/com/depromeet/team3/wishlist/controller/WishlistApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/team3/wishlist/controller/WishlistApiExamples.kt
@@ -12,47 +12,52 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpStatus
 
 @Configuration
-class WishlistApiExamples(private val openApiObjectMapper: OpenApiObjectMapper) {
-
+class WishlistApiExamples(
+    private val openApiObjectMapper: OpenApiObjectMapper,
+) {
     @Bean
-    fun wishlistOpenApiExamples(): OperationCustomizer = OperationCustomizer { operation, handlerMethod ->
-        if (handlerMethod.binds(WishlistController::register)) {
-            operation.examples(openApiObjectMapper.delegate) {
-                add(
-                    status = HttpStatus.CREATED,
-                    name = "등록 성공",
-                    payload = ApiResponseBody.created(
-                        WishlistRegisterResponse(
-                            wishId = 1024,
-                            name = "에어 조던 1 미드",
-                            regularPrice = 159_000,
-                            discountedPrice = 119_000,
-                            discountRate = 25,
-                            currency = "KRW",
-                            imageUrl = "https://cdn.example.com/p/1024.jpg",
-                        ),
-                    ),
-                )
-                add(
-                    status = HttpStatus.BAD_REQUEST,
-                    name = "URL 형식 오류",
-                    payload = ApiResponseBody.fail<Unit>(
-                        category = ErrorCategory.INVALID_INPUT,
+    fun wishlistOpenApiExamples(): OperationCustomizer =
+        OperationCustomizer { operation, handlerMethod ->
+            if (handlerMethod.binds(WishlistController::register)) {
+                operation.examples(openApiObjectMapper.delegate) {
+                    add(
+                        status = HttpStatus.CREATED,
+                        name = "등록 성공",
+                        payload =
+                            ApiResponseBody.created(
+                                WishlistRegisterResponse(
+                                    wishId = 1024,
+                                    name = "에어 조던 1 미드",
+                                    regularPrice = 159_000,
+                                    discountedPrice = 119_000,
+                                    discountRate = 25,
+                                    currency = "KRW",
+                                    imageUrl = "https://cdn.example.com/p/1024.jpg",
+                                ),
+                            ),
+                    )
+                    add(
                         status = HttpStatus.BAD_REQUEST,
-                        detail = "지원하지 않는 URL 형식입니다.",
-                    ),
-                )
-                add(
-                    status = HttpStatus.CONFLICT,
-                    name = "중복 등록",
-                    payload = ApiResponseBody.fail<Unit>(
-                        category = ErrorCategory.CONFLICT,
+                        name = "URL 형식 오류",
+                        payload =
+                            ApiResponseBody.fail<Unit>(
+                                category = ErrorCategory.INVALID_INPUT,
+                                status = HttpStatus.BAD_REQUEST,
+                                detail = "지원하지 않는 URL 형식입니다.",
+                            ),
+                    )
+                    add(
                         status = HttpStatus.CONFLICT,
-                        detail = "이미 위시리스트에 등록된 상품입니다.",
-                    ),
-                )
+                        name = "중복 등록",
+                        payload =
+                            ApiResponseBody.fail<Unit>(
+                                category = ErrorCategory.CONFLICT,
+                                status = HttpStatus.CONFLICT,
+                                detail = "이미 위시리스트에 등록된 상품입니다.",
+                            ),
+                    )
+                }
             }
+            operation
         }
-        operation
-    }
 }

--- a/src/main/kotlin/com/depromeet/team3/wishlist/controller/WishlistController.kt
+++ b/src/main/kotlin/com/depromeet/team3/wishlist/controller/WishlistController.kt
@@ -19,7 +19,9 @@ class WishlistController(
 ) : WishlistApi {
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    override fun register(@Valid @RequestBody request: WishlistRegisterRequest): ApiResponseBody<WishlistRegisterResponse> {
+    override fun register(
+        @Valid @RequestBody request: WishlistRegisterRequest,
+    ): ApiResponseBody<WishlistRegisterResponse> {
         val result = wishlistService.register(rawUrl = request.url, guestId = request.guestId)
         return ApiResponseBody.created(WishlistRegisterResponse.from(result.wish))
     }

--- a/src/main/kotlin/com/depromeet/team3/wishlist/controller/dto/WishlistRegisterRequest.kt
+++ b/src/main/kotlin/com/depromeet/team3/wishlist/controller/dto/WishlistRegisterRequest.kt
@@ -16,7 +16,6 @@ data class WishlistRegisterRequest(
         requiredMode = Schema.RequiredMode.REQUIRED,
     )
     val url: String,
-
     @field:NotNull
     @field:Schema(
         description = "게스트 식별자 (게스트 발급 API로 받은 UUID)",

--- a/src/main/kotlin/com/depromeet/team3/wishlist/controller/dto/WishlistRegisterResponse.kt
+++ b/src/main/kotlin/com/depromeet/team3/wishlist/controller/dto/WishlistRegisterResponse.kt
@@ -7,22 +7,16 @@ import io.swagger.v3.oas.annotations.media.Schema
 data class WishlistRegisterResponse(
     @field:Schema(description = "위시리스트 항목 ID", example = "1024")
     val wishId: Long,
-
     @field:Schema(description = "상품명 (추출 실패 시 null)", example = "에어 조던 1 미드", nullable = true)
     val name: String?,
-
     @field:Schema(description = "정가 (할인 전 가격)", example = "159000", nullable = true)
     val regularPrice: Int?,
-
     @field:Schema(description = "할인가", example = "119000", nullable = true)
     val discountedPrice: Int?,
-
     @field:Schema(description = "할인율 (%)", example = "25", nullable = true)
     val discountRate: Int?,
-
     @field:Schema(description = "통화 코드 (ISO 4217)", example = "KRW", nullable = true)
     val currency: String?,
-
     @field:Schema(
         description = "상품 대표 이미지 URL",
         example = "https://cdn.example.com/p/1024.jpg",
@@ -31,14 +25,15 @@ data class WishlistRegisterResponse(
     val imageUrl: String?,
 ) {
     companion object {
-        fun from(wish: Wish): WishlistRegisterResponse = WishlistRegisterResponse(
-            wishId = wish.getId(),
-            name = wish.product.name,
-            regularPrice = wish.product.regularPrice,
-            discountedPrice = wish.product.discountedPrice,
-            discountRate = wish.product.discountRate,
-            currency = wish.product.currency,
-            imageUrl = wish.product.imageUrl,
-        )
+        fun from(wish: Wish): WishlistRegisterResponse =
+            WishlistRegisterResponse(
+                wishId = wish.getId(),
+                name = wish.product.name,
+                regularPrice = wish.product.regularPrice,
+                discountedPrice = wish.product.discountedPrice,
+                discountRate = wish.product.discountRate,
+                currency = wish.product.currency,
+                imageUrl = wish.product.imageUrl,
+            )
     }
 }

--- a/src/main/kotlin/com/depromeet/team3/wishlist/domain/Wish.kt
+++ b/src/main/kotlin/com/depromeet/team3/wishlist/domain/Wish.kt
@@ -16,11 +16,9 @@ import java.util.UUID
 class Wish(
     @Column(name = "guest_id", nullable = false, columnDefinition = "BINARY(16)")
     val guestId: UUID,
-
     @Embedded
     val product: Product,
 ) : BaseEntity<Long>() {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id")

--- a/src/main/kotlin/com/depromeet/team3/wishlist/repository/WishJpaRepository.kt
+++ b/src/main/kotlin/com/depromeet/team3/wishlist/repository/WishJpaRepository.kt
@@ -11,6 +11,13 @@ interface WishJpaRepository : JpaRepository<Wish, Long> {
     // product 가 @Embedded 라 derivation 파서가 productLink → product.link 로
     // 폴백 resolve 하는 형태로 동작은 하나, 의존하기엔 모호해 JPQL 로 명시한다.
     @Query("select count(w) > 0 from Wish w where w.guestId = :guestId and w.product.link = :link")
-    fun existsByGuestIdAndProductLink(@Param("guestId") guestId: UUID, @Param("link") link: ProductLink): Boolean
-    fun countByIdInAndGuestId(ids: Collection<Long>, guestId: UUID): Long
+    fun existsByGuestIdAndProductLink(
+        @Param("guestId") guestId: UUID,
+        @Param("link") link: ProductLink,
+    ): Boolean
+
+    fun countByIdInAndGuestId(
+        ids: Collection<Long>,
+        guestId: UUID,
+    ): Long
 }

--- a/src/main/kotlin/com/depromeet/team3/wishlist/repository/WishRepository.kt
+++ b/src/main/kotlin/com/depromeet/team3/wishlist/repository/WishRepository.kt
@@ -6,6 +6,14 @@ import java.util.UUID
 
 interface WishRepository {
     fun save(wish: Wish): Wish
-    fun existsByGuestIdAndProductLink(guestId: UUID, link: ProductLink): Boolean
-    fun countByIdsAndGuestId(ids: List<Long>, guestId: UUID): Long
+
+    fun existsByGuestIdAndProductLink(
+        guestId: UUID,
+        link: ProductLink,
+    ): Boolean
+
+    fun countByIdsAndGuestId(
+        ids: List<Long>,
+        guestId: UUID,
+    ): Long
 }

--- a/src/main/kotlin/com/depromeet/team3/wishlist/repository/WishRepositoryImpl.kt
+++ b/src/main/kotlin/com/depromeet/team3/wishlist/repository/WishRepositoryImpl.kt
@@ -11,9 +11,13 @@ class WishRepositoryImpl(
 ) : WishRepository {
     override fun save(wish: Wish): Wish = wishJpaRepository.save(wish)
 
-    override fun existsByGuestIdAndProductLink(guestId: UUID, link: ProductLink): Boolean =
-        wishJpaRepository.existsByGuestIdAndProductLink(guestId, link)
+    override fun existsByGuestIdAndProductLink(
+        guestId: UUID,
+        link: ProductLink,
+    ): Boolean = wishJpaRepository.existsByGuestIdAndProductLink(guestId, link)
 
-    override fun countByIdsAndGuestId(ids: List<Long>, guestId: UUID): Long =
-        wishJpaRepository.countByIdInAndGuestId(ids, guestId)
+    override fun countByIdsAndGuestId(
+        ids: List<Long>,
+        guestId: UUID,
+    ): Long = wishJpaRepository.countByIdInAndGuestId(ids, guestId)
 }

--- a/src/main/kotlin/com/depromeet/team3/wishlist/service/WishException.kt
+++ b/src/main/kotlin/com/depromeet/team3/wishlist/service/WishException.kt
@@ -11,22 +11,24 @@ class WishException private constructor(
     message: String,
     override val category: ErrorCategory,
     override val httpStatus: HttpStatus,
-) : BaseException(message), HttpMappable {
-
+) : BaseException(message),
+    HttpMappable {
     companion object {
         fun alreadyExists(
             guestId: UUID,
             link: ProductLink,
-        ): WishException = WishException(
-            "이미 위시리스트에 등록된 상품입니다. guestId=$guestId link=$link",
-            ErrorCategory.CONFLICT,
-            HttpStatus.CONFLICT,
-        )
+        ): WishException =
+            WishException(
+                "이미 위시리스트에 등록된 상품입니다. guestId=$guestId link=$link",
+                ErrorCategory.CONFLICT,
+                HttpStatus.CONFLICT,
+            )
 
-        fun forbiddenWishItems(): WishException = WishException(
-            "해당 위시 아이템에 접근할 권한이 없습니다.",
-            ErrorCategory.FORBIDDEN,
-            HttpStatus.FORBIDDEN,
-        )
+        fun forbiddenWishItems(): WishException =
+            WishException(
+                "해당 위시 아이템에 접근할 권한이 없습니다.",
+                ErrorCategory.FORBIDDEN,
+                HttpStatus.FORBIDDEN,
+            )
     }
 }

--- a/src/main/kotlin/com/depromeet/team3/wishlist/service/WishPersistenceService.kt
+++ b/src/main/kotlin/com/depromeet/team3/wishlist/service/WishPersistenceService.kt
@@ -18,7 +18,10 @@ class WishPersistenceService(
     private val wishRepository: WishRepository,
 ) {
     @Transactional
-    fun persist(guestId: UUID, product: Product): WishRegisterResult =
+    fun persist(
+        guestId: UUID,
+        product: Product,
+    ): WishRegisterResult =
         try {
             val wish = wishRepository.save(Wish(guestId = guestId, product = product))
             WishRegisterResult(wish = wish)
@@ -28,10 +31,12 @@ class WishPersistenceService(
             // 진짜 데이터 오류가 "이미 존재함" 으로 사일런트 fail 한다.
             // Hibernate 가 constraintName 을 "wishes.uk_wishes_guest_source" 처럼 테이블 prefix
             // 와 함께 주는 경우가 있어 endsWith 도 함께 본다.
-            val constraint = (e.cause as? ConstraintViolationException)?.constraintName?.lowercase()
-                ?: throw e
-            val matched = constraint == UK_WISHES_GUEST_SOURCE ||
-                constraint.endsWith(".$UK_WISHES_GUEST_SOURCE")
+            val constraint =
+                (e.cause as? ConstraintViolationException)?.constraintName?.lowercase()
+                    ?: throw e
+            val matched =
+                constraint == UK_WISHES_GUEST_SOURCE ||
+                    constraint.endsWith(".$UK_WISHES_GUEST_SOURCE")
             if (!matched) throw e
             throw WishException.alreadyExists(guestId = guestId, link = product.link)
         }

--- a/src/main/kotlin/com/depromeet/team3/wishlist/service/WishlistService.kt
+++ b/src/main/kotlin/com/depromeet/team3/wishlist/service/WishlistService.kt
@@ -20,7 +20,10 @@ class WishlistService(
     // register 전체를 @Transactional 로 묶으면 외부 fetch + Gemini 호출 (read-timeout 60s)
     // 동안 DB 커넥션이 잡혀 풀 고갈 → 다른 API 까지 latency 폭증으로 번진다.
     // 외부 호출은 트랜잭션 바깥에서 끝내고, 영속화는 별도 빈에 위임해 proxy 를 통해 호출.
-    fun register(rawUrl: String, guestId: UUID): WishRegisterResult {
+    fun register(
+        rawUrl: String,
+        guestId: UUID,
+    ): WishRegisterResult {
         val link = ProductLink.parse(rawUrl)
 
         // dedup 검사를 추출 전에 먼저 — 중복이면 LLM 호출 비용 자체를 회피.

--- a/src/test/kotlin/com/depromeet/team3/Team3ApplicationTests.kt
+++ b/src/test/kotlin/com/depromeet/team3/Team3ApplicationTests.kt
@@ -4,7 +4,6 @@ import com.depromeet.team3.support.IntegrationTestSupport
 import org.junit.jupiter.api.Test
 
 class Team3ApplicationTests : IntegrationTestSupport() {
-
     @Test
     fun contextLoads() {
     }

--- a/src/test/kotlin/com/depromeet/team3/guest/controller/GuestControllerTest.kt
+++ b/src/test/kotlin/com/depromeet/team3/guest/controller/GuestControllerTest.kt
@@ -1,7 +1,6 @@
 package com.depromeet.team3.guest.controller
 
 import com.depromeet.team3.support.IntegrationTestSupport
-import tools.jackson.databind.ObjectMapper
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
@@ -10,12 +9,12 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.context.WebApplicationContext
+import tools.jackson.databind.ObjectMapper
 import java.util.UUID
 import kotlin.test.assertNotEquals
 
 @Transactional
 class GuestControllerTest : IntegrationTestSupport() {
-
     @Autowired
     private lateinit var webApplicationContext: WebApplicationContext
 
@@ -26,12 +25,20 @@ class GuestControllerTest : IntegrationTestSupport() {
     fun `POST api v1 guests 는 UUID 형식의 guestId 를 반환한다`() {
         val mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build()
 
-        val response = mockMvc.perform(post("/api/v1/guests"))
-            .andExpect(status().isCreated)
-            .andExpect(jsonPath("$.data.guestId").exists())
-            .andReturn().response.contentAsString
+        val response =
+            mockMvc
+                .perform(post("/api/v1/guests"))
+                .andExpect(status().isCreated)
+                .andExpect(jsonPath("$.data.guestId").exists())
+                .andReturn()
+                .response.contentAsString
 
-        val guestId = objectMapper.readTree(response).path("data").path("guestId").asString()
+        val guestId =
+            objectMapper
+                .readTree(response)
+                .path("data")
+                .path("guestId")
+                .asString()
         UUID.fromString(guestId)
     }
 
@@ -39,15 +46,33 @@ class GuestControllerTest : IntegrationTestSupport() {
     fun `POST api v1 guests 는 매 요청마다 서로 다른 UUID 를 발급한다`() {
         val mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build()
 
-        val first = mockMvc.perform(post("/api/v1/guests"))
-            .andExpect(status().isCreated)
-            .andReturn().response.contentAsString
-            .let { objectMapper.readTree(it).path("data").path("guestId").asString() }
+        val first =
+            mockMvc
+                .perform(post("/api/v1/guests"))
+                .andExpect(status().isCreated)
+                .andReturn()
+                .response.contentAsString
+                .let {
+                    objectMapper
+                        .readTree(it)
+                        .path("data")
+                        .path("guestId")
+                        .asString()
+                }
 
-        val second = mockMvc.perform(post("/api/v1/guests"))
-            .andExpect(status().isCreated)
-            .andReturn().response.contentAsString
-            .let { objectMapper.readTree(it).path("data").path("guestId").asString() }
+        val second =
+            mockMvc
+                .perform(post("/api/v1/guests"))
+                .andExpect(status().isCreated)
+                .andReturn()
+                .response.contentAsString
+                .let {
+                    objectMapper
+                        .readTree(it)
+                        .path("data")
+                        .path("guestId")
+                        .asString()
+                }
 
         assertNotEquals(first, second)
     }

--- a/src/test/kotlin/com/depromeet/team3/guest/service/GuestServiceTest.kt
+++ b/src/test/kotlin/com/depromeet/team3/guest/service/GuestServiceTest.kt
@@ -7,7 +7,6 @@ import java.util.UUID
 import kotlin.test.assertEquals
 
 class GuestServiceTest {
-
     private class StubGuestRepository : GuestRepository {
         val saved = mutableListOf<UUID>()
 

--- a/src/test/kotlin/com/depromeet/team3/product/domain/ProductLinkTest.kt
+++ b/src/test/kotlin/com/depromeet/team3/product/domain/ProductLinkTest.kt
@@ -6,30 +6,32 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class ProductLinkTest {
-
     @Test
     fun `빈 문자열 또는 공백만 있으면 거부한다`() {
         listOf("", "   ", "\t\n").forEach { raw ->
-            val ex = assertFailsWith<IllegalArgumentException>("'$raw' 는 거부되어야 함") {
-                ProductLink.parse(raw)
-            }
+            val ex =
+                assertFailsWith<IllegalArgumentException>("'$raw' 는 거부되어야 함") {
+                    ProductLink.parse(raw)
+                }
             assertEquals("URL이 비어 있습니다.", ex.message)
         }
     }
 
     @Test
     fun `https 가 아닌 scheme 은 모두 거부한다`() {
-        val cases = listOf(
-            "http://example.com",
-            "ftp://example.com",
-            "file:///etc/passwd",
-            "javascript:alert(1)",
-            "ws://example.com/socket",
-        )
+        val cases =
+            listOf(
+                "http://example.com",
+                "ftp://example.com",
+                "file:///etc/passwd",
+                "javascript:alert(1)",
+                "ws://example.com/socket",
+            )
         cases.forEach { raw ->
-            val ex = assertFailsWith<IllegalArgumentException>("$raw 는 거부되어야 함") {
-                ProductLink.parse(raw)
-            }
+            val ex =
+                assertFailsWith<IllegalArgumentException>("$raw 는 거부되어야 함") {
+                    ProductLink.parse(raw)
+                }
             assertEquals("https URL만 허용합니다.", ex.message)
         }
     }
@@ -37,17 +39,19 @@ class ProductLinkTest {
     @Test
     fun `URI 파싱 자체가 실패하는 raw 는 형식 오류로 거부한다`() {
         // 예: data: URI 의 본문에 illegal character 가 들어가면 URI_create 단계에서 IllegalArgumentException
-        val ex = assertFailsWith<IllegalArgumentException> {
-            ProductLink.parse("data:text/html,<h1>x</h1>")
-        }
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                ProductLink.parse("data:text/html,<h1>x</h1>")
+            }
         assertTrue(ex.message?.startsWith("유효한 URL 형식이 아닙니다") == true)
     }
 
     @Test
     fun `scheme 없이 호스트만 있는 raw 는 거부한다`() {
-        val ex = assertFailsWith<IllegalArgumentException> {
-            ProductLink.parse("example.com/product")
-        }
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                ProductLink.parse("example.com/product")
+            }
         assertEquals("https URL만 허용합니다.", ex.message)
     }
 

--- a/src/test/kotlin/com/depromeet/team3/product/service/ProductExtractE2ETest.kt
+++ b/src/test/kotlin/com/depromeet/team3/product/service/ProductExtractE2ETest.kt
@@ -18,18 +18,19 @@ import java.util.concurrent.TimeUnit
  */
 @Disabled("실제 Gemini API 호출 + 외부 쇼핑몰 fetch. 측정 필요 시 수동으로 enable 후 실행.")
 class ProductExtractE2ETest {
-
     private val pageFetcher = HttpPageFetcher()
     private val objectMapper = jacksonObjectMapper()
-    private val properties = GeminiProperties(
-        apiKey = System.getenv("GEMINI_API_KEY"),
-        model = "gemini-3-flash-preview",
-    )
-    private val extractor = GeminiProductExtractor(
-        objectMapper = objectMapper,
-        geminiProperties = properties,
-        pageFetcher = pageFetcher,
-    )
+    private val properties =
+        GeminiProperties(
+            apiKey = System.getenv("GEMINI_API_KEY"),
+            model = "gemini-3-flash-preview",
+        )
+    private val extractor =
+        GeminiProductExtractor(
+            objectMapper = objectMapper,
+            geminiProperties = properties,
+            pageFetcher = pageFetcher,
+        )
 
     @Test
     @Timeout(value = 30, unit = TimeUnit.MINUTES)
@@ -39,32 +40,33 @@ class ProductExtractE2ETest {
             repeat(ITERATIONS) { i ->
                 val link = ProductLink.parse(rawUrl)
                 val started = System.nanoTime()
-                val outcome = try {
-                    val product = extractor.extract(link)
-                    val ms = (System.nanoTime() - started) / 1_000_000
-                    Outcome(
-                        url = rawUrl,
-                        attempt = i + 1,
-                        status = "OK",
-                        name = product.name,
-                        regularPrice = product.regularPrice,
-                        discountedPrice = product.discountedPrice,
-                        elapsedMs = ms,
-                        error = null,
-                    )
-                } catch (e: Exception) {
-                    val ms = (System.nanoTime() - started) / 1_000_000
-                    Outcome(
-                        url = rawUrl,
-                        attempt = i + 1,
-                        status = "FAIL",
-                        name = null,
-                        regularPrice = null,
-                        discountedPrice = null,
-                        elapsedMs = ms,
-                        error = "${e.javaClass.simpleName}: ${e.message}",
-                    )
-                }
+                val outcome =
+                    try {
+                        val product = extractor.extract(link)
+                        val ms = (System.nanoTime() - started) / 1_000_000
+                        Outcome(
+                            url = rawUrl,
+                            attempt = i + 1,
+                            status = "OK",
+                            name = product.name,
+                            regularPrice = product.regularPrice,
+                            discountedPrice = product.discountedPrice,
+                            elapsedMs = ms,
+                            error = null,
+                        )
+                    } catch (e: Exception) {
+                        val ms = (System.nanoTime() - started) / 1_000_000
+                        Outcome(
+                            url = rawUrl,
+                            attempt = i + 1,
+                            status = "FAIL",
+                            name = null,
+                            regularPrice = null,
+                            discountedPrice = null,
+                            elapsedMs = ms,
+                            error = "${e.javaClass.simpleName}: ${e.message}",
+                        )
+                    }
                 results += outcome
                 println(formatLine(outcome))
             }
@@ -74,9 +76,9 @@ class ProductExtractE2ETest {
 
     private fun formatLine(o: Outcome): String =
         if (o.status == "OK") {
-            "[${o.attempt}/${ITERATIONS}] ${o.elapsedMs}ms  ${o.url}  name=${o.name}  reg=${o.regularPrice}  disc=${o.discountedPrice}"
+            "[${o.attempt}/$ITERATIONS] ${o.elapsedMs}ms  ${o.url}  name=${o.name}  reg=${o.regularPrice}  disc=${o.discountedPrice}"
         } else {
-            "[${o.attempt}/${ITERATIONS}] ${o.elapsedMs}ms  ${o.url}  FAIL  ${o.error}"
+            "[${o.attempt}/$ITERATIONS] ${o.elapsedMs}ms  ${o.url}  FAIL  ${o.error}"
         }
 
     private fun printSummary(results: List<Outcome>) {
@@ -86,7 +88,7 @@ class ProductExtractE2ETest {
             val avg = rs.map { it.elapsedMs }.average().toInt()
             val regs = rs.filter { it.status == "OK" }.map { it.regularPrice }.distinct()
             val discs = rs.filter { it.status == "OK" }.map { it.discountedPrice }.distinct()
-            println("$url: ${ok}/${rs.size} OK  avg=${avg}ms  uniqueReg=$regs  uniqueDisc=$discs")
+            println("$url: $ok/${rs.size} OK  avg=${avg}ms  uniqueReg=$regs  uniqueDisc=$discs")
         }
     }
 
@@ -105,11 +107,12 @@ class ProductExtractE2ETest {
         private const val ITERATIONS = 3
 
         // SSR / CSR / JSON-LD 보유 / 보유 안 함 등 다양한 패턴으로 섞었음.
-        private val URLS = listOf(
-            "https://www.musinsa.com/products/1551840",
-            "https://www.musinsa.com/products/6029415",
-            "https://www.29cm.co.kr/products/3915051",
-            "https://www.29cm.co.kr/products/1437795",
-        )
+        private val URLS =
+            listOf(
+                "https://www.musinsa.com/products/1551840",
+                "https://www.musinsa.com/products/6029415",
+                "https://www.29cm.co.kr/products/3915051",
+                "https://www.29cm.co.kr/products/1437795",
+            )
     }
 }

--- a/src/test/kotlin/com/depromeet/team3/product/service/gemini/GeminiExtractionResponseTest.kt
+++ b/src/test/kotlin/com/depromeet/team3/product/service/gemini/GeminiExtractionResponseTest.kt
@@ -5,7 +5,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 class GeminiExtractionResponseTest {
-
     @Test
     fun `candidates 가 비어 있으면 noTextPart 예외를 던진다`() {
         val response = GeminiExtractionResponse(candidates = emptyList())
@@ -17,13 +16,15 @@ class GeminiExtractionResponseTest {
 
     @Test
     fun `parts 가 비어 있으면 noTextPart 예외를 던진다`() {
-        val response = GeminiExtractionResponse(
-            candidates = listOf(
-                GeminiExtractionResponse.Candidate(
-                    content = GeminiExtractionResponse.Content(parts = emptyList()),
-                ),
-            ),
-        )
+        val response =
+            GeminiExtractionResponse(
+                candidates =
+                    listOf(
+                        GeminiExtractionResponse.Candidate(
+                            content = GeminiExtractionResponse.Content(parts = emptyList()),
+                        ),
+                    ),
+            )
 
         assertFailsWith<GeminiApiException> {
             response.extractText()
@@ -32,17 +33,21 @@ class GeminiExtractionResponseTest {
 
     @Test
     fun `정상 응답은 첫번째 candidate 의 첫번째 part text 를 반환한다`() {
-        val response = GeminiExtractionResponse(
-            candidates = listOf(
-                GeminiExtractionResponse.Candidate(
-                    content = GeminiExtractionResponse.Content(
-                        parts = listOf(
-                            GeminiExtractionResponse.Part(text = """{"isProductPage":true}"""),
+        val response =
+            GeminiExtractionResponse(
+                candidates =
+                    listOf(
+                        GeminiExtractionResponse.Candidate(
+                            content =
+                                GeminiExtractionResponse.Content(
+                                    parts =
+                                        listOf(
+                                            GeminiExtractionResponse.Part(text = """{"isProductPage":true}"""),
+                                        ),
+                                ),
                         ),
                     ),
-                ),
-            ),
-        )
+            )
 
         assertEquals("""{"isProductPage":true}""", response.extractText())
     }

--- a/src/test/kotlin/com/depromeet/team3/product/service/gemini/GeminiExtractionResultTest.kt
+++ b/src/test/kotlin/com/depromeet/team3/product/service/gemini/GeminiExtractionResultTest.kt
@@ -8,15 +8,15 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 
 class GeminiExtractionResultTest {
-
     private val link = ProductLink.parse("https://shop.example.com/products/42")
 
     @Test
     fun `isProductPage 가 false 이면 notProductPage 예외를 던진다`() {
-        val result = GeminiExtractionResult(
-            isProductPage = false,
-            name = null,
-        )
+        val result =
+            GeminiExtractionResult(
+                isProductPage = false,
+                name = null,
+            )
 
         assertFailsWith<ProductExtractionException> {
             result.toProduct(link)
@@ -25,10 +25,11 @@ class GeminiExtractionResultTest {
 
     @Test
     fun `name 이 비어 있어도 Product 로 변환되며 name 은 null 로 정규화된다`() {
-        val result = GeminiExtractionResult(
-            isProductPage = true,
-            name = "   ",
-        )
+        val result =
+            GeminiExtractionResult(
+                isProductPage = true,
+                name = "   ",
+            )
 
         val product = result.toProduct(link)
 
@@ -37,11 +38,12 @@ class GeminiExtractionResultTest {
 
     @Test
     fun `일부 필드만 있어도 Product 로 변환된다`() {
-        val result = GeminiExtractionResult(
-            isProductPage = true,
-            name = "테스트 상품",
-            regularPrice = 10_000,
-        )
+        val result =
+            GeminiExtractionResult(
+                isProductPage = true,
+                name = "테스트 상품",
+                regularPrice = 10_000,
+            )
 
         val product = result.toProduct(link)
 
@@ -53,14 +55,15 @@ class GeminiExtractionResultTest {
 
     @Test
     fun `전 필드가 채워진 경우 그대로 Product 에 매핑되고 discountRate 는 서버에서 계산된다`() {
-        val result = GeminiExtractionResult(
-            isProductPage = true,
-            name = "나이키 에어포스",
-            regularPrice = 139_000,
-            discountedPrice = 99_000,
-            currency = "KRW",
-            imageUrl = "https://cdn.example.com/p/42.jpg",
-        )
+        val result =
+            GeminiExtractionResult(
+                isProductPage = true,
+                name = "나이키 에어포스",
+                regularPrice = 139_000,
+                discountedPrice = 99_000,
+                currency = "KRW",
+                imageUrl = "https://cdn.example.com/p/42.jpg",
+            )
 
         val product = result.toProduct(link)
 
@@ -75,11 +78,12 @@ class GeminiExtractionResultTest {
 
     @Test
     fun `비어 있는 문자열 필드는 null 로 정규화된다`() {
-        val result = GeminiExtractionResult(
-            isProductPage = true,
-            name = "테스트",
-            imageUrl = "",
-        )
+        val result =
+            GeminiExtractionResult(
+                isProductPage = true,
+                name = "테스트",
+                imageUrl = "",
+            )
 
         val product = result.toProduct(link)
 
@@ -88,29 +92,32 @@ class GeminiExtractionResultTest {
 
     @Test
     fun `regularPrice 또는 discountedPrice 가 없으면 discountRate 는 null 이다`() {
-        val onlyRegular = GeminiExtractionResult(
-            isProductPage = true,
-            name = "상품",
-            regularPrice = 10_000,
-        )
+        val onlyRegular =
+            GeminiExtractionResult(
+                isProductPage = true,
+                name = "상품",
+                regularPrice = 10_000,
+            )
         assertNull(onlyRegular.toProduct(link).discountRate)
 
-        val onlyDiscounted = GeminiExtractionResult(
-            isProductPage = true,
-            name = "상품",
-            discountedPrice = 9_000,
-        )
+        val onlyDiscounted =
+            GeminiExtractionResult(
+                isProductPage = true,
+                name = "상품",
+                discountedPrice = 9_000,
+            )
         assertNull(onlyDiscounted.toProduct(link).discountRate)
     }
 
     @Test
     fun `할인가가 원가 이상이면 discountRate 는 null 이다`() {
-        val noDiscount = GeminiExtractionResult(
-            isProductPage = true,
-            name = "상품",
-            regularPrice = 10_000,
-            discountedPrice = 10_000,
-        )
+        val noDiscount =
+            GeminiExtractionResult(
+                isProductPage = true,
+                name = "상품",
+                regularPrice = 10_000,
+                discountedPrice = 10_000,
+            )
 
         assertNull(noDiscount.toProduct(link).discountRate)
     }

--- a/src/test/kotlin/com/depromeet/team3/product/service/gemini/GeminiProductExtractorTest.kt
+++ b/src/test/kotlin/com/depromeet/team3/product/service/gemini/GeminiProductExtractorTest.kt
@@ -17,7 +17,6 @@ import kotlin.test.assertNotNull
  */
 @Disabled("실제 Gemini API 호출. 검증 필요 시 수동으로 enable 후 실행.")
 class GeminiProductExtractorTest : IntegrationTestSupport() {
-
     @Autowired
     lateinit var extractor: GeminiProductExtractor
 

--- a/src/test/kotlin/com/depromeet/team3/support/IntegrationContainers.kt
+++ b/src/test/kotlin/com/depromeet/team3/support/IntegrationContainers.kt
@@ -12,13 +12,13 @@ import org.testcontainers.junit.jupiter.Container
 // @ImportTestcontainers 의 reflection scan 이 컨테이너를 발견하지 못한다.
 // Kotlin object 의 @JvmStatic val 은 진짜 static field 로 노출되어 정상 동작한다.
 object IntegrationContainers {
-
     @Container
     @ServiceConnection
     @JvmStatic
-    val MYSQL: MySQLContainer<*> = MySQLContainer("mysql:8.4").apply {
-        withDatabaseName("team3")
-        withUsername("team3")
-        withPassword("team3")
-    }
+    val MYSQL: MySQLContainer<*> =
+        MySQLContainer("mysql:8.4").apply {
+            withDatabaseName("team3")
+            withUsername("team3")
+            withPassword("team3")
+        }
 }

--- a/src/test/kotlin/com/depromeet/team3/support/IntegrationStubs.kt
+++ b/src/test/kotlin/com/depromeet/team3/support/IntegrationStubs.kt
@@ -2,6 +2,7 @@ package com.depromeet.team3.support
 
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Primary
 
 // 통합 테스트의 외부 호출 stub 빈을 한 곳에 모은다.
 // IntegrationTestSupport 가 import 하므로 모든 통합 테스트가 같은 컨텍스트를 공유한다.
@@ -9,5 +10,6 @@ import org.springframework.context.annotation.Bean
 @TestConfiguration(proxyBeanMethods = false)
 class IntegrationStubs {
     @Bean
+    @Primary
     fun productExtractor(): StubProductExtractor = StubProductExtractor()
 }

--- a/src/test/kotlin/com/depromeet/team3/support/StubProductExtractor.kt
+++ b/src/test/kotlin/com/depromeet/team3/support/StubProductExtractor.kt
@@ -14,5 +14,6 @@ class StubProductExtractor : ProductExtractor {
     var build: (ProductLink) -> Product = {
         error("stub.build 를 테스트 본문에서 명시 세팅해야 한다. CLAUDE.md '테스트 셋업 원칙' 참고.")
     }
+
     override fun extract(link: ProductLink): Product = build(link)
 }

--- a/src/test/kotlin/com/depromeet/team3/tournament/controller/TournamentControllerTest.kt
+++ b/src/test/kotlin/com/depromeet/team3/tournament/controller/TournamentControllerTest.kt
@@ -1,13 +1,13 @@
 package com.depromeet.team3.tournament.controller
 
 import com.depromeet.team3.tournament.service.TournamentService
+import com.depromeet.team3.tournament.service.dto.RecordMatch
+import com.depromeet.team3.tournament.service.dto.StartTournament
 import com.depromeet.team3.tournament.service.dto.TournamentHistoryInfo
 import com.depromeet.team3.tournament.service.dto.TournamentInfo
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import com.depromeet.team3.tournament.service.dto.RecordMatch
-import com.depromeet.team3.tournament.service.dto.StartTournament
 import org.mockito.BDDMockito.given
 import org.mockito.BDDMockito.then
 import org.mockito.InjectMocks
@@ -24,7 +24,6 @@ import java.util.UUID
 
 @ExtendWith(MockitoExtension::class)
 class TournamentControllerTest {
-
     @Mock
     private lateinit var tournamentService: TournamentService
 
@@ -44,64 +43,67 @@ class TournamentControllerTest {
     fun `POST tournaments 는 생성된 tournamentId 를 반환하고 201 을 응답한다`() {
         given(tournamentService.start(userId, StartTournament("테스트 토너먼트", 8, (1L..8L).toList()))).willReturn(1L)
 
-        mockMvc.perform(
-            post("/api/v1/tournaments")
-                .header("X-User-Id", userId.toString())
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(
-                    """{"name":"테스트 토너먼트","round":8,"wishItemIds":[1,2,3,4,5,6,7,8]}""",
-                ),
-        )
-            .andExpect(status().isCreated)
+        mockMvc
+            .perform(
+                post("/api/v1/tournaments")
+                    .header("X-User-Id", userId.toString())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """{"name":"테스트 토너먼트","round":8,"wishItemIds":[1,2,3,4,5,6,7,8]}""",
+                    ),
+            ).andExpect(status().isCreated)
             .andExpect(jsonPath("$.data.tournamentId").value(1))
             .andExpect(jsonPath("$.status").value(201))
     }
 
     @Test
     fun `POST tournaments tournamentId matches 는 매치를 기록하고 200 을 응답한다`() {
-        val expectedRecordMatch = RecordMatch(
-            tournamentId = 1L,
-            currentRound = 4,
-            firstWishItemId = 10L,
-            secondWishItemId = 20L,
-            winnerWishItemId = 10L,
-        )
+        val expectedRecordMatch =
+            RecordMatch(
+                tournamentId = 1L,
+                currentRound = 4,
+                firstWishItemId = 10L,
+                secondWishItemId = 20L,
+                winnerWishItemId = 10L,
+            )
 
-        mockMvc.perform(
-            post("/api/v1/tournaments/1/matches")
-                .header("X-User-Id", userId.toString())
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(
-                    """{"currentRound":4,"firstWishItemId":10,"secondWishItemId":20,"winnerWishItemId":10}""",
-                ),
-        )
-            .andExpect(status().isOk)
+        mockMvc
+            .perform(
+                post("/api/v1/tournaments/1/matches")
+                    .header("X-User-Id", userId.toString())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """{"currentRound":4,"firstWishItemId":10,"secondWishItemId":20,"winnerWishItemId":10}""",
+                    ),
+            ).andExpect(status().isOk)
 
         then(tournamentService).should().recordMatch(userId, expectedRecordMatch)
     }
 
     @Test
     fun `GET tournaments id 는 토너먼트 정보를 반환한다`() {
-        val tournamentInfo = TournamentInfo(
-            tournamentId = 1L,
-            round = 4,
-            finalWinnerWishItemId = 10L,
-            history = listOf(
-                TournamentHistoryInfo(
-                    currentRound = 2,
-                    firstWishItemId = 10L,
-                    secondWishItemId = 20L,
-                    winnerWishItemId = 10L,
-                ),
-            ),
-        )
+        val tournamentInfo =
+            TournamentInfo(
+                tournamentId = 1L,
+                round = 4,
+                finalWinnerWishItemId = 10L,
+                history =
+                    listOf(
+                        TournamentHistoryInfo(
+                            currentRound = 2,
+                            firstWishItemId = 10L,
+                            secondWishItemId = 20L,
+                            winnerWishItemId = 10L,
+                        ),
+                    ),
+            )
         given(tournamentService.getTournamentById(1L, userId)).willReturn(tournamentInfo)
 
-        mockMvc.perform(
-            get("/api/v1/tournaments/1")
-                .header("X-User-Id", userId.toString()),
-        )
-            .andExpect(status().isOk)
+        mockMvc
+            .perform(
+                get("/api/v1/tournaments/1")
+                    .header("X-User-Id", userId.toString()),
+            ).andExpect(status().isOk)
             .andExpect(jsonPath("$.data.tournamentId").value(1))
             .andExpect(jsonPath("$.data.round").value(4))
             .andExpect(jsonPath("$.data.finalWinnerWishItemId").value(10))

--- a/src/test/kotlin/com/depromeet/team3/tournament/service/TournamentServiceTest.kt
+++ b/src/test/kotlin/com/depromeet/team3/tournament/service/TournamentServiceTest.kt
@@ -18,14 +18,20 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 
 class TournamentServiceTest {
-
     private class TestWishRepository(
         private val allOwned: Boolean = true,
     ) : WishRepository {
         override fun save(wish: Wish): Wish = wish
-        override fun existsByGuestIdAndProductLink(guestId: UUID, link: ProductLink): Boolean = false
-        override fun countByIdsAndGuestId(ids: List<Long>, guestId: UUID): Long =
-            if (allOwned) ids.size.toLong() else 0L
+
+        override fun existsByGuestIdAndProductLink(
+            guestId: UUID,
+            link: ProductLink,
+        ): Boolean = false
+
+        override fun countByIdsAndGuestId(
+            ids: List<Long>,
+            guestId: UUID,
+        ): Long = if (allOwned) ids.size.toLong() else 0L
     }
 
     private class TestTournamentRepository : TournamentRepository {
@@ -49,7 +55,10 @@ class TournamentServiceTest {
         override fun findTournamentHistoriesByTournamentId(tournamentId: Long): List<TournamentHistory> =
             histories.filter { it.tournamentId == tournamentId }
 
-        private fun setId(tournament: Tournament, id: Long) {
+        private fun setId(
+            tournament: Tournament,
+            id: Long,
+        ) {
             val field = LongBaseEntity::class.java.getDeclaredField("id")
             field.isAccessible = true
             field.set(tournament, id)
@@ -73,13 +82,14 @@ class TournamentServiceTest {
     @Test
     fun `recordMatch 는 히스토리를 저장한다`() {
         val tournamentId = service.start(userId, StartTournament("토너먼트", round = 8, wishItemIds = (1L..8L).toList()))
-        val match = RecordMatch(
-            tournamentId = tournamentId,
-            currentRound = 4,
-            firstWishItemId = 1L,
-            secondWishItemId = 2L,
-            winnerWishItemId = 1L,
-        )
+        val match =
+            RecordMatch(
+                tournamentId = tournamentId,
+                currentRound = 4,
+                firstWishItemId = 1L,
+                secondWishItemId = 2L,
+                winnerWishItemId = 1L,
+            )
 
         service.recordMatch(userId, match)
 
@@ -90,13 +100,14 @@ class TournamentServiceTest {
     @Test
     fun `recordMatch 에서 currentRound 가 2 면 토너먼트가 COMPLETED 로 완료된다`() {
         val tournamentId = service.start(userId, StartTournament("결승 토너먼트", round = 2, wishItemIds = listOf(10L, 20L)))
-        val finalMatch = RecordMatch(
-            tournamentId = tournamentId,
-            currentRound = 2,
-            firstWishItemId = 10L,
-            secondWishItemId = 20L,
-            winnerWishItemId = 10L,
-        )
+        val finalMatch =
+            RecordMatch(
+                tournamentId = tournamentId,
+                currentRound = 2,
+                firstWishItemId = 10L,
+                secondWishItemId = 20L,
+                winnerWishItemId = 10L,
+            )
 
         service.recordMatch(userId, finalMatch)
 
@@ -107,13 +118,14 @@ class TournamentServiceTest {
 
     @Test
     fun `recordMatch 에서 존재하지 않는 tournamentId 면 예외가 발생한다`() {
-        val match = RecordMatch(
-            tournamentId = 999L,
-            currentRound = 2,
-            firstWishItemId = 1L,
-            secondWishItemId = 2L,
-            winnerWishItemId = 1L,
-        )
+        val match =
+            RecordMatch(
+                tournamentId = 999L,
+                currentRound = 2,
+                firstWishItemId = 1L,
+                secondWishItemId = 2L,
+                winnerWishItemId = 1L,
+            )
 
         assertFailsWith<TournamentException> {
             service.recordMatch(userId, match)
@@ -123,13 +135,14 @@ class TournamentServiceTest {
     @Test
     fun `recordMatch 에서 다른 사용자의 토너먼트면 예외가 발생한다`() {
         val tournamentId = service.start(userId, StartTournament("내 토너먼트", round = 4, wishItemIds = (1L..4L).toList()))
-        val match = RecordMatch(
-            tournamentId = tournamentId,
-            currentRound = 4,
-            firstWishItemId = 1L,
-            secondWishItemId = 2L,
-            winnerWishItemId = 1L,
-        )
+        val match =
+            RecordMatch(
+                tournamentId = tournamentId,
+                currentRound = 4,
+                firstWishItemId = 1L,
+                secondWishItemId = 2L,
+                winnerWishItemId = 1L,
+            )
 
         assertFailsWith<TournamentException> {
             service.recordMatch(otherUserId, match)
@@ -139,13 +152,14 @@ class TournamentServiceTest {
     @Test
     fun `recordMatch 에서 승자가 대결 아이템이 아니면 예외가 발생한다`() {
         val tournamentId = service.start(userId, StartTournament("토너먼트", round = 4, wishItemIds = (1L..4L).toList()))
-        val match = RecordMatch(
-            tournamentId = tournamentId,
-            currentRound = 4,
-            firstWishItemId = 1L,
-            secondWishItemId = 2L,
-            winnerWishItemId = 99L,
-        )
+        val match =
+            RecordMatch(
+                tournamentId = tournamentId,
+                currentRound = 4,
+                firstWishItemId = 1L,
+                secondWishItemId = 2L,
+                winnerWishItemId = 99L,
+            )
 
         assertFailsWith<TournamentException> {
             service.recordMatch(userId, match)
@@ -155,13 +169,14 @@ class TournamentServiceTest {
     @Test
     fun `recordMatch 에서 이미 완료된 토너먼트면 예외가 발생한다`() {
         val tournamentId = service.start(userId, StartTournament("결승 토너먼트", round = 2, wishItemIds = listOf(10L, 20L)))
-        val finalMatch = RecordMatch(
-            tournamentId = tournamentId,
-            currentRound = 2,
-            firstWishItemId = 10L,
-            secondWishItemId = 20L,
-            winnerWishItemId = 10L,
-        )
+        val finalMatch =
+            RecordMatch(
+                tournamentId = tournamentId,
+                currentRound = 2,
+                firstWishItemId = 10L,
+                secondWishItemId = 20L,
+                winnerWishItemId = 10L,
+            )
         service.recordMatch(userId, finalMatch)
 
         assertFailsWith<TournamentException> {

--- a/src/test/kotlin/com/depromeet/team3/wishlist/controller/WishlistControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/team3/wishlist/controller/WishlistControllerIntegrationTest.kt
@@ -17,7 +17,6 @@ import java.util.UUID
 
 @Transactional
 class WishlistControllerIntegrationTest : IntegrationTestSupport() {
-
     @Autowired
     private lateinit var webApplicationContext: WebApplicationContext
 
@@ -44,12 +43,12 @@ class WishlistControllerIntegrationTest : IntegrationTestSupport() {
         }
         val body = objectMapper.writeValueAsString(mapOf("url" to url, "guestId" to guestId))
 
-        mockMvc.perform(
-            post("/api/v1/wishlists")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(body)
-        )
-            .andExpect(status().isCreated)
+        mockMvc
+            .perform(
+                post("/api/v1/wishlists")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(body),
+            ).andExpect(status().isCreated)
             .andExpect(jsonPath("$.status").value(201))
             .andExpect(jsonPath("$.code").value("CREATED"))
             .andExpect(jsonPath("$.data.wishId").isNumber)
@@ -69,18 +68,19 @@ class WishlistControllerIntegrationTest : IntegrationTestSupport() {
         stubExtractor.build = { Product(link = it, name = "기본 상품") }
         val body = objectMapper.writeValueAsString(mapOf("url" to url, "guestId" to guestId))
 
-        mockMvc.perform(
-            post("/api/v1/wishlists")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(body)
-        ).andExpect(status().isCreated)
+        mockMvc
+            .perform(
+                post("/api/v1/wishlists")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(body),
+            ).andExpect(status().isCreated)
 
-        mockMvc.perform(
-            post("/api/v1/wishlists")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(body)
-        )
-            .andExpect(status().isConflict)
+        mockMvc
+            .perform(
+                post("/api/v1/wishlists")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(body),
+            ).andExpect(status().isConflict)
             .andExpect(jsonPath("$.status").value(409))
             .andExpect(jsonPath("$.code").value("CONFLICT"))
             .andExpect(jsonPath("$.data").doesNotExist())
@@ -94,17 +94,19 @@ class WishlistControllerIntegrationTest : IntegrationTestSupport() {
         val firstBody = objectMapper.writeValueAsString(mapOf("url" to url, "guestId" to UUID.randomUUID()))
         val secondBody = objectMapper.writeValueAsString(mapOf("url" to url, "guestId" to UUID.randomUUID()))
 
-        mockMvc.perform(
-            post("/api/v1/wishlists")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(firstBody)
-        ).andExpect(status().isCreated)
+        mockMvc
+            .perform(
+                post("/api/v1/wishlists")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(firstBody),
+            ).andExpect(status().isCreated)
 
-        mockMvc.perform(
-            post("/api/v1/wishlists")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(secondBody)
-        ).andExpect(status().isCreated)
+        mockMvc
+            .perform(
+                post("/api/v1/wishlists")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(secondBody),
+            ).andExpect(status().isCreated)
     }
 
     @Test
@@ -112,10 +114,11 @@ class WishlistControllerIntegrationTest : IntegrationTestSupport() {
         val mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build()
         val body = objectMapper.writeValueAsString(mapOf("url" to "", "guestId" to UUID.randomUUID()))
 
-        mockMvc.perform(
-            post("/api/v1/wishlists")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(body)
-        ).andExpect(status().isBadRequest)
+        mockMvc
+            .perform(
+                post("/api/v1/wishlists")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(body),
+            ).andExpect(status().isBadRequest)
     }
 }

--- a/src/test/kotlin/com/depromeet/team3/wishlist/controller/WishlistRegisterConcurrencyIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/team3/wishlist/controller/WishlistRegisterConcurrencyIntegrationTest.kt
@@ -19,7 +19,6 @@ import kotlin.test.assertEquals
 // 일반 통합 테스트와 달리 @Transactional 을 사용하지 않는다 — 별도 트랜잭션 동시 진행이
 // race 시뮬레이션의 본질이다. 데이터 격리는 매 테스트가 새 UUID guestId 를 써서 보장한다.
 class WishlistRegisterConcurrencyIntegrationTest : IntegrationTestSupport() {
-
     @Autowired
     private lateinit var webApplicationContext: WebApplicationContext
 
@@ -43,17 +42,20 @@ class WishlistRegisterConcurrencyIntegrationTest : IntegrationTestSupport() {
         val executor = Executors.newFixedThreadPool(2)
         val workersReady = CountDownLatch(2)
         val start = CountDownLatch(1)
-        val futures = (0..1).map {
-            executor.submit<Int> {
-                workersReady.countDown()
-                start.await()
-                mockMvc.perform(
-                    post("/api/v1/wishlists")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(body)
-                ).andReturn().response.status
+        val futures =
+            (0..1).map {
+                executor.submit<Int> {
+                    workersReady.countDown()
+                    start.await()
+                    mockMvc
+                        .perform(
+                            post("/api/v1/wishlists")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(body),
+                        ).andReturn()
+                        .response.status
+                }
             }
-        }
         workersReady.await()
         start.countDown()
         val statuses = futures.map { it.get(10, TimeUnit.SECONDS) }.toSet()


### PR DESCRIPTION
## Situation
- dev 브랜치 push 시 테스트 통과 여부와 무관하게 즉시 배포가 시작되는 구조였음
- ktlint가 없어 코드 포맷 일관성을 보장할 수단이 없었음
- feat 브랜치를 staging에 올려 직접 테스트할 방법이 없었음
- Gradle·Actions 의존성 업데이트가 수동이었음

## Task
- CI가 통과한 코드만 배포되도록 흐름 재설계
- `./gradlew check` 한 번으로 컴파일·ktlint·테스트를 모두 검증
- feat 브랜치를 수동으로 staging에 올릴 수 있는 탈출구 마련

## Action

### CI (`ci.yml` 신규)
- `push: dev` 및 `pull_request: dev/main` 에서 `./gradlew check` 실행
- `concurrency: cancel-in-progress: true` 로 중복 CI 실행 방지
- `dorny/test-reporter` 로 테스트 결과를 Actions 화면에 노출

### Deploy 자동화 (`deploy.yml` 수정)
- 트리거를 `push: dev` → `workflow_run` 으로 전환 — CI 성공 후에만 배포
- Docker 이미지에 git SHA 태그 추가로 롤백 가능하게
- 배포 후 `/health` 폴링(5s × 12회 = 60s) 헬스체크 추가
- Slack 알림의 COMMIT_MSG jq 경로를 `workflow_run` 이벤트 구조에 맞게 수정 (`.workflow_run.head_commit.message`)

### 수동 Staging 배포 (`deploy-manual.yml` 신규)
- Actions 탭에서 브랜치 이름 입력 → staging EC2에 강제 배포
- 브랜치명 `/` → `-` 정규화로 Docker 태그 오염 방지 (`feat/123-login` → `staging-feat-123-login`)
- CI 성공 여부 체크 없이 동작 (의도적 — feat 브랜치는 CI 없이 올려야 할 때가 있음)

### 코드 품질
- ktlint 1.4.1 도입 (`build.gradle.kts`) — Kotlin 2.3.x 호환 버전 명시 필요
- `./gradlew check`에 ktlint 자동 포함되어 PR마다 포맷 검증
- 기존 전체 소스 `ktlintFormat` 일괄 적용

### 의존성 관리
- `dependabot.yml` 신규: GitHub Actions·Gradle 주간 자동 업데이트

## Result
- CI 통과 코드만 dev EC2에 배포됨
- Gradle 캐시로 CI 속도 단축
- 코드 포맷 위반 시 PR 단계에서 차단
- main → prod EC2 연결은 prod EC2 생성 후 별도 PR로 완성 예정

---
## 연관 이슈

- close #90

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **자동화 및 인프라**
  * 지속적 통합/배포 워크플로우 추가로 자동화된 빌드 및 배포 프로세스 구축
  * 의존성 자동 업데이트 정책 적용

* **안정성 개선**
  * 헬스 체크 메커니즘 강화
  * 예외 처리 및 오류 복구 로직 최적화

* **코드 품질**
  * 코드 포맷팅 및 일관성 개선
  * 테스트 커버리지 및 자동화 강화

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/PIKI-Server/pull/91)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->