### PR TITLE
GitHub Actions 워크플로 옛 레포명 정리 + pr-issue-sync 인자 버그 수정

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,5 +2,5 @@ blank_issues_enabled: false
 
 contact_links:
   - name: 💬 Discussions (질문 / 논의)
-    url: https://github.com/depromeet/18th-team3-server/discussions
+    url: https://github.com/depromeet/PIKI-Server/discussions
     about: 기능 제안, 질문, 기술 논의는 Discussions를 이용해주세요.

--- a/.github/workflows/auto-reviewer.yml
+++ b/.github/workflows/auto-reviewer.yml
@@ -28,7 +28,7 @@ jobs:
 
           # 이미 리뷰어가 지정되어 있으면 스킵 (중복 방지)
           EXISTING=$(gh pr view "$PR_NUMBER" \
-            --repo depromeet/18th-team3-server \
+            --repo depromeet/PIKI-Server \
             --json reviewRequests \
             --jq '.reviewRequests | length')
 
@@ -40,6 +40,6 @@ jobs:
           REVIEWER_STR=$(IFS=,; echo "${REVIEWERS[*]}")
           gh pr edit "$PR_NUMBER" \
             --add-reviewer "$REVIEWER_STR" \
-            --repo depromeet/18th-team3-server
+            --repo depromeet/PIKI-Server
 
           echo "Assigned reviewers: $REVIEWER_STR"

--- a/.github/workflows/epic-tracker.yml
+++ b/.github/workflows/epic-tracker.yml
@@ -27,7 +27,7 @@ jobs:
           # 후보 이슈 전체 조회 후 본문을 직접 파싱
           # (Search API는 본문 어디든 #N이 언급되면 매칭되어 false positive 발생)
           CANDIDATES=$(gh issue list \
-            --repo depromeet/18th-team3-server \
+            --repo depromeet/PIKI-Server \
             --state all \
             --limit 500 \
             --json number,state,body,labels)
@@ -55,9 +55,9 @@ jobs:
           if [[ "$CLOSED" -eq "$TOTAL" ]]; then
             gh issue comment "$EPIC_NUM" \
               --body "🎉 모든 이슈가 완료되었습니다! ($CLOSED/$TOTAL)" \
-              --repo depromeet/18th-team3-server
+              --repo depromeet/PIKI-Server
           else
             gh issue comment "$EPIC_NUM" \
               --body "✅ 이슈 #$ISSUE_NUMBER 완료 — 진행률: **$CLOSED / $TOTAL**" \
-              --repo depromeet/18th-team3-server
+              --repo depromeet/PIKI-Server
           fi

--- a/.github/workflows/issue-project-sync.yml
+++ b/.github/workflows/issue-project-sync.yml
@@ -111,6 +111,6 @@ jobs:
           if echo "$ASSIGNEES" | jq -e 'length == 0' > /dev/null; then
             gh issue edit "$ISSUE_NUMBER" \
               --add-assignee "$CREATOR" \
-              --repo depromeet/18th-team3-server
+              --repo depromeet/PIKI-Server
             echo "Auto-assigned to creator: $CREATOR"
           fi

--- a/.github/workflows/pr-issue-sync.yml
+++ b/.github/workflows/pr-issue-sync.yml
@@ -71,8 +71,8 @@ jobs:
                   }
                 }
               }' \
-              -F owner=depromeet -F repo=18th-team3-server -F num="$ISSUE_NUM" \
-              --jq --arg pid "$PROJECT_ID" '.data.repository.issue.projectItems.nodes[] | select(.project.id == $pid) | .id')
+              -F owner=depromeet -F repo=PIKI-Server -F num="$ISSUE_NUM" \
+              --jq ".data.repository.issue.projectItems.nodes[] | select(.project.id == \"$PROJECT_ID\") | .id")
 
             if [[ -n "$ITEM_ID" ]]; then
               gh api graphql \


### PR DESCRIPTION
## Situation
- 18th-team3-server → PIKI-Server 레포 rename 후에도 `.github/` 하위 워크플로·템플릿 5개 파일에 옛 이름이 잔존. 현재는 GitHub redirect 가 받아주지만 redirect 정책 변경이나 누가 옛 이름으로 새 레포를 만들면 끊김 위험
- `pr-issue-sync.yml` 의 `gh api graphql --jq --arg pid ...` 호출이 매번 "accepts 1 arg(s), received 4" 로 실패. Project 자동 상태 갱신이 동작 안 함

## Task
- 워크플로 옛 레포명 일괄 갱신 + `pr-issue-sync` 인자 버그 동시 정리
- 상위 이슈 #86 (PIKI-Server rename 후속) 의 `.github/` 영역 분리 + 별개 버그 묶어 한 PR

## Action
- 옛 레포명 갱신 (5 파일): `auto-reviewer.yml` / `issue-project-sync.yml` / `epic-tracker.yml` / `pr-issue-sync.yml` / `ISSUE_TEMPLATE/config.yml`
- `pr-issue-sync.yml` 의 `--jq --arg pid "$PROJECT_ID" '...'` → `--jq "...\"$PROJECT_ID\"..."` 으로 변경. `gh` CLI 의 `--jq` 는 단일 JQ 필터 인자만 받고 `jq` CLI 의 `--arg` 옵션을 받지 않는 한계라, `PROJECT_ID` 를 jq 표현식 안에 shell 보간으로 직접 박는 방식으로 우회
- 커밋은 두 의도로 분리: `chore` (4 파일 일괄 rename) + `fix` (pr-issue-sync 인자 버그 + 같은 hunk 의 rename 한 줄)

## Result
- `.github/` 의 옛 레포명 잔재 0건 (`grep -r 18th-team3-server .github/` 확인)
- `pr-issue-sync` 다음 트리거 시 Project 자동 상태 갱신 복원 예상
- #86 의 `.github/` 영역 정리 완료. 남은 영역 (`.claude/commands/issue.md`, src 코드 Swagger contact URL, Webhooks/Branch protection 점검) 은 별도 후속 작업

---
## 연관 이슈

- close #135

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* 리포지토리 자동화 워크플로우가 업데이트되었습니다.
* PR 검토 자동 할당, 이슈 추적, 에픽 관리 및 프로젝트 동기화 자동화 프로세스가 개선되었습니다.
* 이슈 템플릿 및 관련 설정이 최적화되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/PIKI-Server/pull/136?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->