### PR TITLE
DevAuthController @Profile 가드 제거 — 배포 환경에서 FE 사용 가능하도록

### DIFF
--- a/src/main/kotlin/com/depromeet/team3/auth/controller/DevAuthApi.kt
+++ b/src/main/kotlin/com/depromeet/team3/auth/controller/DevAuthApi.kt
@@ -15,7 +15,7 @@ import org.springframework.http.MediaType
 interface DevAuthApi {
     @Operation(
         summary = "개발용 MEMBER 생성",
-        description = "OAuth 없이 MEMBER User 를 생성하고 JWT 토큰 쌍을 발급한다. GUEST 토큰으로 호출해야 한다. dev/local 프로파일에서만 활성화된다.",
+        description = "OAuth 없이 MEMBER User 를 생성하고 JWT 토큰 쌍을 발급한다. GUEST 토큰으로 호출해야 한다. OAuth 통합 전까지의 임시 endpoint.",
     )
     @ApiResponses(
         value = [

--- a/src/main/kotlin/com/depromeet/team3/auth/controller/DevAuthController.kt
+++ b/src/main/kotlin/com/depromeet/team3/auth/controller/DevAuthController.kt
@@ -5,7 +5,6 @@ import com.depromeet.team3.auth.controller.dto.GuestCreateResponse
 import com.depromeet.team3.auth.service.AuthService
 import com.depromeet.team3.common.response.ApiResponseBody
 import jakarta.validation.Valid
-import org.springframework.context.annotation.Profile
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -13,7 +12,6 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
-@Profile("dev", "local")
 @RestController
 @RequestMapping("/api/v1/dev")
 class DevAuthController(


### PR DESCRIPTION
## Situation
- 배포 환경에 `SPRING_PROFILES_ACTIVE` 가 설정돼 있지 않아 active profile 이 비어있는 상태(default)
- `DevAuthController` 는 `@Profile("dev", "local")` 이라 빈 등록 자체가 안 됨 → Stoplight (`/v3/api-docs`) 에 dev API 미노출 → FE 가 호출 경로를 찾지 못함
- OAuth 통합(epic #122 task 8) 전까지 FE 가 MEMBER 토큰을 받을 유일한 경로가 dev API

## Task
- dev API 가 배포 환경에서 호출 가능한 상태로 회복
- 단, profile 구분 정책 자체가 아직 없는 단계라 정식 해결은 OAuth 통합 시점으로 미루고 임시 조치로 처리

## Action
- 두 갈래 검토:
  - (A) 배포에 `SPRING_PROFILES_ACTIVE=dev` 주입 — 환경 분리가 갖춰진 미래엔 자연스럽지만, 지금은 dev profile 만의 의미가 모호
  - (B) `@Profile` 제거 — 현 단계(모든 서버 = 개발 서버) 사실과 일치하는 가장 단순한 선택. **채택.**
- `DevAuthController` 의 `@Profile("dev", "local")` + import 제거
- `DevAuthApi` description 의 "dev/local 프로파일에서만 활성화된다" 도 사실이 아니게 되어 "OAuth 통합 전까지의 임시 endpoint" 로 갱신
- 권한 가드는 SecurityConfig 의 `/api/v1/dev/**` → `hasAuthority(GUEST)` 그대로 유지

## Result
- 모든 배포 환경에서 빈 등록 → Stoplight 에 dev API 노출 → FE 호출 가능
- 임시 조치 — task 8 (OAuth 통합, #162) 작업 시점에 정식 정리 (재제한 / 환경 분리 / 컨트롤러 자체 제거 중 결정). epic #122 본문에 후속 라인 박아둠

---
## 연관 이슈

- close #177


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **리팩토링**
  * 개발 인증 엔드포인트의 환경별 제한이 제거되어 더 많은 환경에서 접근 가능하도록 변경

* **문서**
  * 개발 인증 엔드포인트의 설명을 "OAuth 통합 전까지의 임시 기능"으로 명확히 업데이트

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/PIKI-Server/pull/178?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->