### PR TITLE
로컬 개발 환경 CORS 허용 및 preflight 401 해결

### DIFF
--- a/src/main/kotlin/com/depromeet/team3/auth/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/depromeet/team3/auth/config/SecurityConfig.kt
@@ -21,6 +21,9 @@ class SecurityConfig {
         jwtAuthenticationFilter: JwtAuthenticationFilter,
     ): SecurityFilterChain =
         http
+            // CorsConfigurationSource 빈을 사용해 CORS 를 Security 필터 단에서 처리한다.
+            // 이걸 빼면 preflight(OPTIONS) 가 anyRequest().authenticated() 에 잡혀 401 이 된다.
+            .cors { }
             .csrf { it.disable() }
             .httpBasic { it.disable() }
             .formLogin { it.disable() }

--- a/src/main/kotlin/com/depromeet/team3/common/config/CorsConfig.kt
+++ b/src/main/kotlin/com/depromeet/team3/common/config/CorsConfig.kt
@@ -1,22 +1,40 @@
 package com.depromeet.team3.common.config
 
+import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.web.servlet.config.annotation.CorsRegistry
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+import org.springframework.web.cors.CorsConfiguration
+import org.springframework.web.cors.CorsConfigurationSource
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 
 @Configuration
-class CorsConfig : WebMvcConfigurer {
-    override fun addCorsMappings(registry: CorsRegistry) {
-        registry
-            .addMapping("/**")
-            .allowedOrigins(
-                "https://depromeet.vercel.app",
-                // 우리 서버 자체 origin — Stoplight UI (/docs/index.html) 의 try-it 이
-                // 브라우저 fetch(mode=cors) 로 호출 시 same-origin 이어도 Origin 헤더가 박혀
-                // CORS 검사를 거치므로 화이트리스트에 포함되어야 한다.
-                "https://api.depromeet18team3.cloud",
-            ).allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
-            .allowedHeaders("*")
-            .allowCredentials(true)
+class CorsConfig {
+    // Spring Security 의 CorsFilter 가 인가(authorization) 이전에 이 source 를 읽어 CORS 를 처리한다.
+    // WebMvcConfigurer.addCorsMappings 로 두면 preflight(OPTIONS) 요청이 Security 필터의
+    // anyRequest().authenticated() 에 먼저 잡혀 401 이 되므로(브라우저는 인증 헤더/JSON 요청 전
+    // preflight 를 보낸다), CorsConfigurationSource 빈 + SecurityConfig 의 http.cors() 로 일원화한다.
+    @Bean
+    fun corsConfigurationSource(): CorsConfigurationSource {
+        val configuration =
+            CorsConfiguration().apply {
+                allowedOrigins =
+                    listOf(
+                        "https://depromeet.vercel.app",
+                        // 우리 서버 자체 origin — Stoplight UI (/docs/index.html) 의 try-it 이
+                        // 브라우저 fetch(mode=cors) 로 호출 시 same-origin 이어도 Origin 헤더가 박혀
+                        // CORS 검사를 거치므로 화이트리스트에 포함되어야 한다.
+                        "https://api.depromeet18team3.cloud",
+                        // 프론트엔드 로컬 개발 환경 (Next.js dev server) — 로컬에서 배포 서버 API 를
+                        // 호출하며 통합 테스트할 때 Origin 헤더가 박혀 CORS 검사를 거치므로 허용한다.
+                        // localhost 와 127.0.0.1 은 브라우저상 서로 다른 origin 이라 둘 다 명시한다.
+                        "http://localhost:3000",
+                        "http://127.0.0.1:3000",
+                    )
+                allowedMethods = listOf("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
+                allowedHeaders = listOf("*")
+                allowCredentials = true
+            }
+        return UrlBasedCorsConfigurationSource().apply {
+            registerCorsConfiguration("/**", configuration)
+        }
     }
 }

--- a/src/test/kotlin/com/depromeet/team3/common/config/CorsIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/team3/common/config/CorsIntegrationTest.kt
@@ -1,0 +1,72 @@
+package com.depromeet.team3.common.config
+
+import com.depromeet.team3.support.IntegrationTestSupport
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpHeaders
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.header
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.web.context.WebApplicationContext
+
+class CorsIntegrationTest : IntegrationTestSupport() {
+    @Autowired
+    private lateinit var webApplicationContext: WebApplicationContext
+
+    @Test
+    fun `인증 경로의 preflight OPTIONS 는 허용 origin 에 대해 인증 없이 200 으로 통과한다`() {
+        // SecurityConfig 에 http.cors() 가 없으면 preflight 가 anyRequest().authenticated() 에 잡혀
+        // 401 이 되어 브라우저의 인증 요청(member 생성 등)이 전부 막힌다. 회귀 가드.
+        val mockMvc =
+            MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .apply<DefaultMockMvcBuilder>(springSecurity())
+                .build()
+
+        mockMvc
+            .perform(
+                options("/api/v1/dev/users")
+                    .header(HttpHeaders.ORIGIN, "http://localhost:3000")
+                    .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "POST"),
+            ).andExpect(status().isOk)
+            .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "http://localhost:3000"))
+            .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS, "true"))
+    }
+
+    @Test
+    fun `127_0_0_1 origin 의 preflight 도 허용된다`() {
+        val mockMvc =
+            MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .apply<DefaultMockMvcBuilder>(springSecurity())
+                .build()
+
+        mockMvc
+            .perform(
+                options("/api/v1/dev/users")
+                    .header(HttpHeaders.ORIGIN, "http://127.0.0.1:3000")
+                    .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "POST"),
+            ).andExpect(status().isOk)
+            .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "http://127.0.0.1:3000"))
+    }
+
+    @Test
+    fun `화이트리스트에 없는 origin 의 preflight 는 403 으로 거부된다`() {
+        // 허용 목록 검증이 실제로 동작함을 함께 단언해 테스트가 vacuous 하지 않도록 한다.
+        val mockMvc =
+            MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .apply<DefaultMockMvcBuilder>(springSecurity())
+                .build()
+
+        mockMvc
+            .perform(
+                options("/api/v1/dev/users")
+                    .header(HttpHeaders.ORIGIN, "https://evil.example.com")
+                    .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "POST"),
+            ).andExpect(status().isForbidden)
+    }
+}


