### PR TITLE
CodeRabbit 리뷰 처리를 /coderabbit 스킬로 분리

### DIFF
--- a/.claude/commands/coderabbit.md
+++ b/.claude/commands/coderabbit.md
@@ -1,0 +1,100 @@
+현재 브랜치 PR 의 CodeRabbit 리뷰를 처리한다 — 인라인 review thread 와 review body 의 nitpick 을 모두 조회해 평가하고, accept/reject 를 reply·resolve 로 남긴다.
+
+## 언제 쓰나
+
+- PR 에 CodeRabbit 리뷰가 달린 뒤, 그 지적을 반영·답변할 때.
+- `/pr` 로 PR 을 올린 뒤 리뷰 대응 단계에서 이어서 호출하거나, 단독으로 호출한다.
+
+## 원칙
+
+- **commit + push 로 끝내지 않는다.** 각 review thread 에 reply 를 남겨 **어떤 commit 으로 반영했는지 / reject 한 이유가 무엇인지** 가 conversation 에 박혀야 다른 리뷰어가 처리 여부를 헷갈리지 않는다.
+- **CodeRabbit 은 코멘트를 두 곳에 나눠 단다 — 반드시 둘 다 본다.**
+  - **인라인 review thread**: actionable 코멘트. `reviewThreads` 로 조회되고 개별 resolve 가능.
+  - **review body 안에 접힌 nitpick / 추가 코멘트**: `🧹 Nitpick comments (N)` 같은 `<details>` 블록. `reviewThreads` 에 **안 잡힌다** — `pulls/{PR}/reviews` 의 review body 를 따로 조회해야 보인다. 이걸 빠뜨리면 nitpick 을 통째로 놓친다 (resolve 대상은 아니지만 평가는 해야 한다).
+- **author 매칭은 `coderabbitai[bot]` 로 한다.** CodeRabbit 의 login 은 `coderabbitai` 가 아니라 `coderabbitai[bot]` 이다 (`[bot]` 접미사). `== "coderabbitai"` 로 비교하면 영원히 매칭되지 않아 봇을 사람으로 오인한다.
+- **사람 리뷰어 thread 는 자동 reply 하지 않는다.** author 가 `coderabbitai[bot]` 이 아니면 (즉 사람 리뷰면) reply / resolve 둘 다 모델이 건드리지 않는다 — 작성자(`@me`)가 직접 의도·뉘앙스를 담아 답한다. 1단계 카운트에서 1건 이상이면 3~4단계(thread reply/resolve)는 건너뛰고 사용자에게 "사람 리뷰 N건 있습니다" 만 알린다. (단 2.5단계 nitpick 조회·평가는 사람 리뷰 여부와 무관하게 수행한다.)
+
+## 절차
+
+### 0. PR 번호 확인
+
+```bash
+PR=$(gh pr view --json number --jq '.number')
+echo "PR #${PR}"
+```
+
+PR 이 없으면 (`gh pr view` 실패) 먼저 `/pr` 로 PR 을 만들라고 안내하고 중단한다.
+
+### 1. 사람 리뷰 thread 카운트 — 1 이상이면 3~4단계 건너뛴다
+
+```bash
+HUMAN_THREADS=$(gh api graphql -f query='
+  query { repository(owner: "depromeet", name: "PIKI-Server") {
+    pullRequest(number: '"$PR"') {
+      reviewThreads(first: 50) { nodes {
+        comments(first: 1) { nodes { author { login } } }
+      } }
+    }
+  }}' --jq '[.data.repository.pullRequest.reviewThreads.nodes[]
+             | select(.comments.nodes[0].author.login != "coderabbitai[bot]")] | length')
+echo "사람 리뷰 thread: ${HUMAN_THREADS}건"
+# HUMAN_THREADS > 0 → 3~4단계(thread reply/resolve) 건너뛰고 사용자에게 알림 (2.5 nitpick 은 그대로)
+```
+
+### 2. CodeRabbit 인라인 thread 조회 — author `coderabbitai[bot]` 고정 필터
+
+```bash
+gh api graphql -f query='
+  query { repository(owner: "depromeet", name: "PIKI-Server") {
+    pullRequest(number: '"$PR"') {
+      reviewThreads(first: 50) { nodes {
+        id isResolved path line
+        comments(first: 1) { nodes { author { login } body } }
+      } }
+    }
+  }}' --jq '.data.repository.pullRequest.reviewThreads.nodes[]
+            | select(.comments.nodes[0].author.login == "coderabbitai[bot]")
+            | {id, isResolved, path, line}'
+```
+
+### 2.5. review body 의 nitpick·추가 코멘트 조회 — reviewThreads 에 안 잡히므로 필수
+
+```bash
+gh api repos/depromeet/PIKI-Server/pulls/$PR/reviews \
+  --jq '.[] | select(.user.login == "coderabbitai[bot]" and (.body | length) > 100) | .body'
+```
+
+출력된 body 를 읽고 `🧹 Nitpick comments` 등 접힌 코멘트를 건별 평가한다. nitpick 은 thread 가 아니라 **resolve 대상이 아니므로**, 반영하면 커밋 + PR `## Updates`(또는 PR 일반 코멘트)로 처리 사실을 남긴다.
+
+### 3. 각 CodeRabbit thread 에 reply
+
+```bash
+gh api graphql -f query='
+  mutation($t: ID!, $b: String!) {
+    addPullRequestReviewThreadReply(input: {pullRequestReviewThreadId: $t, body: $b}) {
+      comment { url }
+    }
+  }' -F t="<thread id>" -f b="<reply 내용>"
+```
+
+### 4. 자동 resolve 안 된 thread 면 resolve
+
+CodeRabbit 은 자동 resolve 하는 경우가 있어 `isResolved` 확인 후 분기한다.
+
+```bash
+gh api graphql -f query='
+  mutation($t: ID!) {
+    resolveReviewThread(input: {threadId: $t}) { thread { isResolved } }
+  }' -F t="<thread id>"
+```
+
+### accept / reject 규칙
+
+- **accept**: reply 에 fix commit hash 명기 (예: "Accepted. Fixed in `371b5ba`."). 자동 resolve 안 됐으면 resolve 까지.
+- **reject**: reply 에 reject 이유 (예: "CLAUDE.md '테스트 셋업 원칙' 과 충돌 — 셋업 hook 으로 stub 상태 리셋 금지"). **resolve 하지 않는다** — 사용자가 검토할 기회 보존.
+- 한 thread 가 여러 commit 으로 해소됐으면 해시 모두 명기.
+
+## 주의
+
+- owner/repo 는 `depromeet/PIKI-Server` 고정. 레포가 바뀌면 갱신한다.
+- nitpick 반영 여부·범위는 선택적이다. actionable thread 와 달리 강제가 아니므로, 반영할지 사용자와 합의하고 진행한다.

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -160,54 +160,7 @@ ISSUE_LABELS=$(gh issue view {번호} --json labels --jq '[.labels[].name] | joi
 6. **제목 변경 필요 검토**: 추가 변경으로 작업 의도/스코프가 바뀌었거나 기존 제목에 오타·부정확한 표현이 있으면 새 제목 제안. 그 외엔 제목 유지.
 7. 사용자에게 갱신본(필요시 새 제목 포함, 변경 이유 짚어서)을 보여주고 확인받는다.
 8. 확인 후 `gh pr edit --body-file /tmp/pr_body.md` 로 갱신. 제목 변경이 있으면 `--title "새 제목"` 추가.
-9. **CodeRabbit 인라인 리뷰 코멘트 처리** — 이번 변경이 CodeRabbit 리뷰 대응이라면 commit + push 로 끝내지 않는다. 각 review thread 에 reply 를 남겨 **어떤 commit 으로 반영했는지 / reject 한 이유가 무엇인지**가 conversation 에 박혀야 다른 리뷰어가 처리 여부를 헷갈리지 않는다.
-
-   **사람 리뷰어 thread 는 자동 reply 하지 않는다.** author 가 `coderabbitai` 가 아니면 (즉 사람 리뷰면) reply / resolve 둘 다 모델이 건드리지 않는다 — 작성자(`@me`)가 직접 의도·뉘앙스를 담아 답한다. 0번 단계 카운트에서 1건 이상이면 아래 1~3 단계는 모두 건너뛰고 사용자에게 "사람 리뷰 N건 있습니다" 만 알린 뒤 10단계로 넘어간다.
-
-   ```bash
-   # 0. 사람 리뷰 thread 카운트 — 1 이상이면 아래 1~3 단계 건너뛴다
-   HUMAN_THREADS=$(gh api graphql -f query='
-     query { repository(owner: "depromeet", name: "PIKI-Server") {
-       pullRequest(number: {N}) {
-         reviewThreads(first: 50) { nodes {
-           comments(first: 1) { nodes { author { login } } }
-         } }
-       }
-     }}' --jq '[.data.repository.pullRequest.reviewThreads.nodes[]
-                | select(.comments.nodes[0].author.login != "coderabbitai")] | length')
-   echo "사람 리뷰 thread: ${HUMAN_THREADS}건"
-   # HUMAN_THREADS > 0 → 아래 1~3 단계 건너뛰고 10단계로
-
-   # 1. CodeRabbit thread 조회 — author "coderabbitai" 고정 필터
-   gh api graphql -f query='
-     query { repository(owner: "depromeet", name: "PIKI-Server") {
-       pullRequest(number: {N}) {
-         reviewThreads(first: 50) { nodes {
-           id isResolved path line
-           comments(first: 1) { nodes { author { login } body } }
-         } }
-       }
-     }}' --jq '.data.repository.pullRequest.reviewThreads.nodes[]
-               | select(.comments.nodes[0].author.login == "coderabbitai")
-               | {id, isResolved, path, line}'
-
-   # 2. 각 CodeRabbit thread 에 reply
-   gh api graphql -f query='
-     mutation($t: ID!, $b: String!) {
-       addPullRequestReviewThreadReply(input: {pullRequestReviewThreadId: $t, body: $b}) {
-         comment { url }
-       }
-     }' -F t="<thread id>" -f b="<reply 내용>"
-
-   # 3. 자동 resolve 안 된 thread 면 resolve (CodeRabbit 은 자동 resolve 하는 경우 있어 isResolved 확인 후 분기)
-   gh api graphql -f query='
-     mutation($t: ID!) {
-       resolveReviewThread(input: {threadId: $t}) { thread { isResolved } }
-     }' -F t="<thread id>"
-   ```
-   - **accept**: reply 에 fix commit hash 명기 (예: "Accepted. Fixed in `371b5ba`."). 자동 resolve 안 됐으면 resolve 까지.
-   - **reject**: reply 에 reject 이유 (예: "CLAUDE.md '테스트 셋업 원칙' 과 충돌 — 셋업 hook 으로 stub 상태 리셋 금지"). **resolve 하지 않는다** — 사용자가 검토할 기회 보존.
-   - 한 thread 가 여러 commit 으로 해소됐으면 해시 모두 명기.
+9. **CodeRabbit 리뷰 대응** — 이번 변경이 CodeRabbit 리뷰 대응이라면 commit + push 로 끝내지 않는다. CodeRabbit 리뷰(인라인 thread + review body nitpick) 조회·평가·reply·resolve 는 **`/coderabbit` 스킬**로 처리한다. 그 스킬이 author `coderabbitai[bot]` 매칭, nitpick 조회, accept/reject reply·resolve 정책을 담는다. (사람 리뷰 thread 는 작성자가 직접 답하므로 `/coderabbit` 도 건드리지 않는다.)
 
 10. **메타데이터 보정** — 이전 버전 스킬로 만든 PR 은 assignee / 라벨 / Project 가 비어 있을 수 있다. update 모드에서도 멱등하게 보정한다 (이미 설정돼 있으면 no-op). `item-add` 는 이미 등록된 PR 이면 기존 item id 를 그대로 반환한다.
     Status 는 **현재 값을 먼저 조회해, 리뷰 이전 단계(`Backlog` / `Ready` / `In progress`)일 때만** `In review` 로 올린다 — 이미 `Done` 등으로 옮긴 PR 을 되돌리지 않기 위함이다. Status 조회는 item 노드를 직접 부르는 GraphQL 이 안정적이다 (`gh project item-list` 는 단일 선택 필드 값을 신뢰성 있게 주지 않는다):

--- a/.claude/hooks/commit-msg
+++ b/.claude/hooks/commit-msg
@@ -1,5 +1,5 @@
 #!/bin/bash
 msg=$(head -1 "$1")
-echo "$msg" | grep -qE '^(feat|fix|refactor|chore|docs|test|style): .+' && exit 0
-echo "커밋 형식 오류: {feat|fix|refactor|chore|docs|test|style}: <제목>" >&2
+echo "$msg" | grep -qE '^(feat|fix|refactor|perf|chore|docs|test|infra|style): .+' && exit 0
+echo "커밋 형식 오류: {feat|fix|refactor|perf|chore|docs|test|infra|style}: <제목>" >&2
 exit 1


### PR DESCRIPTION
## Situation
- `/pr` 스킬이 PR 생성·갱신과 CodeRabbit 리뷰 처리를 한 파일에 다 담아 비대했다.
- 실제로 CodeRabbit 리뷰를 처리하다 두 가지 문제가 드러났다: (1) author 매칭이 `coderabbitai` 인데 실제 login 은 `coderabbitai[bot]` 이라 봇을 사람으로 오인하던 버그, (2) review body 에 접힌 nitpick 을 조회하지 않아 통째로 놓치던 누락.

## Task
- CodeRabbit 리뷰 처리를 `/pr` 에서 떼어 독립 `/coderabbit` 스킬로 분리한다.
- 분리하면서 위 버그·누락을 함께 보강한다.
- 김에 막혔던 commit-msg hook 타입도 라벨 체계에 맞춰 보강한다.

## Action
- **새 `/coderabbit` 스킬**: 인라인 review thread + review body nitpick 을 모두 조회·평가하고 accept/reject 를 reply·resolve 로 남기는 절차를 독립 스킬로. PR 번호 자동 감지(`gh pr view`)로 단독 호출 가능.
- **author 매칭 교정**: `coderabbitai` → `coderabbitai[bot]`. 기존 비교는 영원히 매칭 안 돼 사람/봇 판별이 깨져 있었다.
- **nitpick 조회 단계 추가**: `reviewThreads` 에 안 잡히는 `pulls/{N}/reviews` review body 를 따로 조회. nitpick 은 resolve 대상이 아니므로 반영 시 커밋 + PR Updates 로 처리 사실을 남기도록 명시.
- **`/pr` 9단계 축소**: CodeRabbit 처리 상세를 제거하고 `/coderabbit` 참조로. `/pr` 은 PR 본문·메타 관리에 집중.
- **commit-msg hook 타입 보강**: 허용 타입에 `perf`·`infra` 추가 (CLAUDE.md 라벨 9개 체계와 정합). `epic` 은 이슈 분류용이라 커밋 타입에서 제외, `style` 은 포맷 커밋용으로 유지.

## Result
- `/pr` 이 슬림해지고, CodeRabbit 대응은 재사용 가능한 단위가 됐다.
- author 매칭 버그·nitpick 누락이 절차에 박혀 다음부터 같은 실수를 반복하지 않는다.
- `perf`·`infra` 커밋이 hook 에 막히지 않는다.

---
## 연관 이슈

- close #182
