### PR TITLE
.kts 파일 ktlint 검사 제외

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,9 @@ plugins {
 
 ktlint {
 	version.set("1.4.1")
+	filter {
+		exclude("*.kts")
+	}
 }
 
 group = "com.depromeet"


### PR DESCRIPTION
## Situation
- PR #109(ktlint 도입) 머지 후 동료 로컬에서 `ktlintKotlinScriptCheck` 실패
- `build.gradle.kts`가 Gradle 기본 탭 들여쓰기를 사용하는데 ktlint가 스페이스를 요구해서 발생

## Task
- `build.gradle.kts` 등 `.kts` 파일을 ktlint 검사 대상에서 제외

## Action
- `ktlint { filter { exclude("*.kts") } }` 추가
- `.kts`는 Gradle 빌드 스크립트로 프로덕션 Kotlin 코드가 아니므로 제외가 적절

## Result
- `ktlintKotlinScriptCheck` 실패 해소

---
## 연관 이슈

- 