### PR TITLE
GitHub PR을 Notion 일정 보드에 자동 반영하는 /notion-board 스킬 추가

### DIFF
--- a/.claude/commands/notion-board.md
+++ b/.claude/commands/notion-board.md
@@ -7,6 +7,7 @@
   ```bash
   [ -z "$NOTION_TOKEN" ] && eval "$(grep '^export NOTION_TOKEN=' ~/.zshrc 2>/dev/null)"
   ```
+- **모든 Notion 호출은 HTTP 200 을 확인한다.** read(카드 조회·본문 조회)가 비-200이면 그 단계에서 멈추고 보드 반영을 생략한다(best-effort). 비-200 응답을 본문인 양 파싱하면 401/403/429/5xx 를 "카드 없음"·"미기록"으로 오인해 잘못 진행한다.
 
 ## 상수
 
@@ -37,9 +38,10 @@
 ```bash
 [ -z "$NOTION_TOKEN" ] && eval "$(grep '^export NOTION_TOKEN=' ~/.zshrc 2>/dev/null)"
 DB=5a0c800c-72cf-8307-8297-8124d888ca79
-curl -s -X POST "https://api.notion.com/v1/databases/$DB/query" \
+code=$(curl -s -X POST "https://api.notion.com/v1/databases/$DB/query" \
   -H "Authorization: Bearer $NOTION_TOKEN" -H "Notion-Version: 2022-06-28" -H "Content-Type: application/json" \
-  --data '{"page_size":100}' -o /tmp/nb_cards.json
+  --data '{"page_size":100}' -o /tmp/nb_cards.json -w "%{http_code}")
+[ "$code" = "200" ] || { echo "Notion query 실패 (HTTP $code) — 보드 반영 생략"; exit 0; }
 python3 - <<'PY'
 import json
 d=json.load(open('/tmp/nb_cards.json'))
@@ -65,8 +67,9 @@ PY
 
 ```bash
 [ -z "$NOTION_TOKEN" ] && eval "$(grep '^export NOTION_TOKEN=' ~/.zshrc 2>/dev/null)"
-curl -s "https://api.notion.com/v1/blocks/<PAGE_ID>/children?page_size=100" \
-  -H "Authorization: Bearer $NOTION_TOKEN" -H "Notion-Version: 2022-06-28" -o /tmp/nb_body.json
+code=$(curl -s "https://api.notion.com/v1/blocks/<PAGE_ID>/children?page_size=100" \
+  -H "Authorization: Bearer $NOTION_TOKEN" -H "Notion-Version: 2022-06-28" -o /tmp/nb_body.json -w "%{http_code}")
+[ "$code" = "200" ] || { echo "카드 본문 조회 실패 (HTTP $code) — 보드 반영 생략"; exit 0; }
 python3 - <<'PY'
 import json
 d=json.load(open('/tmp/nb_body.json'))
@@ -101,9 +104,10 @@ PY
 
 ```bash
 [ -z "$NOTION_TOKEN" ] && eval "$(grep '^export NOTION_TOKEN=' ~/.zshrc 2>/dev/null)"
-curl -s -X PATCH "https://api.notion.com/v1/blocks/<PAGE_ID>/children" \
+code=$(curl -s -X PATCH "https://api.notion.com/v1/blocks/<PAGE_ID>/children" \
   -H "Authorization: Bearer $NOTION_TOKEN" -H "Notion-Version: 2022-06-28" -H "Content-Type: application/json" \
-  --data @/tmp/nb_append.json -o /dev/null -w "append HTTP %{http_code}\n"
+  --data @/tmp/nb_append.json -o /dev/null -w "%{http_code}")
+echo "append HTTP $code"; [ "$code" = "200" ] || echo "append 실패 — 사용자에게 보고"
 ```
 
 ### 6. 상태 이동 (계획중 → 진행중만)
@@ -113,9 +117,10 @@ curl -s -X PATCH "https://api.notion.com/v1/blocks/<PAGE_ID>/children" \
 - `계획중` → `진행중` 으로:
   ```bash
   [ -z "$NOTION_TOKEN" ] && eval "$(grep '^export NOTION_TOKEN=' ~/.zshrc 2>/dev/null)"
-  curl -s -X PATCH "https://api.notion.com/v1/pages/<PAGE_ID>" \
+  code=$(curl -s -X PATCH "https://api.notion.com/v1/pages/<PAGE_ID>" \
     -H "Authorization: Bearer $NOTION_TOKEN" -H "Notion-Version: 2022-06-28" -H "Content-Type: application/json" \
-    --data '{"properties":{"상태":{"status":{"name":"진행중"}}}}' -o /dev/null -w "status HTTP %{http_code}\n"
+    --data '{"properties":{"상태":{"status":{"name":"진행중"}}}}' -o /dev/null -w "%{http_code}")
+  echo "status HTTP $code"; [ "$code" = "200" ] || echo "상태 변경 실패 — 사용자에게 보고"
   ```
 - `진행중` / `보류` / `완료` → 건드리지 않는다. **`완료` 이동은 자동화하지 않는다** — 기능 완료는 사람의 편집적 판단이다.
 