### PR DESCRIPTION
## Situation
- 로컬 프론트(`http://localhost:3000`)에서 게스트 로그인 API 직접 호출 시 `403 Forbidden (Invalid CORS request)` 발생
- 브라우저 → 백엔드 직접 요청은 403, 브라우저 → Next API Route 경유는 201 → API 자체가 아니라 CORS 설정 문제로 확인
- production(`api.depromeet18team3.cloud`)에 직접 curl 로 재현: 허용 origin(vercel)·서버직접호출은 정상(201), localhost 만 403. 응답 본문이 `Invalid CORS request` 라 nginx 가 아닌 Spring Security CORS 처리기가 거부한 것으로 확정

## Task
- 로컬 개발 origin 의 CORS 허용
- 진단 중 발견한 더 근본적인 문제까지 해결: preflight(OPTIONS)가 Spring Security 단에서 401 로 막혀, 허용된 origin 이어도 `Authorization` 헤더/JSON 요청은 전부 차단되던 문제

## Action
### 원인 진단
- 문제가 두 겹이었다
  - (1) `CorsConfig` 의 허용 origin 목록에 `localhost` 가 없음 → guest 같은 단순 요청이 origin 체크에서 403
  - (2) `CorsConfig` 가 `WebMvcConfigurer.addCorsMappings` 로만 잡혀 있고 `SecurityConfig` 에 `http.cors()` 가 없음 → preflight OPTIONS 가 `anyRequest().authenticated()` 에 먼저 잡혀 401. production 에 OPTIONS 를 직접 쳐서 vercel origin 으로도 401 임을 확인 (운영도 동일 영향)

### 변경
- `CorsConfig` 를 `WebMvcConfigurer` → `CorsConfigurationSource` 빈으로 전환하고 `SecurityConfig` 에 `.cors { }` 추가 → Spring Security `CorsFilter` 가 인가 이전에 CORS·preflight 를 처리하도록 일원화
- 허용 origin 에 `http://localhost:3000`, `http://127.0.0.1:3000` 추가 (브라우저상 둘은 다른 origin). credentials·메서드(GET/POST/PUT/PATCH/DELETE/OPTIONS)·헤더(`*`)는 기존 설정으로 프론트 요청을 충족

### 안전망
- CORS contract 통합 테스트 추가: 인증 경로(`/api/v1/dev/users`)의 preflight 가 허용 origin(localhost·127.0.0.1)에 대해 인증 없이 200 통과 / 화이트리스트 밖 origin 403 거부를 단언 → preflight 401 회귀 가드

## Result
- 로컬 프론트에서 게스트 호출 및 인증(member 생성 등) 요청이 CORS 통과
- 운영 origin(vercel)의 preflight 401 잠재 문제도 함께 해소
- 전체 테스트 스위트 통과 (단위 + 통합)
- 참고: 운영 서버가 localhost origin 을 허용하게 되나, 로컬 origin 은 피해자 자기 머신에서만 악용 가능해 위험이 낮음. 추후 환경별 origin 분리(dev/prod profile)가 필요하면 후속으로 분리 가능

---
## 연관 이슈

- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * CORS 설정을 Spring Security와 일원화하여 preflight(OPTIONS) 요청이 올바르게 처리되도록 개선했습니다.

* **Tests**
  * CORS preflight 동작을 통합 테스트로 검증하는 테스트를 추가했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/PIKI-Server/pull/201?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->