### PR TITLE
CodeRabbit author 매칭을 두 API 표기 모두 커버하도록 수정

### DIFF
--- a/.claude/commands/coderabbit.md
+++ b/.claude/commands/coderabbit.md
@@ -11,8 +11,8 @@
 - **CodeRabbit 은 코멘트를 두 곳에 나눠 단다 — 반드시 둘 다 본다.**
   - **인라인 review thread**: actionable 코멘트. `reviewThreads` 로 조회되고 개별 resolve 가능.
   - **review body 안에 접힌 nitpick / 추가 코멘트**: `🧹 Nitpick comments (N)` 같은 `<details>` 블록. `reviewThreads` 에 **안 잡힌다** — `pulls/{PR}/reviews` 의 review body 를 따로 조회해야 보인다. 이걸 빠뜨리면 nitpick 을 통째로 놓친다 (resolve 대상은 아니지만 평가는 해야 한다).
-- **author 매칭은 `coderabbitai[bot]` 로 한다.** CodeRabbit 의 login 은 `coderabbitai` 가 아니라 `coderabbitai[bot]` 이다 (`[bot]` 접미사). `== "coderabbitai"` 로 비교하면 영원히 매칭되지 않아 봇을 사람으로 오인한다.
-- **사람 리뷰어 thread 는 자동 reply 하지 않는다.** author 가 `coderabbitai[bot]` 이 아니면 (즉 사람 리뷰면) reply / resolve 둘 다 모델이 건드리지 않는다 — 작성자(`@me`)가 직접 의도·뉘앙스를 담아 답한다. 1단계 카운트에서 1건 이상이면 3~4단계(thread reply/resolve)는 건너뛰고 사용자에게 "사람 리뷰 N건 있습니다" 만 알린다. (단 2.5단계 nitpick 조회·평가는 사람 리뷰 여부와 무관하게 수행한다.)
+- **author 매칭은 `coderabbitai` 로 시작하는지(`startswith`)로 한다.** GitHub 의 두 API 가 같은 봇을 다르게 표기한다 — GraphQL `reviewThreads` 의 `author.login` 은 `coderabbitai`, REST `pulls/{PR}/reviews` 의 `user.login` 은 `coderabbitai[bot]`. 어느 한쪽 값으로 고정하면 다른 API 에서 매칭이 깨져 봇을 사람으로 오인하므로(예: reviewThreads 를 `coderabbitai[bot]` 로 비교하면 영원히 안 잡힘), 양쪽 모두 `coderabbitai` 로 시작하는지로 매칭한다.
+- **사람 리뷰어 thread 는 자동 reply 하지 않는다.** author 가 `coderabbitai` 로 시작하지 않으면 (즉 사람 리뷰면) reply / resolve 둘 다 모델이 건드리지 않는다 — 작성자(`@me`)가 직접 의도·뉘앙스를 담아 답한다. 1단계 카운트에서 1건 이상이면 3~4단계(thread reply/resolve)는 건너뛰고 사용자에게 "사람 리뷰 N건 있습니다" 만 알린다. (단 2.5단계 nitpick 조회·평가는 사람 리뷰 여부와 무관하게 수행한다.)
 
 ## 절차
 
@@ -36,12 +36,12 @@ HUMAN_THREADS=$(gh api graphql -f query='
       } }
     }
   }}' --jq '[.data.repository.pullRequest.reviewThreads.nodes[]
-             | select(.comments.nodes[0].author.login != "coderabbitai[bot]")] | length')
+             | select(((.comments.nodes[0].author.login // "") | startswith("coderabbitai")) | not)] | length')
 echo "사람 리뷰 thread: ${HUMAN_THREADS}건"
 # HUMAN_THREADS > 0 → 3~4단계(thread reply/resolve) 건너뛰고 사용자에게 알림 (2.5 nitpick 은 그대로)
 ```
 
-### 2. CodeRabbit 인라인 thread 조회 — author `coderabbitai[bot]` 고정 필터
+### 2. CodeRabbit 인라인 thread 조회 — author `coderabbitai*` 필터
 
 ```bash
 gh api graphql -f query='
@@ -53,7 +53,7 @@ gh api graphql -f query='
       } }
     }
   }}' --jq '.data.repository.pullRequest.reviewThreads.nodes[]
