### PR TITLE
Project 보드 timeline 자동화 — PR 스킬 Start date + CI 머지 hook

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -123,19 +123,35 @@ ISSUE_LABELS=$(gh issue view {번호} --json labels --jq '[.labels[].name] | joi
    - `--assignee @me` — PR 작성자가 작업자라는 가정 (`issue` 스킬과 동일).
    - `--label` — 1단계에서 수집한 `$ISSUE_LABELS` 가 있을 때만 붙인다.
    - 라벨이 레포에 없어 실패하면 라벨 없이 재시도하고 사용자에게 보고한다.
-4. **Project 추가 + Status In review** — 생성된 PR 을 Project 99 에 등록하고 Status 를 `In review` 로 세팅한다. `item-add` 만 하면 기본값 `Backlog` 이 되므로, 반환된 item id 로 `item-edit` 를 이어서 호출한다:
+4. **Project 추가 + Status In review + Start date** — 생성된 PR 을 Project 99 에 등록하고 Status 를 `In review`, Start date 를 첫 commit author date 로 세팅한다. `item-add` 만 하면 기본값 `Backlog` 이 되므로, 반환된 item id 로 후속 mutation 들을 이어서 호출한다:
    ```bash
    ITEM_ID=$(gh project item-add 99 --owner depromeet --url {PR URL} --format json --jq '.id')
+
+   # Status → In review
    gh project item-edit \
      --project-id PVT_kwDOARZVGM4BVVRV \
      --id "$ITEM_ID" \
      --field-id PVTSSF_lADOARZVGM4BVVRVzhQxyAA \
      --single-select-option-id df73e18b
+
+   # Start date → 첫 commit author date (작업이 실제로 시작된 시점의 fact)
+   START_DATE=$(git log --reverse "$BASE..HEAD" --format=%aI | head -1 | cut -d'T' -f1)
+   gh api graphql -F itemId="$ITEM_ID" -F date="$START_DATE" -f query='
+     mutation($itemId: ID!, $date: Date!) {
+       updateProjectV2ItemFieldValue(input: {
+         projectId: "PVT_kwDOARZVGM4BVVRV"
+         itemId: $itemId
+         fieldId: "PVTF_lADOARZVGM4BVVRVzhQxyGA"
+         value: { date: $date }
+       }) { projectV2Item { id } }
+     }'
    ```
    - PR 을 올린다는 것은 곧 리뷰 대기 상태이므로 `In review` 가 자연스럽다. create 모드는 방금 만든 PR 이라 Status 가 항상 기본값(`Backlog`)이므로 조건 없이 세팅한다 (update 모드 10단계는 기존 Status 를 확인 후 분기).
-   - ID 의미: project=99 노드 ID, field=Status 필드 ID, option=`In review` 옵션 ID. 보드에서 Status 옵션이 바뀌면 이 ID 들도 갱신 필요.
-   - 권한 부족 시 사용자에게 `gh auth refresh -h github.com -s project` 안내 (일회성 디바이스 인증).
-5. PR URL 과 부여된 assignee / 라벨 / Project(Status: In review) 결과를 사용자에게 전달
+   - Start date 는 "이슈 생성일" 이 아니라 **첫 commit author date** 를 쓴다 — 이슈만 만들어 두고 작업 안 들어가는 백로그 케이스의 노이즈를 피하기 위해. 첫 commit 은 history rewrite 가 없는 한 바뀌지 않는 fact 라 create 모드에선 무조건 set.
+   - ID 의미: project=99 노드 ID, Status 필드/`In review` 옵션 ID, Start date 필드 ID(`PVTF_..GA`, DATE 타입). 보드에서 필드/옵션이 바뀌면 이 ID 들도 갱신 필요.
+   - Target date 와 Status `Done` 은 PR 머지 시점에 별도 CI workflow (`.github/workflows/project-sync-on-pr-close.yml`) 가 자동 세팅. PR 스킬은 머지 이전 단계만 책임짐.
+   - 권한 부족 시 사용자에게 `gh auth refresh -h github.com -s project,read:project` 안내 (일회성 디바이스 인증).
+5. PR URL 과 부여된 assignee / 라벨 / Project(Status: In review, Start date) 결과를 사용자에게 전달
 
 ### 3-B. Update 모드 — 기존 PR 본문 갱신
 
@@ -162,27 +178,48 @@ ISSUE_LABELS=$(gh issue view {번호} --json labels --jq '[.labels[].name] | joi
 8. 확인 후 `gh pr edit --body-file /tmp/pr_body.md` 로 갱신. 제목 변경이 있으면 `--title "새 제목"` 추가.
 9. **CodeRabbit 리뷰 대응** — 이번 변경이 CodeRabbit 리뷰 대응이라면 commit + push 로 끝내지 않는다. CodeRabbit 리뷰(인라인 thread + review body nitpick) 조회·평가·reply·resolve 는 **`/coderabbit` 스킬**로 처리한다. 그 스킬이 author `coderabbitai[bot]` 매칭, nitpick 조회, accept/reject reply·resolve 정책을 담는다. (사람 리뷰 thread 는 작성자가 직접 답하므로 `/coderabbit` 도 건드리지 않는다.)
 
-10. **메타데이터 보정** — 이전 버전 스킬로 만든 PR 은 assignee / 라벨 / Project 가 비어 있을 수 있다. update 모드에서도 멱등하게 보정한다 (이미 설정돼 있으면 no-op). `item-add` 는 이미 등록된 PR 이면 기존 item id 를 그대로 반환한다.
-    Status 는 **현재 값을 먼저 조회해, 리뷰 이전 단계(`Backlog` / `Ready` / `In progress`)일 때만** `In review` 로 올린다 — 이미 `Done` 등으로 옮긴 PR 을 되돌리지 않기 위함이다. Status 조회는 item 노드를 직접 부르는 GraphQL 이 안정적이다 (`gh project item-list` 는 단일 선택 필드 값을 신뢰성 있게 주지 않는다):
+10. **메타데이터 보정** — 이전 버전 스킬로 만든 PR 은 assignee / 라벨 / Project / Start date 가 비어 있을 수 있다. update 모드에서도 멱등하게 보정한다 (이미 설정돼 있으면 no-op). `item-add` 는 이미 등록된 PR 이면 기존 item id 를 그대로 반환한다.
+    Status 는 **현재 값을 먼저 조회해, 리뷰 이전 단계(`Backlog` / `Ready` / `In progress`)일 때만** `In review` 로 올린다 — 이미 `Done` 등으로 옮긴 PR 을 되돌리지 않기 위함이다. Start date 도 멱등 — 이미 set 되어 있으면 건드리지 않는다 (사람이 수동으로 다른 의미로 박았을 수 있어 보존). Status / Start date 조회는 item 노드를 직접 부르는 GraphQL 이 안정적이다 (`gh project item-list` 는 단일 선택 필드 값을 신뢰성 있게 주지 않는다):
     ```bash
     gh pr edit --add-assignee @me ${ISSUE_LABELS:+--add-label "$ISSUE_LABELS"}
     ITEM_ID=$(gh project item-add 99 --owner depromeet --url {PR URL} --format json --jq '.id')
-    CURRENT_STATUS=$(gh api graphql -F id="$ITEM_ID" -f query='
+
+    # Status + Start date 현재 값 동시 조회
+    read CURRENT_STATUS CURRENT_START < <(gh api graphql -F id="$ITEM_ID" -f query='
       query($id: ID!) {
         node(id: $id) {
           ... on ProjectV2Item {
-            fieldValueByName(name: "Status") {
+            status: fieldValueByName(name: "Status") {
               ... on ProjectV2ItemFieldSingleSelectValue { name }
+            }
+            start: fieldValueByName(name: "Start date") {
+              ... on ProjectV2ItemFieldDateValue { date }
             }
           }
         }
-      }' --jq '.data.node.fieldValueByName.name')
+      }' --jq '[(.data.node.status.name // "null"), (.data.node.start.date // "null")] | @tsv')
+
+    # Status: 리뷰 이전 단계일 때만 In review 로 올림
     if [[ "$CURRENT_STATUS" == "Backlog" || "$CURRENT_STATUS" == "Ready" || "$CURRENT_STATUS" == "In progress" ]]; then
       gh project item-edit \
         --project-id PVT_kwDOARZVGM4BVVRV \
         --id "$ITEM_ID" \
         --field-id PVTSSF_lADOARZVGM4BVVRVzhQxyAA \
         --single-select-option-id df73e18b
+    fi
+
+    # Start date: 비어있을 때만 첫 commit author date 로 세팅
+    if [[ "$CURRENT_START" == "null" ]]; then
+      START_DATE=$(git log --reverse "$BASE..HEAD" --format=%aI | head -1 | cut -d'T' -f1)
+      gh api graphql -F itemId="$ITEM_ID" -F date="$START_DATE" -f query='
+        mutation($itemId: ID!, $date: Date!) {
+          updateProjectV2ItemFieldValue(input: {
+            projectId: "PVT_kwDOARZVGM4BVVRV"
+            itemId: $itemId
+            fieldId: "PVTF_lADOARZVGM4BVVRVzhQxyGA"
+            value: { date: $date }
+          }) { projectV2Item { id } }
+        }'
     fi
     ```
 11. PR URL 재출력.

--- a/.github/workflows/pr-merge-project-sync.yml
+++ b/.github/workflows/pr-merge-project-sync.yml
@@ -1,0 +1,86 @@
+name: PR Merge → Project Sync
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  sync:
+    # 머지된 PR + dev base + 같은 repo 의 head 일 때만 동작 (fork PR 은 secrets 접근 불가라 skip).
+    if: |
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'dev' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Set Target date + Status Done on merged PR
+        env:
+          # org-level Projects v2 는 default GITHUB_TOKEN 으로 접근 불가 — PAT (project, read:project) 필요.
+          # 기존 issue-project-sync.yml 와 동일한 secret 재사용.
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+          PR_NODE_ID: ${{ github.event.pull_request.node_id }}
+          MERGED_AT: ${{ github.event.pull_request.merged_at }}
+        run: |
+          set -euo pipefail
+
+          # 머지 날짜 (YYYY-MM-DD)
+          MERGE_DATE=$(echo "$MERGED_AT" | cut -d'T' -f1)
+          echo "Merge date: $MERGE_DATE"
+
+          # 프로젝트 + 필드 메타 동적 조회 (보드 변경에 자동 추종).
+          PROJECT_ID=$(gh api graphql -f query='{
+            organization(login: "depromeet") {
+              projectV2(number: 99) { id }
+            }
+          }' --jq '.data.organization.projectV2.id')
+
+          FIELDS=$(gh api graphql -f query='{
+            organization(login: "depromeet") {
+              projectV2(number: 99) {
+                fields(first: 30) {
+                  nodes {
+                    ... on ProjectV2Field { id name dataType }
+                    ... on ProjectV2SingleSelectField { id name options { id name } }
+                  }
+                }
+              }
+            }
+          }' --jq '.data.organization.projectV2.fields.nodes')
+
+          TARGET_FIELD=$(echo "$FIELDS" | jq -r '.[] | select(.name == "Target date" and .dataType == "DATE") | .id')
+          STATUS_FIELD=$(echo "$FIELDS" | jq -r '.[] | select(.name == "Status") | .id')
+          DONE_OPTION=$(echo "$FIELDS" | jq -r '.[] | select(.name == "Status") | .options[] | select(.name == "Done") | .id')
+          echo "TARGET_FIELD=$TARGET_FIELD STATUS_FIELD=$STATUS_FIELD DONE_OPTION=$DONE_OPTION"
+
+          # PR 을 프로젝트에 추가 — 이미 있으면 기존 item id 리턴 (addProjectV2ItemById 의 멱등성).
+          ITEM_ID=$(gh api graphql \
+            -f query='mutation($pid:ID!,$cid:ID!) {
+              addProjectV2ItemById(input:{projectId:$pid,contentId:$cid}) {
+                item { id }
+              }
+            }' \
+            -f pid="$PROJECT_ID" \
+            -f cid="$PR_NODE_ID" \
+            --jq '.data.addProjectV2ItemById.item.id')
+          echo "Item ID: $ITEM_ID"
+
+          # Target date = mergedAt
+          gh api graphql \
+            -f query='mutation($pid:ID!,$iid:ID!,$fid:ID!,$date:Date!) {
+              updateProjectV2ItemFieldValue(input:{
+                projectId:$pid, itemId:$iid, fieldId:$fid, value:{date:$date}
+              }) { projectV2Item { id } }
+            }' \
+            -f pid="$PROJECT_ID" -f iid="$ITEM_ID" -f fid="$TARGET_FIELD" -f date="$MERGE_DATE"
+
+          # Status → Done
+          gh api graphql \
+            -f query='mutation($pid:ID!,$iid:ID!,$fid:ID!,$oid:String!) {
+              updateProjectV2ItemFieldValue(input:{
+                projectId:$pid, itemId:$iid, fieldId:$fid, value:{singleSelectOptionId:$oid}
+              }) { projectV2Item { id } }
+            }' \
+            -f pid="$PROJECT_ID" -f iid="$ITEM_ID" -f fid="$STATUS_FIELD" -f oid="$DONE_OPTION"
+
+          echo "Synced: Target date=$MERGE_DATE, Status=Done"


