### PR TITLE
/pr 스킬에 CodeRabbit 인라인 리뷰 처리 단계 추가

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -160,9 +160,12 @@ ISSUE_LABELS=$(gh issue view {번호} --json labels --jq '[.labels[].name] | joi
 6. **제목 변경 필요 검토**: 추가 변경으로 작업 의도/스코프가 바뀌었거나 기존 제목에 오타·부정확한 표현이 있으면 새 제목 제안. 그 외엔 제목 유지.
 7. 사용자에게 갱신본(필요시 새 제목 포함, 변경 이유 짚어서)을 보여주고 확인받는다.
 8. 확인 후 `gh pr edit --body-file /tmp/pr_body.md` 로 갱신. 제목 변경이 있으면 `--title "새 제목"` 추가.
-9. **인라인 리뷰 코멘트 처리** — 이번 변경이 CodeRabbit (또는 사람) 리뷰 대응이라면 commit + push 로 끝내지 않는다. 각 review thread 에 reply 를 남겨 **어떤 commit 으로 반영했는지 / reject 한 이유가 무엇인지**가 conversation 에 박혀야 다른 리뷰어가 처리 여부를 헷갈리지 않는다.
+9. **CodeRabbit 인라인 리뷰 코멘트 처리** — 이번 변경이 CodeRabbit 리뷰 대응이라면 commit + push 로 끝내지 않는다. 각 review thread 에 reply 를 남겨 **어떤 commit 으로 반영했는지 / reject 한 이유가 무엇인지**가 conversation 에 박혀야 다른 리뷰어가 처리 여부를 헷갈리지 않는다.
+
+   **사람 리뷰어 thread 는 자동 reply 하지 않는다.** author 가 `coderabbitai` 가 아니면 (즉 사람 리뷰면) reply / resolve 둘 다 모델이 건드리지 않는다 — 작성자(`@me`)가 직접 의도·뉘앙스를 담아 답한다. 처리해야 할 thread 가 사람이면 사용자에게 "사람 리뷰 N건 있습니다" 만 알리고 멈춘다.
+
    ```bash
-   # 1. Thread 조회 — CodeRabbit 필터 (사람 리뷰어면 author 만 바꾼다)
+   # 1. CodeRabbit thread 조회 — author "coderabbitai" 고정 필터
    gh api graphql -f query='
      query { repository(owner: "depromeet", name: "PIKI-Server") {
        pullRequest(number: {N}) {
@@ -175,7 +178,7 @@ ISSUE_LABELS=$(gh issue view {번호} --json labels --jq '[.labels[].name] | joi
               | select(.comments.nodes[0].author.login == "coderabbitai")
               | {id, isResolved, path, line}'
 
-   # 2. 각 thread 에 reply
+   # 2. 각 CodeRabbit thread 에 reply
    gh api graphql -f query='
      mutation($t: ID!, $b: String!) {
        addPullRequestReviewThreadReply(input: {pullRequestReviewThreadId: $t, body: $b}) {

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -132,7 +132,7 @@ ISSUE_LABELS=$(gh issue view {번호} --json labels --jq '[.labels[].name] | joi
      --field-id PVTSSF_lADOARZVGM4BVVRVzhQxyAA \
      --single-select-option-id df73e18b
    ```
-   - PR 을 올린다는 것은 곧 리뷰 대기 상태이므로 `In review` 가 자연스럽다. create 모드는 방금 만든 PR 이라 Status 가 항상 기본값(`Backlog`)이므로 조건 없이 세팅한다 (update 모드 9단계는 기존 Status 를 확인 후 분기).
+   - PR 을 올린다는 것은 곧 리뷰 대기 상태이므로 `In review` 가 자연스럽다. create 모드는 방금 만든 PR 이라 Status 가 항상 기본값(`Backlog`)이므로 조건 없이 세팅한다 (update 모드 10단계는 기존 Status 를 확인 후 분기).
    - ID 의미: project=99 노드 ID, field=Status 필드 ID, option=`In review` 옵션 ID. 보드에서 Status 옵션이 바뀌면 이 ID 들도 갱신 필요.
    - 권한 부족 시 사용자에게 `gh auth refresh -h github.com -s project` 안내 (일회성 디바이스 인증).
 5. PR URL 과 부여된 assignee / 라벨 / Project(Status: In review) 결과를 사용자에게 전달
@@ -162,9 +162,22 @@ ISSUE_LABELS=$(gh issue view {번호} --json labels --jq '[.labels[].name] | joi
 8. 확인 후 `gh pr edit --body-file /tmp/pr_body.md` 로 갱신. 제목 변경이 있으면 `--title "새 제목"` 추가.
 9. **CodeRabbit 인라인 리뷰 코멘트 처리** — 이번 변경이 CodeRabbit 리뷰 대응이라면 commit + push 로 끝내지 않는다. 각 review thread 에 reply 를 남겨 **어떤 commit 으로 반영했는지 / reject 한 이유가 무엇인지**가 conversation 에 박혀야 다른 리뷰어가 처리 여부를 헷갈리지 않는다.
 
-   **사람 리뷰어 thread 는 자동 reply 하지 않는다.** author 가 `coderabbitai` 가 아니면 (즉 사람 리뷰면) reply / resolve 둘 다 모델이 건드리지 않는다 — 작성자(`@me`)가 직접 의도·뉘앙스를 담아 답한다. 처리해야 할 thread 가 사람이면 사용자에게 "사람 리뷰 N건 있습니다" 만 알리고 멈춘다.
+   **사람 리뷰어 thread 는 자동 reply 하지 않는다.** author 가 `coderabbitai` 가 아니면 (즉 사람 리뷰면) reply / resolve 둘 다 모델이 건드리지 않는다 — 작성자(`@me`)가 직접 의도·뉘앙스를 담아 답한다. 0번 단계 카운트에서 1건 이상이면 아래 1~3 단계는 모두 건너뛰고 사용자에게 "사람 리뷰 N건 있습니다" 만 알린 뒤 10단계로 넘어간다.
 
    ```bash
+   # 0. 사람 리뷰 thread 카운트 — 1 이상이면 아래 1~3 단계 건너뛴다
+   HUMAN_THREADS=$(gh api graphql -f query='
+     query { repository(owner: "depromeet", name: "PIKI-Server") {
+       pullRequest(number: {N}) {
+         reviewThreads(first: 50) { nodes {
+           comments(first: 1) { nodes { author { login } } }
+         } }
+       }
+     }}' --jq '[.data.repository.pullRequest.reviewThreads.nodes[]
+                | select(.comments.nodes[0].author.login != "coderabbitai")] | length')
+   echo "사람 리뷰 thread: ${HUMAN_THREADS}건"
+   # HUMAN_THREADS > 0 → 아래 1~3 단계 건너뛰고 10단계로
+
    # 1. CodeRabbit thread 조회 — author "coderabbitai" 고정 필터
    gh api graphql -f query='
      query { repository(owner: "depromeet", name: "PIKI-Server") {
@@ -174,9 +187,9 @@ ISSUE_LABELS=$(gh issue view {번호} --json labels --jq '[.labels[].name] | joi
            comments(first: 1) { nodes { author { login } body } }
          } }
        }
-     }' --jq '.data.repository.pullRequest.reviewThreads.nodes[]
-              | select(.comments.nodes[0].author.login == "coderabbitai")
-              | {id, isResolved, path, line}'
+     }}' --jq '.data.repository.pullRequest.reviewThreads.nodes[]
+               | select(.comments.nodes[0].author.login == "coderabbitai")
+               | {id, isResolved, path, line}'
 
    # 2. 각 CodeRabbit thread 에 reply
    gh api graphql -f query='

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -160,30 +160,63 @@ ISSUE_LABELS=$(gh issue view {번호} --json labels --jq '[.labels[].name] | joi
 6. **제목 변경 필요 검토**: 추가 변경으로 작업 의도/스코프가 바뀌었거나 기존 제목에 오타·부정확한 표현이 있으면 새 제목 제안. 그 외엔 제목 유지.
 7. 사용자에게 갱신본(필요시 새 제목 포함, 변경 이유 짚어서)을 보여주고 확인받는다.
 8. 확인 후 `gh pr edit --body-file /tmp/pr_body.md` 로 갱신. 제목 변경이 있으면 `--title "새 제목"` 추가.
-9. **메타데이터 보정** — 이전 버전 스킬로 만든 PR 은 assignee / 라벨 / Project 가 비어 있을 수 있다. update 모드에서도 멱등하게 보정한다 (이미 설정돼 있으면 no-op). `item-add` 는 이미 등록된 PR 이면 기존 item id 를 그대로 반환한다.
-   Status 는 **현재 값을 먼저 조회해, 리뷰 이전 단계(`Backlog` / `Ready` / `In progress`)일 때만** `In review` 로 올린다 — 이미 `Done` 등으로 옮긴 PR 을 되돌리지 않기 위함이다. Status 조회는 item 노드를 직접 부르는 GraphQL 이 안정적이다 (`gh project item-list` 는 단일 선택 필드 값을 신뢰성 있게 주지 않는다):
+9. **인라인 리뷰 코멘트 처리** — 이번 변경이 CodeRabbit (또는 사람) 리뷰 대응이라면 commit + push 로 끝내지 않는다. 각 review thread 에 reply 를 남겨 **어떤 commit 으로 반영했는지 / reject 한 이유가 무엇인지**가 conversation 에 박혀야 다른 리뷰어가 처리 여부를 헷갈리지 않는다.
    ```bash
-   gh pr edit --add-assignee @me ${ISSUE_LABELS:+--add-label "$ISSUE_LABELS"}
-   ITEM_ID=$(gh project item-add 99 --owner depromeet --url {PR URL} --format json --jq '.id')
-   CURRENT_STATUS=$(gh api graphql -F id="$ITEM_ID" -f query='
-     query($id: ID!) {
-       node(id: $id) {
-         ... on ProjectV2Item {
-           fieldValueByName(name: "Status") {
-             ... on ProjectV2ItemFieldSingleSelectValue { name }
-           }
-         }
+   # 1. Thread 조회 — CodeRabbit 필터 (사람 리뷰어면 author 만 바꾼다)
+   gh api graphql -f query='
+     query { repository(owner: "depromeet", name: "PIKI-Server") {
+       pullRequest(number: {N}) {
+         reviewThreads(first: 50) { nodes {
+           id isResolved path line
+           comments(first: 1) { nodes { author { login } body } }
+         } }
        }
-     }' --jq '.data.node.fieldValueByName.name')
-   if [[ "$CURRENT_STATUS" == "Backlog" || "$CURRENT_STATUS" == "Ready" || "$CURRENT_STATUS" == "In progress" ]]; then
-     gh project item-edit \
-       --project-id PVT_kwDOARZVGM4BVVRV \
-       --id "$ITEM_ID" \
-       --field-id PVTSSF_lADOARZVGM4BVVRVzhQxyAA \
-       --single-select-option-id df73e18b
-   fi
+     }' --jq '.data.repository.pullRequest.reviewThreads.nodes[]
+              | select(.comments.nodes[0].author.login == "coderabbitai")
+              | {id, isResolved, path, line}'
+
+   # 2. 각 thread 에 reply
+   gh api graphql -f query='
+     mutation($t: ID!, $b: String!) {
+       addPullRequestReviewThreadReply(input: {pullRequestReviewThreadId: $t, body: $b}) {
+         comment { url }
+       }
+     }' -F t="<thread id>" -f b="<reply 내용>"
+
+   # 3. 자동 resolve 안 된 thread 면 resolve (CodeRabbit 은 자동 resolve 하는 경우 있어 isResolved 확인 후 분기)
+   gh api graphql -f query='
+     mutation($t: ID!) {
+       resolveReviewThread(input: {threadId: $t}) { thread { isResolved } }
+     }' -F t="<thread id>"
    ```
-10. PR URL 재출력.
+   - **accept**: reply 에 fix commit hash 명기 (예: "Accepted. Fixed in `371b5ba`."). 자동 resolve 안 됐으면 resolve 까지.
+   - **reject**: reply 에 reject 이유 (예: "CLAUDE.md '테스트 셋업 원칙' 과 충돌 — 셋업 hook 으로 stub 상태 리셋 금지"). **resolve 하지 않는다** — 사용자가 검토할 기회 보존.
+   - 한 thread 가 여러 commit 으로 해소됐으면 해시 모두 명기.
+
+10. **메타데이터 보정** — 이전 버전 스킬로 만든 PR 은 assignee / 라벨 / Project 가 비어 있을 수 있다. update 모드에서도 멱등하게 보정한다 (이미 설정돼 있으면 no-op). `item-add` 는 이미 등록된 PR 이면 기존 item id 를 그대로 반환한다.
+    Status 는 **현재 값을 먼저 조회해, 리뷰 이전 단계(`Backlog` / `Ready` / `In progress`)일 때만** `In review` 로 올린다 — 이미 `Done` 등으로 옮긴 PR 을 되돌리지 않기 위함이다. Status 조회는 item 노드를 직접 부르는 GraphQL 이 안정적이다 (`gh project item-list` 는 단일 선택 필드 값을 신뢰성 있게 주지 않는다):
+    ```bash
+    gh pr edit --add-assignee @me ${ISSUE_LABELS:+--add-label "$ISSUE_LABELS"}
+    ITEM_ID=$(gh project item-add 99 --owner depromeet --url {PR URL} --format json --jq '.id')
+    CURRENT_STATUS=$(gh api graphql -F id="$ITEM_ID" -f query='
+      query($id: ID!) {
+        node(id: $id) {
+          ... on ProjectV2Item {
+            fieldValueByName(name: "Status") {
+              ... on ProjectV2ItemFieldSingleSelectValue { name }
+            }
+          }
+        }
+      }' --jq '.data.node.fieldValueByName.name')
+    if [[ "$CURRENT_STATUS" == "Backlog" || "$CURRENT_STATUS" == "Ready" || "$CURRENT_STATUS" == "In progress" ]]; then
+      gh project item-edit \
+        --project-id PVT_kwDOARZVGM4BVVRV \
+        --id "$ITEM_ID" \
+        --field-id PVTSSF_lADOARZVGM4BVVRVzhQxyAA \
+        --single-select-option-id df73e18b
+    fi
+    ```
+11. PR URL 재출력.
 
 ### PR 제목 규칙
 - 70자 이내


### PR DESCRIPTION
## Situation

PR #160 (라벨 체계 + `/issue` 스킬) 진행 중 CodeRabbit 리뷰 처리 흐름에 누락이 있음을 발견했다. 수정 commit + push 만 하고 review thread 에 reply 를 빼먹어 unresolved 로 남는 패턴이 반복 — 다른 리뷰어가 처리 여부를 헷갈리게 한다. PR #145 때는 했었는데 #160 에서 또 빠졌다. 스킬에 박지 않으면 재발할 가능성 큼.

또한 LLM 이 사람 리뷰어 thread 까지 자동 reply 하면 결·뉘앙스가 어그러질 위험이 있어, **사람 리뷰는 자동 처리 영역 밖**으로 명시할 필요도 같이 확인됨.

원래 이 변경은 PR #160 에 같이 들어갔어야 했다. 단 #160 머지 시점 이후에 push 한 탓에 dev 에 반영 안 됨 — 별도 PR 로 복구.

## Task

`/pr` 의 update 모드(3-B)에 "CodeRabbit 인라인 리뷰 코멘트 처리" 단계를 추가하되:
- 자동 처리 범위는 **CodeRabbit thread 한정**
- 사람 리뷰는 작성자가 직접 답한다 (모델은 알리고 멈춤)

## Action

`pr.md` 의 3-B 절차에 새 9단계 추가, 기존 9·10 단계를 10·11 로 재번호. (`e2b4e61`, `13b2c50`)

### 자동 처리 (CodeRabbit thread)

- author `coderabbitai` 고정 필터로 thread 조회
- accept: reply 에 fix commit hash 명기 (예: ``Accepted. Fixed in `371b5ba`.``). 자동 resolve 안 됐으면 `resolveReviewThread` mutation 으로 resolve
- reject: reply 에 reject 이유 (예: "CLAUDE.md X 원칙과 충돌"). **resolve 하지 않는다** — 사용자가 검토할 기회 보존
- 한 thread 가 여러 commit 으로 해소됐으면 해시 모두 명기

### 사람 리뷰 thread (자동 처리 금지)

- author 가 `coderabbitai` 가 아니면 reply / resolve 둘 다 모델이 건드리지 않는다
- 작성자(`@me`)가 직접 의도·뉘앙스를 담아 답한다
- 처리할 thread 가 사람이면 "사람 리뷰 N건 있습니다" 만 알리고 멈춤

### 검토하다 채택 안 한 안

- **별도 `/coderabbit` 스킬 신설**: review reply / resolve / `full review` 트리거 등 CodeRabbit 관련 작업 모음. 표현력 좋지만 지금 작업량 대비 과한 분리. `/pr` 안에 흡수가 간결.

## Result

- `/pr` 사용 시 update 모드 흐름에서 thread 처리가 빠지지 않음
- 사람 리뷰의 결·뉘앙스가 자동 reply 로 어그러질 위험 차단
- PR #145 식 분기 reject 처리도 같은 절차로 일관 가능

---

## 연관 이슈

- close #164


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **문서화**
  * PR 검토 프로세스 가이드를 확장하여 인라인 리뷰 처리 절차를 명확히 했습니다.
  * 리뷰 회신 규칙과 메타데이터 보정 단계의 조건 처리 방식을 문서에 추가했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/PIKI-Server/pull/165?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Updates

### CodeRabbit nit 3건 반영 (`1c18064`)

CodeRabbit 가 Python + graphql-core 로 직접 parse 검증까지 한 진지한 리뷰. 모두 정당해서 accept.

- **GraphQL brace 1개 누락** — 마지막 `}'` 를 `}}'` 로 수정. 새로 추가한 0번 단계 query 에도 같은 패턴 적용.
- **"사람 리뷰 N건이면 멈춤" 이 글로만 있고 snippet 에 분기 없음** — 9단계 안에 **0번 단계 (사람 thread 카운트)** 추가. 1 이상이면 1~3 단계 (자동 처리) 건너뛰고 10단계 (메타데이터 보정) 로 넘어가는 분기.
- **라인 135 의 "update 모드 9단계" 참조가 재번호 (9→10) 와 어긋남** — 10 으로 정정 (재번호 시 다른 곳 참조 빠뜨린 누락).

새 9단계 절차를 자기 자신에 적용해서 thread 2건 reply + resolve 까지 완료 (자기 dogfood).

#### 검토하다 채택 안 한 안

- CodeRabbit 제안의 `exit 0` 는 후속 10/11 단계까지 막아버려서 부적합. 대신 절차 텍스트로 "HUMAN_THREADS > 0 → 1~3 단계 건너뛰고 10단계로" 분기를 명시 — 모델이 절차 따라가다 인지하는 형태.