-            | select(.comments.nodes[0].author.login == "coderabbitai[bot]")
+            | select((.comments.nodes[0].author.login // "") | startswith("coderabbitai"))
             | {id, isResolved, path, line}'
 ```
 
@@ -61,7 +61,7 @@ gh api graphql -f query='
 
 ```bash
 gh api repos/depromeet/PIKI-Server/pulls/$PR/reviews \
-  --jq '.[] | select(.user.login == "coderabbitai[bot]" and (.body | length) > 100) | .body'
+  --jq '.[] | select(((.user.login // "") | startswith("coderabbitai")) and (.body | length) > 100) | .body'
 ```
 
 출력된 body 를 읽고 `🧹 Nitpick comments` 등 접힌 코멘트를 건별 평가한다. nitpick 은 thread 가 아니라 **resolve 대상이 아니므로**, 반영하면 커밋 + PR `## Updates`(또는 PR 일반 코멘트)로 처리 사실을 남긴다.

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -160,7 +160,7 @@ ISSUE_LABELS=$(gh issue view {번호} --json labels --jq '[.labels[].name] | joi
 6. **제목 변경 필요 검토**: 추가 변경으로 작업 의도/스코프가 바뀌었거나 기존 제목에 오타·부정확한 표현이 있으면 새 제목 제안. 그 외엔 제목 유지.
 7. 사용자에게 갱신본(필요시 새 제목 포함, 변경 이유 짚어서)을 보여주고 확인받는다.
 8. 확인 후 `gh pr edit --body-file /tmp/pr_body.md` 로 갱신. 제목 변경이 있으면 `--title "새 제목"` 추가.
-9. **CodeRabbit 리뷰 대응** — 이번 변경이 CodeRabbit 리뷰 대응이라면 commit + push 로 끝내지 않는다. CodeRabbit 리뷰(인라인 thread + review body nitpick) 조회·평가·reply·resolve 는 **`/coderabbit` 스킬**로 처리한다. 그 스킬이 author `coderabbitai[bot]` 매칭, nitpick 조회, accept/reject reply·resolve 정책을 담는다. (사람 리뷰 thread 는 작성자가 직접 답하므로 `/coderabbit` 도 건드리지 않는다.)
+9. **CodeRabbit 리뷰 대응** — 이번 변경이 CodeRabbit 리뷰 대응이라면 commit + push 로 끝내지 않는다. CodeRabbit 리뷰(인라인 thread + review body nitpick) 조회·평가·reply·resolve 는 **`/coderabbit` 스킬**로 처리한다. 그 스킬이 author 매칭(GraphQL `reviewThreads` 는 `coderabbitai`, REST `reviews` 는 `coderabbitai[bot]` 이라 `coderabbitai` 로 시작하는지로 판별), nitpick 조회, accept/reject reply·resolve 정책을 담는다. (사람 리뷰 thread 는 작성자가 직접 답하므로 `/coderabbit` 도 건드리지 않는다.)
 
 10. **메타데이터 보정** — 이전 버전 스킬로 만든 PR 은 assignee / 라벨 / Project 가 비어 있을 수 있다. update 모드에서도 멱등하게 보정한다 (이미 설정돼 있으면 no-op). `item-add` 는 이미 등록된 PR 이면 기존 item id 를 그대로 반환한다.
     Status 는 **현재 값을 먼저 조회해, 리뷰 이전 단계(`Backlog` / `Ready` / `In progress`)일 때만** `In review` 로 올린다 — 이미 `Done` 등으로 옮긴 PR 을 되돌리지 않기 위함이다. Status 조회는 item 노드를 직접 부르는 GraphQL 이 안정적이다 (`gh project item-list` 는 단일 선택 필드 값을 신뢰성 있게 주지 않는다):


### PR DESCRIPTION
## Situation
- PR #183 에서 CodeRabbit author 매칭을 `coderabbitai[bot]` 으로 통일했는데, GitHub 의 두 API 가 같은 봇 계정을 다르게 표기한다는 걸 놓쳤다 — GraphQL `reviewThreads.comments.author.login` 은 `coderabbitai`, REST `pulls/{n}/reviews[].user.login` 은 `coderabbitai[bot]`.
- 그 결과 `reviewThreads` 필터가 `coderabbitai[bot]` 이면 CodeRabbit inline thread 를 영원히 못 잡고 **사람 리뷰로 오분류**해 자동 reply 를 건너뛴다. 실제로 PR #188 에서 CodeRabbit 리뷰 2건이 "사람 리뷰"로 잡혔다.

## Task
- `/coderabbit`·`/pr` 스킬의 author 매칭을 두 API 표기 모두에서 동작하도록 고친다.

## Action
- `reviewThreads`(GraphQL)·`reviews`(REST) 양쪽 jq 필터를 `coderabbitai` 로 시작하는지(`startswith`)로 바꿔, 두 표기를 모두 커버. 한쪽 값으로 고정하면 다른 API 에서 깨지므로 prefix 매칭이 견고하다.
- `coderabbit.md` 의 사람 카운트·CodeRabbit thread 필터·nitpick(reviews) 필터와 설명을 정정하고, `pr.md` 9단계의 author 매칭 문구도 함께 정정.
- PR #188 로 검증: 수정 전 `사람 2 / CodeRabbit 0`(오분류) → 수정 후 `사람 0 / CodeRabbit 3`(정상), reviews(REST) 2건도 정상 매칭.

## Result
- CodeRabbit inline thread 가 사람 리뷰로 오분류되지 않아, `/coderabbit` 의 자동 reply·resolve 가 정상 동작한다.
- 두 API 의 login 표기 차이를 스킬 설명에 명시해 같은 실수가 반복되지 않게 했다.

---
## 연관 이슈

- close #190
