### PR TITLE
slack-pr-bot 빈 PR 코멘트('No description provided') 해소

### DIFF
--- a/.github/workflows/slack-pr-bot.yml
+++ b/.github/workflows/slack-pr-bot.yml
@@ -279,7 +279,9 @@ jobs:
         shell: bash
         run: |
           INITIAL_REVIEWERS=$(jq -c '[.pull_request.requested_reviewers[]?.login]' "$GITHUB_EVENT_PATH")
-          BODY="<!-- slack-pr-bot: {\"channel\":\"${{ secrets.SLACK_CHANNEL_ID }}\",\"ts\":\"${{ steps.post_parent.outputs.ts }}\",\"initial_reviewers\":$INITIAL_REVIEWERS} -->"
+          META="<!-- slack-pr-bot: {\"channel\":\"${{ secrets.SLACK_CHANNEL_ID }}\",\"ts\":\"${{ steps.post_parent.outputs.ts }}\",\"initial_reviewers\":$INITIAL_REVIEWERS} -->"
+          # visible 안내문 + 숨겨진 metadata 주석. find_ts 의 contains("slack-pr-bot") 검색은 주석을 그대로 잡으므로 연동에 영향 없다.
+          BODY=$(printf '%s\n%s' 'Slack 스레드 연동용 메타데이터입니다. slack-pr-bot 워크플로가 자동 생성하며, 수정·삭제하면 PR 과 Slack 알림 연동이 끊깁니다.' "$META")
 
           curl -s -X POST \
             -H "Authorization: Bearer $GH_TOKEN" \


### PR DESCRIPTION
## Situation
- slack-pr-bot 워크플로는 PR 과 Slack 스레드를 연결하기 위해 Slack 메시지의 `ts`(스레드 식별자)를 **PR 코멘트에 HTML 주석으로 숨겨 저장**한다 (나중에 `contains("slack-pr-bot")` 으로 다시 찾아 스레드를 갱신)
- 그 코멘트가 HTML 주석뿐이라 visible 텍스트가 없어, GitHub UI 에 "No description provided" 빈 코멘트로 노출되고 PR 마다 하나씩 쌓여 지저분했음

## Task
- 빈 코멘트로 보이지 않게 하되, `ts` metadata 재검색 동작은 깨지 않기

## Action
- "Save Slack ts into PR comment" 스텝에서 코멘트 본문 앞에 visible 안내문 한 줄 추가: `Slack 스레드 연동용 메타데이터입니다. ... 수정·삭제하면 PR 과 Slack 알림 연동이 끊깁니다.`
- HTML 주석(metadata)은 그대로 유지 — `find_ts` 의 `contains("slack-pr-bot")` 검색이 주석을 그대로 잡으므로 연동 동작 불변
- 왜 이렇게 두는지 코드 주석도 한 줄 남겨, 미래에 누가 다시 주석만으로 되돌리지 않게 함

## Result
- PR 코멘트가 "No description provided" 대신 안내문으로 표시됨. 다른 사람도 이 코멘트의 정체(자동 생성 metadata)를 알 수 있음
- Slack 알림 연동(스레드 ts 재검색·갱신) 동작은 변화 없음

---
## 연관 이슈

- close #179