### PR DESCRIPTION
## Situation
- Project 99 보드에 등록까지는 PR 스킬이 자동화하고 있었지만 timeline 메타(Start/Target date, Status Done)는 수동 — 일정 시각화의 핵심 데이터가 늘 빈 상태였음
- PR 생성 시점엔 첫 commit author date 가 fact 로, 머지 시점엔 `mergedAt` 이 fact 로 존재 — 자동 채울 수 있는 값이 다 있는데도 흐름에 안 탔던 상태
- Project 99 필드 확인: Start date / Target date 둘 다 이미 존재 (새 필드 제작 불필요), Status 의 `Done` 옵션도 정의됨

## Task
- PR 생성 시 Start date 자동 세팅
- PR 머지 시 Target date + Status `Done` 자동 세팅
- 사람이 보드에서 따로 채워야 할 메타를 0 으로 만들고, 보드 view 의 Start ~ Target timeline 시각화를 활성화

## Action

### PR 스킬 보강 (`.claude/commands/pr.md`)
- create 모드(3-A 4단계): Project 등록 후 Status `In review` + Start date(첫 commit author date) 동시 set. 첫 commit 은 history rewrite 없는 한 fact 라 무조건 set
- update 모드(3-B 10단계): Status + Start date 둘 다 멱등 — Start date 는 비어있을 때만 set (사람 수동 입력 보존)
- 기준 후보 비교 (이슈 생성일 / 브랜치 생성일 / 첫 commit) 중 첫 commit author date 채택 — 이슈 생성일은 백로그 노이즈, 브랜치 생성일은 GitHub API 가 직접 안 줌

