### PR TITLE
dependabot PR 노이즈 방지

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,16 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns: ["*"]
 
   - package-ecosystem: "gradle"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    groups:
+      gradle-deps:
+        patterns: ["*"]


### PR DESCRIPTION
## Situation
- dependabot 설정에 groups 없이 도입했더니 첫 실행에서 의존성별 PR이 한꺼번에 대량 생성됨 (#94~#103)
- GitHub Actions 업데이트, Gradle 업데이트가 각각 별도 PR로 열려 노이즈 발생

## Task
- 의존성 업데이트 PR을 생태계별로 묶어 관리 부담 최소화

## Action
- `dependabot.yml`에 `groups` 설정 추가
  - `github-actions` 업데이트 → PR 1개로 묶음
  - `gradle` 의존성 업데이트 → PR 1개로 묶음

## Result
- 다음 실행부터 GitHub Actions PR 1개 + Gradle PR 1개로 정리됨
- 현재 열린 #94~#103은 수동으로 닫거나 머지 필요
  - testcontainers 메이저 버전 업 PR은 별도 검토 권장

---
## 연관 이슈

- 