--- a/.claude/commands/notion-board.md
+++ b/.claude/commands/notion-board.md
@@ -1,0 +1,130 @@
+`/pr` 의 마지막 단계로 자동 호출되어, 이번 PR을 Notion `프로젝트 일정 관리` 보드의 매칭 카드에 반영합니다 — 카드 본문 `개발 로그` 에 PR 링크 한 줄 append + `계획중` 이면 `진행중` 으로. 카드 생성·`완료` 이동·일정/담당자 변경은 하지 않습니다(사람 몫). 단독 수동 호출보다 `/pr` 흐름의 일부로 도는 것을 전제합니다.
+
+## 전제
+
+- **`$NOTION_TOKEN`** (Notion internal integration 토큰)이 필요하다. 없으면 이 단계 전체를 **조용히 스킵**하고 한 줄 안내만 남긴다 — PR 흐름을 실패시키지 않는다.
+- 이 Bash 도구는 `~/.zshrc` 를 자동 로드하지 않으므로, 각 curl 블록 시작에 토큰을 로드한다:
+  ```bash
+  [ -z "$NOTION_TOKEN" ] && eval "$(grep '^export NOTION_TOKEN=' ~/.zshrc 2>/dev/null)"
+  ```
+
+## 상수
+
+- 보드(DB) id: `5a0c800c-72cf-8307-8297-8124d888ca79`
+- API 버전 헤더: `Notion-Version: 2022-06-28`
+- 상태 property 이름: `상태`, 옵션: `계획중` / `진행중` / `보류` / `완료`
+
+## 입력 (`/pr` 가 넘겨준다)
+
+이번 PR 의 URL · 번호 · 브랜치명 · 연관 이슈 번호·제목 · `$ISSUE_LABELS` · PR 제목, 그리고 이번 대화 맥락.
+
+## 절차
+
+### 1. 게이트 (조용한 스킵)
+
+다음이면 아무것도 하지 않고 한 줄만 보고한 뒤 종료한다 (PR 결과에 영향 없음):
+
+- `$NOTION_TOKEN` 미설정 → 스킵 ("Notion 토큰 없어 보드 반영 생략").
+- `$ISSUE_LABELS` 가 `chore` / `test` / `infra` / `docs` / `refactor` 중 하나(또는 그 집합) → 스킵 ("내부 작업이라 보드 비대상").
+- `perf` / `feat` / `fix` / `epic` 또는 라벨 없음 → **진행**.
+
+> 라벨은 "명백한 내부 노이즈 버리기" 용도일 뿐, 가시성 자체는 아래 카드 매칭이 결정한다. 매칭되는 카드가 없으면 자연히 보드에 안 올라간다.
+
+### 2. 후보 카드 조회 (완료 아닌 카드)
+
+전체를 받아 클라이언트에서 `상태 != 완료` 만 추린다 (`파트` 필드는 보드에서 일관되지 않으므로 필터·판단에 쓰지 않는다 — 참고용으로만 표시):
+
+```bash
+[ -z "$NOTION_TOKEN" ] && eval "$(grep '^export NOTION_TOKEN=' ~/.zshrc 2>/dev/null)"
+DB=5a0c800c-72cf-8307-8297-8124d888ca79
+curl -s -X POST "https://api.notion.com/v1/databases/$DB/query" \
+  -H "Authorization: Bearer $NOTION_TOKEN" -H "Notion-Version: 2022-06-28" -H "Content-Type: application/json" \
+  --data '{"page_size":100}' -o /tmp/nb_cards.json
+python3 - <<'PY'
+import json
+d=json.load(open('/tmp/nb_cards.json'))
+for p in d.get('results',[]):
+    pr=p['properties']
+    title=''.join(t['plain_text'] for t in pr['프로젝트명']['title'])
+    st=pr['상태']['status']; st=st['name'] if st else '-'
+    if st=='완료': continue
+    part=pr['파트']['select']; part=part['name'] if part else '-'
+    print(f"{st:<5} {part:<7} {p['id']}  {title}")
+PY
+```
+
+### 3. 매칭 + 확인 (유일한 판단 지점)
+
+- 이번 PR 단서(브랜치명·연관 이슈 번호·제목·PR 제목·대화 맥락)로 후보 중 가장 맞는 카드를 고른다. 백엔드 작업이면 보통 `[BE] ...` · `User` · 위시/토너먼트 등 기능 카드.
+- 사용자에게 제안하고 확인받는다: **"이 PR을 '<카드명>' 에 기록할게, 맞아?"** (애매하면 상위 2~3개 제시)
+- 적절한 카드가 없으면 → **"보드에 맞는 카드가 없어. 직접 만든 뒤 다시 `/pr` 돌릴래?"** 하고 멈춘다. **자동 생성하지 않는다.**
+
+이후 단계는 확정된 카드의 `<PAGE_ID>` 로 진행.
+
+### 4. dedup (이미 기록됐는지) + 본문 구조 확인
+
+```bash
+[ -z "$NOTION_TOKEN" ] && eval "$(grep '^export NOTION_TOKEN=' ~/.zshrc 2>/dev/null)"
+curl -s "https://api.notion.com/v1/blocks/<PAGE_ID>/children?page_size=100" \
+  -H "Authorization: Bearer $NOTION_TOKEN" -H "Notion-Version: 2022-06-28" -o /tmp/nb_body.json
+python3 - <<'PY'
+import json
+d=json.load(open('/tmp/nb_body.json'))
+heading=False; pr_seen=False
+for b in d.get('results',[]):
+    t=b['type']; node=b.get(t,{})
+    txt=''.join(x.get('plain_text','') for x in (node.get('rich_text',[]) if isinstance(node,dict) else []))
+    if t=='heading_3' and txt.strip()=='개발 로그': heading=True
+    if 'PR #<번호>' in txt: pr_seen=True   # <번호> 를 실제 PR 번호로
+print('heading_exists=',heading,'pr_already_logged=',pr_seen)
+PY
+```
+
+- `pr_already_logged=True` → append 생략하고 6단계(상태)로.
+- `heading_exists` 값으로 5단계에서 heading 포함 여부 결정.
+
+### 5. append (개발 로그)
+
+`/tmp/nb_append.json` 을 만든다 — `개발 로그` heading 이 **없을 때만** heading_3 을 먼저 포함, 이어서 PR bullet (전체를 PR 링크로):
+
+```json
+{"children":[
+  {"object":"block","type":"heading_3","heading_3":{"rich_text":[{"type":"text","text":{"content":"개발 로그"}}]}},
+  {"object":"block","type":"bulleted_list_item","bulleted_list_item":{"rich_text":[
+    {"type":"text","text":{"content":"PR #169 토너먼트 아이템 삭제 API (2026-05-24)","link":{"url":"<PR_URL>"}}}
+  ]}}
+]}
+```
+
+- bullet 텍스트 = `PR #<번호> <사람이 읽는 PR 제목> (<KST 오늘 날짜>)`. 날짜는 `date +%Y-%m-%d`.
+- heading 이 이미 있으면 위 children 에서 heading_3 객체를 빼고 bullet 만.
+
+```bash
+[ -z "$NOTION_TOKEN" ] && eval "$(grep '^export NOTION_TOKEN=' ~/.zshrc 2>/dev/null)"
+curl -s -X PATCH "https://api.notion.com/v1/blocks/<PAGE_ID>/children" \
+  -H "Authorization: Bearer $NOTION_TOKEN" -H "Notion-Version: 2022-06-28" -H "Content-Type: application/json" \
+  --data @/tmp/nb_append.json -o /dev/null -w "append HTTP %{http_code}\n"
+```
+
+### 6. 상태 이동 (계획중 → 진행중만)
+
+2/4 에서 읽은 카드 `상태` 기준:
+
+- `계획중` → `진행중` 으로:
+  ```bash
+  [ -z "$NOTION_TOKEN" ] && eval "$(grep '^export NOTION_TOKEN=' ~/.zshrc 2>/dev/null)"
+  curl -s -X PATCH "https://api.notion.com/v1/pages/<PAGE_ID>" \
+    -H "Authorization: Bearer $NOTION_TOKEN" -H "Notion-Version: 2022-06-28" -H "Content-Type: application/json" \
+    --data '{"properties":{"상태":{"status":{"name":"진행중"}}}}' -o /dev/null -w "status HTTP %{http_code}\n"
+  ```
+- `진행중` / `보류` / `완료` → 건드리지 않는다. **`완료` 이동은 자동화하지 않는다** — 기능 완료는 사람의 편집적 판단이다.
+
+### 7. 보고
+
+한 줄로: 어느 카드에 무엇을 했는지. 예) `'[BE] Tournament' 에 PR #169 기록, 상태 계획중→진행중.` dedup/스킵이면 그 사실을 보고.
+
+## 안 하는 것 (스코프 경계)
+
+- 카드 자동 생성, `완료` 상태 이동, 일정 필드(`시작일`/`마감일`/`진행률`)·`담당자` 변경 — 전부 사람 몫.
+- `파트` 필드 신뢰 (보드에서 일관되지 않음). 매칭은 제목·맥락으로만.
+- Claude 안 쓰는 팀원의 PR 은 잡지 못한다 (알려진 한계). 필요해지면 GitHub Action 으로 보강.

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,4 +1,4 @@
-브랜치에서 작업한 내용을 STAR 구조 PR로 정리하여 GitHub에 올립니다. 이미 PR이 있으면 본문을 덮어쓰지 않고 `## Updates` 섹션에 추가 변경 내역을 append 합니다. assignee(`@me`) · 라벨(연관 이슈에서 복사) · Project(99) 도 자동 설정합니다.
+브랜치에서 작업한 내용을 STAR 구조 PR로 정리하여 GitHub에 올립니다. 이미 PR이 있으면 본문을 덮어쓰지 않고 `## Updates` 섹션에 추가 변경 내역을 append 합니다. assignee(`@me`) · 라벨(연관 이슈에서 복사) · Project(99) 도 자동 설정합니다. 마지막에 `/notion-board` 로 Notion `프로젝트 일정 관리` 보드 반영도 자동 시도합니다 (내부 작업 라벨이거나 토큰 없으면 조용히 생략).
 
 ## PR 본문 작성 원칙
 
