### PR TITLE
CorsConfig 에 우리 서버 origin 추가 — Stoplight try-it 403 해결

### DIFF
--- a/src/main/kotlin/com/depromeet/team3/common/config/CorsConfig.kt
+++ b/src/main/kotlin/com/depromeet/team3/common/config/CorsConfig.kt
@@ -9,8 +9,13 @@ class CorsConfig : WebMvcConfigurer {
     override fun addCorsMappings(registry: CorsRegistry) {
         registry
             .addMapping("/**")
-            .allowedOrigins("https://depromeet.vercel.app")
-            .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
+            .allowedOrigins(
+                "https://depromeet.vercel.app",
+                // 우리 서버 자체 origin — Stoplight UI (/docs/index.html) 의 try-it 이
+                // 브라우저 fetch(mode=cors) 로 호출 시 same-origin 이어도 Origin 헤더가 박혀
+                // CORS 검사를 거치므로 화이트리스트에 포함되어야 한다.
+                "https://api.depromeet18team3.cloud",
+            ).allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
             .allowedHeaders("*")
             .allowCredentials(true)
     }


### PR DESCRIPTION
## Situation
- 우리 Stoplight UI (`https://api.depromeet18team3.cloud/docs/index.html`) 의 try-it 이 `POST /api/v1/auth/guest` 를 포함한 모든 endpoint 에서 403 반환
- Insomnia 로 같은 endpoint 호출 시 201 정상 응답 → 서버 자체는 정상, **브라우저 경로만 막힌 상태**

## Task
- 브라우저 fetch(mode=cors) 의 `Origin` 헤더와 우리 CORS 화이트리스트 mismatch 를 추적 → 우리 docs UI 가 우리 서버에 요청하는데 자가 차단된 상황 해결

## Action
- 진단 과정: 응답 헤더의 `vary: Origin, Access-Control-Request-*` 와 Insomnia vs 브라우저 헤더 차이로 좁힘. 같은 origin 인데도 fetch with `mode=cors` 는 `Origin` 헤더를 박는 동작이 트랩
- `CorsConfig.allowedOrigins` 에 `https://api.depromeet18team3.cloud` 추가
- 주석으로 "Stoplight UI 의 try-it 이 same-origin 이어도 Origin 헤더가 박혀 CORS 검사를 거친다" 명시 — 다음 사람이 왜 자기 origin 이 화이트리스트에 있는지 헤매지 않게

## Result
- docs UI 의 try-it 이 모든 endpoint 에서 정상 동작 → FE/BE 가 엔드포인트 수동 테스트 가능
- 후속: FE 의 dev/staging/prod origin 추가 (FE 팀 확인 필요), 기존 `https://depromeet.vercel.app` 의 생사 확인 — 모두 별도 작업

---
## 연관 이슈

- close #192


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **설정 업데이트**
  * API 접근 가능한 도메인이 확장되었습니다. 추가 도메인에서 서버에 대한 요청이 정상적으로 처리될 수 있도록 정책이 업데이트되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/PIKI-Server/pull/193?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->