### PR TITLE
User / UserDetail 엔티티 및 Repository 구현

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,35 @@
 - 외부 라이브러리 시그니처가 강제하는 경우 (예: `Optional.isPresent()` 같은 Java interop)
 - 이 경우에도 **주석으로 이유를 명시**한다.
 
+## 도메인 예외 정책 — `require` / `check` / `error` vs 커스텀 예외
+
+**판단 기준 한 줄: "멀쩡한 클라이언트가 정상 요청으로 여기 닿을 수 있나?"**
+
+- 닿는다 → **계약** → 커스텀 예외 (`*Exception.factoryMethod()`, 400 / 409 / 403 등)
+- 못 닿는다 → **불변식** → `require` / `check` / `error` (500, 의도된 코드 버그 신호)
+
+| 상황 | 누가 터뜨리나 | 범주 | 도구 | 결과 |
+|---|---|---|---|---|
+| `error(MISSING_ID)` — 영속화 전 `getId()` | 개발자(버그) | 불변식 | `error` | 500 |
+| 닉네임 17자 | 클라이언트 | 계약 | 커스텀 | 400 |
+| 이미 완료된 토너먼트에 재요청 | 클라이언트 | 계약 | 커스텀 | 409 |
+| `winnerId` 가 참가 목록에 없음 (서비스가 보장한 값) | 개발자(버그) | 불변식 | `require` | 500 |
+
+### 규칙
+- `require` 로 우연히 400 이 나오는 건 캐치올 핸들러 덕분. throw 지점에 "이건 400이다"가 박혀 있지 않다. 커스텀 예외는 `status` · `category` 가 코드에 박힌다.
+- **도메인이 자기방어** 한다. 도메인 메서드가 직접 커스텀 예외를 던지면 호출 위치(서비스 / 다른 도메인 / 테스트)에 무관하게 같은 결과가 나온다. 서비스에서 `check` 와 같은 조건을 사전 `if` 로 막는 패턴은 도메인에 동일 검증을 옮긴 뒤 제거 가능.
+- **한 메서드 안에 `require` 와 커스텀 예외가 공존하는 게 정상.** 각 줄이 다른 질문("누가 터뜨리나")에 답하고 있을 뿐.
+  ```kotlin
+  fun complete(winnerWishItemId: Long) {
+      if (isCompleted()) throw TournamentException.alreadyCompleted()      // 계약: 클라이언트 도달 가능 → 409
+      require(winnerWishItemId in wishItemIds) { "우승자가 참가 목록에 없음" }  // 불변식: 서비스가 보장 → 500
+  }
+  ```
+- 커스텀 예외는 `*Exception : BaseException, HttpMappable` 패턴 (예: `TournamentException`, `UserException`). `private constructor` + `companion object` 의 factory 메서드로 사유별 메시지·`ErrorCategory`·`HttpStatus` 를 한 자리에 박는다.
+
+### 한 줄 외울 것
+코드 모양 보지 말고 **"멀쩡한 클라이언트가 정상 요청으로 여기 닿을 수 있나?"** 만 물을 것. 닿으면 커스텀, 못 닿으면 `require` / `check` / `error`.
+
 ## 테스트 분류
 
 테스트는 두 종류만 둔다.

--- a/src/main/kotlin/com/depromeet/team3/user/domain/IdentityType.kt
+++ b/src/main/kotlin/com/depromeet/team3/user/domain/IdentityType.kt
@@ -1,0 +1,3 @@
+package com.depromeet.team3.user.domain
+
+enum class IdentityType { GUEST, MEMBER }

--- a/src/main/kotlin/com/depromeet/team3/user/domain/IdentityType.kt
+++ b/src/main/kotlin/com/depromeet/team3/user/domain/IdentityType.kt
@@ -1,3 +1,8 @@
 package com.depromeet.team3.user.domain
 
-enum class IdentityType { GUEST, MEMBER }
+enum class IdentityType(
+    val description: String,
+) {
+    GUEST("게스트"),
+    MEMBER("회원"),
+}

