### PR TITLE
t4g.micro OOM 방지 - 블루그린 배포 JVM 힙 제한

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -110,6 +110,7 @@ jobs:
             docker run -d \
               --name "team3-$INACTIVE" \
               -p "$INACTIVE_PORT:8080" \
+              -e JAVA_TOOL_OPTIONS="-Xmx256m -Xms64m" \
               -e GEMINI_API_KEY=${{ secrets.GEMINI_API_KEY }} \
               -e DB_HOST=${{ secrets.DB_HOST }} \
               -e DB_PORT=${{ secrets.DB_PORT }} \


### PR DESCRIPTION
## Situation
- 블루그린 배포 첫 실 테스트에서 EC2(t4g.micro, RAM 906MB)가 두 컨테이너 동시 기동으로 OOM 발생
- sshd까지 죽어 SSH 접근 불가 → AWS 콘솔 강제 중지/시작으로 복구

## Task
- t4g.micro 단일 인스턴스에서 블루그린 배포 시 OOM 재발 방지

## Action
- `docker run`에 `JAVA_TOOL_OPTIONS="-Xmx256m -Xms64m"` 추가
- `JAVA_OPTS` 대신 `JAVA_TOOL_OPTIONS` 선택 - Dockerfile entrypoint가 `java` 직접 실행이라 shell을 거치지 않아 `JAVA_OPTS`는 JVM에 전달되지 않음
- EC2 스왑 1GB 추가는 인스턴스에서 직접 처리 (안전망, 코드 변경 없음)

## Result
- 두 컨테이너 동시 기동 시 JVM 힙이 각 256MB로 제한되어 OOM 위험 해소
- 스왑까지 있으니 순간적인 메모리 초과도 흡수 가능
- 근본 해결은 t4g.small(2GB) 업그레이드이나 현재는 비용 절감 우선

---
## 연관 이슈

- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Docker 배포 프로세스의 Java 메모리 설정이 개선되었습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/PIKI-Server/pull/116)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->