### PR TITLE
SecurityConfig 의 docs 경로를 Stoplight 의 /docs/** 로 정리

### DIFF
--- a/src/main/kotlin/com/depromeet/team3/auth/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/depromeet/team3/auth/config/SecurityConfig.kt
@@ -40,7 +40,9 @@ class SecurityConfig {
                     .authenticated()
                     .requestMatchers("/api/v1/dev/**")
                     .hasAuthority(IdentityType.GUEST.name)
-                    .requestMatchers("/swagger-ui/**", "/v3/api-docs/**")
+                    // API 문서: Stoplight Elements UI (/docs/**, static resource) + OpenAPI spec
+                    // (/v3/api-docs/**, springdoc 제공). Swagger UI 는 사용하지 않음.
+                    .requestMatchers("/docs/**", "/v3/api-docs/**")
                     .permitAll()
                     .requestMatchers("/api/v1/wishlists/**")
                     .hasAuthority(IdentityType.MEMBER.name)

--- a/src/test/kotlin/com/depromeet/team3/common/controller/DocsAccessIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/team3/common/controller/DocsAccessIntegrationTest.kt
@@ -1,0 +1,45 @@
+package com.depromeet.team3.common.controller
+
+import com.depromeet.team3.support.IntegrationTestSupport
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.web.context.WebApplicationContext
+
+class DocsAccessIntegrationTest : IntegrationTestSupport() {
+    @Autowired
+    private lateinit var webApplicationContext: WebApplicationContext
+
+    @Test
+    fun `GET docs index html - 인증 없이 200 응답이 와야 한다 (Stoplight UI 접근 회귀 가드)`() {
+        // anyRequest().authenticated() 가 적용된 상태에서 /docs/** 가 permitAll 명시 누락 시
+        // 401 응답으로 운영 docs UI (https://api.depromeet18team3.cloud/docs/index.html) 가 차단된다.
+        val mockMvc =
+            MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .apply<DefaultMockMvcBuilder>(springSecurity())
+                .build()
+
+        mockMvc
+            .perform(get("/docs/index.html"))
+            .andExpect(status().isOk)
+    }
+
+    @Test
+    fun `GET v3 api-docs - 인증 없이 200 응답이 와야 한다 (Stoplight 가 fetch 하는 OpenAPI spec)`() {
+        // Stoplight UI 가 동작하려면 spec endpoint 도 인증 없이 접근 가능해야 한다.
+        val mockMvc =
+            MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .apply<DefaultMockMvcBuilder>(springSecurity())
+                .build()
+
+        mockMvc
+            .perform(get("/v3/api-docs"))
+            .andExpect(status().isOk)
+    }
+}


### PR DESCRIPTION
## Situation
- 우리는 Spring Boot 4 / springdoc 3 라인에서 Swagger UI 안 쓰고 **Stoplight Elements** 사용 (application.yml 의 springdoc 섹션 주석에 명시)
- 실제 docs UI 는 `https://api.depromeet18team3.cloud/docs/index.html` 경로 (`resources/static/docs/index.html` 정적 자원)
- SecurityConfig 가 관성으로 `/swagger-ui/**` + `/v3/api-docs/**` 만 permitAll → `/docs/**` 가 `anyRequest().authenticated()` 에 잡혀 401. 운영 docs UI 실 사용 불가 상태

## Task
- `/docs/**` permitAll 추가, `/swagger-ui/**` 제거 (사용 X)
- 회귀 가드 통합 테스트 추가 — PR #155 의 `/health` permitAll 패턴 동일

## Action
- `SecurityConfig` 의 permitAll matcher 정정: `/swagger-ui/**` → `/docs/**`. `/v3/api-docs/**` 는 Stoplight 가 fetch 하는 OpenAPI spec endpoint 라 유지
- 주석 한 줄 — "Stoplight Elements UI + OpenAPI spec, Swagger UI 안 씀" 명시. 다음 사람이 또 swagger-ui 로 잘못 박지 않게
- `DocsAccessIntegrationTest` 신규 — `GET /docs/index.html` 과 `GET /v3/api-docs` 둘 다 인증 없이 200 단언. `springSecurity()` 적용한 MockMvc 로 실제 필터 체인 검증

## Result
- 운영 docs UI (`https://api.depromeet18team3.cloud/docs/index.html`) 정상 접근 복구
- SecurityConfig 변경 시 docs UI 다시 막히면 통합 테스트가 빌드 단계에서 잡음

---
## 연관 이슈

- close #172


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * API 문서 접근 경로 최적화로 인증 없이 문서에 접근 가능하도록 개선

* **Tests**
  * API 문서 엔드포인트가 정상 작동하는지 검증하는 통합 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/PIKI-Server/pull/173?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->