--- a/src/main/kotlin/com/depromeet/team3/user/domain/User.kt
+++ b/src/main/kotlin/com/depromeet/team3/user/domain/User.kt
@@ -1,6 +1,7 @@
 package com.depromeet.team3.user.domain
 
 import com.depromeet.team3.common.domain.BaseEntity
+import com.depromeet.team3.user.service.UserException
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
@@ -17,9 +18,13 @@ class User(
     nickname: String,
     identityType: IdentityType,
 ) : BaseEntity<UUID>() {
+    init {
+        validateNickname(nickname)
+    }
+
     @Id
     @Column(name = "id", columnDefinition = "BINARY(16)")
-    val id: UUID = id
+    private val id: UUID = id
 
     override fun getIdOrNull(): UUID = id
 
@@ -32,17 +37,21 @@ class User(
         protected set
 
     fun promoteToMember() {
-        check(identityType == IdentityType.GUEST) { "이미 MEMBER 입니다." }
+        if (identityType != IdentityType.GUEST) throw UserException.alreadyMember()
         identityType = IdentityType.MEMBER
     }
 
     fun updateNickname(newNickname: String) {
-        require(newNickname.isNotBlank()) { "닉네임은 공백일 수 없습니다." }
-        require(newNickname.length <= 16) { "닉네임은 16자 이하여야 합니다." }
+        validateNickname(newNickname)
         nickname = newNickname
     }
 
     fun softDelete() {
         deletedAt = LocalDateTime.now()
+    }
+
+    private fun validateNickname(value: String) {
+        if (value.isBlank()) throw UserException.nicknameBlank()
+        if (value.length > 16) throw UserException.nicknameTooLong()
     }
 }

--- a/src/main/kotlin/com/depromeet/team3/user/domain/User.kt
+++ b/src/main/kotlin/com/depromeet/team3/user/domain/User.kt
@@ -1,0 +1,48 @@
+package com.depromeet.team3.user.domain
+
+import com.depromeet.team3.common.domain.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Entity
+@Table(name = "user")
+class User(
+    id: UUID,
+    nickname: String,
+    identityType: IdentityType,
+) : BaseEntity<UUID>() {
+    @Id
+    @Column(name = "id", columnDefinition = "BINARY(16)")
+    val id: UUID = id
+
+    override fun getIdOrNull(): UUID = id
+
+    var nickname: String = nickname
+        protected set
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "identity_type", nullable = false, length = 10)
+    var identityType: IdentityType = identityType
+        protected set
+
+    fun promoteToMember() {
+        check(identityType == IdentityType.GUEST) { "이미 MEMBER 입니다." }
+        identityType = IdentityType.MEMBER
+    }
+
+    fun updateNickname(newNickname: String) {
+        require(newNickname.isNotBlank()) { "닉네임은 공백일 수 없습니다." }
+        require(newNickname.length <= 16) { "닉네임은 16자 이하여야 합니다." }
+        nickname = newNickname
+    }
+
+    fun softDelete() {
+        deletedAt = LocalDateTime.now()
+    }
+}

--- a/src/main/kotlin/com/depromeet/team3/user/domain/UserDetail.kt
+++ b/src/main/kotlin/com/depromeet/team3/user/domain/UserDetail.kt
@@ -1,29 +1,27 @@
 package com.depromeet.team3.user.domain
 
+import com.depromeet.team3.common.domain.BaseEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
-import jakarta.persistence.EntityListeners
 import jakarta.persistence.Id
 import jakarta.persistence.Table
-import org.springframework.data.annotation.CreatedDate
-import org.springframework.data.annotation.LastModifiedDate
-import org.springframework.data.jpa.domain.support.AuditingEntityListener
-import java.time.LocalDateTime
 import java.util.UUID
 
-// user_detail 테이블에는 deleted_at 컬럼이 없어 BaseEntity 상속 대신 직접 auditing 어노테이션을 사용한다.
 @Entity
 @Table(name = "user_detail")
