### PR TITLE
기본 Gemini 모델을 gemini-3.1-flash-lite 로 변경 및 기본값 단일화

### DIFF
--- a/src/main/kotlin/com/depromeet/team3/product/service/gemini/GeminiProperties.kt
+++ b/src/main/kotlin/com/depromeet/team3/product/service/gemini/GeminiProperties.kt
@@ -5,7 +5,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 @ConfigurationProperties(prefix = "gemini")
 data class GeminiProperties(
     val apiKey: String,
-    val model: String = "gemini-2.5-flash",
+    val model: String = DEFAULT_MODEL,
     val retry: Retry = Retry(),
 ) {
     init {
@@ -30,5 +30,18 @@ data class GeminiProperties(
             require(maxAttempts >= 1) { "gemini.retry.max-attempts 는 1 이상이어야 합니다: $maxAttempts" }
             require(initialDelayMs >= 0) { "gemini.retry.initial-delay-ms 는 0 이상이어야 합니다: $initialDelayMs" }
         }
+    }
+
+    companion object {
+        /**
+         * 기본 모델의 단일 진실 원천(single source of truth).
+         *
+         * application.yml 등 다른 곳에 모델 리터럴을 중복 정의하지 않는다 — 여러 곳에 흩어지면
+         * 한쪽만 바뀌어 "다른 모델이 기본값이 되는" drift 가 생긴다. 운영에서 모델을 바꾸려면
+         * GEMINI_MODEL 환경변수로 override 한다 (relaxed binding: GEMINI_MODEL -> gemini.model).
+         *
+         * preview 모델은 2 주 사전공지 후 deprecate 정책이라 운영 안정성을 위해 GA 모델만 기본값으로 둔다.
+         */
+        const val DEFAULT_MODEL = "gemini-3.1-flash-lite"
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -48,8 +48,8 @@ oauth:
 
 gemini:
   api-key: ${GEMINI_API_KEY:}
-  # preview 모델은 2 주 사전공지 후 deprecate 정책이라 운영 안정성을 위해 GA 모델 사용.
-  model: ${GEMINI_MODEL:gemini-2.5-flash}
+  # 기본 모델은 GeminiProperties.DEFAULT_MODEL 한 곳에서만 정의한다 (drift 방지). 여기엔 리터럴을 두지 않는다.
+  # 운영에서 모델을 바꾸려면 GEMINI_MODEL 환경변수로 override (relaxed binding: GEMINI_MODEL -> gemini.model).
   retry:
     # max-attempts 는 총 시도 횟수(초기 호출 + 재시도). 기본 2 = 초기 호출 1회 + 재시도 1회.
     # 한 요청이 유발하는 billed API 호출 횟수 상한이므로 비용·quota 에 맞춰 환경변수로 조정.

--- a/src/test/kotlin/com/depromeet/team3/product/service/gemini/GeminiPropertiesTest.kt
+++ b/src/test/kotlin/com/depromeet/team3/product/service/gemini/GeminiPropertiesTest.kt
@@ -1,0 +1,30 @@
+package com.depromeet.team3.product.service.gemini
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+/**
+ * 기본 Gemini 모델이 "다른 모델로 바뀌는" 회귀를 빌드 단계에서 차단하는 가드.
+ *
+ * 기본값의 단일 진실 원천은 [GeminiProperties.DEFAULT_MODEL] 한 곳뿐이다 (application.yml 에는 리터럴을 두지 않는다).
+ * 따라서 이 상수만 고정하면 운영·테스트 양쪽의 기본 모델이 함께 고정된다.
+ */
+class GeminiPropertiesTest {
+    @Test
+    fun `기본 모델은 gemini-3_1-flash-lite 로 고정된다`() {
+        assertEquals("gemini-3.1-flash-lite", GeminiProperties.DEFAULT_MODEL)
+    }
+
+    @Test
+    fun `model 을 지정하지 않으면 DEFAULT_MODEL 이 적용된다`() {
+        val props = GeminiProperties(apiKey = "dummy")
+        assertEquals(GeminiProperties.DEFAULT_MODEL, props.model)
+    }
+
+    @Test
+    fun `기본 모델은 preview 가 아닌 GA 모델이어야 한다`() {
+        // preview 모델은 2 주 사전공지 후 deprecate 정책이라 운영 안정성상 기본값으로 두지 않는다.
+        assertFalse(GeminiProperties.DEFAULT_MODEL.contains("preview"))
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -9,7 +9,7 @@ spring:
 # 컨텍스트 로딩 자체는 깨지지 않는다.
 gemini:
   api-key: ${GEMINI_API_KEY:test-dummy-key}
-  model: ${GEMINI_MODEL:gemini-2.5-flash}
+  # model 미지정 → GeminiProperties.DEFAULT_MODEL 적용. 테스트는 외부 호출을 stub 하므로 모델 문자열은 실제로 쓰이지 않는다.
 
 # 운영 application.yml 은 JWT_SECRET env 를 강제하지만 테스트는 dummy secret 으로
 # 컨텍스트 로딩만 통과시킨다 (HS256 최소 키 길이 32 bytes 충족).


### PR DESCRIPTION
## Situation

- 추출 파이프라인의 기본 Gemini 모델이 `gemini-2.5-flash` 였다. I/O 2026 이후 더 새롭고 저렴한 GA 모델 후보(`gemini-3.1-flash-lite`)를 검토했다.
- 기본값(default)이 `application.yml`(main)·`application.yml`(test)·`GeminiProperties` **세 곳에 흩어진 리터럴**로 존재해, 한쪽만 바뀌면 "다른 모델이 기본값이 되는" drift 위험이 있었다.
- 배포 워크플로(`deploy.yml`/`deploy-manual.yml`)는 `GEMINI_API_KEY` 만 주입하고 `GEMINI_MODEL` 은 넘기지 않는다 → **운영의 기본 모델 = 이 default 그 자체**다.

## Task

- 기본 모델을 `gemini-3.1-flash-lite` 로 변경한다.
- 다른 모델이 실수로 기본값이 되는 일이 **구조적으로 불가능**하도록 기본값을 단일 지점으로 통합하고, 회귀를 빌드 단계에서 차단한다.

## Action

**1) 실측 비교 (실제 `GEMINI_API_KEY` 로 두 콜을 동일 요청 형식으로 호출)**

- HTML 추출 콜(`responseJsonSchema`)·OCR 이미지 콜(구형 `responseSchema` + `inlineData`) **둘 다 코드 변경 없이 `gemini-3.1-flash-lite` 가 그대로 수용**함을 확인.
- 대표 6 케이스(할인가/취소선, 외화 KRW·USD·JPY·EUR, 비상품 페이지 판별, 소수점→정수, OCR 스크린샷) **품질 동등**.

| 항목 | gemini-2.5-flash (현재) | gemini-3.1-flash-lite | gemini-3.5-flash (최신) |
|---|---|---|---|
| 대표 케이스 정확도 (5 HTML + OCR) | 전부 정답 | 전부 정답 | 전부 정답 |
| HTML 응답속도 (5회 median) | 4440ms | **1194ms** | 4406ms |
| OCR 응답속도 (합성 카드) | 4706ms | **2662ms** | 3186ms |
| 기본 thinking | 있음 (~610토큰, output 단가 과금) | **없음** | 있음 (~660토큰) |
| 단가 (입력/출력 /1M) | $0.30 / $2.50 | $0.25 / $1.50 | $1.50 / $9.00 |
| 비용 — HTML 소형 (1콜 / 1k콜) | $0.0017 / $1.66 | **$0.0002 / $0.19** | $0.0068 / $6.84 |
| 비용 — HTML 대형 15k (1콜 / 1k콜) | $0.0061 / $6.06 | **$0.0039 / $3.86** | $0.0288 / $28.82 |
| 비용 — OCR (1콜 / 1k콜) | $0.0011 / $1.08 | **$0.0004 / $0.37** | $0.0058 / $5.81 |
| 상태 | GA | GA (preview 아님) | GA (5/19 출시) |

> 비용 = **1콜당 / 1,000콜당** (USD). 측정 토큰 × 공식 단가 기준. 가장 비싼 3.5-flash 도 1콜당 ~$0.03(수십 원) 수준이다.

비용 차이의 주된 원인은 단가(입력 17%↓)보다 **2.5-flash 의 기본 thinking 토큰**이다. 추출 작업엔 frontier 추론이 불필요해 thinking 없는 Lite 가 품질 손실 없이 더 싸고 빠르다.

**2) 기본값 단일화 (drift 차단)**

- 기본값의 **단일 진실 원천**을 `GeminiProperties.DEFAULT_MODEL` 한 곳으로 두고, `application.yml`(main·test)의 모델 리터럴을 제거.
- 운영 override 노브는 `GEMINI_MODEL` 환경변수로 유지 (Spring relaxed binding: `GEMINI_MODEL` → `gemini.model`).
- `GeminiPropertiesTest` 로 기본값이 `gemini-3.1-flash-lite`(그리고 preview 가 아닌 GA)임을 못박아, 다른 모델로의 회귀 시 빌드가 깨지도록 함.

## Result

- 단위 + 통합 테스트 전체 통과 (`./gradlew test` BUILD SUCCESSFUL). YAML 에서 `model` 을 제거해도 컨텍스트 로딩이 정상임을 확인 (생성자 기본값 적용).
- 배포가 `GEMINI_MODEL` 을 넘기지 않으므로, 머지 후 **운영은 자동으로 `gemini-3.1-flash-lite` 를 사용**한다. 특정 모델로 고정하려면 배포 env 에 `GEMINI_MODEL` 을 추가하면 된다.
- 기본 모델 리터럴이 코드 한 곳으로 모여 더 이상 여러 파일 사이에서 갈라지지 않는다.

## 참고

- 표본 6 케이스로는 가장 지저분한 실제 페이지(heavy-JS·가격 모호)까지 동등을 단정하긴 어렵다. 운영 전환 후 추출 실패율을 모니터링하고, 품질이 흔들리면 Lite 에 `thinkingConfig` 를 소폭 켜는 레버가 있다(별도 변경 필요).

## Updates

### gemini-3.5-flash (최신) 추가 + 3모델 동일 윈도우 재측정

- 표에 `gemini-3.5-flash`(5/19 출시) 컬럼을 추가하며 세 모델을 같은 측정 윈도우에서 다시 돌렸다(thinking 토큰 변동으로 2.5/3.1 수치도 소폭 갱신).
- 3.5-flash 는 2.5-flash 처럼 **기본 thinking 을 해 latency 가 동일하게 느리다**(bounded 추출엔 불필요한 추론). 정확도 우위 없이 비용만 **현재의 ~4.7배 · Flash-Lite 의 ~7.5배**(HTML 대형 기준). agentic/coding frontier 모델이라 이 워크로드엔 과함 → 후보에서 제외.

### 실제 무신사 페이지 1건 검증 (위 `## 참고` caveat 보강)

실제 무신사 상품으로 검증 — **링크와 OCR 이미지는 서로 다른 상품**이었다(링크 `5848781` = 롱슬리브, 정가 70,000 → 할인가 38,900 / 이미지 = 숏팬츠, 정가 82,000 → 할인가 22,800):

- **OCR(스크린샷, 3회)**: 3모델 모두 할인가 **22,800 정확 추출** — 취소선 정가·카드할인 함정 무시. 단 **현재 모델 2.5-flash 는 한글 상품명을 영어로 번역**("Training Sweat Short Pants")해 "표시된 그대로" 규칙을 위반, 3.1-flash-lite·3.5-flash 는 한글 원문 유지. 실이미지 OCR median: 2.5-flash 5.6s(+503 1회), **3.1-flash-lite 2.5s**, 3.5-flash 3.9s. → 실제 페이지 테스트가 오히려 교체를 더 강하게 지지.
- **링크(server-side fetch)**: 무신사 `5848781`(롱슬리브)을 fetch → 3모델 모두 **할인가 38,900 정확 추출**(정가 70,000·쿠폰가 함정 무시). 무신사 정적 HTML 의 JSON(`salePrice`/`finalPrice`)에서 읽혀 **PageFetcher 가 무신사에서도 정상 동작**함을 확인 → OCR·링크 두 경로 모두 실제 무신사 페이지에서 정확.


