### PR TITLE
ProductLink 파싱 검증을 도메인 예외로 분리

### DIFF
--- a/src/main/kotlin/com/depromeet/team3/product/domain/ProductLink.kt
+++ b/src/main/kotlin/com/depromeet/team3/product/domain/ProductLink.kt
@@ -23,16 +23,16 @@ class ProductLink private constructor(
 
         fun parse(raw: String): ProductLink {
             val trimmed = raw.trim()
-            require(trimmed.isNotBlank()) { "URL이 비어 있습니다." }
+            if (trimmed.isBlank()) throw ProductLinkException.blank()
             val uri =
                 try {
                     URI.create(trimmed)
                 } catch (e: IllegalArgumentException) {
-                    throw IllegalArgumentException("유효한 URL 형식이 아닙니다: $trimmed", e)
+                    throw ProductLinkException.invalidFormat(e)
                 }
             // URI.create 는 스킴 없는 "example.com/product" 도 relative URI 로 통과시키므로 명시 검증.
             // RFC 3986 은 scheme 을 case-insensitive 로 정의하므로 비교 전에 lowercase 정규화한다.
-            require(uri.scheme?.lowercase() in HTTP_SCHEMES) { "https URL만 허용합니다." }
+            if (uri.scheme?.lowercase() !in HTTP_SCHEMES) throw ProductLinkException.unsupportedScheme()
             return ProductLink(uri)
         }
     }

--- a/src/main/kotlin/com/depromeet/team3/product/domain/ProductLinkException.kt
+++ b/src/main/kotlin/com/depromeet/team3/product/domain/ProductLinkException.kt
@@ -1,0 +1,41 @@
+package com.depromeet.team3.product.domain
+
+import com.depromeet.team3.common.exception.BaseException
+import com.depromeet.team3.common.exception.ErrorCategory
+import com.depromeet.team3.common.exception.HttpMappable
+import org.springframework.http.HttpStatus
+
+class ProductLinkException private constructor(
+    message: String,
+    override val category: ErrorCategory,
+    override val httpStatus: HttpStatus,
+    cause: Throwable? = null,
+) : BaseException(message, cause),
+    HttpMappable {
+    companion object {
+        fun blank(): ProductLinkException =
+            ProductLinkException(
+                "URL이 비어 있습니다.",
+                ErrorCategory.INVALID_INPUT,
+                HttpStatus.BAD_REQUEST,
+            )
+
+        // 원본 URL 은 message 에 박지 않는다. GlobalExceptionHandler 가 message 를 응답 detail·로그
+        // 양쪽에 박는 구조라, 쿼리스트링/fragment 에 섞일 수 있는 토큰·세션이 외부로 새는 경로가 되기 때문.
+        // 디버깅용 컨텍스트는 cause 로 연결해 stack trace 로만 남긴다.
+        fun invalidFormat(cause: Throwable): ProductLinkException =
+            ProductLinkException(
+                "유효한 URL 형식이 아닙니다.",
+                ErrorCategory.INVALID_INPUT,
+                HttpStatus.BAD_REQUEST,
+                cause,
+            )
+
+        fun unsupportedScheme(): ProductLinkException =
+            ProductLinkException(
+                "https URL만 허용합니다.",
+                ErrorCategory.INVALID_INPUT,
+                HttpStatus.BAD_REQUEST,
+            )
+    }
+}

--- a/src/test/kotlin/com/depromeet/team3/product/domain/ProductLinkTest.kt
+++ b/src/test/kotlin/com/depromeet/team3/product/domain/ProductLinkTest.kt
@@ -3,7 +3,6 @@ package com.depromeet.team3.product.domain
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
-import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class ProductLinkTest {
@@ -44,7 +43,7 @@ class ProductLinkTest {
             assertFailsWith<ProductLinkException> {
                 ProductLink.parse("data:text/html,<h1>x</h1>")
             }
-        assertTrue(ex.message?.startsWith("유효한 URL 형식이 아닙니다") == true)
+        assertEquals("유효한 URL 형식이 아닙니다.", ex.message)
     }
 
     @Test
@@ -57,7 +56,6 @@ class ProductLinkTest {
                 ProductLink.parse(rawWithSecret)
             }
         assertEquals("유효한 URL 형식이 아닙니다.", ex.message)
-        assertFalse(ex.message!!.contains("SHOULD_NOT_LEAK"))
     }
 
     @Test

