### PR TITLE
User API 구현 (게스트 닉네임 fill·수정 흐름 포함)

### DIFF
--- a/src/main/kotlin/com/depromeet/team3/auth/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/depromeet/team3/auth/config/SecurityConfig.kt
@@ -47,6 +47,11 @@ class SecurityConfig {
                     // 토너먼트 플레이는 GUEST 도 허용
                     .requestMatchers("/api/v1/tournaments/**")
                     .authenticated()
+                    // /users/me 와 /users/nickname/check 는 게스트도 호출 가능 (닉네임 확정/수정 흐름)
+                    .requestMatchers(HttpMethod.GET, "/api/v1/users/me", "/api/v1/users/nickname/check")
+                    .authenticated()
+                    .requestMatchers(HttpMethod.PATCH, "/api/v1/users/me")
+                    .authenticated()
                     .anyRequest()
                     .authenticated()
             }.exceptionHandling {

--- a/src/main/kotlin/com/depromeet/team3/auth/controller/AuthApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/team3/auth/controller/AuthApiExamples.kt
@@ -7,10 +7,13 @@ import com.depromeet.team3.common.openapi.OpenApiObjectMapper
 import com.depromeet.team3.common.openapi.binds
 import com.depromeet.team3.common.openapi.examples
 import com.depromeet.team3.common.response.ApiResponseBody
+import com.depromeet.team3.user.controller.dto.UserResponse
+import com.depromeet.team3.user.domain.IdentityType
 import org.springdoc.core.customizers.OperationCustomizer
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpStatus
+import java.util.UUID
 
 @Configuration
 class AuthApiExamples(
@@ -30,6 +33,14 @@ class AuthApiExamples(
                                     GuestCreateResponse(
                                         accessToken = "eyJhbGciOiJIUzI1NiJ9.access",
                                         refreshToken = "eyJhbGciOiJIUzI1NiJ9.refresh",
+                                        user =
+                                            UserResponse(
+                                                id = UUID.fromString("8f1a3c2b-9d44-4e2a-9b12-1a2b3c4d5e6f"),
+                                                nickname = "뛰어다니는 강아지",
+                                                profileImage =
+                                                    "https://api.dicebear.com/9.x/bottts/svg?seed=8f1a3c2b-9d44-4e2a-9b12-1a2b3c4d5e6f",
+                                                identityType = IdentityType.GUEST,
+                                            ),
                                     ),
                                 ),
                         )

--- a/src/main/kotlin/com/depromeet/team3/auth/controller/AuthController.kt
+++ b/src/main/kotlin/com/depromeet/team3/auth/controller/AuthController.kt
@@ -23,8 +23,8 @@ class AuthController(
     @PostMapping("/guest")
     @ResponseStatus(HttpStatus.CREATED)
     override fun createGuest(): ApiResponseBody<GuestCreateResponse> {
-        val tokenPair = authService.createGuest()
-        return ApiResponseBody.created(GuestCreateResponse.from(tokenPair))
+        val result = authService.createGuest()
+        return ApiResponseBody.created(GuestCreateResponse.from(result.tokenPair, result.user))
     }
 
     @PostMapping("/token/refresh")

--- a/src/main/kotlin/com/depromeet/team3/auth/controller/DevAuthController.kt
+++ b/src/main/kotlin/com/depromeet/team3/auth/controller/DevAuthController.kt
@@ -24,7 +24,7 @@ class DevAuthController(
     override fun createDevUser(
         @Valid @RequestBody request: DevUserCreateRequest,
     ): ApiResponseBody<GuestCreateResponse> {
-        val tokenPair = authService.createMember(request.nickname)
-        return ApiResponseBody.created(GuestCreateResponse.from(tokenPair))
+        val result = authService.createMember(request.nickname)
+        return ApiResponseBody.created(GuestCreateResponse.from(result.tokenPair, result.user))
     }
 }

--- a/src/main/kotlin/com/depromeet/team3/auth/controller/dto/GuestCreateResponse.kt
+++ b/src/main/kotlin/com/depromeet/team3/auth/controller/dto/GuestCreateResponse.kt
@@ -1,6 +1,8 @@
 package com.depromeet.team3.auth.controller.dto
 
 import com.depromeet.team3.auth.service.dto.TokenPair
+import com.depromeet.team3.user.controller.dto.UserResponse
+import com.depromeet.team3.user.domain.User
 import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "게스트 생성 응답")
@@ -9,12 +11,18 @@ data class GuestCreateResponse(
     val accessToken: String,
     @field:Schema(description = "리프레시 토큰", example = "eyJhbGciOiJIUzI1NiJ9...")
     val refreshToken: String,
+    @field:Schema(description = "서버가 fill 한 초기 유저 정보. FE 가 확정/수정 UI 의 초기값으로 사용.")
+    val user: UserResponse,
 ) {
     companion object {
-        fun from(tokenPair: TokenPair): GuestCreateResponse =
+        fun from(
+            tokenPair: TokenPair,
+            user: User,
+        ): GuestCreateResponse =
             GuestCreateResponse(
                 accessToken = tokenPair.accessToken,
                 refreshToken = tokenPair.refreshToken,
+                user = UserResponse.from(user),
             )
     }
 }

--- a/src/main/kotlin/com/depromeet/team3/auth/service/AuthService.kt
+++ b/src/main/kotlin/com/depromeet/team3/auth/service/AuthService.kt
@@ -3,6 +3,7 @@ package com.depromeet.team3.auth.service
 import com.depromeet.team3.auth.exception.AuthException
 import com.depromeet.team3.auth.infrastructure.jwt.JwtProvider
 import com.depromeet.team3.auth.infrastructure.redis.RefreshTokenStore
+import com.depromeet.team3.auth.service.dto.SignupResult
 import com.depromeet.team3.auth.service.dto.TokenPair
 import com.depromeet.team3.user.domain.User
 import com.depromeet.team3.user.service.UserService
@@ -15,14 +16,16 @@ class AuthService(
     private val jwtProvider: JwtProvider,
     private val refreshTokenStore: RefreshTokenStore,
 ) {
-    fun createGuest(): TokenPair {
+    fun createGuest(): SignupResult {
         val user = userService.createGuest()
-        return issueTokenPair(user)
+        val tokenPair = issueTokenPair(user)
+        return SignupResult(tokenPair = tokenPair, user = user)
     }
 
-    fun createMember(nickname: String): TokenPair {
+    fun createMember(nickname: String): SignupResult {
         val user = userService.createMember(nickname)
-        return issueTokenPair(user)
+        val tokenPair = issueTokenPair(user)
+        return SignupResult(tokenPair = tokenPair, user = user)
     }
 
     fun refresh(refreshToken: String): TokenPair {

--- a/src/main/kotlin/com/depromeet/team3/auth/service/dto/SignupResult.kt
+++ b/src/main/kotlin/com/depromeet/team3/auth/service/dto/SignupResult.kt
@@ -1,0 +1,10 @@
+package com.depromeet.team3.auth.service.dto
+
+import com.depromeet.team3.user.domain.User
+
+// 회원/게스트 생성 결과를 controller 에 넘기는 묶음. 토큰만 반환하면 controller 가 user 정보를
+// 다시 조회해야 하므로 생성한 user 와 발급한 토큰을 함께 들고 나간다.
+data class SignupResult(
+    val tokenPair: TokenPair,
+    val user: User,
+)

--- a/src/main/kotlin/com/depromeet/team3/user/controller/UserApi.kt
+++ b/src/main/kotlin/com/depromeet/team3/user/controller/UserApi.kt
@@ -1,0 +1,146 @@
+package com.depromeet.team3.user.controller
+
+import com.depromeet.team3.common.response.ApiResponseBody
+import com.depromeet.team3.user.controller.dto.NicknameCheckRequest
+import com.depromeet.team3.user.controller.dto.NicknameCheckResponse
+import com.depromeet.team3.user.controller.dto.UserResponse
+import com.depromeet.team3.user.controller.dto.UserUpdateRequest
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.MediaType
+import java.util.UUID
+
+@Tag(name = "User", description = "유저 API")
+interface UserApi {
+    @Operation(
+        summary = "내 정보 조회",
+        description = "현재 로그인된 유저(GUEST 포함) 의 정보를 조회한다.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "조회 성공",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "인증 필요",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun getMe(
+        @Parameter(hidden = true) userId: UUID,
+    ): ApiResponseBody<UserResponse>
+
+    @Operation(
+        summary = "내 정보 수정",
+        description =
+            "내 정보를 부분 수정한다. 현재는 nickname 만 수정 가능 — GUEST 도 호출할 수 있다. " +
+                "회원 전용 필드는 추후 같은 PATCH 에 추가되며 권한 분기는 service 가 처리한다.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "수정 성공",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "닉네임 길이/공백 검증 실패",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "인증 필요",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "409",
+                description = "닉네임 중복",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun updateMe(
+        @Parameter(hidden = true) userId: UUID,
+        request: UserUpdateRequest,
+    ): ApiResponseBody<UserResponse>
+
+    @Operation(
+        summary = "닉네임 중복 체크",
+        description = "닉네임이 이미 다른 유저에게 점유됐는지 확인한다. 회원 전환 / 닉네임 수정 전 사전 확인용.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "확인 성공",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "닉네임 형식 검증 실패",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "인증 필요",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun checkNickname(request: NicknameCheckRequest): ApiResponseBody<NicknameCheckResponse>
+}

--- a/src/main/kotlin/com/depromeet/team3/user/controller/UserApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/team3/user/controller/UserApiExamples.kt
@@ -1,0 +1,106 @@
+package com.depromeet.team3.user.controller
+
+import com.depromeet.team3.common.exception.ErrorCategory
+import com.depromeet.team3.common.openapi.OpenApiObjectMapper
+import com.depromeet.team3.common.openapi.binds
+import com.depromeet.team3.common.openapi.examples
+import com.depromeet.team3.common.response.ApiResponseBody
+import com.depromeet.team3.user.controller.dto.NicknameCheckResponse
+import com.depromeet.team3.user.controller.dto.UserResponse
+import com.depromeet.team3.user.domain.IdentityType
+import org.springdoc.core.customizers.OperationCustomizer
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpStatus
+import java.util.UUID
+
+@Configuration
+class UserApiExamples(
+    private val openApiObjectMapper: OpenApiObjectMapper,
+) {
+    @Bean
+    fun userOpenApiExamples(): OperationCustomizer =
+        OperationCustomizer { operation, handlerMethod ->
+            when {
+                handlerMethod.binds(UserController::getMe) ->
+                    operation.examples(openApiObjectMapper.delegate) {
+                        add(
+                            status = HttpStatus.OK,
+                            name = "내 정보 조회 성공",
+                            payload = ApiResponseBody.ok(sampleUser()),
+                        )
+                        add(
+                            status = HttpStatus.UNAUTHORIZED,
+                            name = "인증 필요",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.UNAUTHORIZED,
+                                    status = HttpStatus.UNAUTHORIZED,
+                                ),
+                        )
+                    }
+
+                handlerMethod.binds(UserController::updateMe) ->
+                    operation.examples(openApiObjectMapper.delegate) {
+                        add(
+                            status = HttpStatus.OK,
+                            name = "닉네임 수정 성공",
+                            payload = ApiResponseBody.ok(sampleUser().copy(nickname = "새닉네임")),
+                        )
+                        add(
+                            status = HttpStatus.BAD_REQUEST,
+                            name = "닉네임 길이/공백 검증 실패",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.INVALID_INPUT,
+                                    status = HttpStatus.BAD_REQUEST,
+                                    detail = "닉네임은 1자 이상 10자 이하여야 한다.",
+                                ),
+                        )
+                        add(
+                            status = HttpStatus.CONFLICT,
+                            name = "닉네임 중복",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.CONFLICT,
+                                    status = HttpStatus.CONFLICT,
+                                    detail = "이미 사용 중인 닉네임입니다.",
+                                ),
+                        )
+                    }
+
+                handlerMethod.binds(UserController::checkNickname) ->
+                    operation.examples(openApiObjectMapper.delegate) {
+                        add(
+                            status = HttpStatus.OK,
+                            name = "사용 가능",
+                            payload = ApiResponseBody.ok(NicknameCheckResponse(available = true)),
+                        )
+                        add(
+                            status = HttpStatus.OK,
+                            name = "이미 사용 중",
+                            payload = ApiResponseBody.ok(NicknameCheckResponse(available = false)),
+                        )
+                        add(
+                            status = HttpStatus.BAD_REQUEST,
+                            name = "닉네임 형식 검증 실패",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.INVALID_INPUT,
+                                    status = HttpStatus.BAD_REQUEST,
+                                    detail = "nickname 은 10자 이하여야 한다.",
+                                ),
+                        )
+                    }
+            }
+            operation
+        }
+
+    private fun sampleUser(): UserResponse =
+        UserResponse(
+            id = UUID.fromString("8f1a3c2b-9d44-4e2a-9b12-1a2b3c4d5e6f"),
+            nickname = "뛰어다니는 강아지",
+            profileImage = "https://api.dicebear.com/9.x/bottts/svg?seed=8f1a3c2b-9d44-4e2a-9b12-1a2b3c4d5e6f",
+            identityType = IdentityType.GUEST,
+        )
+}

--- a/src/main/kotlin/com/depromeet/team3/user/controller/UserController.kt
+++ b/src/main/kotlin/com/depromeet/team3/user/controller/UserController.kt
@@ -1,0 +1,47 @@
+package com.depromeet.team3.user.controller
+
+import com.depromeet.team3.common.response.ApiResponseBody
+import com.depromeet.team3.user.controller.dto.NicknameCheckRequest
+import com.depromeet.team3.user.controller.dto.NicknameCheckResponse
+import com.depromeet.team3.user.controller.dto.UserResponse
+import com.depromeet.team3.user.controller.dto.UserUpdateRequest
+import com.depromeet.team3.user.service.UserService
+import jakarta.validation.Valid
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping("/api/v1/users")
+class UserController(
+    private val userService: UserService,
+) : UserApi {
+    @GetMapping("/me")
+    override fun getMe(
+        @AuthenticationPrincipal userId: UUID,
+    ): ApiResponseBody<UserResponse> {
+        val user = userService.findById(userId)
+        return ApiResponseBody.ok(UserResponse.from(user))
+    }
+
+    @PatchMapping("/me")
+    override fun updateMe(
+        @AuthenticationPrincipal userId: UUID,
+        @Valid @RequestBody request: UserUpdateRequest,
+    ): ApiResponseBody<UserResponse> {
+        val user =
+            request.nickname?.let { userService.updateNickname(userId, it) }
+                ?: userService.findById(userId)
+        return ApiResponseBody.ok(UserResponse.from(user))
+    }
+
+    @GetMapping("/nickname/check")
+    override fun checkNickname(
+        @Valid request: NicknameCheckRequest,
+    ): ApiResponseBody<NicknameCheckResponse> =
+        ApiResponseBody.ok(NicknameCheckResponse(available = userService.isNicknameAvailable(request.nickname)))
+}

--- a/src/main/kotlin/com/depromeet/team3/user/controller/dto/NicknameCheckRequest.kt
+++ b/src/main/kotlin/com/depromeet/team3/user/controller/dto/NicknameCheckRequest.kt
@@ -1,0 +1,13 @@
+package com.depromeet.team3.user.controller.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+@Schema(description = "닉네임 중복 체크 요청 (query parameter)")
+data class NicknameCheckRequest(
+    @field:NotBlank(message = "nickname 은 비어 있거나 공백만으로 구성될 수 없다.")
+    @field:Size(max = 10, message = "nickname 은 10자 이하여야 한다.")
+    @field:Schema(description = "확인할 닉네임 (최대 10자)", example = "새닉네임")
+    val nickname: String,
+)

--- a/src/main/kotlin/com/depromeet/team3/user/controller/dto/NicknameCheckResponse.kt
+++ b/src/main/kotlin/com/depromeet/team3/user/controller/dto/NicknameCheckResponse.kt
@@ -1,0 +1,9 @@
+package com.depromeet.team3.user.controller.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "닉네임 중복 체크 결과")
+data class NicknameCheckResponse(
+    @field:Schema(description = "사용 가능 여부 (이미 다른 유저가 쓰고 있으면 false)")
+    val available: Boolean,
+)

--- a/src/main/kotlin/com/depromeet/team3/user/controller/dto/UserResponse.kt
+++ b/src/main/kotlin/com/depromeet/team3/user/controller/dto/UserResponse.kt
@@ -1,0 +1,28 @@
+package com.depromeet.team3.user.controller.dto
+
+import com.depromeet.team3.user.domain.IdentityType
+import com.depromeet.team3.user.domain.User
+import io.swagger.v3.oas.annotations.media.Schema
+import java.util.UUID
+
+@Schema(description = "유저 정보")
+data class UserResponse(
+    @field:Schema(description = "유저 식별자", format = "uuid")
+    val id: UUID,
+    @field:Schema(description = "닉네임 (최대 10자)", example = "뛰어다니는 강아지")
+    val nickname: String,
+    @field:Schema(description = "프로필 이미지 URL")
+    val profileImage: String,
+    @field:Schema(description = "유저 종류")
+    val identityType: IdentityType,
+) {
+    companion object {
+        fun from(user: User): UserResponse =
+            UserResponse(
+                id = user.id,
+                nickname = user.nickname,
+                profileImage = user.profileImage,
+                identityType = user.identityType,
+            )
+    }
+}

--- a/src/main/kotlin/com/depromeet/team3/user/controller/dto/UserUpdateRequest.kt
+++ b/src/main/kotlin/com/depromeet/team3/user/controller/dto/UserUpdateRequest.kt
@@ -1,0 +1,13 @@
+package com.depromeet.team3.user.controller.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Size
+
+@Schema(description = "유저 정보 수정 요청")
+data class UserUpdateRequest(
+    // 게스트도 호출 가능한 PATCH 라 모든 필드 nullable. 추후 회원 전용 필드 추가 시에도 같은 PATCH 가
+    // 자기 권한 안의 필드만 수정하게 된다.
+    @field:Size(min = 1, max = 10, message = "닉네임은 1자 이상 10자 이하여야 한다.")
+    @field:Schema(description = "변경할 닉네임 (선택, 최대 10자)", example = "새닉네임", nullable = true)
+    val nickname: String?,
+)

--- a/src/main/kotlin/com/depromeet/team3/user/domain/User.kt
+++ b/src/main/kotlin/com/depromeet/team3/user/domain/User.kt
@@ -19,8 +19,7 @@ class User(
     identityType: IdentityType,
 ) : BaseEntity<UUID>() {
     init {
-        if (nickname.isBlank()) throw UserException.invalidNickname("닉네임은 공백일 수 없습니다.")
-        if (nickname.length > 16) throw UserException.invalidNickname("닉네임은 16자 이하여야 합니다.")
+        validateNickname(nickname)
     }
 
     @Id
@@ -51,12 +50,22 @@ class User(
     }
 
     fun updateNickname(newNickname: String) {
-        if (newNickname.isBlank()) throw UserException.invalidNickname("닉네임은 공백일 수 없습니다.")
-        if (newNickname.length > 16) throw UserException.invalidNickname("닉네임은 16자 이하여야 합니다.")
+        validateNickname(newNickname)
         nickname = newNickname
     }
 
     fun softDelete() {
         deletedAt = deletedAt ?: LocalDateTime.now()
+    }
+
+    companion object {
+        const val NICKNAME_MAX_LENGTH = 10
+
+        private fun validateNickname(nickname: String) {
+            if (nickname.isBlank()) throw UserException.invalidNickname("닉네임은 공백일 수 없습니다.")
+            if (nickname.length > NICKNAME_MAX_LENGTH) {
+                throw UserException.invalidNickname("닉네임은 $NICKNAME_MAX_LENGTH 자 이하여야 합니다.")
+            }
+        }
     }
 }

--- a/src/main/kotlin/com/depromeet/team3/user/domain/UserException.kt
+++ b/src/main/kotlin/com/depromeet/team3/user/domain/UserException.kt
@@ -34,9 +34,9 @@ class UserException private constructor(
                 HttpStatus.CONFLICT,
             )
 
-        fun duplicateNickname(nickname: String): UserException =
+        fun duplicateNickname(): UserException =
             UserException(
-                "이미 사용 중인 닉네임입니다. nickname=$nickname",
+                "이미 사용 중인 닉네임입니다.",
                 ErrorCategory.CONFLICT,
                 HttpStatus.CONFLICT,
             )

--- a/src/main/kotlin/com/depromeet/team3/user/service/UserService.kt
+++ b/src/main/kotlin/com/depromeet/team3/user/service/UserService.kt
@@ -69,7 +69,7 @@ class UserService(
 
     @Transactional
     fun createMember(nickname: String): User {
-        if (userRepository.existsByNickname(nickname)) throw UserException.duplicateNickname(nickname)
+        if (userRepository.existsByNickname(nickname)) throw UserException.duplicateNickname()
         val id = UUID.randomUUID()
         val profileImage = dicebearUrl(id)
         return try {
@@ -77,7 +77,7 @@ class UserService(
                 User(id = id, nickname = nickname, profileImage = profileImage, identityType = IdentityType.MEMBER),
             )
         } catch (e: DataIntegrityViolationException) {
-            throw UserException.duplicateNickname(nickname)
+            throw UserException.duplicateNickname()
         }
     }
 
@@ -95,7 +95,7 @@ class UserService(
         val user = findById(userId)
         user.deletedAt?.let { throw UserException.deletedUser(userId) }
         if (user.nickname != newNickname && userRepository.existsByNickname(newNickname)) {
-            throw UserException.duplicateNickname(newNickname)
+            throw UserException.duplicateNickname()
         }
         user.updateNickname(newNickname)
         return userRepository.save(user)

--- a/src/main/kotlin/com/depromeet/team3/user/service/UserService.kt
+++ b/src/main/kotlin/com/depromeet/team3/user/service/UserService.kt
@@ -84,6 +84,9 @@ class UserService(
     @Transactional(readOnly = true)
     fun findById(userId: UUID): User = userRepository.findById(userId) ?: throw UserException.notFound(userId)
 
+    @Transactional(readOnly = true)
+    fun isNicknameAvailable(nickname: String): Boolean = !userRepository.existsByNickname(nickname)
+
     @Transactional
     fun updateNickname(
         userId: UUID,

--- a/src/main/resources/db/migration/V18__shrink_user_nickname_to_10.sql
+++ b/src/main/resources/db/migration/V18__shrink_user_nickname_to_10.sql
@@ -1,4 +1,6 @@
 -- 기획 반영: 닉네임 정책 16자 → 10자.
--- 현재 GUEST 닉네임 생성은 prefix + animal 조합으로 최대 9자라 기존 데이터 영향 없음.
--- VARCHAR(16) 컬럼을 VARCHAR(10) 로 좁힌다.
+-- 사전 검증 (2026-05-21 dev RDS): 11자 초과 닉네임 0건.
+--   SELECT COUNT(*) FROM `user` WHERE CHAR_LENGTH(nickname) > 10;  → 0
+-- 신규 입력 가드: GUEST 닉네임 생성은 prefix + animal 조합으로 최대 9자,
+-- MEMBER 도 @field:Size(max=10) 으로 막힘. 기존 데이터 잘림 위험 없음 확인.
 ALTER TABLE `user` MODIFY COLUMN nickname VARCHAR(10) NOT NULL;

--- a/src/main/resources/db/migration/V18__shrink_user_nickname_to_10.sql
+++ b/src/main/resources/db/migration/V18__shrink_user_nickname_to_10.sql
@@ -1,0 +1,4 @@
+-- 기획 반영: 닉네임 정책 16자 → 10자.
+-- 현재 GUEST 닉네임 생성은 prefix + animal 조합으로 최대 9자라 기존 데이터 영향 없음.
+-- VARCHAR(16) 컬럼을 VARCHAR(10) 로 좁힌다.
+ALTER TABLE `user` MODIFY COLUMN nickname VARCHAR(10) NOT NULL;

--- a/src/test/kotlin/com/depromeet/team3/auth/controller/AuthControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/team3/auth/controller/AuthControllerIntegrationTest.kt
@@ -30,7 +30,8 @@ class AuthControllerIntegrationTest : IntegrationTestSupport() {
             .build()
 
     @Test
-    fun `POST auth guest - 201 과 accessToken, refreshToken 이 응답에 포함된다`() {
+    fun `POST auth guest - 201 과 accessToken, refreshToken, user 가 응답에 포함된다`() {
+        // FE 의 진입 fill 흐름을 위해 user 정보가 응답에 같이 와야 한다. 회귀 가드.
         mockMvc()
             .perform(post("/api/v1/auth/guest").contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isCreated)
@@ -38,6 +39,10 @@ class AuthControllerIntegrationTest : IntegrationTestSupport() {
             .andExpect(jsonPath("$.code").value("CREATED"))
             .andExpect(jsonPath("$.data.accessToken").isString)
             .andExpect(jsonPath("$.data.refreshToken").isString)
+            .andExpect(jsonPath("$.data.user.id").isString)
+            .andExpect(jsonPath("$.data.user.nickname").isString)
+            .andExpect(jsonPath("$.data.user.profileImage").isString)
+            .andExpect(jsonPath("$.data.user.identityType").value("GUEST"))
     }
 
     @Test

--- a/src/test/kotlin/com/depromeet/team3/user/controller/UserControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/team3/user/controller/UserControllerIntegrationTest.kt
@@ -1,0 +1,211 @@
+package com.depromeet.team3.user.controller
+
+import com.depromeet.team3.auth.infrastructure.jwt.JwtProvider
+import com.depromeet.team3.support.IntegrationTestSupport
+import com.depromeet.team3.support.uuidToBytes
+import com.depromeet.team3.user.domain.IdentityType
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.context.WebApplicationContext
+import tools.jackson.databind.ObjectMapper
+import java.util.UUID
+
+@Transactional
+class UserControllerIntegrationTest : IntegrationTestSupport() {
+    @Autowired
+    private lateinit var webApplicationContext: WebApplicationContext
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @Autowired
+    private lateinit var jdbcTemplate: JdbcTemplate
+
+    @Autowired
+    private lateinit var jwtProvider: JwtProvider
+
+    private fun insertUser(
+        userId: UUID,
+        nickname: String = userId.toString().take(10),
+        identityType: IdentityType = IdentityType.GUEST,
+    ) {
+        jdbcTemplate.update(
+            "INSERT INTO user (id, nickname, profile_image, identity_type, created_at, updated_at) " +
+                "VALUES (?, ?, ?, ?, NOW(6), NOW(6))",
+            uuidToBytes(userId),
+            nickname,
+            "https://example.com/img.png",
+            identityType.name,
+        )
+    }
+
+    private fun token(
+        userId: UUID,
+        identityType: IdentityType = IdentityType.GUEST,
+    ): String = jwtProvider.generateAccessToken(userId, identityType)
+
+    @Test
+    fun `GET users me - 게스트가 자기 정보를 200 으로 조회한다`() {
+        val mockMvc =
+            MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .apply<DefaultMockMvcBuilder>(springSecurity())
+                .build()
+        val userId = UUID.randomUUID()
+        insertUser(userId, nickname = "테스트닉네임", identityType = IdentityType.GUEST)
+
+        mockMvc
+            .perform(
+                get("/api/v1/users/me")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer ${token(userId, IdentityType.GUEST)}"),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.status").value(200))
+            .andExpect(jsonPath("$.code").value("OK"))
+            .andExpect(jsonPath("$.data.id").value(userId.toString()))
+            .andExpect(jsonPath("$.data.nickname").value("테스트닉네임"))
+            .andExpect(jsonPath("$.data.identityType").value("GUEST"))
+            .andExpect(jsonPath("$.data.profileImage").isString)
+    }
+
+    @Test
+    fun `GET users me - 인증 헤더 없으면 401 이 반환된다`() {
+        val mockMvc =
+            MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .apply<DefaultMockMvcBuilder>(springSecurity())
+                .build()
+
+        mockMvc.perform(get("/api/v1/users/me")).andExpect(status().isUnauthorized)
+    }
+
+    @Test
+    fun `PATCH users me - 게스트가 닉네임을 수정하면 200 과 변경된 닉네임이 반환된다`() {
+        val mockMvc =
+            MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .apply<DefaultMockMvcBuilder>(springSecurity())
+                .build()
+        val userId = UUID.randomUUID()
+        insertUser(userId, nickname = "초기닉네임", identityType = IdentityType.GUEST)
+        val body = objectMapper.writeValueAsString(mapOf("nickname" to "새닉네임"))
+
+        mockMvc
+            .perform(
+                patch("/api/v1/users/me")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer ${token(userId, IdentityType.GUEST)}")
+                    .content(body),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.nickname").value("새닉네임"))
+    }
+
+    @Test
+    fun `PATCH users me - 닉네임 11자는 400 이 반환된다`() {
+        val mockMvc =
+            MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .apply<DefaultMockMvcBuilder>(springSecurity())
+                .build()
+        val userId = UUID.randomUUID()
+        insertUser(userId)
+        val body = objectMapper.writeValueAsString(mapOf("nickname" to "12345678901"))
+
+        mockMvc
+            .perform(
+                patch("/api/v1/users/me")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer ${token(userId)}")
+                    .content(body),
+            ).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `PATCH users me - 이미 사용 중인 닉네임으로 변경하면 409 가 반환된다`() {
+        val mockMvc =
+            MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .apply<DefaultMockMvcBuilder>(springSecurity())
+                .build()
+        val otherUserId = UUID.randomUUID()
+        insertUser(otherUserId, nickname = "점유닉네임")
+        val myUserId = UUID.randomUUID()
+        insertUser(myUserId, nickname = "내닉네임")
+        val body = objectMapper.writeValueAsString(mapOf("nickname" to "점유닉네임"))
+
+        mockMvc
+            .perform(
+                patch("/api/v1/users/me")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer ${token(myUserId)}")
+                    .content(body),
+            ).andExpect(status().isConflict)
+            .andExpect(jsonPath("$.code").value("CONFLICT"))
+    }
+
+    @Test
+    fun `GET users nickname check - 사용 가능한 닉네임이면 available true 가 반환된다`() {
+        val mockMvc =
+            MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .apply<DefaultMockMvcBuilder>(springSecurity())
+                .build()
+        val userId = UUID.randomUUID()
+        insertUser(userId)
+
+        mockMvc
+            .perform(
+                get("/api/v1/users/nickname/check")
+                    .param("nickname", "안쓰는닉네임")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer ${token(userId)}"),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.available").value(true))
+    }
+
+    @Test
+    fun `GET users nickname check - 이미 사용 중인 닉네임이면 available false 가 반환된다`() {
+        val mockMvc =
+            MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .apply<DefaultMockMvcBuilder>(springSecurity())
+                .build()
+        val userId = UUID.randomUUID()
+        insertUser(userId, nickname = "점유닉네임")
+
+        mockMvc
+            .perform(
+                get("/api/v1/users/nickname/check")
+                    .param("nickname", "점유닉네임")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer ${token(userId)}"),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.available").value(false))
+    }
+
+    @Test
+    fun `GET users nickname check - 11자 닉네임은 400 이 반환된다`() {
+        val mockMvc =
+            MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .apply<DefaultMockMvcBuilder>(springSecurity())
+                .build()
+        val userId = UUID.randomUUID()
+        insertUser(userId)
+
+        mockMvc
+            .perform(
+                get("/api/v1/users/nickname/check")
+                    .param("nickname", "12345678901")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer ${token(userId)}"),
+            ).andExpect(status().isBadRequest)
+    }
+}

--- a/src/test/kotlin/com/depromeet/team3/user/domain/UserTest.kt
+++ b/src/test/kotlin/com/depromeet/team3/user/domain/UserTest.kt
@@ -38,16 +38,16 @@ class UserTest {
     }
 
     @Test
-    fun `닉네임 16자는 허용된다`() {
+    fun `닉네임 10자는 허용된다`() {
         val user = guest()
-        user.updateNickname("1234567890123456")
-        assertEquals("1234567890123456", user.nickname)
+        user.updateNickname("1234567890")
+        assertEquals("1234567890", user.nickname)
     }
 
     @Test
-    fun `닉네임 17자는 예외가 발생한다`() {
+    fun `닉네임 11자는 예외가 발생한다`() {
         val user = guest()
-        assertFailsWith<UserException> { user.updateNickname("12345678901234567") }
+        assertFailsWith<UserException> { user.updateNickname("12345678901") }
     }
 
     @Test

--- a/src/test/kotlin/com/depromeet/team3/wishlist/controller/WishlistControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/team3/wishlist/controller/WishlistControllerIntegrationTest.kt
@@ -43,7 +43,7 @@ class WishlistControllerIntegrationTest : IntegrationTestSupport() {
         jdbcTemplate.update(
             "INSERT INTO user (id, nickname, identity_type, created_at, updated_at) VALUES (?, ?, ?, NOW(6), NOW(6))",
             uuidToBytes(userId),
-            userId.toString().take(16),
+            userId.toString().take(10),
             "MEMBER",
         )
     }


### PR DESCRIPTION
## Situation
- 게스트가 첫 진입 시 닉네임을 확정/수정할 수 있는 UI 가 필요한데, 기존 `GuestCreateResponse` 는 토큰만 반환해서 FE 가 user 정보 받으려면 추가 호출 필요
- User 도메인 닉네임 길이 정책이 16자였는데 기획상 10자 max
- `GET/PATCH /users/me`, `GET /users/nickname/check` 같은 회원 정보 endpoint 가 없었음

## Task
- #128 (Task 5) — User API 구현
- 기획 반영 3가지:
  - 닉네임 정책 10자
  - 게스트도 닉네임 수정 가능 (회원 전환 전 단계)
  - 게스트 생성 응답에 user 정보 fill (FE 가 확정/수정 UI 초기값 받음)

## Action

### 닉네임 정책 10자로 좁힘
- `User.kt` 의 검증 분기 (init / updateNickname) 를 `validateNickname()` 함수로 통합. `NICKNAME_MAX_LENGTH = 10` 상수
- V18 마이그레이션 — `user.nickname VARCHAR(16) → VARCHAR(10)`. 현재 GUEST 닉네임은 최대 9자라 기존 데이터 영향 없음

### 게스트 생성 응답에 user 정보 fill
- `GuestCreateResponse` 에 `user: UserResponse` nested 추가. FE 가 확정/수정 UI 초기값으로 사용
- `UserResponse` 공통 DTO 신규 — `GET /users/me` 도 같은 모양 공유
- `SignupResult(tokenPair, user)` DTO 신규 — service 가 토큰만 반환하면 controller 가 user 재조회로 DB 라운드트립 1번 더. service 가 이미 만들어둔 데이터를 한 트랜잭션 결과로 노출하는 게 정직 + 효율
- `AuthService.createGuest/Member` 반환 타입 `TokenPair` → `SignupResult`. 양쪽 endpoint 일관

### User API
- `GET /users/me` — `authenticated`, 자기 정보 조회
- `PATCH /users/me` — `authenticated`, 닉네임 수정 (게스트도 호출 가능)
- `GET /users/nickname/check` — `authenticated`, 중복 체크
- `SecurityConfig` 에 위 경로 정책 추가
- 권한 매처는 `authenticated()` — IdentityType (MEMBER + GUEST) 모두 허용 의도. `hasAuthority("MEMBER")` 는 회원 전용 endpoint (별 후속) 에만

### 컨벤션 정렬
- 검증 어노테이션은 DTO field 에 (`@field:NotBlank`, `@field:Size(max=10)`), `@Valid` 는 controller method param 에. Interface (`UserApi`) 는 어노테이션 없음 — CLAUDE.md "컨트롤러/OpenAPI 문서" 컨벤션 따름
- 다른 controller (`WishlistController`, `AuthController`) 와 동일한 `@Valid + DTO field constraint` 패턴

## Result
- FE 흐름: `POST /auth/guest` 한 번으로 token + user 받음 → 확정/수정 UI 띄움 → 수정 시 `PATCH /users/me`. 추가 API 호출 없음
- 도메인·DB·DTO 닉네임 길이 일관 (10자)
- 기존 `WishlistControllerIntegrationTest` fixture (`take(16)`) 도 10자로 좁혀 V18 와 정합성
- 테스트: `UserControllerIntegrationTest` 8 케이스 신규, `AuthControllerIntegrationTest` 의 createGuest 검증에 user 필드 추가 (회귀 가드), `UserTest` 길이 케이스 갱신. 로컬 curl 9 케이스 직접 검증 완료
- 후속 (별 작업, Task 5 분할):
  - `PUT /users/me/profile-image` — S3 의존성 검토 필요
  - `DELETE /users/me` — 탈퇴 정책 (soft vs hard, 연관 데이터 처리) 결정 필요

---
## 연관 이슈

- close #128


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 사용자 프로필 조회 엔드포인트 추가
  * 사용자 프로필 수정 엔드포인트 추가
  * 닉네임 중복 확인 기능 추가
  * 게스트/멤버 로그인 응답에 사용자 정보 포함

* **Improvements**
  * 닉네임 길이 제한을 10자로 단축
  * 인증된 사용자만 프로필 접근 가능하도록 보안 강화

* **Tests**
  * 사용자 관련 엔드포인트 통합 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/PIKI-Server/pull/161?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->