@@ -151,7 +151,7 @@ ISSUE_LABELS=$(gh issue view {번호} --json labels --jq '[.labels[].name] | joi
    - ID 의미: project=99 노드 ID, Status 필드/`In review` 옵션 ID, Start date 필드 ID(`PVTF_..GA`, DATE 타입). 보드에서 필드/옵션이 바뀌면 이 ID 들도 갱신 필요.
    - Target date 와 Status `Done` 은 PR 머지 시점에 별도 CI workflow (`.github/workflows/project-sync-on-pr-close.yml`) 가 자동 세팅. PR 스킬은 머지 이전 단계만 책임짐.
    - 권한 부족 시 사용자에게 `gh auth refresh -h github.com -s project,read:project` 안내 (일회성 디바이스 인증).
-5. PR URL 과 부여된 assignee / 라벨 / Project(Status: In review, Start date) 결과를 사용자에게 전달
+5. PR URL 과 부여된 assignee / 라벨 / Project(Status: In review, Start date) 결과를 사용자에게 전달한 뒤, `### 4. Notion 보드 반영` 으로 이어진다.
 
 ### 3-B. Update 모드 — 기존 PR 본문 갱신
 
@@ -222,7 +222,15 @@ ISSUE_LABELS=$(gh issue view {번호} --json labels --jq '[.labels[].name] | joi
         }'
     fi
     ```
-11. PR URL 재출력.
+11. PR URL 재출력 후, `### 4. Notion 보드 반영` 으로 이어진다.
+
+### 4. Notion 보드 반영 (자동)
+
+**create / update 양 모드 완료 후 (PR URL 확정 후), 이어서 `/notion-board` 스킬을 실행한다.** 이번 PR을 Notion `프로젝트 일정 관리` 보드의 매칭 카드에 반영한다 (카드 본문 `개발 로그` 에 PR 링크 append + `계획중` 이면 `진행중` 으로). 사용자가 따로 호출하지 않아도 `/pr` 흐름의 일부로 돈다.
+
+- 이번 PR 의 URL · 번호 · 브랜치명 · 연관 이슈 번호 · `$ISSUE_LABELS` · 제목과 대화 맥락을 그대로 입력으로 넘긴다.
+- `chore` / `test` / `infra` / `docs` / `refactor` 라벨이거나 `$NOTION_TOKEN` 이 없으면 `/notion-board` 가 알아서 조용히 스킵한다.
+- **best-effort** 다 — 보드 반영이 실패해도 PR 생성/갱신 결과를 되돌리지 않는다.
 
 ### PR 제목 규칙
 - 70자 이내

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -228,7 +228,7 @@ ISSUE_LABELS=$(gh issue view {번호} --json labels --jq '[.labels[].name] | joi
 
 **create / update 양 모드 완료 후 (PR URL 확정 후), 이어서 `/notion-board` 스킬을 실행한다.** 이번 PR을 Notion `프로젝트 일정 관리` 보드의 매칭 카드에 반영한다 (카드 본문 `개발 로그` 에 PR 링크 append + `계획중` 이면 `진행중` 으로). 사용자가 따로 호출하지 않아도 `/pr` 흐름의 일부로 돈다.
 
-- 이번 PR 의 URL · 번호 · 브랜치명 · 연관 이슈 번호 · `$ISSUE_LABELS` · 제목과 대화 맥락을 그대로 입력으로 넘긴다.
+- 이번 PR 의 URL · 번호 · 브랜치명 · 연관 이슈 번호·제목 · `$ISSUE_LABELS` · 제목과 대화 맥락을 그대로 입력으로 넘긴다.
 - `chore` / `test` / `infra` / `docs` / `refactor` 라벨이거나 `$NOTION_TOKEN` 이 없으면 `/notion-board` 가 알아서 조용히 스킵한다.
 - **best-effort** 다 — 보드 반영이 실패해도 PR 생성/갱신 결과를 되돌리지 않는다.
 


### PR DESCRIPTION
## Situation
- 타 직군(웹·디자인·기획)이 보는 Notion 칸반 보드(`프로젝트 일정 관리`)에 백엔드 GitHub 작업 흐름을 드러내고 싶었다.
- 출발 질문: "GitHub 자동 연동(Action) vs Claude 스킬" 중 무엇이 나은가.

## Task
- 보드 granularity가 issue/PR 단위가 아니라 **기능 카드 단위**(`[BE] Tournament` 카드 하나 = PR 수십 개)임을 확인 → issue마다 카드를 만드는 단순 이벤트 미러는 사람이 큐레이션한 보드를 오염시킨다.
- 핵심 판단: "이게 외부 가시성 있는 작업인가" 와 "기능이 완료됐는가" 는 둘 다 사람의 편집적 판단이라 결정론적 이벤트 자동화로 표현할 수 없다 → 스킬이 적합하다.

## Action
### 설계 결정
- **GitHub Action 대신 Claude 스킬 채택**: Notion MCP/CI 인프라 없이 REST API + 토큰으로 처리하고, `/pr` 의식에 올라타 "돌리는 걸 까먹는" 스킬의 약점을 제거.
- **가시성 게이트를 라벨이 아니라 카드 소속으로 판단**: 라벨은 명백한 내부 노이즈만 버리는 용도. `chore`/`test`/`infra`/`docs`/`refactor` 는 조용히 스킵, `perf`/`feat`/`fix`/`epic` 진행. 매칭 카드가 없으면 자연히 보드에 안 올라간다.
- **단순화**: 카드 ID 저장·GitHub write-back·hidden 주석을 전부 버리고, 매 실행 시 완료 아닌 카드를 조회해 제목/맥락으로 매칭 + 사람 확인. 카드 자동 생성·`완료` 이동·일정/담당자 변경은 사람 몫으로 남김.

### 구현
- `.claude/commands/notion-board.md` 신규: 완료 아닌 카드 조회 → 매칭 확인 → 카드 본문 `개발 로그` 에 PR 링크 append + `계획중`→`진행중`. dedup은 본문에 PR 번호가 있으면 재기록 안 함.
- `/pr` 마지막에 `### 4. Notion 보드 반영` 단계로 자동 호출 연결 (best-effort — 보드 반영이 실패해도 PR 생성/갱신은 안 깨짐).
- 실제 보드로 API 전 구간(query / body read / status PATCH / append / delete) HTTP 200 검증. 보드의 `파트` 필드가 일관되지 않음(`[BE]` 카드가 파트 비어있음)을 확인해 매칭 기준에서 제외.

## Result
- 다음 `feat`/`fix` PR부터 `/pr` 이 자동으로 매칭 카드를 제안 → 확인 시 개발 로그 기록 + 상태 진행.
- 토큰은 로컬 `~/.zshrc` 의 `NOTION_TOKEN` (REST API 방식, 레포에 비밀값 없음).
- 알려진 한계: Claude를 안 쓰는 팀원의 PR은 반영되지 않는다 — 필요해지면 GitHub Action으로 보강.
- 매칭 정확도는 첫 실전 PR에서 검증 예정.

---
## 연관 이슈

- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Notion 프로젝트 일정 관리 보드에 PR 기록을 자동으로 반영하는 절차 문서화
  * PR 생성/갱신 프로세스에 Notion 보드 동기화 단계 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/PIKI-Server/pull/204?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->