--- a/src/test/kotlin/com/depromeet/team3/product/domain/ProductLinkTest.kt
+++ b/src/test/kotlin/com/depromeet/team3/product/domain/ProductLinkTest.kt
@@ -3,6 +3,7 @@ package com.depromeet.team3.product.domain
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class ProductLinkTest {
@@ -10,7 +11,7 @@ class ProductLinkTest {
     fun `빈 문자열 또는 공백만 있으면 거부한다`() {
         listOf("", "   ", "\t\n").forEach { raw ->
             val ex =
-                assertFailsWith<IllegalArgumentException>("'$raw' 는 거부되어야 함") {
+                assertFailsWith<ProductLinkException>("'$raw' 는 거부되어야 함") {
                     ProductLink.parse(raw)
                 }
             assertEquals("URL이 비어 있습니다.", ex.message)
@@ -29,7 +30,7 @@ class ProductLinkTest {
             )
         cases.forEach { raw ->
             val ex =
-                assertFailsWith<IllegalArgumentException>("$raw 는 거부되어야 함") {
+                assertFailsWith<ProductLinkException>("$raw 는 거부되어야 함") {
                     ProductLink.parse(raw)
                 }
             assertEquals("https URL만 허용합니다.", ex.message)
@@ -40,16 +41,29 @@ class ProductLinkTest {
     fun `URI 파싱 자체가 실패하는 raw 는 형식 오류로 거부한다`() {
         // 예: data: URI 의 본문에 illegal character 가 들어가면 URI_create 단계에서 IllegalArgumentException
         val ex =
-            assertFailsWith<IllegalArgumentException> {
+            assertFailsWith<ProductLinkException> {
                 ProductLink.parse("data:text/html,<h1>x</h1>")
             }
         assertTrue(ex.message?.startsWith("유효한 URL 형식이 아닙니다") == true)
     }
 
     @Test
+    fun `예외 메시지에 원본 raw 는 포함되지 않는다`() {
+        // GlobalExceptionHandler 가 message 를 응답 detail · 로그에 그대로 박는 구조라
+        // 쿼리스트링에 섞일 수 있는 토큰 · 세션이 새지 않도록 message 단계에서 원본을 제거한다.
+        val rawWithSecret = "data:text/html,<token=SHOULD_NOT_LEAK>"
+        val ex =
+            assertFailsWith<ProductLinkException> {
+                ProductLink.parse(rawWithSecret)
+            }
+        assertEquals("유효한 URL 형식이 아닙니다.", ex.message)
+        assertFalse(ex.message!!.contains("SHOULD_NOT_LEAK"))
+    }
+
+    @Test
     fun `scheme 없이 호스트만 있는 raw 는 거부한다`() {
         val ex =
-            assertFailsWith<IllegalArgumentException> {
+            assertFailsWith<ProductLinkException> {
                 ProductLink.parse("example.com/product")
             }
         assertEquals("https URL만 허용합니다.", ex.message)

--- a/src/test/kotlin/com/depromeet/team3/wishlist/controller/WishlistControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/team3/wishlist/controller/WishlistControllerIntegrationTest.kt
@@ -118,4 +118,24 @@ class WishlistControllerIntegrationTest : IntegrationTestSupport() {
                     .content(body),
             ).andExpect(status().isBadRequest)
     }
+
+    @Test
+    fun `잘못된 형식의 url 은 400 BAD_REQUEST 로 응답되며 detail 에 원본 url 이 새지 않는다`() {
+        // GlobalExceptionHandler 가 IllegalArgumentException_message 를 응답 detail 에 그대로 박는 구조라
+        // ProductLink_parse 가 원본을 메시지에 담으면 쿼리스트링 토큰이 클라이언트 응답으로 새어 나간다.
+        // ProductLink_parse 의 message 정책과 contract 양 끝을 함께 묶어 회귀를 잡는다.
+        val mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build()
+        val rawWithSecret = "data:text/html,<token=SHOULD_NOT_LEAK>"
+        val body = objectMapper.writeValueAsString(mapOf("url" to rawWithSecret, "guestId" to UUID.randomUUID()))
+
+        mockMvc
+            .perform(
+                post("/api/v1/wishlists")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(body),
+            ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value("BAD_REQUEST"))
+            .andExpect(jsonPath("$.detail").value("유효한 URL 형식이 아닙니다."))
+    }
 }


### PR DESCRIPTION
## Situation
- `ProductLink.parse` 가 검증 실패 시 `IllegalArgumentException("…: $trimmed", e)` 로 원본 URL 을 메시지에 담고 있었다.
- `GlobalExceptionHandler.handleIllegalArgument` 가 `e.message` 를 응답 `detail` 과 로그 양쪽에 그대로 박는 구조 → 쿼리스트링/fragment 에 섞인 토큰·세션이 외부로 새는 경로.
- 같은 파일 line 10 의 `safeLogString()` 주석이 이미 *"쿼리스트링·fragment 에 토큰/세션이 섞일 수 있어 host+path 만 노출한다"* 라고 명시 — 파일이 위험을 인식하면서도 `parse()` 만 inconsistency.

## Task
- 메시지 노출 정책을 도메인 측에서 명시적으로 통제.
- `IllegalArgumentException` 일반 핸들러 정책에 묶이지 않게 분리.
- 회귀를 잡을 수 있도록 단위 · 통합 양쪽 contract 단언 추가.

## Action
- `ProductLinkException` 추가 (`BaseException` + `HttpMappable`, HTTP 400 + `INVALID_INPUT`).
- 코드베이스 컨벤션(`WishException`, `ProductExtractionException`) 그대로 — companion object 정적 팩토리 메서드 패턴:
  - `blank()` — 빈 입력
  - `invalidFormat(cause: Throwable)` — URI 파싱 실패. 원본을 message 에 박지 않고 cause 로만 연결해 stack trace 에 남김.
  - `unsupportedScheme()` — https 외 스킴
- `ProductLink.parse` 의 `require` · `throw` 를 모두 새 예외로 전환. `IllegalArgumentException` 경로 제거.
- 단위 테스트 (`ProductLinkTest`) — `ProductLinkException` 으로 단언 전환, 원본 raw 가 message 에 포함되지 않음 명시 단언 추가.
- 통합 테스트 (`WishlistControllerIntegrationTest`) — 잘못된 형식 URL 요청 시 응답 `status` · `code` · `detail` contract 단언으로 회귀 가드.

## Result
- 응답 detail / 로그 양쪽으로 원본 URL 이 새지 않음.
- `IllegalArgumentException` 일반 핸들러 정책에 묶이지 않고, ProductLink 메시지 정책이 도메인 안에서 통제됨.
- 후속 고려: `GlobalExceptionHandler.handleIllegalArgument` 가 4xx 응답 detail 에 `e.message` 를 무방비로 박는 패턴 자체도 잠재 위험. 다른 4xx 응답 contract 와 얽혀 영향도 평가가 별도로 필요하므로 본 PR 스코프 밖. 필요하면 별도 이슈로.

---
## 연관 이슈

- close #114

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 제품 링크 URL 검증 강화: 빈 입력, 잘못된 형식, 비(非)HTTPS 스킴에 대해 명확한 오류 응답을 반환하고 원본 URL 내용이 에러 메시지에 노출되지 않도록 수정
* **Tests**
  * URL 검증 및 에러 응답(400) 동작과 민감 정보 비노출을 검증하는 단위/통합 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/PIKI-Server/pull/118)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->