### PR TITLE
chore:블루-그린 무중단 배포 구성

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,10 @@ on:
     types: [completed]
   workflow_dispatch:
 
+concurrency:
+  group: deploy-ec2-dev
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,18 +77,18 @@ jobs:
             IMAGE="${{ secrets.DOCKERHUB_USERNAME }}/team3-server:${{ github.event.workflow_run.head_sha || github.sha }}"
             docker pull "$IMAGE"
 
-            # 구버전 team3-server 컨테이너 마이그레이션 (최초 1회)
-            if docker ps --filter "name=team3-server" --filter "status=running" -q | grep -q .; then
-              echo "  MIGRATE : team3-server → blue-green 슬롯으로 전환"
-              docker stop team3-server || true
-              docker rm team3-server || true
-            fi
-
-            # 현재 active 슬롯 감지
-            if docker ps --filter "name=team3-blue" --filter "status=running" -q | grep -q .; then
-              ACTIVE="blue" ACTIVE_PORT=8080 INACTIVE="green" INACTIVE_PORT=8081
+            # team3-upstream.conf를 source of truth로 현재 서빙 포트 결정
+            # (없으면 8080 기본값 — team3-server가 8080에서 서비스 중인 초기 상태)
+            if [ -f /etc/nginx/team3-upstream.conf ]; then
+              ACTIVE_PORT=$(grep -oP '\d+' /etc/nginx/team3-upstream.conf | head -1)
             else
-              ACTIVE="green" ACTIVE_PORT=8081 INACTIVE="blue" INACTIVE_PORT=8080
+              ACTIVE_PORT=8080
+              echo "server localhost:8080;" | sudo tee /etc/nginx/team3-upstream.conf
+            fi
+            if [ "$ACTIVE_PORT" = "8080" ]; then
+              ACTIVE="blue" INACTIVE="green" INACTIVE_PORT=8081
+            else
+              ACTIVE="green" INACTIVE="blue" INACTIVE_PORT=8080
             fi
             echo "================================================"
             echo "  CURRENT : $ACTIVE (port $ACTIVE_PORT) [serving traffic]"
@@ -122,11 +122,12 @@ jobs:
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
-            # 비활성 슬롯 감지 (deploy 스텝과 반대)
-            if docker ps --filter "name=team3-blue" --filter "status=running" -q | grep -q .; then
-              ACTIVE="blue" ACTIVE_PORT=8080 INACTIVE="green" INACTIVE_PORT=8081
+            # team3-upstream.conf에서 현재 서빙 포트 읽기 (source of truth)
+            ACTIVE_PORT=$(grep -oP '\d+' /etc/nginx/team3-upstream.conf | head -1)
+            if [ "$ACTIVE_PORT" = "8080" ]; then
+              ACTIVE="blue" INACTIVE="green" INACTIVE_PORT=8081
             else
-              ACTIVE="green" ACTIVE_PORT=8081 INACTIVE="blue" INACTIVE_PORT=8080
+              ACTIVE="green" INACTIVE="blue" INACTIVE_PORT=8080
             fi
 
             # 새로 뜬 컨테이너(INACTIVE) 헬스체크
@@ -140,9 +141,9 @@ jobs:
                 echo "server localhost:$INACTIVE_PORT;" | sudo tee /etc/nginx/team3-upstream.conf
                 sudo nginx -s reload
                 echo "  SWITCHED : Nginx now → $INACTIVE (port $INACTIVE_PORT)"
-                # 구버전 종료
-                docker stop "team3-$ACTIVE" || true
-                docker rm "team3-$ACTIVE" || true
+                # 구버전 종료 (team3-server 마이그레이션 포함)
+                docker stop "team3-$ACTIVE" team3-server 2>/dev/null || true
+                docker rm "team3-$ACTIVE" team3-server 2>/dev/null || true
                 echo "  STOPPED  : $ACTIVE (port $ACTIVE_PORT)"
                 echo "================================================"
                 exit 0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,6 +77,13 @@ jobs:
             IMAGE="${{ secrets.DOCKERHUB_USERNAME }}/team3-server:${{ github.event.workflow_run.head_sha || github.sha }}"
             docker pull "$IMAGE"
 
