### PR TITLE
Jackson ObjectMapper 임포트 수정 및 배포 로그 보관 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,6 +77,9 @@ jobs:
             IMAGE="${{ secrets.DOCKERHUB_USERNAME }}/team3-server:${{ github.event.workflow_run.head_sha || github.sha }}"
             docker pull "$IMAGE"
             docker stop team3-server || true
+            mkdir -p /var/log/team3
+            docker logs team3-server > /var/log/team3/team3-$(date +%Y%m%d-%H%M%S).log 2>&1 || true
+            find /var/log/team3 -name "*.log" -mtime +7 -delete || true
             docker rm team3-server || true
             docker run -d \
               --name team3-server \

--- a/src/main/kotlin/com/depromeet/team3/common/openapi/OpenApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/team3/common/openapi/OpenApiExamples.kt
@@ -1,12 +1,12 @@
 package com.depromeet.team3.common.openapi
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import io.swagger.v3.oas.models.Operation
 import io.swagger.v3.oas.models.examples.Example
 import io.swagger.v3.oas.models.media.Content
 import io.swagger.v3.oas.models.media.MediaType
 import org.springframework.http.HttpStatus
 import org.springframework.web.method.HandlerMethod
+import tools.jackson.databind.ObjectMapper
 import kotlin.reflect.KFunction
 import kotlin.reflect.jvm.javaMethod
 import org.springframework.http.MediaType as SpringMediaType

--- a/src/main/kotlin/com/depromeet/team3/common/openapi/OpenApiObjectMapper.kt
+++ b/src/main/kotlin/com/depromeet/team3/common/openapi/OpenApiObjectMapper.kt
@@ -1,8 +1,8 @@
 package com.depromeet.team3.common.openapi
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import tools.jackson.databind.ObjectMapper
 
 class OpenApiObjectMapper(val delegate: ObjectMapper)
 


### PR DESCRIPTION
## Situation
- 5/5 PR #72에서 `OpenApiObjectMapper`가 추가될 때 `import com.fasterxml.jackson.databind.ObjectMapper` 사용 — Jackson 2.x 패키지
- Spring Boot 4는 Jackson 3.x를 사용하며, Jackson 3.x에서 Maven groupId와 Java 패키지 모두 `com.fasterxml.jackson` → `tools.jackson`으로 이전됨
  - 참고: [Jackson 3.0 Release Notes](https://github.com/FasterXML/jackson/wiki/Jackson-Release-3.0) · [Migration Guide](https://github.com/FasterXML/jackson/blob/main/jackson3/MIGRATING_TO_JACKSON_3.md)
- 구 `deploy.yml`에 헬스체크가 없어 앱 크래시가 감지되지 않았고, 5/5 이후 서버가 계속 죽어있었음
- 오늘 헬스체크가 붙은 새 deploy.yml 배포 후 비로소 502 확인 → EC2 SSH로 `docker logs` 검증

```
APPLICATION FAILED TO START
Parameter 0 of method openApiObjectMapper ... required a bean of type
'com.fasterxml.jackson.databind.ObjectMapper' that could not be found.
```

## Task
- Spring Boot 4 환경에서 앱이 정상 기동되도록 Jackson 임포트 수정
- 다음 배포 크래시 시 원인 추적이 가능하도록 컨테이너 로그 보관

## Action
- `OpenApiObjectMapper.kt`, `OpenApiExamples.kt`: `com.fasterxml.jackson.databind.ObjectMapper` → `tools.jackson.databind.ObjectMapper`
- `deploy.yml`: `docker rm` 전에 `/var/log/team3/team3-{날짜}.log`로 로그 저장, 7일 초과 파일 자동 삭제

## Result
- 이 PR 머지 후 deploy가 트리거되면 서버 정상 기동 예상
- 이후 배포 시 이전 컨테이너 로그가 EC2 `/var/log/team3/`에 7일간 보관됨

---
## 연관 이슈

- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * EC2 배포 프로세스에 로그 관리 기능 추가: 지속적인 로깅 디렉토리 생성, 타임스탬프가 지정된 로그 파일에 컨테이너 로그 저장, 7일 이상 된 로그 파일 자동 삭제

* **Refactor**
  * 내부 라이브러리 의존성 업데이트로 시스템 안정성 개선

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/PIKI-Server/pull/109)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->