### PR TITLE
배포 가시성 개선 및 CodeRabbit PR 제목 검증 비활성화

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -49,11 +49,7 @@ reviews:
 
   pre_merge_checks:
     title:
-      mode: warning
-      requirements: |
-        Conventional Commits 형식: <type>(선택 scope): <한 줄 요약>
-        type 예: feat, fix, chore, refactor, docs, test, ci, build 등.
-        콜론 뒤 요약은 명령형·짧게(대략 72자 이내 권장). 예: chore: PR 템플릿 STAR 구조로 변경
+      mode: off
     description:
       mode: warning
     issue_assessment:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -160,6 +160,56 @@ jobs:
             docker rm "team3-$INACTIVE" || true
             exit 1
 
+      - name: Write deployment summary
+        if: always()
+        continue-on-error: true
+        shell: bash
+        run: |
+          SHORT_SHA="${{ github.event.workflow_run.head_sha || github.sha }}"
+          SHORT_SHA="${SHORT_SHA:0:7}"
+          COMMIT_URL="https://github.com/${{ github.repository }}/commit/${{ github.event.workflow_run.head_sha || github.sha }}"
+
+          echo "${{ secrets.EC2_SSH_KEY }}" > /tmp/ec2_key && chmod 600 /tmp/ec2_key
+          ACTIVE_PORT=$(ssh -i /tmp/ec2_key -o StrictHostKeyChecking=no \
+            "${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }}" \
+            'grep -oP "\\d+" /etc/nginx/team3-upstream.conf 2>/dev/null | head -1' 2>/dev/null || echo "")
+          rm -f /tmp/ec2_key
+
+          if [ "$ACTIVE_PORT" = "8080" ]; then
+            NOW="🔵 blue (8080)"
+          elif [ "$ACTIVE_PORT" = "8081" ]; then
+            NOW="🟢 green (8081)"
+          else
+            NOW="알 수 없음"
+          fi
+
+          if [ "${{ steps.health.outcome }}" = "success" ]; then
+            STATUS="✅ 성공"
+          elif [ "${{ steps.health.outcome }}" = "failure" ]; then
+            STATUS="❌ 실패 (헬스체크)"
+          elif [ "${{ steps.deploy.outcome }}" = "failure" ]; then
+            STATUS="❌ 실패 (EC2 배포)"
+          elif [ "${{ steps.docker_push.outcome }}" = "failure" ]; then
+            STATUS="❌ 실패 (Docker 푸시)"
+          elif [ "${{ steps.build.outcome }}" = "failure" ]; then
+            STATUS="❌ 실패 (Gradle 빌드)"
+          else
+            STATUS="⚠️ 알 수 없음"
+          fi
+
+          {
+            echo "## 배포 결과: $STATUS"
+            echo ""
+            echo "| 항목 | 값 |"
+            echo "|------|-----|"
+            echo "| 커밋 | [\`$SHORT_SHA\`]($COMMIT_URL) |"
+            echo "| 현재 활성 슬롯 | $NOW |"
+            echo "| Gradle 빌드 | ${{ steps.build.outcome }} |"
+            echo "| Docker 푸시 | ${{ steps.docker_push.outcome }} |"
+            echo "| EC2 배포 | ${{ steps.deploy.outcome }} |"
+            echo "| 헬스체크 & 전환 | ${{ steps.health.outcome }} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Notify Slack on success
         if: success()
         continue-on-error: true


### PR DESCRIPTION
## Situation
- CodeRabbit `pre_merge_checks.title`에 Conventional Commits 형식(`<type>: 요약`) 검증이 warning으로 설정되어 있어 /pr 스킬 컨벤션(type prefix 없음)과 충돌

## Task
- 팀 PR 제목 컨벤션을 /pr 스킬 기준으로 통일

## Action
- `.coderabbit.yml` `pre_merge_checks.title.mode` 를 `warning` → `off` 로 변경

## Result
- CodeRabbit이 PR 제목에 type prefix 없다고 경고 안 띄움
- PR 제목 컨벤션은 /pr 스킬 규칙을 따름 (70자 이내, type prefix 없음)

---
## 연관 이슈

- 

## Updates

### Job Summary 추가

- 배포 후 Actions Summary 탭에서 현재 활성 슬롯(🔵 blue / 🟢 green)과 각 스텝 결과를 한눈에 확인 가능하게
- `if: always()`라 배포 실패 시에도 어느 단계에서 실패했는지 표시
- EC2에 SSH해 `team3-upstream.conf` 읽어 현재 활성 슬롯 확인 후 `$GITHUB_STEP_SUMMARY`에 마크다운 표로 출력