+            # 구버전 team3-server 컨테이너 마이그레이션 (최초 1회)
+            if docker ps --filter "name=team3-server" --filter "status=running" -q | grep -q .; then
+              echo "  MIGRATE : team3-server → blue-green 슬롯으로 전환"
+              docker stop team3-server || true
+              docker rm team3-server || true
+            fi
+
             # 현재 active 슬롯 감지
             if docker ps --filter "name=team3-blue" --filter "status=running" -q | grep -q .; then
               ACTIVE="blue" ACTIVE_PORT=8080 INACTIVE="green" INACTIVE_PORT=8081

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,14 +76,29 @@ jobs:
           script: |
             IMAGE="${{ secrets.DOCKERHUB_USERNAME }}/team3-server:${{ github.event.workflow_run.head_sha || github.sha }}"
             docker pull "$IMAGE"
-            docker stop team3-server || true
+
+            # 현재 active 슬롯 감지
+            if docker ps --filter "name=team3-blue" --filter "status=running" -q | grep -q .; then
+              ACTIVE="blue" ACTIVE_PORT=8080 INACTIVE="green" INACTIVE_PORT=8081
+            else
+              ACTIVE="green" ACTIVE_PORT=8081 INACTIVE="blue" INACTIVE_PORT=8080
+            fi
+            echo "================================================"
+            echo "  CURRENT : $ACTIVE (port $ACTIVE_PORT) [serving traffic]"
+            echo "  DEPLOY  : $INACTIVE (port $INACTIVE_PORT) [new version]"
+            echo "================================================"
+
+            # 로그 백업 후 비활성 슬롯 정리
             mkdir -p /var/log/team3
-            docker logs team3-server > /var/log/team3/team3-$(date +%Y%m%d-%H%M%S).log 2>&1 || true
-            find /var/log/team3 -name "*.log" -mtime +7 -delete || true
-            docker rm team3-server || true
+            docker logs "team3-$INACTIVE" > /var/log/team3/team3-$INACTIVE-$(date +%Y%m%d-%H%M%S).log 2>&1 || true
+            find /var/log/team3 -name "team3-*.log" -mtime +7 -delete || true
+            docker stop "team3-$INACTIVE" || true
+            docker rm "team3-$INACTIVE" || true
+
+            # 새 버전 비활성 포트에 기동
             docker run -d \
-              --name team3-server \
-              -p 8080:8080 \
+              --name "team3-$INACTIVE" \
+              -p "$INACTIVE_PORT:8080" \
               -e GEMINI_API_KEY=${{ secrets.GEMINI_API_KEY }} \
               -e DB_HOST=${{ secrets.DB_HOST }} \
               -e DB_PORT=${{ secrets.DB_PORT }} \
@@ -92,7 +107,7 @@ jobs:
               -e DB_PASSWORD=${{ secrets.DB_PASSWORD }} \
               "$IMAGE"
 
-      - name: Health check
+      - name: Health check and switch
         id: health
         uses: appleboy/ssh-action@v1
         with:
@@ -100,16 +115,37 @@ jobs:
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
+            # 비활성 슬롯 감지 (deploy 스텝과 반대)
+            if docker ps --filter "name=team3-blue" --filter "status=running" -q | grep -q .; then
+              ACTIVE="blue" ACTIVE_PORT=8080 INACTIVE="green" INACTIVE_PORT=8081
+            else
+              ACTIVE="green" ACTIVE_PORT=8081 INACTIVE="blue" INACTIVE_PORT=8080
+            fi
+
+            # 새로 뜬 컨테이너(INACTIVE) 헬스체크
             for i in $(seq 1 12); do
-              STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/health || echo "000")
+              STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:$INACTIVE_PORT/health || echo "000")
               if [ "$STATUS" = "200" ]; then
