### PR TITLE
PR 머지 hook 의 Target date 가 UTC 날짜로 박히던 문제 정정

### DIFF
--- a/.github/workflows/pr-merge-project-sync.yml
+++ b/.github/workflows/pr-merge-project-sync.yml
@@ -24,9 +24,13 @@ jobs:
         run: |
           set -euo pipefail
 
-          # 머지 날짜 (YYYY-MM-DD)
-          MERGE_DATE=$(echo "$MERGED_AT" | cut -d'T' -f1)
-          echo "Merge date: $MERGE_DATE"
+          # 머지 날짜 (YYYY-MM-DD, KST 기준)
+          # mergedAt 은 GitHub API 가 UTC 로 주는데(예: 2026-05-22T16:40:46Z),
+          # 단순 cut 으로 T 앞만 떼면 timezone 정보가 사라져 UTC 의 5/22 가 저장된다.
+          # KST(+9) 로는 5/23 새벽인데 보드의 Start date(KST 기준 첫 commit 일) 와 어긋나
+          # timeline 이 역행하는 사고가 있었음 (#195/#196). TZ 명시로 강제 변환한다.
+          MERGE_DATE=$(TZ=Asia/Seoul date -d "$MERGED_AT" '+%Y-%m-%d')
+          echo "Merge date (KST): $MERGE_DATE"
 
           # 프로젝트 + 필드 메타 동적 조회 (보드 변경에 자동 추종).
           PROJECT_ID=$(gh api graphql -f query='{


### PR DESCRIPTION
## Situation
- PR #195 (Project timeline 자동화) 의 첫 dogfooding 직후 보드에서 **Start date(5/23) > Target date(5/22)** 의 timeline 역행 발견
- 머지 시각은 KST 기준 5/23 새벽 01:40 — 의미상 같은 날이 되어야 하는데 보드엔 전날로 박힘

## Task
- 원인은 timezone 처리 누락 — `mergedAt` 은 UTC 로 오는데 `cut -d'T' -f1` 이 timezone 무시
- workflow 의 날짜 추출을 KST 강제 변환으로 정정

## Action
- `.github/workflows/pr-merge-project-sync.yml` 의 MERGE_DATE 계산 한 줄을 `TZ=Asia/Seoul date -d "$MERGED_AT" '+%Y-%m-%d'` 로 교체
- 주석에 사고 맥락(PR #195/#196, Start date 와의 일관성) 명시 — 다음 사람이 또 cut 한 줄로 단순화하다가 같은 함정 반복하지 않게
- Start date(`%aI`) 는 git author 의 +09:00 offset 이 박혀있어 우연히 KST 로 떨어졌던 것 — 일관성 위해 PR 스킬에도 TZ 명시 검토할지는 별도 후속 (이번 hotfix 스코프 밖)

## Result
- 다음 머지부터 Target date 가 KST 의 날짜로 박힘 → Start ~ Target timeline 정상
- PR #195 의 잘못된 값은 머지 후 그 PR 의 workflow 를 수동 re-trigger 해 자동 갱신 (보드 수동 정정 불필요)

---
## 연관 이슈

- close #196
