### PR TITLE
토너먼트 목록 조회 API 추가

### DIFF
--- a/src/main/kotlin/com/depromeet/team3/tournament/controller/TournamentApi.kt
+++ b/src/main/kotlin/com/depromeet/team3/tournament/controller/TournamentApi.kt
@@ -6,6 +6,8 @@ import com.depromeet.team3.tournament.controller.dto.CreateTournamentRequest
 import com.depromeet.team3.tournament.controller.dto.CreateTournamentResponse
 import com.depromeet.team3.tournament.controller.dto.RecordMatchRequest
 import com.depromeet.team3.tournament.controller.dto.TournamentInfoResponse
+import com.depromeet.team3.tournament.controller.dto.TournamentSummaryResponse
+import com.depromeet.team3.tournament.domain.TournamentStatus
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
@@ -113,6 +115,25 @@ interface TournamentApi {
         tournamentId: Long,
         request: RecordMatchRequest,
     ): ApiResponseBody<Unit>
+
+    @Operation(
+        summary = "토너먼트 목록 조회",
+        description = "내 토너먼트 목록을 최근 업데이트 순으로 조회한다. status 파라미터로 상태 필터링 가능. 생략 시 전체 반환. status 값은 대문자(PENDING/IN_PROGRESS/COMPLETED)로 전달해야 한다.",
+    )
+    @ApiResponse(
+        responseCode = "200",
+        description = "목록 조회 성공",
+        content = [
+            Content(
+                mediaType = MediaType.APPLICATION_JSON_VALUE,
+                schema = Schema(implementation = ApiResponseBody::class),
+            ),
+        ],
+    )
+    fun getTournaments(
+        userId: UUID,
+        status: TournamentStatus?,
+    ): ApiResponseBody<List<TournamentSummaryResponse>>
 
     @Operation(
         summary = "토너먼트 조회",

--- a/src/main/kotlin/com/depromeet/team3/tournament/controller/TournamentApi.kt
+++ b/src/main/kotlin/com/depromeet/team3/tournament/controller/TournamentApi.kt
@@ -118,7 +118,7 @@ interface TournamentApi {
 
     @Operation(
         summary = "토너먼트 목록 조회",
-        description = "내 토너먼트 목록을 최근 업데이트 순으로 조회한다. status 파라미터로 상태 필터링 가능. 생략 시 전체 반환. status 값은 대문자(PENDING/IN_PROGRESS/COMPLETED)로 전달해야 한다.",
+        description = "내 토너먼트 목록을 최근 생성 순으로 조회한다. status 파라미터로 상태 필터링 가능하며 여러 값을 중복 전달할 수 있다(예: ?status=PENDING&status=IN_PROGRESS). 생략 시 전체 반환. status 값은 대문자(PENDING/IN_PROGRESS/COMPLETED)로 전달해야 한다.",
     )
     @ApiResponse(
         responseCode = "200",
@@ -132,7 +132,7 @@ interface TournamentApi {
     )
     fun getTournaments(
         userId: UUID,
-        status: TournamentStatus?,
+        status: List<TournamentStatus>?,
     ): ApiResponseBody<List<TournamentSummaryResponse>>
 
     @Operation(

--- a/src/main/kotlin/com/depromeet/team3/tournament/controller/TournamentApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/team3/tournament/controller/TournamentApiExamples.kt
@@ -36,7 +36,7 @@ class TournamentApiExamples(
                                             tournamentId = 1,
                                             name = "내 토너먼트",
                                             status = TournamentStatus.PENDING,
-                                            updatedAt = LocalDateTime.of(2026, 5, 22, 12, 0, 0),
+                                            createdAt = LocalDateTime.of(2026, 5, 22, 12, 0, 0),
                                             participantProfileImages = listOf(
                                                 "https://cdn.example.com/profiles/user1.jpg",
                                                 "https://cdn.example.com/profiles/user2.jpg",

--- a/src/main/kotlin/com/depromeet/team3/tournament/controller/TournamentApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/team3/tournament/controller/TournamentApiExamples.kt
@@ -8,6 +8,9 @@ import com.depromeet.team3.tournament.controller.dto.CreateTournamentResponse
 import com.depromeet.team3.tournament.controller.dto.TournamentHistoryInfoResponse
 import com.depromeet.team3.tournament.controller.dto.TournamentInfoResponse
 import com.depromeet.team3.tournament.controller.dto.TournamentItemInfoResponse
+import com.depromeet.team3.tournament.controller.dto.TournamentSummaryResponse
+import com.depromeet.team3.tournament.domain.TournamentStatus
+import java.time.LocalDateTime
 import org.springdoc.core.customizers.OperationCustomizer
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -21,6 +24,29 @@ class TournamentApiExamples(
     fun tournamentOpenApiExamples(): OperationCustomizer =
         OperationCustomizer { operation, handlerMethod ->
             when {
+                handlerMethod.binds(TournamentController::getTournaments) ->
+                    operation.examples(openApiObjectMapper.delegate) {
+                        add(
+                            status = HttpStatus.OK,
+                            name = "목록 조회 성공",
+                            payload =
+                                ApiResponseBody.ok(
+                                    listOf(
+                                        TournamentSummaryResponse(
+                                            tournamentId = 1,
+                                            name = "내 토너먼트",
+                                            status = TournamentStatus.PENDING,
+                                            updatedAt = LocalDateTime.of(2026, 5, 22, 12, 0, 0),
+                                            participantProfileImages = listOf(
+                                                "https://cdn.example.com/profiles/user1.jpg",
+                                                "https://cdn.example.com/profiles/user2.jpg",
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                        )
+                    }
+
                 handlerMethod.binds(TournamentController::create) ->
                     operation.examples(openApiObjectMapper.delegate) {
                         add(

--- a/src/main/kotlin/com/depromeet/team3/tournament/controller/TournamentController.kt
+++ b/src/main/kotlin/com/depromeet/team3/tournament/controller/TournamentController.kt
@@ -80,7 +80,7 @@ class TournamentController(
     @GetMapping
     override fun getTournaments(
         @AuthenticationPrincipal userId: UUID,
-        @RequestParam(required = false) status: TournamentStatus?,
+        @RequestParam(required = false) status: List<TournamentStatus>?,
     ): ApiResponseBody<List<TournamentSummaryResponse>> {
         val summaries = tournamentService.getTournaments(userId, status)
         return ApiResponseBody.ok(summaries.map(TournamentSummaryResponse::from))

--- a/src/main/kotlin/com/depromeet/team3/tournament/controller/TournamentController.kt
+++ b/src/main/kotlin/com/depromeet/team3/tournament/controller/TournamentController.kt
@@ -6,6 +6,8 @@ import com.depromeet.team3.tournament.controller.dto.CreateTournamentRequest
 import com.depromeet.team3.tournament.controller.dto.CreateTournamentResponse
 import com.depromeet.team3.tournament.controller.dto.RecordMatchRequest
 import com.depromeet.team3.tournament.controller.dto.TournamentInfoResponse
+import com.depromeet.team3.tournament.controller.dto.TournamentSummaryResponse
+import com.depromeet.team3.tournament.domain.TournamentStatus
 import com.depromeet.team3.tournament.service.TournamentService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
@@ -16,6 +18,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
@@ -72,6 +75,15 @@ class TournamentController(
     ): ApiResponseBody<Unit> {
         tournamentService.recordMatch(userId, request.toRecordMatch(tournamentId))
         return ApiResponseBody.ok()
+    }
+
+    @GetMapping
+    override fun getTournaments(
+        @AuthenticationPrincipal userId: UUID,
+        @RequestParam(required = false) status: TournamentStatus?,
+    ): ApiResponseBody<List<TournamentSummaryResponse>> {
+        val summaries = tournamentService.getTournaments(userId, status)
+        return ApiResponseBody.ok(summaries.map(TournamentSummaryResponse::from))
     }
 
     @GetMapping("/{tournamentId}")

--- a/src/main/kotlin/com/depromeet/team3/tournament/controller/dto/TournamentSummaryResponse.kt
+++ b/src/main/kotlin/com/depromeet/team3/tournament/controller/dto/TournamentSummaryResponse.kt
@@ -8,7 +8,7 @@ data class TournamentSummaryResponse(
     val tournamentId: Long,
     val name: String,
     val status: TournamentStatus,
-    val updatedAt: LocalDateTime,
+    val createdAt: LocalDateTime,
     val participantProfileImages: List<String>,
 ) {
     companion object {
@@ -17,7 +17,7 @@ data class TournamentSummaryResponse(
                 tournamentId = summary.tournamentId,
                 name = summary.name,
                 status = summary.status,
-                updatedAt = summary.updatedAt,
+                createdAt = summary.createdAt,
                 participantProfileImages = summary.participantProfileImages,
             )
     }

--- a/src/main/kotlin/com/depromeet/team3/tournament/controller/dto/TournamentSummaryResponse.kt
+++ b/src/main/kotlin/com/depromeet/team3/tournament/controller/dto/TournamentSummaryResponse.kt
@@ -1,0 +1,24 @@
+package com.depromeet.team3.tournament.controller.dto
+
+import com.depromeet.team3.tournament.domain.TournamentStatus
+import com.depromeet.team3.tournament.service.dto.TournamentSummary
+import java.time.LocalDateTime
+
+data class TournamentSummaryResponse(
+    val tournamentId: Long,
+    val name: String,
+    val status: TournamentStatus,
+    val updatedAt: LocalDateTime,
+    val participantProfileImages: List<String>,
+) {
+    companion object {
+        fun from(summary: TournamentSummary): TournamentSummaryResponse =
+            TournamentSummaryResponse(
+                tournamentId = summary.tournamentId,
+                name = summary.name,
+                status = summary.status,
+                updatedAt = summary.updatedAt,
+                participantProfileImages = summary.participantProfileImages,
+            )
+    }
+}

--- a/src/main/kotlin/com/depromeet/team3/tournament/repository/TournamentJpaRepository.kt
+++ b/src/main/kotlin/com/depromeet/team3/tournament/repository/TournamentJpaRepository.kt
@@ -1,6 +1,11 @@
 package com.depromeet.team3.tournament.repository
 
 import com.depromeet.team3.tournament.domain.Tournament
+import com.depromeet.team3.tournament.domain.TournamentStatus
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface TournamentJpaRepository : JpaRepository<Tournament, Long>
+interface TournamentJpaRepository : JpaRepository<Tournament, Long> {
+    fun findByIdInAndStatusOrderByUpdatedAtDesc(ids: Collection<Long>, status: TournamentStatus): List<Tournament>
+
+    fun findByIdInOrderByUpdatedAtDesc(ids: Collection<Long>): List<Tournament>
+}

--- a/src/main/kotlin/com/depromeet/team3/tournament/repository/TournamentJpaRepository.kt
+++ b/src/main/kotlin/com/depromeet/team3/tournament/repository/TournamentJpaRepository.kt
@@ -5,7 +5,7 @@ import com.depromeet.team3.tournament.domain.TournamentStatus
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface TournamentJpaRepository : JpaRepository<Tournament, Long> {
-    fun findByIdInAndStatusOrderByUpdatedAtDesc(ids: Collection<Long>, status: TournamentStatus): List<Tournament>
+    fun findByIdInAndStatusInOrderByCreatedAtDesc(ids: List<Long>, statuses: List<TournamentStatus>): List<Tournament>
 
-    fun findByIdInOrderByUpdatedAtDesc(ids: Collection<Long>): List<Tournament>
+    fun findByIdInOrderByCreatedAtDesc(ids: List<Long>): List<Tournament>
 }

--- a/src/main/kotlin/com/depromeet/team3/tournament/repository/TournamentRepository.kt
+++ b/src/main/kotlin/com/depromeet/team3/tournament/repository/TournamentRepository.kt
@@ -13,5 +13,5 @@ interface TournamentRepository {
 
     fun findTournamentHistoriesByTournamentId(tournamentId: Long): List<TournamentHistory>
 
-    fun findByIdsAndStatus(ids: List<Long>, status: TournamentStatus?): List<Tournament>
+    fun findByIdsAndStatuses(ids: List<Long>, statuses: List<TournamentStatus>?): List<Tournament>
 }

--- a/src/main/kotlin/com/depromeet/team3/tournament/repository/TournamentRepository.kt
+++ b/src/main/kotlin/com/depromeet/team3/tournament/repository/TournamentRepository.kt
@@ -2,6 +2,7 @@ package com.depromeet.team3.tournament.repository
 
 import com.depromeet.team3.tournament.domain.Tournament
 import com.depromeet.team3.tournament.domain.TournamentHistory
+import com.depromeet.team3.tournament.domain.TournamentStatus
 
 interface TournamentRepository {
     fun saveTournament(tournament: Tournament): Tournament
@@ -11,4 +12,6 @@ interface TournamentRepository {
     fun findTournamentById(tournamentId: Long): Tournament?
 
     fun findTournamentHistoriesByTournamentId(tournamentId: Long): List<TournamentHistory>
+
+    fun findByIdsAndStatus(ids: List<Long>, status: TournamentStatus?): List<Tournament>
 }

--- a/src/main/kotlin/com/depromeet/team3/tournament/repository/TournamentRepositoryImpl.kt
+++ b/src/main/kotlin/com/depromeet/team3/tournament/repository/TournamentRepositoryImpl.kt
@@ -23,9 +23,11 @@ class TournamentRepositoryImpl(
     override fun findTournamentHistoriesByTournamentId(tournamentId: Long): List<TournamentHistory> =
         tournamentHistoryJpaRepository.findAllByTournamentIdOrderByCurrentRoundAscIdAsc(tournamentId)
 
-    override fun findByIdsAndStatus(ids: List<Long>, status: TournamentStatus?): List<Tournament> {
+    override fun findByIdsAndStatuses(ids: List<Long>, statuses: List<TournamentStatus>?): List<Tournament> {
         if (ids.isEmpty()) return emptyList()
-        return status?.let { tournamentJpaRepository.findByIdInAndStatusOrderByUpdatedAtDesc(ids, it) }
-            ?: tournamentJpaRepository.findByIdInOrderByUpdatedAtDesc(ids)
+        return statuses
+            ?.takeIf { it.isNotEmpty() }
+            ?.let { tournamentJpaRepository.findByIdInAndStatusInOrderByCreatedAtDesc(ids, it) }
+            ?: tournamentJpaRepository.findByIdInOrderByCreatedAtDesc(ids)
     }
 }

--- a/src/main/kotlin/com/depromeet/team3/tournament/repository/TournamentRepositoryImpl.kt
+++ b/src/main/kotlin/com/depromeet/team3/tournament/repository/TournamentRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.depromeet.team3.tournament.repository
 
 import com.depromeet.team3.tournament.domain.Tournament
 import com.depromeet.team3.tournament.domain.TournamentHistory
+import com.depromeet.team3.tournament.domain.TournamentStatus
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Repository
 
@@ -19,7 +20,12 @@ class TournamentRepositoryImpl(
     override fun findTournamentById(tournamentId: Long): Tournament? =
         tournamentJpaRepository.findByIdOrNull(tournamentId)
 
-    // 인덱스 추가 필요: tournament_id, current_round, id
     override fun findTournamentHistoriesByTournamentId(tournamentId: Long): List<TournamentHistory> =
         tournamentHistoryJpaRepository.findAllByTournamentIdOrderByCurrentRoundAscIdAsc(tournamentId)
+
+    override fun findByIdsAndStatus(ids: List<Long>, status: TournamentStatus?): List<Tournament> {
+        if (ids.isEmpty()) return emptyList()
+        return status?.let { tournamentJpaRepository.findByIdInAndStatusOrderByUpdatedAtDesc(ids, it) }
+            ?: tournamentJpaRepository.findByIdInOrderByUpdatedAtDesc(ids)
+    }
 }

--- a/src/main/kotlin/com/depromeet/team3/tournament/repository/TournamentUserJpaRepository.kt
+++ b/src/main/kotlin/com/depromeet/team3/tournament/repository/TournamentUserJpaRepository.kt
@@ -2,6 +2,8 @@ package com.depromeet.team3.tournament.repository
 
 import com.depromeet.team3.tournament.domain.TournamentUser
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import java.util.UUID
 
 interface TournamentUserJpaRepository : JpaRepository<TournamentUser, Long> {
@@ -9,4 +11,11 @@ interface TournamentUserJpaRepository : JpaRepository<TournamentUser, Long> {
         tournamentId: Long,
         userId: UUID,
     ): TournamentUser?
+
+    @Query("SELECT tu.tournamentId FROM TournamentUser tu WHERE tu.userId = :userId")
+    fun findTournamentIdsByUserId(
+        @Param("userId") userId: UUID,
+    ): List<Long>
+
+    fun findByTournamentIdIn(tournamentIds: Collection<Long>): List<TournamentUser>
 }

--- a/src/main/kotlin/com/depromeet/team3/tournament/repository/TournamentUserRepository.kt
+++ b/src/main/kotlin/com/depromeet/team3/tournament/repository/TournamentUserRepository.kt
@@ -10,4 +10,8 @@ interface TournamentUserRepository {
         tournamentId: Long,
         userId: UUID,
     ): TournamentUser?
+
+    fun findTournamentIdsByUserId(userId: UUID): List<Long>
+
+    fun findByTournamentIds(tournamentIds: List<Long>): List<TournamentUser>
 }

--- a/src/main/kotlin/com/depromeet/team3/tournament/repository/TournamentUserRepositoryImpl.kt
+++ b/src/main/kotlin/com/depromeet/team3/tournament/repository/TournamentUserRepositoryImpl.kt
@@ -14,4 +14,11 @@ class TournamentUserRepositoryImpl(
         tournamentId: Long,
         userId: UUID,
     ): TournamentUser? = tournamentUserJpaRepository.findByTournamentIdAndUserId(tournamentId, userId)
+
+    override fun findTournamentIdsByUserId(userId: UUID): List<Long> =
+        tournamentUserJpaRepository.findTournamentIdsByUserId(userId)
+
+    override fun findByTournamentIds(tournamentIds: List<Long>): List<TournamentUser> =
+        if (tournamentIds.isEmpty()) emptyList()
+        else tournamentUserJpaRepository.findByTournamentIdIn(tournamentIds)
 }

--- a/src/main/kotlin/com/depromeet/team3/tournament/service/TournamentService.kt
+++ b/src/main/kotlin/com/depromeet/team3/tournament/service/TournamentService.kt
@@ -3,6 +3,7 @@ package com.depromeet.team3.tournament.service
 import com.depromeet.team3.tournament.domain.Tournament
 import com.depromeet.team3.tournament.domain.TournamentHistory
 import com.depromeet.team3.tournament.domain.TournamentItem
+import com.depromeet.team3.tournament.domain.TournamentStatus
 import com.depromeet.team3.tournament.domain.TournamentUser
 import com.depromeet.team3.tournament.repository.TournamentItemRepository
 import com.depromeet.team3.tournament.repository.TournamentRepository
@@ -11,6 +12,8 @@ import com.depromeet.team3.tournament.service.dto.AddTournamentItems
 import com.depromeet.team3.tournament.service.dto.CreateTournament
 import com.depromeet.team3.tournament.service.dto.RecordMatch
 import com.depromeet.team3.tournament.service.dto.TournamentInfo
+import com.depromeet.team3.tournament.service.dto.TournamentSummary
+import com.depromeet.team3.user.repository.UserRepository
 import com.depromeet.team3.wishlist.repository.WishRepository
 import com.depromeet.team3.wishlist.service.WishException
 import org.springframework.stereotype.Service
@@ -23,6 +26,7 @@ class TournamentService(
     private val tournamentRepository: TournamentRepository,
     private val tournamentItemRepository: TournamentItemRepository,
     private val wishRepository: WishRepository,
+    private val userRepository: UserRepository,
 ) {
     @Transactional
     fun create(
@@ -99,6 +103,30 @@ class TournamentService(
         val items = tournamentItemRepository.findAllByTournamentId(tournamentId)
         val histories = tournamentRepository.findTournamentHistoriesByTournamentId(tournamentId)
         return TournamentInfo.of(tournament, items, histories)
+    }
+
+    @Transactional(readOnly = true)
+    fun getTournaments(
+        userId: UUID,
+        status: TournamentStatus?,
+    ): List<TournamentSummary> {
+        val tournamentIds = tournamentUserRepository.findTournamentIdsByUserId(userId)
+        val tournaments = tournamentRepository.findByIdsAndStatus(tournamentIds, status)
+        if (tournaments.isEmpty()) return emptyList()
+
+        val tournamentUsers = tournamentUserRepository.findByTournamentIds(tournaments.map { it.getId() })
+        val userIds = tournamentUsers.map { it.userId }.toSet()
+        val profileImageByUserId = userRepository.findByIds(userIds).associate { it.id to it.profileImage }
+        val profileImagesByTournamentId = tournamentUsers
+            .groupBy { it.tournamentId }
+            .mapValues { (_, users) -> users.mapNotNull { profileImageByUserId[it.userId] } }
+
+        return tournaments.map { tournament ->
+            TournamentSummary.of(
+                tournament = tournament,
+                participantProfileImages = profileImagesByTournamentId[tournament.getId()] ?: emptyList(),
+            )
+        }
     }
 
     @Transactional

--- a/src/main/kotlin/com/depromeet/team3/tournament/service/TournamentService.kt
+++ b/src/main/kotlin/com/depromeet/team3/tournament/service/TournamentService.kt
@@ -108,10 +108,10 @@ class TournamentService(
     @Transactional(readOnly = true)
     fun getTournaments(
         userId: UUID,
-        status: TournamentStatus?,
+        statuses: List<TournamentStatus>?,
     ): List<TournamentSummary> {
         val tournamentIds = tournamentUserRepository.findTournamentIdsByUserId(userId)
-        val tournaments = tournamentRepository.findByIdsAndStatus(tournamentIds, status)
+        val tournaments = tournamentRepository.findByIdsAndStatuses(tournamentIds, statuses)
         if (tournaments.isEmpty()) return emptyList()
 
         val tournamentUsers = tournamentUserRepository.findByTournamentIds(tournaments.map { it.getId() })

--- a/src/main/kotlin/com/depromeet/team3/tournament/service/dto/TournamentSummary.kt
+++ b/src/main/kotlin/com/depromeet/team3/tournament/service/dto/TournamentSummary.kt
@@ -8,7 +8,7 @@ data class TournamentSummary(
     val tournamentId: Long,
     val name: String,
     val status: TournamentStatus,
-    val updatedAt: LocalDateTime,
+    val createdAt: LocalDateTime,
     val participantProfileImages: List<String>,
 ) {
     companion object {
@@ -20,7 +20,7 @@ data class TournamentSummary(
                 tournamentId = tournament.getId(),
                 name = tournament.name,
                 status = tournament.status,
-                updatedAt = tournament.updatedAt,
+                createdAt = tournament.createdAt,
                 participantProfileImages = participantProfileImages,
             )
     }

--- a/src/main/kotlin/com/depromeet/team3/tournament/service/dto/TournamentSummary.kt
+++ b/src/main/kotlin/com/depromeet/team3/tournament/service/dto/TournamentSummary.kt
@@ -1,0 +1,27 @@
+package com.depromeet.team3.tournament.service.dto
+
+import com.depromeet.team3.tournament.domain.Tournament
+import com.depromeet.team3.tournament.domain.TournamentStatus
+import java.time.LocalDateTime
+
+data class TournamentSummary(
+    val tournamentId: Long,
+    val name: String,
+    val status: TournamentStatus,
+    val updatedAt: LocalDateTime,
+    val participantProfileImages: List<String>,
+) {
+    companion object {
+        fun of(
+            tournament: Tournament,
+            participantProfileImages: List<String>,
+        ): TournamentSummary =
+            TournamentSummary(
+                tournamentId = tournament.getId(),
+                name = tournament.name,
+                status = tournament.status,
+                updatedAt = tournament.updatedAt,
+                participantProfileImages = participantProfileImages,
+            )
+    }
+}

--- a/src/main/kotlin/com/depromeet/team3/user/repository/UserRepository.kt
+++ b/src/main/kotlin/com/depromeet/team3/user/repository/UserRepository.kt
@@ -8,5 +8,7 @@ interface UserRepository {
 
     fun findById(id: UUID): User?
 
+    fun findByIds(ids: Collection<UUID>): List<User>
+
     fun existsByNickname(nickname: String): Boolean
 }

--- a/src/main/kotlin/com/depromeet/team3/user/repository/UserRepositoryImpl.kt
+++ b/src/main/kotlin/com/depromeet/team3/user/repository/UserRepositoryImpl.kt
@@ -13,5 +13,7 @@ class UserRepositoryImpl(
 
     override fun findById(id: UUID): User? = userJpaRepository.findByIdOrNull(id)
 
+    override fun findByIds(ids: Collection<UUID>): List<User> = userJpaRepository.findAllById(ids)
+
     override fun existsByNickname(nickname: String): Boolean = userJpaRepository.existsByNickname(nickname)
 }

--- a/src/main/resources/db/migration/V20260522175338__add_index_on_tournament_users_user_id.sql
+++ b/src/main/resources/db/migration/V20260522175338__add_index_on_tournament_users_user_id.sql
@@ -1,0 +1,2 @@
+ALTER TABLE tournament_users
+    ADD KEY idx_tournament_users_user_id (user_id);

--- a/src/test/kotlin/com/depromeet/team3/tournament/controller/TournamentControllerTest.kt
+++ b/src/test/kotlin/com/depromeet/team3/tournament/controller/TournamentControllerTest.kt
@@ -214,7 +214,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
             .andExpect(jsonPath("$.data[0].tournamentId").isNumber)
             .andExpect(jsonPath("$.data[0].name").isString)
             .andExpect(jsonPath("$.data[0].status").isString)
-            .andExpect(jsonPath("$.data[0].updatedAt").isString)
+            .andExpect(jsonPath("$.data[0].createdAt").isString)
             .andExpect(jsonPath("$.data[0].participantProfileImages").isArray)
             .andExpect(jsonPath("$.data[0].participantProfileImages[0]").value(userProfileImage))
     }
@@ -240,6 +240,28 @@ class TournamentControllerTest : IntegrationTestSupport() {
             .andExpect(jsonPath("$.data.length()").value(1))
             .andExpect(jsonPath("$.data[0].tournamentId").value(pendingId))
             .andExpect(jsonPath("$.data[0].participantProfileImages[0]").value(userProfileImage))
+    }
+
+    @Test
+    fun `GET tournaments 에서 복수 status 필터를 지정하면 해당 상태들만 반환된다`() {
+        val mockMvc = buildMockMvc()
+        val pendingId = createTournament(mockMvc, "대기중")
+        val startedId = createTournament(mockMvc, "진행중")
+        addItemsToTournament(mockMvc, startedId, userId, 100L, 200L)
+        mockMvc.perform(
+            post("/api/v1/tournaments/$startedId/start")
+                .header(HttpHeaders.AUTHORIZATION, authHeader(userId)),
+        )
+
+        mockMvc
+            .perform(
+                get("/api/v1/tournaments")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(userId))
+                    .param("status", "PENDING", "IN_PROGRESS"),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.length()").value(2))
+            .andExpect(jsonPath("$.data[?(@.tournamentId == $pendingId)]").exists())
+            .andExpect(jsonPath("$.data[?(@.tournamentId == $startedId)]").exists())
     }
 
     @Test

--- a/src/test/kotlin/com/depromeet/team3/tournament/controller/TournamentControllerTest.kt
+++ b/src/test/kotlin/com/depromeet/team3/tournament/controller/TournamentControllerTest.kt
@@ -5,6 +5,8 @@ import com.depromeet.team3.support.IntegrationTestSupport
 import com.depromeet.team3.tournament.domain.TournamentItem
 import com.depromeet.team3.tournament.repository.TournamentItemJpaRepository
 import com.depromeet.team3.user.domain.IdentityType
+import com.depromeet.team3.user.domain.User
+import com.depromeet.team3.user.repository.UserJpaRepository
 import com.depromeet.team3.wishlist.domain.Wish
 import com.depromeet.team3.wishlist.repository.WishJpaRepository
 import kotlin.test.assertEquals
@@ -36,10 +38,13 @@ class TournamentControllerTest : IntegrationTestSupport() {
 
     @Autowired private lateinit var tournamentItemJpaRepository: TournamentItemJpaRepository
 
+    @Autowired private lateinit var userJpaRepository: UserJpaRepository
+
     @Autowired private lateinit var jwtProvider: JwtProvider
 
     private val userId: UUID = UUID.fromString("11111111-2222-3333-4444-555555555555")
     private val otherUserId: UUID = UUID.fromString("99999999-8888-7777-6666-555555555555")
+    private val userProfileImage = "https://cdn.example.com/profiles/user.jpg"
 
     private fun authHeader(userId: UUID): String =
         "Bearer ${jwtProvider.generateAccessToken(userId, IdentityType.MEMBER)}"
@@ -189,6 +194,73 @@ class TournamentControllerTest : IntegrationTestSupport() {
                     ),
             ).andExpect(status().isForbidden)
             .andExpect(jsonPath("$.status").value(403))
+    }
+
+    @Test
+    fun `GET tournaments 는 내 토너먼트 목록을 200 과 함께 반환하고 참여자 프로필 이미지를 포함한다`() {
+        val mockMvc = buildMockMvc()
+        saveUser(userId, userProfileImage)
+        createTournament(mockMvc, "토너먼트A")
+        createTournament(mockMvc, "토너먼트B")
+
+        mockMvc
+            .perform(
+                get("/api/v1/tournaments")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(userId)),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.status").value(200))
+            .andExpect(jsonPath("$.code").value("OK"))
+            .andExpect(jsonPath("$.data.length()").value(2))
+            .andExpect(jsonPath("$.data[0].tournamentId").isNumber)
+            .andExpect(jsonPath("$.data[0].name").isString)
+            .andExpect(jsonPath("$.data[0].status").isString)
+            .andExpect(jsonPath("$.data[0].updatedAt").isString)
+            .andExpect(jsonPath("$.data[0].participantProfileImages").isArray)
+            .andExpect(jsonPath("$.data[0].participantProfileImages[0]").value(userProfileImage))
+    }
+
+    @Test
+    fun `GET tournaments 에서 status 필터를 지정하면 해당 상태만 반환된다`() {
+        val mockMvc = buildMockMvc()
+        saveUser(userId, userProfileImage)
+        val pendingId = createTournament(mockMvc, "대기중")
+        val startedId = createTournament(mockMvc, "진행중")
+        addItemsToTournament(mockMvc, startedId, userId, 100L, 200L)
+        mockMvc.perform(
+            post("/api/v1/tournaments/$startedId/start")
+                .header(HttpHeaders.AUTHORIZATION, authHeader(userId)),
+        )
+
+        mockMvc
+            .perform(
+                get("/api/v1/tournaments")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(userId))
+                    .param("status", "PENDING"),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.length()").value(1))
+            .andExpect(jsonPath("$.data[0].tournamentId").value(pendingId))
+            .andExpect(jsonPath("$.data[0].participantProfileImages[0]").value(userProfileImage))
+    }
+
+    @Test
+    fun `GET tournaments 에서 토너먼트가 없으면 빈 배열을 반환한다`() {
+        val mockMvc = buildMockMvc()
+
+        mockMvc
+            .perform(
+                get("/api/v1/tournaments")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(userId)),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.length()").value(0))
+    }
+
+    @Test
+    fun `GET tournaments 에서 인증 없이 요청하면 401 을 반환한다`() {
+        val mockMvc = buildMockMvc()
+
+        mockMvc
+            .perform(get("/api/v1/tournaments"))
+            .andExpect(status().isUnauthorized)
     }
 
     @Test
@@ -356,6 +428,12 @@ class TournamentControllerTest : IntegrationTestSupport() {
                 ).andReturn()
         return objectMapper.readTree(result.response.contentAsString)["data"]["tournamentId"].asLong()
     }
+
+    private fun saveUser(
+        id: UUID,
+        profileImage: String,
+        nickname: String = "테스트유저",
+    ): User = userJpaRepository.save(User(id = id, nickname = nickname, profileImage = profileImage, identityType = IdentityType.MEMBER))
 
     private fun saveWishes(
         owner: UUID,

--- a/src/test/kotlin/com/depromeet/team3/tournament/service/TournamentServiceTest.kt
+++ b/src/test/kotlin/com/depromeet/team3/tournament/service/TournamentServiceTest.kt
@@ -143,11 +143,11 @@ class TournamentServiceTest {
         override fun findTournamentHistoriesByTournamentId(tournamentId: Long): List<TournamentHistory> =
             histories.filter { it.tournamentId == tournamentId }
 
-        override fun findByIdsAndStatus(ids: List<Long>, status: TournamentStatus?): List<Tournament> =
+        override fun findByIdsAndStatuses(ids: List<Long>, statuses: List<TournamentStatus>?): List<Tournament> =
             tournaments.values
                 .filter { it.getId() in ids }
-                .filter { status?.let { s -> it.status == s } ?: true }
-                .sortedByDescending { it.updatedAt }
+                .filter { statuses.isNullOrEmpty() || it.status in statuses }
+                .sortedByDescending { it.createdAt }
 
         private fun setEntityId(
             entity: LongBaseEntity,
@@ -523,10 +523,28 @@ class TournamentServiceTest {
         service.addItems(userId, AddTournamentItems(startedId, listOf(1L, 2L)))
         service.start(userId, startedId)
 
-        val result = service.getTournaments(userId, TournamentStatus.PENDING)
+        val result = service.getTournaments(userId, listOf(TournamentStatus.PENDING))
 
         assertEquals(1, result.size)
         assertEquals("대기중", result[0].name)
+    }
+
+    @Test
+    fun `getTournaments 에서 복수 status 필터가 주어지면 해당 상태들만 반환한다`() {
+        service.create(userId, CreateTournament("대기중"))
+        val startedId = service.create(userId, CreateTournament("진행중"))
+        service.addItems(userId, AddTournamentItems(startedId, listOf(1L, 2L)))
+        service.start(userId, startedId)
+        val completedId = service.create(userId, CreateTournament("완료됨"))
+        service.addItems(userId, AddTournamentItems(completedId, listOf(3L, 4L)))
+        service.start(userId, completedId)
+        val completedItems = itemRepository.findAllByTournamentId(completedId)
+        service.recordMatch(userId, RecordMatch(completedId, 2, completedItems[0].getId(), completedItems[1].getId(), completedItems[0].getId()))
+
+        val result = service.getTournaments(userId, listOf(TournamentStatus.PENDING, TournamentStatus.COMPLETED))
+
+        assertEquals(2, result.size)
+        assert(result.none { it.status == TournamentStatus.IN_PROGRESS })
     }
 
     @Test

--- a/src/test/kotlin/com/depromeet/team3/tournament/service/TournamentServiceTest.kt
+++ b/src/test/kotlin/com/depromeet/team3/tournament/service/TournamentServiceTest.kt
@@ -12,6 +12,9 @@ import com.depromeet.team3.tournament.repository.TournamentUserRepository
 import com.depromeet.team3.tournament.service.dto.AddTournamentItems
 import com.depromeet.team3.tournament.service.dto.CreateTournament
 import com.depromeet.team3.tournament.service.dto.RecordMatch
+import com.depromeet.team3.user.domain.IdentityType
+import com.depromeet.team3.user.domain.User
+import com.depromeet.team3.user.repository.UserRepository
 import com.depromeet.team3.wishlist.domain.Wish
 import com.depromeet.team3.wishlist.domain.WishCursor
 import com.depromeet.team3.wishlist.repository.WishRepository
@@ -38,6 +41,12 @@ class TournamentServiceTest {
             userId: UUID,
         ): TournamentUser? = users.find { it.tournamentId == tournamentId && it.userId == userId }
 
+        override fun findTournamentIdsByUserId(userId: UUID): List<Long> =
+            users.filter { it.userId == userId }.map { it.tournamentId }
+
+        override fun findByTournamentIds(tournamentIds: List<Long>): List<TournamentUser> =
+            users.filter { it.tournamentId in tournamentIds }
+
         private fun setEntityId(
             entity: LongBaseEntity,
             id: Long,
@@ -46,6 +55,17 @@ class TournamentServiceTest {
             field.isAccessible = true
             field.set(entity, id)
         }
+    }
+
+    private class TestUserRepository : UserRepository {
+        private val users = mutableMapOf<UUID, User>()
+
+        fun add(user: User) { users[user.id] = user }
+
+        override fun save(user: User): User = user.also { users[it.id] = it }
+        override fun findById(id: UUID): User? = users[id]
+        override fun findByIds(ids: Collection<UUID>): List<User> = ids.mapNotNull { users[it] }
+        override fun existsByNickname(nickname: String): Boolean = users.values.any { it.nickname == nickname }
     }
 
     private class TestWishRepository(
@@ -123,6 +143,12 @@ class TournamentServiceTest {
         override fun findTournamentHistoriesByTournamentId(tournamentId: Long): List<TournamentHistory> =
             histories.filter { it.tournamentId == tournamentId }
 
+        override fun findByIdsAndStatus(ids: List<Long>, status: TournamentStatus?): List<Tournament> =
+            tournaments.values
+                .filter { it.getId() in ids }
+                .filter { status?.let { s -> it.status == s } ?: true }
+                .sortedByDescending { it.updatedAt }
+
         private fun setEntityId(
             entity: LongBaseEntity,
             id: Long,
@@ -137,7 +163,8 @@ class TournamentServiceTest {
     private val userRepository = TestTournamentUserRepository()
     private val repository = TestTournamentRepository()
     private val wishRepository = TestWishRepository()
-    private val service = TournamentService(userRepository, repository, itemRepository, wishRepository)
+    private val testUserRepository = TestUserRepository()
+    private val service = TournamentService(userRepository, repository, itemRepository, wishRepository, testUserRepository)
     private val userId = UUID.randomUUID()
     private val otherUserId = UUID.randomUUID()
 
@@ -171,7 +198,7 @@ class TournamentServiceTest {
     @Test
     fun `addItems 에서 위시 아이템이 요청자의 것이 아니면 예외가 발생한다`() {
         val serviceWithNoOwnership =
-            TournamentService(userRepository, repository, itemRepository, TestWishRepository(allOwned = false))
+            TournamentService(userRepository, repository, itemRepository, TestWishRepository(allOwned = false), testUserRepository)
         val tournamentId = service.create(userId, CreateTournament("토너먼트"))
 
         assertFailsWith<WishException> {
@@ -468,6 +495,49 @@ class TournamentServiceTest {
         assertFailsWith<TournamentException> {
             service.getTournamentById(999L, userId)
         }
+    }
+
+    @Test
+    fun `getTournaments 는 자신이 참여한 토너먼트만 반환한다`() {
+        service.create(userId, CreateTournament("내 토너먼트1"))
+        service.create(userId, CreateTournament("내 토너먼트2"))
+        service.create(otherUserId, CreateTournament("남의 토너먼트"))
+
+        val result = service.getTournaments(userId, null)
+
+        assertEquals(2, result.size)
+        assert(result.all { r -> repository.tournaments.containsKey(r.tournamentId) })
+    }
+
+    @Test
+    fun `getTournaments 에서 참여한 토너먼트가 없으면 빈 리스트를 반환한다`() {
+        val result = service.getTournaments(userId, null)
+
+        assertEquals(0, result.size)
+    }
+
+    @Test
+    fun `getTournaments 에서 status 필터가 주어지면 해당 상태만 반환한다`() {
+        service.create(userId, CreateTournament("대기중"))
+        val startedId = service.create(userId, CreateTournament("진행중"))
+        service.addItems(userId, AddTournamentItems(startedId, listOf(1L, 2L)))
+        service.start(userId, startedId)
+
+        val result = service.getTournaments(userId, TournamentStatus.PENDING)
+
+        assertEquals(1, result.size)
+        assertEquals("대기중", result[0].name)
+    }
+
+    @Test
+    fun `getTournaments 에서 참여자 프로필 이미지를 반환한다`() {
+        testUserRepository.add(User(id = userId, nickname = "테스터", profileImage = "https://cdn.example.com/test.jpg", identityType = IdentityType.MEMBER))
+        service.create(userId, CreateTournament("이미지 토너먼트"))
+
+        val result = service.getTournaments(userId, null)
+
+        assertEquals(1, result.size)
+        assertEquals(listOf("https://cdn.example.com/test.jpg"), result[0].participantProfileImages)
     }
 
     @Test


### PR DESCRIPTION
## Situation
- 토너먼트 목록 화면에 필요한 `GET /api/v1/tournaments` API가 없었음
- 단순 목록뿐 아니라 참여자 프로필 이미지, 상태 필터링도 함께 요구됨

## Task
- 내 토너먼트 목록을 생성일 기준 내림차순으로 반환하는 API 구현
- 응답에 참여자 프로필 이미지 포함 및 N+1 방지
- status 필터는 단일이 아닌 복수 값을 수신할 수 있도록 설계 (`?status=PENDING&status=IN_PROGRESS`)

## Action

### 조회 로직
- `tournament_users → tournaments → tournament_users(전참여자) → users` 4-query 배치로 N+1 방지
- status 필터: `List<TournamentStatus>?` nullable 수신, null이면 전체 반환. 쿼리 파라미터 특성상 빈 리스트는 Spring 바인딩상 도달 불가
- 정렬 기준 `createdAt DESC` (화면 표시 날짜도 `updatedAt` → `createdAt`으로 통일)
- `tournament_users(user_id)` 인덱스 Flyway 마이그레이션 추가 — 기존 복합 인덱스 `(tournament_id, user_id)`는 단일 `user_id` 조회를 커버하지 못함

### 설계
- Controller 파라미터: `@RequestParam(required = false) status: List<TournamentStatus>?` — 복수 파라미터를 하나의 리스트로 바인딩하는 Spring MVC 표준 방식
- 레포지토리 메서드명: `findByIdsAndStatuses` + `findByIdInAndStatusInOrderByCreatedAtDesc`

### 테스트
- 통합 테스트: 목록 반환·프로필 이미지 포함·단일 status 필터·복수 status 필터·빈 목록·인증 없음 케이스 추가
- 단위 테스트: 자기 토너먼트만 반환·빈 목록·status 필터·복수 status 필터·프로필 이미지 매핑 케이스 추가

## Result
- `GET /api/v1/tournaments?status=PENDING&status=IN_PROGRESS` 형태로 복수 상태 필터링 가능
- 참여자 수에 무관하게 항상 4개의 쿼리로 처리됨

---
## 연관 이슈
- close #158