-                echo "Health check passed (attempt $i)"
+                echo "================================================"
+                echo "  HEALTH CHECK PASSED on $INACTIVE (attempt $i)"
+                echo "================================================"
+                # Nginx upstream 전환
+                echo "server localhost:$INACTIVE_PORT;" | sudo tee /etc/nginx/team3-upstream.conf
+                sudo nginx -s reload
+                echo "  SWITCHED : Nginx now → $INACTIVE (port $INACTIVE_PORT)"
+                # 구버전 종료
+                docker stop "team3-$ACTIVE" || true
+                docker rm "team3-$ACTIVE" || true
+                echo "  STOPPED  : $ACTIVE (port $ACTIVE_PORT)"
+                echo "================================================"
                 exit 0
               fi
               echo "Attempt $i: status=$STATUS, retrying in 5s..."
               sleep 5
             done
-            echo "Health check failed after 60s"
+            echo "Health check failed — rolling back"
+            docker stop "team3-$INACTIVE" || true
+            docker rm "team3-$INACTIVE" || true
             exit 1
 
       - name: Notify Slack on success


### PR DESCRIPTION
## Situation
- 기존 배포는 `docker stop → docker rm → docker run` 순서로 컨테이너 교체 시 짧은 다운타임 발생
- EC2에 Nginx + Let's Encrypt가 이미 구성해놓았으므로 (`/etc/nginx/sites-enabled/api.depromeet18team3.cloud`), 블루-그린 전환 비용이 낮은 상황
- 인스턴스 추가 없이 단일 EC2에서 무중단 배포 가능한지 확인 → 가능

## Task
- 단일 EC2에서 인스턴스 비용 추가 없이 무중단 배포 구현
- 헬스체크 실패 시 자동 롤백

## Action
### Nginx 설정 (EC2에서 직접)
- `/etc/nginx/team3-upstream.conf` 생성 - 활성 포트를 한 줄로 관리
- Nginx config에 `upstream team3 { include team3-upstream.conf; }` 추가, `proxy_pass http://team3;`으로 변경

### deploy.yml
- blue(8080) / green(8081) 슬롯 감지 - `docker ps --filter name=team3-blue`로 active 판단
- 기존 `team3-server` 컨테이너가 남아있으면 최초 1회 마이그레이션 처리 (포트 충돌 방지)
- 비활성 슬롯에 새 버전 기동 → 헬스체크 통과 시 `team3-upstream.conf` 덮어쓰기 + `nginx -s reload` (graceful, 무중단)
- 헬스체크 실패 시 새 컨테이너 제거 후 `exit 1` (자동 롤백)
- Actions 로그에 현재/배포 슬롯 배너 출력으로 어느 슬롯인지 한눈에 확인 가능

## Result
- 배포 중 트래픽 중단 없음 - Nginx reload는 기존 커넥션을 graceful하게 처리
- 헬스체크 실패 시 구버전 유지 (자동 롤백)
- Actions 로그에서 `CURRENT / DEPLOY / SWITCHED / STOPPED` 배너로 슬롯 전환 흐름 추적 가능
- **테스트 방법**: 머지 후 Actions → Deploy to EC2 → Run workflow로 수동 트리거

---
## 연관 이슈

- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 배포 워크플로우를 개선하여 더욱 안정적인 배포 프로세스를 제공합니다.
  * 헬스 체크 검증 후에만 트래픽을 전환하므로 배포 중 서비스 중단을 최소화합니다.
  * 배포 실패 시 자동으로 이전 상태로 복구되어 서비스 신뢰성이 향상됩니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/PIKI-Server/pull/112)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Updates

### CodeRabbit 리뷰 대응 (3건)

- **슬롯 감지 방식 변경**: `docker ps` 기반 → `team3-upstream.conf` 파일 기반으로 변경. deploy step과 health check step 모두 동일한 source of truth를 참조해 일관성 확보 (기존 본문의 `docker ps` 설명은 구버전)
- **마이그레이션 순서 수정**: `team3-server` 컨테이너 종료 시점을 배포 전 → Nginx 전환 완료 후로 이동. 전환 전 종료 시 새 컨테이너 헬스체크 실패하면 구버전도 없는 완전 다운타임 위험 차단
- **동시 배포 방지**: workflow 레벨 `concurrency: group: deploy-ec2-dev, cancel-in-progress: false` 추가. 이전 배포 완료 전 새 트리거 시 대기 후 순차 실행
