### PR TITLE
SecurityConfig 의 /health 를 permitAll 로 풀어 배포 health check 통과시키기

### DIFF
--- a/src/main/kotlin/com/depromeet/team3/auth/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/depromeet/team3/auth/config/SecurityConfig.kt
@@ -27,6 +27,11 @@ class SecurityConfig {
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
             .authorizeHttpRequests { auth ->
                 auth
+                    // 배포 워크플로우의 health check (`curl http://localhost:$PORT/health`) 가 인증 없이
+                    // 통과해야 한다. anyRequest().authenticated() 에 잡히면 401 응답 → 워크플로우 실패 →
+                    // 신규 컨테이너 롤백 → 배포 차단으로 이어진다.
+                    .requestMatchers(HttpMethod.GET, "/health")
+                    .permitAll()
                     .requestMatchers(HttpMethod.POST, "/api/v1/auth/guest")
                     .permitAll()
                     .requestMatchers(HttpMethod.POST, "/api/v1/auth/token/refresh")

--- a/src/test/kotlin/com/depromeet/team3/common/controller/HealthControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/team3/common/controller/HealthControllerIntegrationTest.kt
@@ -1,0 +1,31 @@
+package com.depromeet.team3.common.controller
+
+import com.depromeet.team3.support.IntegrationTestSupport
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.web.context.WebApplicationContext
+
+class HealthControllerIntegrationTest : IntegrationTestSupport() {
+    @Autowired
+    private lateinit var webApplicationContext: WebApplicationContext
+
+    @Test
+    fun `GET health - 인증 없이 200 응답이 와야 한다 (배포 워크플로우 health check 회귀 가드)`() {
+        // anyRequest().authenticated() 가 적용된 상태에서 /health 가 permitAll 명시 누락 시
+        // 401 응답으로 배포가 차단된다. contract 가드로 통합 테스트에서 직접 검증한다.
+        val mockMvc =
+            MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .apply<DefaultMockMvcBuilder>(springSecurity())
+                .build()
+
+        mockMvc
+            .perform(get("/health"))
+            .andExpect(status().isOk)
+    }
+}


### PR DESCRIPTION
## Situation
- PR #147 머지로 `SecurityConfig` 의 `anyRequest().authenticated()` 정책이 적용되면서 명시 안 된 모든 endpoint 가 인증 대상이 됨
- 그 영향으로 `/health` 도 인증을 요구하게 되어 배포 워크플로우의 health check (`curl http://localhost:$PORT/health`) 가 401 응답
- 12회 retry 모두 실패 → 자동 롤백 → 신규 컨테이너 배포 차단

## Task
- `/health` 만 인증 면제로 풀어서 배포 health check 통과시키기
- 회귀 가드로 통합 테스트 추가 — 미래 SecurityConfig 변경 시 같은 차단이 또 발생하지 않게

## Action
- `SecurityConfig` 의 `authorizeHttpRequests` 첫 항목으로 `GET /health` → `permitAll()` 명시. 주석으로 "deploy 워크플로우 차단 방지" 사유 박음
- `HealthControllerIntegrationTest` 신규 — `springSecurity()` 적용한 MockMvc 로 `GET /health` 가 200 응답하는지 단언

## Result
- 배포 워크플로우의 health check 가 200 응답을 받게 됨 → 신규 컨테이너 정상 승격 흐름 복구
- 통합 테스트가 회귀 가드 역할 → SecurityConfig 변경 시 `/health` 가 다시 막히면 빌드 단계에서 잡힘

## 배포 부수 작업 — Redis 환경 구성
이 PR 의 코드 변경과는 별개로, 같은 배포 차단의 또 다른 갈래로 Redis 연결 이슈가 같이 있었다. PR #140 가 인증 인프라 (`RedisRefreshTokenStore` 포함) 를 도입하면서 Redis 연결이 부팅 필수가 됐는데, GitHub Secrets 에 `REDIS_HOST` / `REDIS_PORT` 가 등록되지 않은 상태였다. (PR #147 머지 시점에야 같이 드러남)

- **임시 구성**: EC2 인스턴스 안에 Redis container (`redis:7-alpine`) 를 직접 띄우고 docker bridge IP (`172.17.0.1:6379`) 에 bind. team3-server container 에서 그 IP 로 접근. GitHub Secrets 에 `REDIS_HOST=172.17.0.1`, `REDIS_PORT=6379` 등록 완료
- **이유**: AWS ElastiCache 는 비용 발생 (작은 t4g.micro 도 월 ~$10+) — 도입 타당성과 EC2 안 docker 구성과의 트레이드오프(가용성·운영 부담·데이터 영속성 등)는 팀원들과 별도로 논의 필요
- **현재 트레이드오프**: EC2 재시작 시 refresh token 데이터 손실 — 사용자 재로그인 정도 영향이라 수용 가능한 수준
- **후속**: ElastiCache 도입이 결정되면 `REDIS_HOST` secret 만 endpoint 로 교체하면 코드 변경 없이 전환됨

---
## 연관 이슈

- close #154


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 헬스 체크 엔드포인트가 인증 없이 정상 작동하도록 수정되었습니다.

* **테스트**
  * 헬스 체크 엔드포인트의 정상 작동을 보장하는 통합 테스트가 추가되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/PIKI-Server/pull/155?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->