### PR TITLE
CI/CD 파이프라인 구성 및 ktlint 도입

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      pull-requests: read
+    outputs:
+      kotlin: ${{ steps.filter.outputs.kotlin }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            kotlin:
+              - '**/*.kt'
+
   build:
     runs-on: ubuntu-latest
     permissions:
@@ -40,8 +55,9 @@ jobs:
         run: ./gradlew assemble --no-daemon
 
   test:
+    needs: changes
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && startsWith(github.head_ref, 'feat/')
+    if: github.event_name == 'pull_request' && needs.changes.outputs.kotlin == 'true'
     permissions:
       contents: read
       checks: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,78 @@
+name: CI
+
+on:
+  push:
+    branches: [dev]
+  pull_request:
+    types: [opened, synchronize]
+    branches: [dev, main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle.kts', '**/gradle-wrapper.properties') }}
+          restore-keys: gradle-${{ runner.os }}-
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build
+        run: ./gradlew assemble --no-daemon
+
+  test:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && startsWith(github.head_ref, 'feat/')
+    permissions:
+      contents: read
+      checks: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle.kts', '**/gradle-wrapper.properties') }}
+          restore-keys: gradle-${{ runner.os }}-
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Test
+        run: ./gradlew test --no-daemon
+
+      - name: Report test results
+        if: always()
+        uses: dorny/test-reporter@v1
+        with:
+          name: Test Results
+          path: build/test-results/**/*.xml
+          reporter: java-junit
+          fail-on-error: false

--- a/.github/workflows/deploy-manual.yml
+++ b/.github/workflows/deploy-manual.yml
@@ -8,6 +8,10 @@ on:
         required: true
         default: 'dev'
 
+concurrency:
+  group: deploy-staging
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-manual.yml
+++ b/.github/workflows/deploy-manual.yml
@@ -111,6 +111,7 @@ jobs:
 
       - name: Notify Slack on success
         if: success()
+        continue-on-error: true
         shell: bash
         run: |
           SLACK_USER_MAP='{"m-a-king":"U0AKAEF2K9U","1o18z":"U0AKQ6G8BT3","sevineleven":"U0AK6U2J62F"}'
@@ -132,6 +133,7 @@ jobs:
 
       - name: Notify Slack on failure
         if: failure()
+        continue-on-error: true
         shell: bash
         run: |
           SLACK_USER_MAP='{"m-a-king":"U0AKAEF2K9U","1o18z":"U0AKQ6G8BT3","sevineleven":"U0AK6U2J62F"}'

--- a/.github/workflows/deploy-manual.yml
+++ b/.github/workflows/deploy-manual.yml
@@ -1,16 +1,16 @@
-name: Deploy to EC2
+name: Deploy to Staging (Manual)
 
 on:
-  workflow_run:
-    workflows: [CI]
-    branches: [dev]
-    types: [completed]
   workflow_dispatch:
+    inputs:
+      branch:
+        description: '배포할 브랜치'
+        required: true
+        default: 'dev'
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     permissions:
       contents: read
 
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          ref: ${{ github.event.inputs.branch }}
 
       - name: Set up JDK 25
         uses: actions/setup-java@v4
@@ -52,6 +52,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Sanitize branch name for Docker tag
+        id: tag
+        run: echo "value=staging-$(echo '${{ github.event.inputs.branch }}' | tr '/' '-')" >> $GITHUB_OUTPUT
+
       - name: Build and push Docker image
         id: docker_push
         uses: docker/build-push-action@v6
@@ -60,11 +64,9 @@ jobs:
           file: Dockerfile.ci
           push: true
           platforms: linux/arm64
-          tags: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/team3-server:latest
-            ${{ secrets.DOCKERHUB_USERNAME }}/team3-server:${{ github.event.workflow_run.head_sha || github.sha }}
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/team3-server:${{ steps.tag.outputs.value }}
 
-      - name: Deploy to EC2
+      - name: Deploy to Staging EC2
         id: deploy
         uses: appleboy/ssh-action@v1
         with:
@@ -72,7 +74,7 @@ jobs:
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
-            IMAGE="${{ secrets.DOCKERHUB_USERNAME }}/team3-server:${{ github.event.workflow_run.head_sha || github.sha }}"
+            IMAGE="${{ secrets.DOCKERHUB_USERNAME }}/team3-server:${{ steps.tag.outputs.value }}"
             docker pull "$IMAGE"
             docker stop team3-server || true
             docker rm team3-server || true
@@ -117,14 +119,10 @@ jobs:
           ACTOR_MENTION="${SLACK_ID:+<@$SLACK_ID>}"
           ACTOR_MENTION="${ACTOR_MENTION:-$ACTOR}"
 
-          SHORT_SHA="${{ github.event.workflow_run.head_sha || github.sha }}"
-          SHORT_SHA="${SHORT_SHA:0:7}"
-          COMMIT_URL="https://github.com/${{ github.repository }}/commit/${{ github.event.workflow_run.head_sha || github.sha }}"
-          COMMIT_MSG=$(jq -r '(.workflow_run.head_commit.message // .head_commit.message // "")' "$GITHUB_EVENT_PATH" | head -n 1)
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
-          TEXT=$(printf '✅ `${{ github.ref_name }}` 배포 성공!  ✅\n• 배포자: %s\n• 커밋: <%s|%s>  %s\n• <%s|워크플로우 로그>' \
-            "$ACTOR_MENTION" "$COMMIT_URL" "$SHORT_SHA" "$COMMIT_MSG" "$RUN_URL")
+          TEXT=$(printf '✅ `${{ github.event.inputs.branch }}` → staging 배포 성공! ✅\n• 배포자: %s\n• <%s|워크플로우 로그>' \
+            "$ACTOR_MENTION" "$RUN_URL")
 
           curl -s -X POST https://slack.com/api/chat.postMessage \
             -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
@@ -142,10 +140,6 @@ jobs:
           ACTOR_MENTION="${SLACK_ID:+<@$SLACK_ID>}"
           ACTOR_MENTION="${ACTOR_MENTION:-$ACTOR}"
 
-          SHORT_SHA="${{ github.event.workflow_run.head_sha || github.sha }}"
-          SHORT_SHA="${SHORT_SHA:0:7}"
-          COMMIT_URL="https://github.com/${{ github.repository }}/commit/${{ github.event.workflow_run.head_sha || github.sha }}"
-          COMMIT_MSG=$(jq -r '(.workflow_run.head_commit.message // .head_commit.message // "")' "$GITHUB_EVENT_PATH" | head -n 1)
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
           if [ "${{ steps.build.outcome }}" = "failure" ]; then
@@ -162,8 +156,8 @@ jobs:
             CAUSE="알 수 없음 (환경 설정 단계)"
           fi
 
-          TEXT=$(printf '❌ `${{ github.ref_name }}` 배포 실패! ❌\n• 배포자: %s\n• 커밋: <%s|%s>  %s\n• 원인: %s\n• <%s|워크플로우 로그 확인>' \
-            "$ACTOR_MENTION" "$COMMIT_URL" "$SHORT_SHA" "$COMMIT_MSG" "$CAUSE" "$RUN_URL")
+          TEXT=$(printf '❌ `${{ github.event.inputs.branch }}` → staging 배포 실패! ❌\n• 배포자: %s\n• 원인: %s\n• <%s|워크플로우 로그 확인>' \
+            "$ACTOR_MENTION" "$CAUSE" "$RUN_URL")
 
           curl -s -X POST https://slack.com/api/chat.postMessage \
             -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,9 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push')
     permissions:
       contents: read
 
@@ -109,6 +111,7 @@ jobs:
 
       - name: Notify Slack on success
         if: success()
+        continue-on-error: true
         shell: bash
         run: |
           SLACK_USER_MAP='{"m-a-king":"U0AKAEF2K9U","1o18z":"U0AKQ6G8BT3","sevineleven":"U0AK6U2J62F"}'
@@ -134,6 +137,7 @@ jobs:
 
       - name: Notify Slack on failure
         if: failure()
+        continue-on-error: true
         shell: bash
         run: |
           SLACK_USER_MAP='{"m-a-king":"U0AKAEF2K9U","1o18z":"U0AKQ6G8BT3","sevineleven":"U0AK6U2J62F"}'

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,11 @@ plugins {
 	kotlin("plugin.jpa") version "2.3.20"
 	id("org.springframework.boot") version "4.0.5"
 	id("io.spring.dependency-management") version "1.1.7"
+	id("org.jlleitschuh.gradle.ktlint") version "12.1.2"
+}
+
+ktlint {
+	version.set("1.4.1")
 }
 
 group = "com.depromeet"


### PR DESCRIPTION
## Situation
- dev 브랜치 push 시 테스트 통과 여부와 무관하게 즉시 배포가 시작되는 구조였음
- ktlint가 없어 코드 포맷 일관성을 보장할 수단이 없었음
- feat 브랜치를 staging에 올려 직접 테스트할 방법이 없었음
- Gradle·Actions 의존성 업데이트가 수동이었음

## Task
- CI가 통과한 코드만 배포되도록 흐름 재설계
- feat → dev PR에서만 테스트 실행, 그 외는 빌드(컴파일)만으로 빠른 피드백
- feat 브랜치를 수동으로 staging에 올릴 수 있는 탈출구 마련

## Action

### CI (ci.yml 신규)
- `push: dev` 및 `pull_request: dev/main`에서 `./gradlew assemble` 빌드 실행
- `feat/*` → `dev` PR에서만 `./gradlew test` 추가 실행 + dorny/test-reporter로 결과 노출
- `concurrency: cancel-in-progress: true`로 중복 CI 실행 방지

### Deploy 자동화 (deploy.yml 수정)
- 트리거를 `push: dev` → `workflow_run`으로 전환 — CI 성공 후에만 배포
- Docker 이미지에 git SHA 태그 추가로 롤백 가능하게
- 배포 후 `/health` 폴링(5s × 12회 = 60s) 헬스체크 추가
- Slack 알림의 COMMIT_MSG jq 경로를 `workflow_run` 이벤트 구조에 맞게 수정

### 수동 Staging 배포 (deploy-manual.yml 신규)
- Actions 탭에서 브랜치 이름 입력 → staging EC2에 강제 배포
- 브랜치명 `/` → `-` 정규화로 Docker 태그 오염 방지 (`feat/123-login` → `staging-feat-123-login`)
- CI 성공 여부 체크 없이 동작 (의도적 — feat 브랜치는 CI 없이 올려야 할 때가 있음)

### 코드 품질 및 의존성
- ktlint 1.4.1 도입 — Kotlin 2.3.x 호환 버전 명시 필요
- dependabot: GitHub Actions·Gradle 주간 자동 업데이트

## Result
- dev 머지 후 CI 통과 시에만 배포 트리거 → 깨진 빌드가 프로덕션에 나가는 사고 차단
- feat → dev PR마다 자동 테스트로 회귀 조기 감지
- staging 수동 배포로 feat 브랜치 직접 검증 가능

---
## 연관 이슈

- close #90

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 자동화된 주간 의존성 업데이트 확인 구성 추가
  * 풀 요청 시 자동 테스트 및 빌드 파이프라인 설정
  * 커밋 SHA 태깅 및 헬스 체크를 포함한 자동 배포 워크플로우 개선
  * 수동 스테이징 배포 옵션 추가
  * 코드 품질 린팅 도구(ktlint 1.4.1) 통합

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/PIKI-Server/pull/92)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