-@EntityListeners(AuditingEntityListener::class)
 class UserDetail(
-    @Id
-    @Column(name = "user_id", columnDefinition = "BINARY(16)")
-    val userId: UUID,
+    userId: UUID,
     profileImage: String = "default",
     email: String,
     provider: String,
     socialId: String,
-) {
+) : BaseEntity<UUID>() {
+    @Id
+    @Column(name = "user_id", columnDefinition = "BINARY(16)")
+    private val userId: UUID = userId
+
+    override fun getIdOrNull(): UUID = userId
+
     @Column(name = "profile_image", nullable = false)
     var profileImage: String = profileImage
         protected set
@@ -38,16 +36,6 @@ class UserDetail(
 
     @Column(name = "social_id", nullable = false)
     var socialId: String = socialId
-        protected set
-
-    @CreatedDate
-    @Column(name = "created_at", nullable = false, updatable = false)
-    var createdAt: LocalDateTime = LocalDateTime.now()
-        protected set
-
-    @LastModifiedDate
-    @Column(name = "updated_at", nullable = false)
-    var updatedAt: LocalDateTime = LocalDateTime.now()
         protected set
 
     fun updateProfileImage(newProfileImage: String) {

--- a/src/main/kotlin/com/depromeet/team3/user/domain/UserDetail.kt
+++ b/src/main/kotlin/com/depromeet/team3/user/domain/UserDetail.kt
@@ -1,0 +1,60 @@
+package com.depromeet.team3.user.domain
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
+import java.util.UUID
+
+// user_detail 테이블에는 deleted_at 컬럼이 없어 BaseEntity 상속 대신 직접 auditing 어노테이션을 사용한다.
+@Entity
+@Table(name = "user_detail")
+@EntityListeners(AuditingEntityListener::class)
+class UserDetail(
+    @Id
+    @Column(name = "user_id", columnDefinition = "BINARY(16)")
+    val userId: UUID,
+    profileImage: String = "default",
+    email: String,
+    provider: String,
+    socialId: String,
+) {
+    @Column(name = "profile_image", nullable = false)
+    var profileImage: String = profileImage
+        protected set
+
+    @Column(nullable = false)
+    var email: String = email
+        protected set
+
+    @Column(nullable = false, length = 20)
+    var provider: String = provider
+        protected set
+
+    @Column(name = "social_id", nullable = false)
+    var socialId: String = socialId
+        protected set
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    var createdAt: LocalDateTime = LocalDateTime.now()
+        protected set
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: LocalDateTime = LocalDateTime.now()
+        protected set
+
+    fun updateProfileImage(newProfileImage: String) {
+        profileImage = newProfileImage
+    }
+
+    fun updateEmail(newEmail: String) {
+        email = newEmail
+    }
+}

--- a/src/main/kotlin/com/depromeet/team3/user/repository/UserDetailJpaRepository.kt
+++ b/src/main/kotlin/com/depromeet/team3/user/repository/UserDetailJpaRepository.kt
@@ -1,0 +1,12 @@
+package com.depromeet.team3.user.repository
+
+import com.depromeet.team3.user.domain.UserDetail
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface UserDetailJpaRepository : JpaRepository<UserDetail, UUID> {
+    fun findByProviderAndSocialId(
+        provider: String,
+        socialId: String,
+    ): UserDetail?
+}

--- a/src/main/kotlin/com/depromeet/team3/user/repository/UserDetailRepository.kt
+++ b/src/main/kotlin/com/depromeet/team3/user/repository/UserDetailRepository.kt
@@ -1,0 +1,15 @@
+package com.depromeet.team3.user.repository
+
+import com.depromeet.team3.user.domain.UserDetail
+import java.util.UUID
+
+interface UserDetailRepository {
+    fun save(userDetail: UserDetail): UserDetail
+
+    fun findByUserId(userId: UUID): UserDetail?
+
+    fun findByProviderAndSocialId(
+        provider: String,
+        socialId: String,
+    ): UserDetail?
+}

--- a/src/main/kotlin/com/depromeet/team3/user/repository/UserDetailRepositoryImpl.kt
+++ b/src/main/kotlin/com/depromeet/team3/user/repository/UserDetailRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.depromeet.team3.user.repository
 
 import com.depromeet.team3.user.domain.UserDetail
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Repository
 import java.util.UUID
 
@@ -10,7 +11,7 @@ class UserDetailRepositoryImpl(
 ) : UserDetailRepository {
     override fun save(userDetail: UserDetail): UserDetail = userDetailJpaRepository.save(userDetail)
 
-    override fun findByUserId(userId: UUID): UserDetail? = userDetailJpaRepository.findById(userId).orElse(null)
+    override fun findByUserId(userId: UUID): UserDetail? = userDetailJpaRepository.findByIdOrNull(userId)
 
     override fun findByProviderAndSocialId(
         provider: String,

--- a/src/main/kotlin/com/depromeet/team3/user/repository/UserDetailRepositoryImpl.kt
+++ b/src/main/kotlin/com/depromeet/team3/user/repository/UserDetailRepositoryImpl.kt
@@ -1,0 +1,19 @@
+package com.depromeet.team3.user.repository
+
+import com.depromeet.team3.user.domain.UserDetail
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+class UserDetailRepositoryImpl(
+    private val userDetailJpaRepository: UserDetailJpaRepository,
+) : UserDetailRepository {
+    override fun save(userDetail: UserDetail): UserDetail = userDetailJpaRepository.save(userDetail)
+
+    override fun findByUserId(userId: UUID): UserDetail? = userDetailJpaRepository.findById(userId).orElse(null)
+
+    override fun findByProviderAndSocialId(
+        provider: String,
+        socialId: String,
+    ): UserDetail? = userDetailJpaRepository.findByProviderAndSocialId(provider, socialId)
+}

--- a/src/main/kotlin/com/depromeet/team3/user/repository/UserJpaRepository.kt
+++ b/src/main/kotlin/com/depromeet/team3/user/repository/UserJpaRepository.kt
@@ -1,0 +1,9 @@
+package com.depromeet.team3.user.repository
+
+import com.depromeet.team3.user.domain.User
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface UserJpaRepository : JpaRepository<User, UUID> {
+    fun existsByNickname(nickname: String): Boolean
+}

--- a/src/main/kotlin/com/depromeet/team3/user/repository/UserRepository.kt
+++ b/src/main/kotlin/com/depromeet/team3/user/repository/UserRepository.kt
@@ -1,0 +1,12 @@
+package com.depromeet.team3.user.repository
+
+import com.depromeet.team3.user.domain.User
+import java.util.UUID
+
+interface UserRepository {
+    fun save(user: User): User
+
+    fun findById(id: UUID): User?
+
+    fun existsByNickname(nickname: String): Boolean
+}

--- a/src/main/kotlin/com/depromeet/team3/user/repository/UserRepositoryImpl.kt
+++ b/src/main/kotlin/com/depromeet/team3/user/repository/UserRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.depromeet.team3.user.repository
 
 import com.depromeet.team3.user.domain.User
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Repository
 import java.util.UUID
 
@@ -10,7 +11,7 @@ class UserRepositoryImpl(
 ) : UserRepository {
     override fun save(user: User): User = userJpaRepository.save(user)
 
-    override fun findById(id: UUID): User? = userJpaRepository.findById(id).orElse(null)
+    override fun findById(id: UUID): User? = userJpaRepository.findByIdOrNull(id)
 
     override fun existsByNickname(nickname: String): Boolean = userJpaRepository.existsByNickname(nickname)
 }

--- a/src/main/kotlin/com/depromeet/team3/user/repository/UserRepositoryImpl.kt
+++ b/src/main/kotlin/com/depromeet/team3/user/repository/UserRepositoryImpl.kt
@@ -1,0 +1,16 @@
+package com.depromeet.team3.user.repository
+
+import com.depromeet.team3.user.domain.User
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+class UserRepositoryImpl(
+    private val userJpaRepository: UserJpaRepository,
+) : UserRepository {
+    override fun save(user: User): User = userJpaRepository.save(user)
+
+    override fun findById(id: UUID): User? = userJpaRepository.findById(id).orElse(null)
+
+    override fun existsByNickname(nickname: String): Boolean = userJpaRepository.existsByNickname(nickname)
+}

--- a/src/main/kotlin/com/depromeet/team3/user/service/UserException.kt
+++ b/src/main/kotlin/com/depromeet/team3/user/service/UserException.kt
@@ -1,0 +1,36 @@
+package com.depromeet.team3.user.service
+
+import com.depromeet.team3.common.exception.BaseException
+import com.depromeet.team3.common.exception.ErrorCategory
+import com.depromeet.team3.common.exception.HttpMappable
+import org.springframework.http.HttpStatus
+
+class UserException private constructor(
+    message: String,
+    override val category: ErrorCategory,
+    override val httpStatus: HttpStatus,
+) : BaseException(message),
+    HttpMappable {
+    companion object {
+        fun nicknameBlank(): UserException =
+            UserException(
+                "닉네임은 공백일 수 없습니다.",
+                ErrorCategory.INVALID_INPUT,
+                HttpStatus.BAD_REQUEST,
+            )
+
+        fun nicknameTooLong(): UserException =
+            UserException(
+                "닉네임은 16자 이하여야 합니다.",
+                ErrorCategory.INVALID_INPUT,
+                HttpStatus.BAD_REQUEST,
+            )
+
+        fun alreadyMember(): UserException =
+            UserException(
+                "이미 MEMBER 입니다.",
+                ErrorCategory.CONFLICT,
+                HttpStatus.CONFLICT,
+            )
+    }
+}

--- a/src/test/kotlin/com/depromeet/team3/user/domain/UserTest.kt
+++ b/src/test/kotlin/com/depromeet/team3/user/domain/UserTest.kt
@@ -1,0 +1,66 @@
+package com.depromeet.team3.user.domain
+
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class UserTest {
+    private fun guest() = User(id = UUID.randomUUID(), nickname = "테스트유저", identityType = IdentityType.GUEST)
+
+    @Test
+    fun `GUEST 유저는 MEMBER 로 승격된다`() {
+        val user = guest()
+        user.promoteToMember()
+        assertEquals(IdentityType.MEMBER, user.identityType)
+    }
+
+    @Test
+    fun `이미 MEMBER 인 유저를 다시 승격하면 예외가 발생한다`() {
+        val user = guest()
+        user.promoteToMember()
+        assertFailsWith<IllegalStateException> { user.promoteToMember() }
+    }
+
+    @Test
+    fun `닉네임을 정상적으로 변경한다`() {
+        val user = guest()
+        user.updateNickname("새닉네임")
+        assertEquals("새닉네임", user.nickname)
+    }
+
+    @Test
+    fun `닉네임 16자는 허용된다`() {
+        val user = guest()
+        user.updateNickname("1234567890123456")
+        assertEquals("1234567890123456", user.nickname)
+    }
+
+    @Test
+    fun `닉네임 17자는 예외가 발생한다`() {
+        val user = guest()
+        assertFailsWith<IllegalArgumentException> { user.updateNickname("12345678901234567") }
+    }
+
+    @Test
+    fun `빈 닉네임은 예외가 발생한다`() {
+        val user = guest()
+        assertFailsWith<IllegalArgumentException> { user.updateNickname("") }
+    }
+
+    @Test
+    fun `공백만 있는 닉네임은 예외가 발생한다`() {
+        val user = guest()
+        assertFailsWith<IllegalArgumentException> { user.updateNickname("   ") }
+    }
+
+    @Test
+    fun `softDelete 호출 시 deletedAt 이 설정된다`() {
+        val user = guest()
+        assertNull(user.deletedAt)
+        user.softDelete()
+        assertNotNull(user.deletedAt)
+    }
+}

--- a/src/test/kotlin/com/depromeet/team3/user/domain/UserTest.kt
+++ b/src/test/kotlin/com/depromeet/team3/user/domain/UserTest.kt
@@ -1,5 +1,8 @@
 package com.depromeet.team3.user.domain
 
+import com.depromeet.team3.user.service.UserException
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -9,6 +12,20 @@ import kotlin.test.assertNull
 
 class UserTest {
     private fun guest() = User(id = UUID.randomUUID(), nickname = "테스트유저", identityType = IdentityType.GUEST)
+
+    @ParameterizedTest
+    @ValueSource(strings = ["", "   ", "12345678901234567"])
+    fun `생성자에 유효하지 않은 닉네임이 들어오면 예외가 발생한다`(invalid: String) {
+        assertFailsWith<UserException> {
+            User(id = UUID.randomUUID(), nickname = invalid, identityType = IdentityType.GUEST)
+        }
+    }
+
+    @Test
+    fun `생성자에 16자 닉네임은 허용된다`() {
+        val user = User(id = UUID.randomUUID(), nickname = "1234567890123456", identityType = IdentityType.GUEST)
+        assertEquals("1234567890123456", user.nickname)
+    }
 
     @Test
     fun `GUEST 유저는 MEMBER 로 승격된다`() {
@@ -21,7 +38,7 @@ class UserTest {
     fun `이미 MEMBER 인 유저를 다시 승격하면 예외가 발생한다`() {
         val user = guest()
         user.promoteToMember()
-        assertFailsWith<IllegalStateException> { user.promoteToMember() }
+        assertFailsWith<UserException> { user.promoteToMember() }
     }
 
     @Test
@@ -41,19 +58,19 @@ class UserTest {
     @Test
     fun `닉네임 17자는 예외가 발생한다`() {
         val user = guest()
-        assertFailsWith<IllegalArgumentException> { user.updateNickname("12345678901234567") }
+        assertFailsWith<UserException> { user.updateNickname("12345678901234567") }
     }
 
     @Test
     fun `빈 닉네임은 예외가 발생한다`() {
         val user = guest()
-        assertFailsWith<IllegalArgumentException> { user.updateNickname("") }
+        assertFailsWith<UserException> { user.updateNickname("") }
     }
 
     @Test
     fun `공백만 있는 닉네임은 예외가 발생한다`() {
         val user = guest()
-        assertFailsWith<IllegalArgumentException> { user.updateNickname("   ") }
+        assertFailsWith<UserException> { user.updateNickname("   ") }
     }
 
     @Test

--- a/src/test/kotlin/com/depromeet/team3/wishlist/controller/WishlistControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/team3/wishlist/controller/WishlistControllerIntegrationTest.kt
@@ -3,10 +3,10 @@ package com.depromeet.team3.wishlist.controller
 import com.depromeet.team3.product.domain.ProductSnapshot
 import com.depromeet.team3.support.IntegrationTestSupport
 import com.depromeet.team3.support.StubProductExtractor
+import com.depromeet.team3.support.uuidToBytes
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
-import com.depromeet.team3.support.uuidToBytes
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath


### PR DESCRIPTION
## Situation
- Flyway 마이그레이션(Task 1)으로 `user`, `user_detail` 스키마가 확정된 뒤 엔티티 계층이 비어 있는 상태
- 이후 인증 인프라(Task 3) 및 Auth API(Task 4) 구현을 위해 도메인 모델이 선행되어야 한다
- `user_detail` 에는 `deleted_at` 컬럼이 없어 `BaseEntity` 를 그대로 상속할 수 없는 구조적 제약이 있었다

## Task
- `User` / `UserDetail` JPA 엔티티 및 3-layer Repository 구현
- `user_detail.deleted_at` 부재 문제 해결 - `BaseEntity` 상속 없이 auditing 만 적용하는 방법 결정
- 도메인 규칙(닉네임 제약, GUEST→MEMBER 승격, soft delete)을 엔티티 메서드로 캡슐화

## Action
### 도메인 모델
- `User`: `BINARY(16)` UUID PK, `nickname` (최대 16자, 공백 불가), `identityType` (GUEST/MEMBER enum)
  - `promoteToMember()` - GUEST에서만 승격 가능, 이미 MEMBER이면 `IllegalStateException`
  - `updateNickname()` - 빈값·16자 초과 시 `IllegalArgumentException`
  - `softDelete()` - `BaseEntity.deletedAt` 에 현재 시각 기록
- `UserDetail`: `user_id` 가 PK이자 FK (`user.id` 참조). `deleted_at` 컬럼이 없으므로 `BaseEntity` 상속 대신 `@EntityListeners(AuditingEntityListener::class)` + `@CreatedDate` / `@LastModifiedDate` 직접 선언
- `allopen` 플러그인으로 JPA 엔티티가 open 처리되어 `private set` 불가 - `protected set` 으로 통일

### Repository
- `UserRepository` / `UserDetailRepository` 인터페이스 + `*RepositoryImpl` 구현체 + JPA 인터페이스의 3-layer 패턴 적용
- `findByIdOrNull` 활용으로 null 반환을 명시적으로 처리

## Result
- `./gradlew test` 50개 전원 통과 (기존 42 + 신규 8개 `UserTest`)
- 단위 테스트로 닉네임 경계값(16자 허용, 17자 예외), 승격 상태 전이, softDelete 시나리오 망라
- 이 브랜치는 `feat/user-auth-flyway-migration` 위에 스택되어 있어 해당 PR 머지 후 squash 또는 rebase 필요

---
## 연관 이슈

- close #125

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 게스트와 멤버로 구분되는 사용자 신원 유형 구현
  * 사용자 닉네임, 프로필 이미지, 이메일 관리 기능 추가
  * 소셜 로그인 제공자별 사용자 식별 및 조회 기능 지원

* **테스트**
  * 사용자 도메인 기능에 대한 포괄적인 단위 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/PIKI-Server/pull/130)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Updates

### 리뷰 대응 (m-a-king + CodeRabbit)

**Situation / Task**
- m-a-king 의 본질적 지적 (BaseEntity 4가지 묶음 / id 캡슐화 / require → 커스텀 예외 / description 라벨 / CLAUDE.md 가이드) + CodeRabbit 의 init 검증 / findByIdOrNull 지적을 일괄 반영
- 기존 결정 (UserDetail audit-only 직접 선언) 의 논리적 약점이 드러나 BaseEntity 일관 패턴으로 통일

**Action**
- UserDetail BaseEntity 상속 전환 + userId private 캡슐화 (audit 중복 제거)
- User id private 캡슐화 + init 블록에 validateNickname 검증 추가
- UserException 도입 — nicknameBlank() / nicknameTooLong() (400) / alreadyMember() (409). require / check 를 커스텀 예외로 전환해 throw 지점에 status / category 명시
- IdentityType 에 description (한국어 라벨) 필드 추가
- UserRepositoryImpl / UserDetailRepositoryImpl 의 findById(...).orElse(null) → findByIdOrNull 정리
- UserTest 에 생성자 검증 케이스 추가 + 예외 단언을 UserException 으로 갱신
- CLAUDE.md 에 도메인 예외 정책 섹션 추가 (require / check / error vs 커스텀 예외 판단 기준)

**Result**
- 전체 빌드 / 테스트 통과
- 본 PR 본문 위의 도메인 메서드 설명에서 예외 타입은 IllegalArgumentException / IllegalStateException → UserException 으로 변경되었음에 유의 (정책 답글에서 사유 설명)
- CodeRabbit 의 UserJpaRepository soft-delete 필터 지적은 본 PR 에 호출처가 없어 (회원가입·인증은 Task 3/4) 후속 Auth PR 에서 정책과 함께 결정 — 답글로 사유 명시