### CI 머지 hook 신규 (`.github/workflows/pr-merge-project-sync.yml`)
- `pull_request: closed` + `merged == true` + base=dev + 같은 repo head (fork PR 은 secrets 접근 불가라 skip)
- 머지된 PR 의 project item 을 찾아 Target date = `mergedAt`, Status = `Done` 으로 set
- 기존 `issue-project-sync.yml` 패턴 그대로 — `PROJECT_TOKEN` secret 재사용, 동적 ID 조회로 보드 변경 자동 추종
- `addProjectV2ItemById` 의 멱등성으로 PR 스킬이 만든 카드를 그대로 갱신

## Result
- 이 PR 자체가 첫 dogfooding 케이스 — 생성 시 Start date 자동 채워지고, 머지 시 새 workflow 가 발동되어 Target date + Status Done 까지 자동 처리됨
- 자동 검증의 한계: PR 스킬은 다음 호출, workflow 는 이 PR 머지 자체가 첫 실행 (chicken-and-egg, deploy.yml 와 동일 패턴). 머지 후 보드 결과 확인 1단계 필요
- 후속: workflow 가 dev 머지 한정 — main 머지 흐름이 생기면 if 조건에 main 추가 (현재 main 은 옛 상태로 사실상 사용 X)

---
## 연관 이슈

- close #194
