### PR TITLE
Gemini 호출 재시도 로직 도입 및 일시 장애 분류 보강

### DIFF
--- a/src/main/kotlin/com/depromeet/team3/ocr/service/gemini/GeminiOcrClient.kt
+++ b/src/main/kotlin/com/depromeet/team3/ocr/service/gemini/GeminiOcrClient.kt
@@ -5,6 +5,7 @@ import com.depromeet.team3.ocr.domain.OcrImage
 import com.depromeet.team3.ocr.service.OcrClient
 import com.depromeet.team3.product.service.gemini.GeminiApiException
 import com.depromeet.team3.product.service.gemini.GeminiProperties
+import com.depromeet.team3.product.service.gemini.GeminiRetry
 import org.springframework.http.MediaType
 import org.springframework.http.client.SimpleClientHttpRequestFactory
 import org.springframework.stereotype.Component
@@ -21,6 +22,8 @@ class GeminiOcrClient(
     private val objectMapper: ObjectMapper,
     private val geminiProperties: GeminiProperties,
 ) : OcrClient {
+    private val geminiRetry = GeminiRetry()
+
     private val restClient = RestClient
         .builder()
         .baseUrl("https://generativelanguage.googleapis.com")
@@ -42,40 +45,34 @@ class GeminiOcrClient(
             image.mimeType,
         )
 
-        // TODO: Gemini API 가 간헐적으로 503(ServiceUnavailable) 을 반환함. 재시도 로직 필요.
-        //       - 대상: 5xx 및 네트워크 타임아웃
-        //       - 방식: 지수 백오프 + 최대 N회 (e.g. Resilience4j Retry 또는 RestClient interceptor)
-        //       - 주의: 4xx (ex. 잘못된 API 키, 지원하지 않는 mimeType) 는 재시도 대상에서 제외
-        val response = try {
-            restClient
-                .post()
-                .uri {
-                    it
-                        .path("/v1beta/models/{model}:generateContent")
-                        .build(geminiProperties.model)
-                }
-                .header(GEMINI_API_KEY_HEADER, geminiProperties.apiKey)
-                .contentType(MediaType.APPLICATION_JSON)
-                .body(request)
-                .retrieve()
-                .body<GeminiOcrResponse>()
-        } catch (e: RestClientResponseException) {
-            throw when {
-                e.statusCode.is5xxServerError -> GeminiApiException.upstreamError(e)
-                else -> GeminiApiException.clientError(e)
-            }
-        } catch (e: ResourceAccessException) {
-            throw GeminiApiException.upstreamError(e)
-        }
-        response ?: throw GeminiApiException.emptyResponse()
+        return geminiRetry.execute {
+            val response = try {
+                restClient
+                    .post()
+                    .uri {
+                        it
+                            .path("/v1beta/models/{model}:generateContent")
+                            .build(geminiProperties.model)
+                    }
+                    .header(GEMINI_API_KEY_HEADER, geminiProperties.apiKey)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(request)
+                    .retrieve()
+                    .body<GeminiOcrResponse>()
+            } catch (e: RestClientResponseException) {
+                throw GeminiApiException.fromResponseError(e)
+            } catch (e: ResourceAccessException) {
+                throw GeminiApiException.upstreamError(e)
+            } ?: throw GeminiApiException.emptyResponse()
 
-        val text = response.extractText()
-        val ocrResult = try {
-            objectMapper.readValue<GeminiOcrResult>(text)
-        } catch (e: Exception) {
-            throw GeminiApiException.parseError(e)
+            val text = response.extractText()
+            val ocrResult = try {
+                objectMapper.readValue<GeminiOcrResult>(text)
+            } catch (e: Exception) {
+                throw GeminiApiException.parseError(e)
+            }
+            ocrResult.toProduct()
         }
-        return ocrResult.toProduct()
     }
 
     companion object {

--- a/src/main/kotlin/com/depromeet/team3/ocr/service/gemini/GeminiOcrClient.kt
+++ b/src/main/kotlin/com/depromeet/team3/ocr/service/gemini/GeminiOcrClient.kt
@@ -22,7 +22,7 @@ class GeminiOcrClient(
     private val objectMapper: ObjectMapper,
     private val geminiProperties: GeminiProperties,
 ) : OcrClient {
-    private val geminiRetry = GeminiRetry()
+    private val geminiRetry = GeminiRetry(geminiProperties.retry)
 
     private val restClient = RestClient
         .builder()

--- a/src/main/kotlin/com/depromeet/team3/product/service/gemini/GeminiApiException.kt
+++ b/src/main/kotlin/com/depromeet/team3/product/service/gemini/GeminiApiException.kt
@@ -4,6 +4,7 @@ import com.depromeet.team3.common.exception.BaseException
 import com.depromeet.team3.common.exception.ErrorCategory
 import com.depromeet.team3.common.exception.HttpMappable
 import org.springframework.http.HttpStatus
+import org.springframework.web.client.RestClientResponseException
 
 class GeminiApiException private constructor(
     message: String,
@@ -19,6 +20,17 @@ class GeminiApiException private constructor(
 
         fun clientError(cause: Throwable): GeminiApiException =
             GeminiApiException("Gemini 요청 오류", ErrorCategory.SERVER_ERROR, cause)
+
+        // HTTP 에러 응답을 카테고리로 분류한다.
+        // 5xx · 429(Too Many Requests) · 408(Request Timeout) 은 일시 장애로 보고 RETRYABLE,
+        // 그 외 4xx(잘못된 키·요청 등) 는 재시도해도 의미 없으므로 SERVER_ERROR.
+        fun fromResponseError(e: RestClientResponseException): GeminiApiException {
+            val status = e.statusCode
+            val retryable = status.is5xxServerError ||
+                status.value() == HttpStatus.TOO_MANY_REQUESTS.value() ||
+                status.value() == HttpStatus.REQUEST_TIMEOUT.value()
+            return if (retryable) upstreamError(e) else clientError(e)
+        }
 
         // body 자체가 없음 (역직렬화 이전). transport/인프라 이슈로 일시적일 가능성이 크므로 RETRYABLE.
         fun emptyResponse(): GeminiApiException = GeminiApiException("Gemini 응답이 비어 있습니다.", ErrorCategory.RETRYABLE)

--- a/src/main/kotlin/com/depromeet/team3/product/service/gemini/GeminiProductExtractor.kt
+++ b/src/main/kotlin/com/depromeet/team3/product/service/gemini/GeminiProductExtractor.kt
@@ -98,8 +98,9 @@ class GeminiProductExtractor(
     companion object {
         private const val CONNECT_TIMEOUT_MS = 5_000
 
-        // LLM 응답은 수십 초까지 갈 수 있어 넉넉하게 설정.
-        private const val READ_TIMEOUT_MS = 60_000
+        // LLM 응답이 길어질 수 있어 넉넉히 두되, 1 분 안에 재시도까지 끝낼 수 있도록 30 초로 제한.
+        // GeminiOcrClient 도 같은 30 초.
+        private const val READ_TIMEOUT_MS = 30_000
 
         // API 키는 access log 에 남지 않도록 쿼리 대신 헤더로 전달.
         // https://ai.google.dev/gemini-api/docs/api-key#provide-api-key-explicitly

--- a/src/main/kotlin/com/depromeet/team3/product/service/gemini/GeminiProductExtractor.kt
+++ b/src/main/kotlin/com/depromeet/team3/product/service/gemini/GeminiProductExtractor.kt
@@ -23,7 +23,7 @@ class GeminiProductExtractor(
 ) : ProductExtractor {
     private val log = LoggerFactory.getLogger(javaClass)
 
-    private val geminiRetry = GeminiRetry()
+    private val geminiRetry = GeminiRetry(geminiProperties.retry)
 
     private val restClient =
         RestClient

--- a/src/main/kotlin/com/depromeet/team3/product/service/gemini/GeminiProductExtractor.kt
+++ b/src/main/kotlin/com/depromeet/team3/product/service/gemini/GeminiProductExtractor.kt
@@ -23,6 +23,8 @@ class GeminiProductExtractor(
 ) : ProductExtractor {
     private val log = LoggerFactory.getLogger(javaClass)
 
+    private val geminiRetry = GeminiRetry()
+
     private val restClient =
         RestClient
             .builder()
@@ -43,28 +45,36 @@ class GeminiProductExtractor(
         val request = GeminiExtractionRequest.forHtmlExtraction(link.value, html)
 
         val llmStart = System.nanoTime()
-        // TODO: Gemini API 의 간헐적 5xx/타임아웃 대응 재시도 로직 필요. RETRYABLE 카테고리 예외 대상.
-        val response =
-            try {
-                restClient
-                    .post()
-                    .uri {
-                        it
-                            .path("/v1beta/models/{model}:generateContent")
-                            .build(geminiProperties.model)
-                    }.header(GEMINI_API_KEY_HEADER, geminiProperties.apiKey)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .body(request)
-                    .retrieve()
-                    .body<GeminiExtractionResponse>()
-            } catch (e: RestClientResponseException) {
-                throw when {
-                    e.statusCode.is5xxServerError -> GeminiApiException.upstreamError(e)
-                    else -> GeminiApiException.clientError(e)
-                }
-            } catch (e: ResourceAccessException) {
-                throw GeminiApiException.upstreamError(e)
-            } ?: throw GeminiApiException.emptyResponse()
+        val snapshot =
+            geminiRetry.execute {
+                val response =
+                    try {
+                        restClient
+                            .post()
+                            .uri {
+                                it
+                                    .path("/v1beta/models/{model}:generateContent")
+                                    .build(geminiProperties.model)
+                            }.header(GEMINI_API_KEY_HEADER, geminiProperties.apiKey)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .body(request)
+                            .retrieve()
+                            .body<GeminiExtractionResponse>()
+                    } catch (e: RestClientResponseException) {
+                        throw GeminiApiException.fromResponseError(e)
+                    } catch (e: ResourceAccessException) {
+                        throw GeminiApiException.upstreamError(e)
+                    } ?: throw GeminiApiException.emptyResponse()
+
+                val text = response.extractText()
+                val result =
+                    try {
+                        objectMapper.readValue<GeminiExtractionResult>(text)
+                    } catch (e: Exception) {
+                        throw GeminiApiException.parseError(e)
+                    }
+                result.toProductSnapshot(link)
+            }
         val llmMs = (System.nanoTime() - llmStart) / 1_000_000
 
         log.info(
@@ -74,15 +84,7 @@ class GeminiProductExtractor(
             html.length,
             link.safeLogString(),
         )
-
-        val text = response.extractText()
-        val result =
-            try {
-                objectMapper.readValue<GeminiExtractionResult>(text)
-            } catch (e: Exception) {
-                throw GeminiApiException.parseError(e)
-            }
-        return result.toProductSnapshot(link)
+        return snapshot
     }
 
     // LLM 입력에서 <script>/<style>/주석을 제거해 토큰 낭비와 오판(스크립트 안의 가짜 가격 JSON 등)을 줄인다.

--- a/src/main/kotlin/com/depromeet/team3/product/service/gemini/GeminiProperties.kt
+++ b/src/main/kotlin/com/depromeet/team3/product/service/gemini/GeminiProperties.kt
@@ -21,8 +21,9 @@ data class GeminiProperties(
      * billed API 호출 횟수 상한이므로, API 비용·quota 를 고려해 운영에서 직접 조정한다.
      */
     data class Retry(
-        // 기본값 1 = 재시도 없음 (호출 1회). 재시도가 필요하면 운영에서 명시적으로 2 이상으로 올린다.
-        val maxAttempts: Int = 1,
+        // max-attempts 는 총 시도 횟수(초기 호출 + 재시도). 기본 2 = 초기 호출 1회 + 재시도 1회.
+        // 한 요청이 유발하는 billed API 호출 횟수 상한이므로 비용·quota 에 맞춰 운영에서 조정한다.
+        val maxAttempts: Int = 2,
         val initialDelayMs: Long = 1_000,
     ) {
         init {

--- a/src/main/kotlin/com/depromeet/team3/product/service/gemini/GeminiProperties.kt
+++ b/src/main/kotlin/com/depromeet/team3/product/service/gemini/GeminiProperties.kt
@@ -21,16 +21,13 @@ data class GeminiProperties(
      * billed API 호출 횟수 상한이므로, API 비용·quota 를 고려해 운영에서 직접 조정한다.
      */
     data class Retry(
-        val maxAttempts: Int = 3,
+        // 기본값 1 = 재시도 없음 (호출 1회). 재시도가 필요하면 운영에서 명시적으로 2 이상으로 올린다.
+        val maxAttempts: Int = 1,
         val initialDelayMs: Long = 1_000,
-        val maxDelayMs: Long = 8_000,
     ) {
         init {
             require(maxAttempts >= 1) { "gemini.retry.max-attempts 는 1 이상이어야 합니다: $maxAttempts" }
             require(initialDelayMs >= 0) { "gemini.retry.initial-delay-ms 는 0 이상이어야 합니다: $initialDelayMs" }
-            require(maxDelayMs >= initialDelayMs) {
-                "gemini.retry.max-delay-ms($maxDelayMs) 는 initial-delay-ms($initialDelayMs) 이상이어야 합니다."
-            }
         }
     }
 }

--- a/src/main/kotlin/com/depromeet/team3/product/service/gemini/GeminiProperties.kt
+++ b/src/main/kotlin/com/depromeet/team3/product/service/gemini/GeminiProperties.kt
@@ -6,6 +6,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 data class GeminiProperties(
     val apiKey: String,
     val model: String = "gemini-2.5-flash",
+    val retry: Retry = Retry(),
 ) {
     init {
         require(apiKey.isNotBlank()) { "GEMINI_API_KEY 가 비어 있습니다." }
@@ -13,5 +14,23 @@ data class GeminiProperties(
     }
 
     // data class 기본 toString 은 apiKey 를 그대로 노출하므로, 로그 유출 방지를 위해 마스킹한다.
-    override fun toString(): String = "GeminiProperties(apiKey=*secret*, model=$model)"
+    override fun toString(): String = "GeminiProperties(apiKey=*secret*, model=$model, retry=$retry)"
+
+    /**
+     * Gemini 호출 재시도 파라미터. maxAttempts 는 곧 한 요청이 유발할 수 있는
+     * billed API 호출 횟수 상한이므로, API 비용·quota 를 고려해 운영에서 직접 조정한다.
+     */
+    data class Retry(
+        val maxAttempts: Int = 3,
+        val initialDelayMs: Long = 1_000,
+        val maxDelayMs: Long = 8_000,
+    ) {
+        init {
+            require(maxAttempts >= 1) { "gemini.retry.max-attempts 는 1 이상이어야 합니다: $maxAttempts" }
+            require(initialDelayMs >= 0) { "gemini.retry.initial-delay-ms 는 0 이상이어야 합니다: $initialDelayMs" }
+            require(maxDelayMs >= initialDelayMs) {
+                "gemini.retry.max-delay-ms($maxDelayMs) 는 initial-delay-ms($initialDelayMs) 이상이어야 합니다."
+            }
+        }
+    }
 }

--- a/src/main/kotlin/com/depromeet/team3/product/service/gemini/GeminiRetry.kt
+++ b/src/main/kotlin/com/depromeet/team3/product/service/gemini/GeminiRetry.kt
@@ -41,11 +41,11 @@ class GeminiRetry(
         }
     }
 
-    // 지수 백오프 + full jitter: [0, min(initial * 2^(attempt-1), max)] 범위의 난수.
+    // 지수 백오프 + full jitter: [0, initial * 2^(attempt-1)] 범위의 난수.
     // jitter 는 동시에 실패한 다수 요청이 같은 시점에 재시도하며 몰리는 thundering herd 를 막는다.
+    // 상한 cap 은 두지 않는다 — max-attempts 가 깊어져(5+) 지수 증가가 부담될 시점에 cap 도 함께 도입한다.
     private fun backoffMillis(attempt: Int): Long {
         val exponential = config.initialDelayMs shl (attempt - 1)
-        val capped = minOf(exponential, config.maxDelayMs)
-        return Random.nextLong(capped + 1)
+        return Random.nextLong(exponential + 1)
     }
 }

--- a/src/main/kotlin/com/depromeet/team3/product/service/gemini/GeminiRetry.kt
+++ b/src/main/kotlin/com/depromeet/team3/product/service/gemini/GeminiRetry.kt
@@ -41,11 +41,22 @@ class GeminiRetry(
         }
     }
 
-    // 지수 백오프 + full jitter: [0, initial * 2^(attempt-1)] 범위의 난수.
+    // 지수 백오프 + full jitter: [0, initial * 2^shift] 범위의 난수.
     // jitter 는 동시에 실패한 다수 요청이 같은 시점에 재시도하며 몰리는 thundering herd 를 막는다.
-    // 상한 cap 은 두지 않는다 — max-attempts 가 깊어져(5+) 지수 증가가 부담될 시점에 cap 도 함께 도입한다.
+    //
+    // shift 는 MAX_SHIFT 로 제한 — 두 가지 목적의 안전망:
+    //   1. shl 결과가 Long 부호 비트를 넘어 음수가 되면 Random.nextLong 이 IllegalArgumentException
+    //      으로 깨진다. 운영자가 max-attempts 를 비현실적으로 크게 설정해도 산술적으로 안전.
+    //   2. 깊은 attempts 에서 base 가 분/시간 단위로 폭주하는 것을 방지.
+    // (운영자 튜닝용 max-delay-ms 와는 별개. 그건 의도적 cap, 이건 산술/폭주 안전망.)
     private fun backoffMillis(attempt: Int): Long {
-        val exponential = config.initialDelayMs shl (attempt - 1)
+        val shift = (attempt - 1).coerceAtMost(MAX_SHIFT)
+        val exponential = config.initialDelayMs shl shift
         return Random.nextLong(exponential + 1)
+    }
+
+    companion object {
+        // 2^5 = 32. initialDelayMs=1000 기본일 때 최대 base ≈ 32 초.
+        private const val MAX_SHIFT = 5
     }
 }

--- a/src/main/kotlin/com/depromeet/team3/product/service/gemini/GeminiRetry.kt
+++ b/src/main/kotlin/com/depromeet/team3/product/service/gemini/GeminiRetry.kt
@@ -1,0 +1,57 @@
+package com.depromeet.team3.product.service.gemini
+
+import com.depromeet.team3.common.exception.ErrorCategory
+import org.slf4j.LoggerFactory
+import kotlin.random.Random
+
+/**
+ * Gemini 호출의 일시 장애를 지수 백오프로 재시도한다.
+ *
+ * `RETRYABLE` 카테고리의 [GeminiApiException](5xx · 429 · 408 · 네트워크 타임아웃 · 빈 응답)만
+ * 재시도하고, `SERVER_ERROR` 등 재시도해도 의미 없는 실패는 즉시 전파한다.
+ * 재시도 여부 판단을 예외 타입이 아니라 [GeminiApiException.category] 에 위임하므로
+ * spring-retry 의 타입 기반 `@Retryable` 보다 분류 한 곳(GeminiApiException)에 모인다.
+ *
+ * [sleep] 을 주입 가능하게 둬, 재시도 횟수·분류 로직을 실제 대기 없이 단위 테스트할 수 있다.
+ */
+class GeminiRetry(
+    private val sleep: (Long) -> Unit = { Thread.sleep(it) },
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    fun <T> execute(block: () -> T): T {
+        var attempt = 1
+        while (true) {
+            try {
+                return block()
+            } catch (e: GeminiApiException) {
+                if (e.category != ErrorCategory.RETRYABLE || attempt >= MAX_ATTEMPTS) throw e
+                val delayMs = backoffMillis(attempt)
+                log.warn(
+                    "Gemini 호출 재시도 {}/{} — {}ms 후 ({})",
+                    attempt,
+                    MAX_ATTEMPTS - 1,
+                    delayMs,
+                    e.message,
+                )
+                sleep(delayMs)
+                attempt++
+            }
+        }
+    }
+
+    // 지수 백오프 + full jitter: [0, min(initial * 2^(attempt-1), max)] 범위의 난수.
+    // jitter 는 동시에 실패한 다수 요청이 같은 시점에 재시도하며 몰리는 thundering herd 를 막는다.
+    private fun backoffMillis(attempt: Int): Long {
+        val exponential = INITIAL_DELAY_MS shl (attempt - 1)
+        val capped = minOf(exponential, MAX_DELAY_MS)
+        return Random.nextLong(capped + 1)
+    }
+
+    companion object {
+        // 첫 호출 + 재시도 2회 = 최대 3회 시도.
+        private const val MAX_ATTEMPTS = 3
+        private const val INITIAL_DELAY_MS = 1_000L
+        private const val MAX_DELAY_MS = 8_000L
+    }
+}

--- a/src/main/kotlin/com/depromeet/team3/product/service/gemini/GeminiRetry.kt
+++ b/src/main/kotlin/com/depromeet/team3/product/service/gemini/GeminiRetry.kt
@@ -12,10 +12,11 @@ import kotlin.random.Random
  * 재시도 여부 판단을 예외 타입이 아니라 [GeminiApiException.category] 에 위임하므로
  * spring-retry 의 타입 기반 `@Retryable` 보다 분류 한 곳(GeminiApiException)에 모인다.
  *
- * [sleep] 을 주입 가능하게 둬, 재시도 횟수·분류 로직을 실제 대기 없이 단위 테스트할 수 있다.
+ * 재시도 횟수·백오프는 [GeminiProperties.Retry] 로 외부 주입한다 — maxAttempts 가 곧
+ * billed API 호출 상한이라 운영에서 비용·quota 에 맞춰 조정할 수 있어야 하기 때문이다.
  */
 class GeminiRetry(
-    private val sleep: (Long) -> Unit = { Thread.sleep(it) },
+    private val config: GeminiProperties.Retry,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -25,16 +26,16 @@ class GeminiRetry(
             try {
                 return block()
             } catch (e: GeminiApiException) {
-                if (e.category != ErrorCategory.RETRYABLE || attempt >= MAX_ATTEMPTS) throw e
+                if (e.category != ErrorCategory.RETRYABLE || attempt >= config.maxAttempts) throw e
                 val delayMs = backoffMillis(attempt)
                 log.warn(
                     "Gemini 호출 재시도 {}/{} — {}ms 후 ({})",
                     attempt,
-                    MAX_ATTEMPTS - 1,
+                    config.maxAttempts - 1,
                     delayMs,
                     e.message,
                 )
-                sleep(delayMs)
+                Thread.sleep(delayMs)
                 attempt++
             }
         }
@@ -43,15 +44,8 @@ class GeminiRetry(
     // 지수 백오프 + full jitter: [0, min(initial * 2^(attempt-1), max)] 범위의 난수.
     // jitter 는 동시에 실패한 다수 요청이 같은 시점에 재시도하며 몰리는 thundering herd 를 막는다.
     private fun backoffMillis(attempt: Int): Long {
-        val exponential = INITIAL_DELAY_MS shl (attempt - 1)
-        val capped = minOf(exponential, MAX_DELAY_MS)
+        val exponential = config.initialDelayMs shl (attempt - 1)
+        val capped = minOf(exponential, config.maxDelayMs)
         return Random.nextLong(capped + 1)
-    }
-
-    companion object {
-        // 첫 호출 + 재시도 2회 = 최대 3회 시도.
-        private const val MAX_ATTEMPTS = 3
-        private const val INITIAL_DELAY_MS = 1_000L
-        private const val MAX_DELAY_MS = 8_000L
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,6 +29,11 @@ gemini:
   api-key: ${GEMINI_API_KEY:}
   # preview 모델은 2 주 사전공지 후 deprecate 정책이라 운영 안정성을 위해 GA 모델 사용.
   model: ${GEMINI_MODEL:gemini-2.5-flash}
+  retry:
+    # max-attempts 는 한 요청이 유발할 수 있는 billed API 호출 횟수 상한. 비용·quota 보고 조정.
+    max-attempts: ${GEMINI_RETRY_MAX_ATTEMPTS:3}
+    initial-delay-ms: ${GEMINI_RETRY_INITIAL_DELAY_MS:1000}
+    max-delay-ms: ${GEMINI_RETRY_MAX_DELAY_MS:8000}
 
 springdoc:
   api-docs:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,9 +30,9 @@ gemini:
   # preview 모델은 2 주 사전공지 후 deprecate 정책이라 운영 안정성을 위해 GA 모델 사용.
   model: ${GEMINI_MODEL:gemini-2.5-flash}
   retry:
-    # max-attempts 는 한 요청이 유발할 수 있는 billed API 호출 횟수 상한. 기본 1 = 재시도 없음.
-    # 재시도가 필요하면 비용·quota 보고 환경변수로 2 이상으로 올린다.
-    max-attempts: ${GEMINI_RETRY_MAX_ATTEMPTS:1}
+    # max-attempts 는 총 시도 횟수(초기 호출 + 재시도). 기본 2 = 초기 호출 1회 + 재시도 1회.
+    # 한 요청이 유발하는 billed API 호출 횟수 상한이므로 비용·quota 에 맞춰 환경변수로 조정.
+    max-attempts: ${GEMINI_RETRY_MAX_ATTEMPTS:2}
     initial-delay-ms: ${GEMINI_RETRY_INITIAL_DELAY_MS:1000}
 
 springdoc:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,10 +30,10 @@ gemini:
   # preview 모델은 2 주 사전공지 후 deprecate 정책이라 운영 안정성을 위해 GA 모델 사용.
   model: ${GEMINI_MODEL:gemini-2.5-flash}
   retry:
-    # max-attempts 는 한 요청이 유발할 수 있는 billed API 호출 횟수 상한. 비용·quota 보고 조정.
-    max-attempts: ${GEMINI_RETRY_MAX_ATTEMPTS:3}
+    # max-attempts 는 한 요청이 유발할 수 있는 billed API 호출 횟수 상한. 기본 1 = 재시도 없음.
+    # 재시도가 필요하면 비용·quota 보고 환경변수로 2 이상으로 올린다.
+    max-attempts: ${GEMINI_RETRY_MAX_ATTEMPTS:1}
     initial-delay-ms: ${GEMINI_RETRY_INITIAL_DELAY_MS:1000}
-    max-delay-ms: ${GEMINI_RETRY_MAX_DELAY_MS:8000}
 
 springdoc:
   api-docs:

--- a/src/test/kotlin/com/depromeet/team3/product/service/gemini/GeminiApiExceptionTest.kt
+++ b/src/test/kotlin/com/depromeet/team3/product/service/gemini/GeminiApiExceptionTest.kt
@@ -1,0 +1,51 @@
+package com.depromeet.team3.product.service.gemini
+
+import com.depromeet.team3.common.exception.ErrorCategory
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import org.springframework.http.HttpStatus
+import org.springframework.web.client.HttpClientErrorException
+import org.springframework.web.client.HttpServerErrorException
+import kotlin.test.assertEquals
+
+class GeminiApiExceptionTest {
+
+    @ParameterizedTest
+    @ValueSource(ints = [500, 502, 503, 504])
+    fun `5xx 응답은 RETRYABLE 로 분류된다`(status: Int) {
+        val responseError = HttpServerErrorException(HttpStatus.valueOf(status))
+
+        val exception = GeminiApiException.fromResponseError(responseError)
+
+        assertEquals(ErrorCategory.RETRYABLE, exception.category)
+    }
+
+    @Test
+    fun `429 Too Many Requests 는 RETRYABLE 로 분류된다`() {
+        val responseError = HttpClientErrorException(HttpStatus.TOO_MANY_REQUESTS)
+
+        val exception = GeminiApiException.fromResponseError(responseError)
+
+        assertEquals(ErrorCategory.RETRYABLE, exception.category)
+    }
+
+    @Test
+    fun `408 Request Timeout 은 RETRYABLE 로 분류된다`() {
+        val responseError = HttpClientErrorException(HttpStatus.REQUEST_TIMEOUT)
+
+        val exception = GeminiApiException.fromResponseError(responseError)
+
+        assertEquals(ErrorCategory.RETRYABLE, exception.category)
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = [400, 401, 403, 404])
+    fun `429·408 을 제외한 4xx 응답은 SERVER_ERROR 로 분류된다`(status: Int) {
+        val responseError = HttpClientErrorException(HttpStatus.valueOf(status))
+
+        val exception = GeminiApiException.fromResponseError(responseError)
+
+        assertEquals(ErrorCategory.SERVER_ERROR, exception.category)
+    }
+}

--- a/src/test/kotlin/com/depromeet/team3/product/service/gemini/GeminiRetryTest.kt
+++ b/src/test/kotlin/com/depromeet/team3/product/service/gemini/GeminiRetryTest.kt
@@ -6,8 +6,13 @@ import kotlin.test.assertFailsWith
 
 class GeminiRetryTest {
 
-    // 실제 대기 없이 재시도 횟수·분류만 검증하기 위해 sleep 을 no-op 으로 주입.
-    private val retry = GeminiRetry(sleep = {})
+    // initial/max delay 를 0 으로 둬 Thread.sleep(0) 로 실제 대기 없이 재시도 횟수·분류만 검증한다.
+    private fun retryWith(maxAttempts: Int) =
+        GeminiRetry(
+            GeminiProperties.Retry(maxAttempts = maxAttempts, initialDelayMs = 0, maxDelayMs = 0),
+        )
+
+    private val retry = retryWith(maxAttempts = 3)
 
     @Test
     fun `첫 시도에 성공하면 재시도하지 않고 결과를 반환한다`() {
@@ -24,7 +29,7 @@ class GeminiRetryTest {
     }
 
     @Test
-    fun `RETRYABLE 예외가 계속 나면 최대 3회 시도 후 마지막 예외를 던진다`() {
+    fun `RETRYABLE 예외가 계속 나면 maxAttempts 만큼 시도 후 마지막 예외를 던진다`() {
         var calls = 0
 
         assertFailsWith<GeminiApiException> {
@@ -35,6 +40,20 @@ class GeminiRetryTest {
         }
 
         assertEquals(3, calls)
+    }
+
+    @Test
+    fun `maxAttempts 가 1 이면 재시도하지 않고 첫 실패를 그대로 던진다`() {
+        var calls = 0
+
+        assertFailsWith<GeminiApiException> {
+            retryWith(maxAttempts = 1).execute {
+                calls++
+                throw GeminiApiException.emptyResponse()
+            }
+        }
+
+        assertEquals(1, calls)
     }
 
     @Test

--- a/src/test/kotlin/com/depromeet/team3/product/service/gemini/GeminiRetryTest.kt
+++ b/src/test/kotlin/com/depromeet/team3/product/service/gemini/GeminiRetryTest.kt
@@ -9,7 +9,7 @@ class GeminiRetryTest {
     // initial/max delay 를 0 으로 둬 Thread.sleep(0) 로 실제 대기 없이 재시도 횟수·분류만 검증한다.
     private fun retryWith(maxAttempts: Int) =
         GeminiRetry(
-            GeminiProperties.Retry(maxAttempts = maxAttempts, initialDelayMs = 0, maxDelayMs = 0),
+            GeminiProperties.Retry(maxAttempts = maxAttempts, initialDelayMs = 0),
         )
 
     private val retry = retryWith(maxAttempts = 3)

--- a/src/test/kotlin/com/depromeet/team3/product/service/gemini/GeminiRetryTest.kt
+++ b/src/test/kotlin/com/depromeet/team3/product/service/gemini/GeminiRetryTest.kt
@@ -1,0 +1,82 @@
+package com.depromeet.team3.product.service.gemini
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class GeminiRetryTest {
+
+    // 실제 대기 없이 재시도 횟수·분류만 검증하기 위해 sleep 을 no-op 으로 주입.
+    private val retry = GeminiRetry(sleep = {})
+
+    @Test
+    fun `첫 시도에 성공하면 재시도하지 않고 결과를 반환한다`() {
+        var calls = 0
+
+        val result =
+            retry.execute {
+                calls++
+                "ok"
+            }
+
+        assertEquals("ok", result)
+        assertEquals(1, calls)
+    }
+
+    @Test
+    fun `RETRYABLE 예외가 계속 나면 최대 3회 시도 후 마지막 예외를 던진다`() {
+        var calls = 0
+
+        assertFailsWith<GeminiApiException> {
+            retry.execute {
+                calls++
+                throw GeminiApiException.emptyResponse()
+            }
+        }
+
+        assertEquals(3, calls)
+    }
+
+    @Test
+    fun `RETRYABLE 예외 후 재시도에서 성공하면 그 결과를 반환한다`() {
+        var calls = 0
+
+        val result =
+            retry.execute {
+                calls++
+                if (calls < 2) throw GeminiApiException.emptyResponse()
+                "recovered"
+            }
+
+        assertEquals("recovered", result)
+        assertEquals(2, calls)
+    }
+
+    @Test
+    fun `SERVER_ERROR 예외는 재시도하지 않고 즉시 던진다`() {
+        var calls = 0
+
+        assertFailsWith<GeminiApiException> {
+            retry.execute {
+                calls++
+                throw GeminiApiException.parseError(RuntimeException("깨진 JSON"))
+            }
+        }
+
+        assertEquals(1, calls)
+    }
+
+    @Test
+    fun `GeminiApiException 이 아닌 예외는 재시도하지 않고 즉시 던진다`() {
+        var calls = 0
+
+        assertFailsWith<IllegalStateException> {
+            retry.execute {
+                calls++
+                throw IllegalStateException("boom")
+            }
+        }
+
+        assertEquals(1, calls)
+    }
+}


### PR DESCRIPTION
## Situation
- 두 Gemini 클라이언트(`GeminiProductExtractor`·`GeminiOcrClient`)가 외부 LLM 호출에 대한 재시도 로직이 없어, 일시 장애(5xx · 네트워크 타임아웃)가 한 번 발생하면 그대로 사용자에게 전파됐다. 두 클라이언트 모두에 `TODO: 재시도 필요` 주석이 박혀 있었다.
- PR #113 CodeRabbit 리뷰가 분류 누락도 지적했다 — 현재 `5xx → upstreamError(RETRYABLE), 그 외 4xx → clientError(SERVER_ERROR)` 구조라 429(Too Many Requests)·408(Request Timeout) 처럼 일시 장애 성격을 가진 4xx 응답이 잘못 SERVER_ERROR 로 빠져 retryable 분류에서 누락됐다.

## Task
- 두 Gemini 클라이언트에 공통 재시도 로직 도입.
- HTTP 에러 분류를 한 곳에 모아 429·408 누락 수정.
- 재시도 파라미터를 운영에서 조정 가능하게 외부화. `max-attempts` 가 billed API 호출 상한이라 비용·1분 동기 예산에 묶이는 점 고려.

## Action

### 분류 중앙화
- `GeminiApiException.fromResponseError(e)` 팩토리 추가 — 5xx · 429 · 408 → RETRYABLE, 그 외 4xx → SERVER_ERROR. 두 클라이언트의 중복된 `when` 분기 제거.

### 재시도 헬퍼
- `GeminiRetry` 추가 — `GeminiApiException.category == RETRYABLE` 이면 지수 백오프 + full jitter 로 재시도, 그 외는 즉시 전파. 재시도 여부 판단을 예외 타입이 아니라 카테고리에 위임해 분류가 `GeminiApiException` 한 곳에 모이게 했다 (spring-retry 의 타입 기반 `@Retryable` 대신).
- `GeminiProductExtractor`·`GeminiOcrClient` 의 Gemini 호출부를 `geminiRetry.execute { ... }` 로 감쌌다. `pageFetcher.fetch` 같은 외부 페이지 fetch 는 retry 대상에서 제외.

### 파라미터 외부화·기본값 결정
- `GeminiProperties.Retry` + `application.yml` `gemini.retry.*` 로 환경변수 조정 가능하게 외부화. `max-attempts` 가 한 요청이 유발하는 billed API 호출 상한이라 운영에서 비용·quota 보고 직접 잡을 수 있어야 하기 때문.
- 기본값: `max-attempts=2` (초기 호출 + 재시도 1회), `initial-delay-ms=1000` (재시도 전 [0,1000]ms full jitter). 1분 동기 예산 안에 재시도까지 끝낼 수 있도록 한 선택. 명칭 혼동(시도 횟수 vs 재시도 횟수) 을 주석에 명시.
- 처음 도입한 `max-delay-ms` cap 은 현재 attempts 에서 한 번도 사용되지 않아 노이즈만 됐다. 제거하고, `max-attempts` 가 4+ 로 깊어질 때 cap 도 함께 도입하기로 했다.
- `GeminiProductExtractor` 의 read timeout 을 60 초에서 30 초로 줄여 `GeminiOcrClient` 와 통일 — 1분 예산 안에서 재시도 1회까지 끝낼 여유 확보 (30 + ~1s backoff + 30 ≈ 61s).

### 테스트
- `GeminiRetryTest` — 재시도 횟수·분기(`maxAttempts` 반영, RETRYABLE/SERVER_ERROR/non-Gemini 처리)를 `initial-delay-ms=0` 주입으로 실제 대기 없이 검증.
- `GeminiApiExceptionTest` — HTTP 상태별 카테고리 분류(5xx·429·408·그 외 4xx) `@ParameterizedTest` 로 망라.

## Result
- 두 Gemini 클라이언트가 일관된 재시도·분류 정책을 공유. 429·408 누락 해소.
- 운영이 환경변수로 `max-attempts`·`initial-delay-ms` 조정 가능 (비용·quota 대응).
- 전체 테스트 통과 (128건).
- 후속: 테스트의 `maxAttempts` 중복 같은 fixture·상수 정리는 #150 으로 분리.

---
## 연관 이슈

- close #115


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gemini API 호출에 자동 재시도 도입(지수 백오프 + full jitter), 재시도 시 파싱/응답 처리도 동일 경로에서 재시도
  * 재시도 횟수(기본 2회) 및 초기 지연(기본 1초) 설정 가능
  * 일시적 오류(5xx, 429, 408 등)는 자동 재시도, 기타 오류는 즉시 실패로 분류

* **Behavior Change**
  * LLM 요청 타임아웃이 60초에서 30초로 단축

* **Tests**
  * 재시도 로직 및 HTTP 상태 코드별 예외 분류 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/PIKI-Server/pull/151?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->