### PR TITLE
토너먼트 대진표 생성 알고리즘 개선 및 시작 API 응답 확장

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
@@ -5,6 +5,7 @@ import com.depromeet.piki.tournament.controller.dto.AddTournamentItemsRequest
 import com.depromeet.piki.tournament.controller.dto.CreateTournamentRequest
 import com.depromeet.piki.tournament.controller.dto.CreateTournamentResponse
 import com.depromeet.piki.tournament.controller.dto.RecordMatchRequest
+import com.depromeet.piki.tournament.controller.dto.TournamentBracketResponse
 import com.depromeet.piki.tournament.controller.dto.TournamentInfoResponse
 import com.depromeet.piki.tournament.controller.dto.TournamentSummaryResponse
 import com.depromeet.piki.tournament.domain.TournamentStatus
@@ -94,7 +95,7 @@ interface TournamentApi {
     fun start(
         userId: UUID,
         tournamentId: Long,
-    ): ApiResponseBody<Unit>
+    ): ApiResponseBody<TournamentBracketResponse>
 
     @Operation(
         summary = "매치 결과 기록",

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApiExamples.kt
@@ -5,16 +5,17 @@ import com.depromeet.piki.common.openapi.binds
 import com.depromeet.piki.common.openapi.examples
 import com.depromeet.piki.common.response.ApiResponseBody
 import com.depromeet.piki.tournament.controller.dto.CreateTournamentResponse
+import com.depromeet.piki.tournament.controller.dto.TournamentBracketResponse
 import com.depromeet.piki.tournament.controller.dto.TournamentHistoryInfoResponse
 import com.depromeet.piki.tournament.controller.dto.TournamentInfoResponse
 import com.depromeet.piki.tournament.controller.dto.TournamentItemInfoResponse
 import com.depromeet.piki.tournament.controller.dto.TournamentSummaryResponse
 import com.depromeet.piki.tournament.domain.TournamentStatus
+import java.time.LocalDateTime
 import org.springdoc.core.customizers.OperationCustomizer
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpStatus
-import java.time.LocalDateTime
 
 @Configuration
 class TournamentApiExamples(
@@ -80,7 +81,44 @@ class TournamentApiExamples(
                         add(
                             status = HttpStatus.OK,
                             name = "시작 성공",
-                            payload = ApiResponseBody.ok<Unit>(),
+                            payload = ApiResponseBody.ok(
+                                TournamentBracketResponse(
+                                    matches = listOf(
+                                        TournamentBracketResponse.MatchResponse(
+                                            firstItem = TournamentBracketResponse.MatchItemResponse(
+                                                tournamentItemId = 1,
+                                                name = "나이키 에어맥스",
+                                                price = 129_000,
+                                                currency = "KRW",
+                                                imageUrl = "https://cdn.example.com/items/1.jpg",
+                                            ),
+                                            secondItem = TournamentBracketResponse.MatchItemResponse(
+                                                tournamentItemId = 2,
+                                                name = "아디다스 울트라부스트",
+                                                price = 189_000,
+                                                currency = "KRW",
+                                                imageUrl = "https://cdn.example.com/items/2.jpg",
+                                            ),
+                                        ),
+                                        TournamentBracketResponse.MatchResponse(
+                                            firstItem = TournamentBracketResponse.MatchItemResponse(
+                                                tournamentItemId = 3,
+                                                name = "뉴발란스 993",
+                                                price = 259_000,
+                                                currency = "KRW",
+                                                imageUrl = "https://cdn.example.com/items/3.jpg",
+                                            ),
+                                            secondItem = TournamentBracketResponse.MatchItemResponse(
+                                                tournamentItemId = 4,
+                                                name = "살로몬 XT-6",
+                                                price = 279_000,
+                                                currency = "USD",
+                                                imageUrl = null,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            ),
                         )
                     }
 

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentController.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentController.kt
@@ -5,6 +5,7 @@ import com.depromeet.piki.tournament.controller.dto.AddTournamentItemsRequest
 import com.depromeet.piki.tournament.controller.dto.CreateTournamentRequest
 import com.depromeet.piki.tournament.controller.dto.CreateTournamentResponse
 import com.depromeet.piki.tournament.controller.dto.RecordMatchRequest
+import com.depromeet.piki.tournament.controller.dto.TournamentBracketResponse
 import com.depromeet.piki.tournament.controller.dto.TournamentInfoResponse
 import com.depromeet.piki.tournament.controller.dto.TournamentSummaryResponse
 import com.depromeet.piki.tournament.domain.TournamentStatus
@@ -62,9 +63,9 @@ class TournamentController(
     override fun start(
         @AuthenticationPrincipal userId: UUID,
         @PathVariable tournamentId: Long,
-    ): ApiResponseBody<Unit> {
-        tournamentService.start(userId, tournamentId)
-        return ApiResponseBody.ok()
+    ): ApiResponseBody<TournamentBracketResponse> {
+        val result = tournamentService.start(userId, tournamentId)
+        return ApiResponseBody.ok(TournamentBracketResponse.from(result))
     }
 
     @PostMapping("/{tournamentId}/matches")

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/dto/TournamentBracketResponse.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/dto/TournamentBracketResponse.kt
@@ -1,0 +1,47 @@
+package com.depromeet.piki.tournament.controller.dto
+
+import com.depromeet.piki.tournament.service.dto.TournamentBracketResult
+
+data class TournamentBracketResponse(val matches: List<MatchResponse>) {
+    data class MatchResponse(
+        val firstItem: MatchItemResponse,
+        val secondItem: MatchItemResponse,
+    )
+
+    data class MatchItemResponse(
+        val tournamentItemId: Long,
+        val name: String?,
+        val price: Int?,
+        val currency: String?,
+        val imageUrl: String?,
+    ) {
+        companion object {
+            fun from(tournamentItemId: Long, detail: TournamentBracketResult.ItemDetail?): MatchItemResponse =
+                MatchItemResponse(
+                    tournamentItemId = tournamentItemId,
+                    name = detail?.name,
+                    price = detail?.price,
+                    currency = detail?.currency,
+                    imageUrl = detail?.imageUrl,
+                )
+        }
+    }
+
+    companion object {
+        fun from(result: TournamentBracketResult): TournamentBracketResponse =
+            TournamentBracketResponse(
+                matches = result.bracket.matches.map { match ->
+                    MatchResponse(
+                        firstItem = MatchItemResponse.from(
+                            match.firstTournamentItemId,
+                            result.itemDetailsByTournamentItemId[match.firstTournamentItemId],
+                        ),
+                        secondItem = MatchItemResponse.from(
+                            match.secondTournamentItemId,
+                            result.itemDetailsByTournamentItemId[match.secondTournamentItemId],
+                        ),
+                    )
+                },
+            )
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/tournament/domain/TournamentBracket.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/domain/TournamentBracket.kt
@@ -1,0 +1,46 @@
+package com.depromeet.piki.tournament.domain
+
+data class TournamentBracket(val matches: List<Match>) {
+    data class Match(
+        val firstTournamentItemId: Long,
+        val secondTournamentItemId: Long,
+    )
+
+    companion object {
+        /**
+         * 가격 오름차순으로 정렬 후 인접 아이템끼리 1라운드 대진표를 생성한다.
+         * - 가장 비슷한 가격의 두 아이템이 맞붙는다.
+         * - 홀수 아이템이 남으면 다음 그룹이 있을 경우 합류시키고, 없으면 해당 아이템은 매치에서 제외된다.
+         * - 가격 정보가 없는 아이템은 마지막에 별도 그룹으로 처리한다.
+         * - itemsWithPrice: List<Pair<tournamentItemId, currentPrice>>
+         */
+        fun generate(itemsWithPrice: List<Pair<Long, Int?>>): TournamentBracket {
+            val (withPrice, noPrice) = itemsWithPrice.partition { it.second is Int }
+
+            val sortedIds = withPrice
+                .sortedBy { it.second }
+                .map { it.first }
+
+            val noPriceIds = noPrice.map { it.first }.shuffled()
+
+            val matches = mutableListOf<Match>()
+            var leftover: Long? = null
+
+            for (group in listOf(sortedIds, noPriceIds)) {
+                if (group.isEmpty()) continue
+                val pool = buildList {
+                    leftover?.let { add(it) }
+                    addAll(group)
+                }.toMutableList()
+                leftover = null
+
+                while (pool.size >= 2) {
+                    matches.add(Match(pool.removeFirst(), pool.removeFirst()))
+                }
+                if (pool.isNotEmpty()) leftover = pool.first()
+            }
+
+            return TournamentBracket(matches.shuffled())
+        }
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentException.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentException.kt
@@ -81,5 +81,12 @@ class TournamentException private constructor(
                 ErrorCategory.NOT_FOUND,
                 HttpStatus.NOT_FOUND,
             )
+
+        fun notFoundItems(): TournamentException =
+            TournamentException(
+                "존재하지 않는 아이템이 포함되어 있습니다.",
+                ErrorCategory.NOT_FOUND,
+                HttpStatus.NOT_FOUND,
+            )
     }
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
@@ -95,6 +95,7 @@ class TournamentService(
         val itemById = itemRepository
             .findByIds(tournamentItems.map { it.itemId })
             .associate { it.getId() to it }
+        if (tournamentItems.any { it.itemId !in itemById }) throw TournamentException.notFoundItems()
         val itemsWithPrice = tournamentItems.map { it.getId() to itemById[it.itemId]?.currentPrice }
         val bracket = TournamentBracket.generate(itemsWithPrice)
 

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
@@ -1,6 +1,8 @@
 package com.depromeet.piki.tournament.service
 
+import com.depromeet.piki.item.repository.ItemRepository
 import com.depromeet.piki.tournament.domain.Tournament
+import com.depromeet.piki.tournament.domain.TournamentBracket
 import com.depromeet.piki.tournament.domain.TournamentHistory
 import com.depromeet.piki.tournament.domain.TournamentItem
 import com.depromeet.piki.tournament.domain.TournamentStatus
@@ -11,6 +13,7 @@ import com.depromeet.piki.tournament.repository.TournamentUserRepository
 import com.depromeet.piki.tournament.service.dto.AddTournamentItems
 import com.depromeet.piki.tournament.service.dto.CreateTournament
 import com.depromeet.piki.tournament.service.dto.RecordMatch
+import com.depromeet.piki.tournament.service.dto.TournamentBracketResult
 import com.depromeet.piki.tournament.service.dto.TournamentInfo
 import com.depromeet.piki.tournament.service.dto.TournamentSummary
 import com.depromeet.piki.user.repository.UserRepository
@@ -24,6 +27,7 @@ class TournamentService(
     private val tournamentRepository: TournamentRepository,
     private val tournamentItemRepository: TournamentItemRepository,
     private val userRepository: UserRepository,
+    private val itemRepository: ItemRepository,
 ) {
     @Transactional
     fun create(
@@ -77,7 +81,7 @@ class TournamentService(
     fun start(
         userId: UUID,
         tournamentId: Long,
-    ) {
+    ): TournamentBracketResult {
         val tournament =
             tournamentRepository.findTournamentById(tournamentId)
                 ?: throw TournamentException.notFoundTournament()
@@ -86,9 +90,25 @@ class TournamentService(
             tournamentUserRepository.findByTournamentIdAndUserId(tournamentId, userId)
                 ?: throw TournamentException.forbiddenTournament()
         if (owner.getId() != tournament.ownerTournamentUserId) throw TournamentException.forbiddenTournament()
-        val itemCount = tournamentItemRepository.findAllByTournamentId(tournamentId).size
-        if (itemCount !in MIN_ITEM_COUNT..MAX_ITEM_COUNT) throw TournamentException.invalidItemCount()
+        val tournamentItems = tournamentItemRepository.findAllByTournamentId(tournamentId)
+        if (tournamentItems.size !in MIN_ITEM_COUNT..MAX_ITEM_COUNT) throw TournamentException.invalidItemCount()
+        val itemById = itemRepository
+            .findByIds(tournamentItems.map { it.itemId })
+            .associate { it.getId() to it }
+        val itemsWithPrice = tournamentItems.map { it.getId() to itemById[it.itemId]?.currentPrice }
+        val bracket = TournamentBracket.generate(itemsWithPrice)
+
+        val itemDetailsByTournamentItemId = tournamentItems.associate { tournamentItem ->
+            val item = itemById[tournamentItem.itemId]
+            tournamentItem.getId() to TournamentBracketResult.ItemDetail(
+                name = item?.name,
+                price = item?.currentPrice,
+                currency = item?.currency,
+                imageUrl = item?.imageUrl,
+            )
+        }
         tournament.start()
+        return TournamentBracketResult(bracket, itemDetailsByTournamentItemId)
     }
 
     @Transactional(readOnly = true)
@@ -116,8 +136,12 @@ class TournamentService(
         if (tournaments.isEmpty()) return emptyList()
 
         val tournamentUsers = tournamentUserRepository.findByTournamentIds(tournaments.map { it.getId() })
-        val userIds = tournamentUsers.map { it.userId }.toSet()
-        val profileImageByUserId = userRepository.findByIds(userIds).associate { it.id to it.profileImage }
+        val userIds = tournamentUsers
+            .map { it.userId }
+            .toSet()
+        val profileImageByUserId = userRepository
+            .findByIds(userIds)
+            .associate { it.id to it.profileImage }
         val profileImagesByTournamentId =
             tournamentUsers
                 .groupBy { it.tournamentId }

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
@@ -65,11 +65,11 @@ class TournamentService(
         val hasDuplicate =
             command.itemIds.toSet().size != command.itemIds.size || command.itemIds.any { it in existingItemIds }
         if (hasDuplicate) throw TournamentException.duplicateTournamentItem()
-        if (existingItemIds.size + command.itemIds.size >
-            MAX_ITEM_COUNT
-        ) {
+        if (existingItemIds.size + command.itemIds.size > MAX_ITEM_COUNT) {
             throw TournamentException.tooManyTournamentItems()
         }
+        val foundItemIds = itemRepository.findByIds(command.itemIds).map { it.getId() }.toSet()
+        if (command.itemIds.any { it !in foundItemIds }) throw TournamentException.notFoundItems()
         tournamentItemRepository.saveAll(
             command.itemIds.map { itemId ->
                 TournamentItem(tournamentId = command.tournamentId, itemId = itemId, userId = userId)

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/dto/TournamentBracketResult.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/dto/TournamentBracketResult.kt
@@ -1,0 +1,15 @@
+package com.depromeet.piki.tournament.service.dto
+
+import com.depromeet.piki.tournament.domain.TournamentBracket
+
+data class TournamentBracketResult(
+    val bracket: TournamentBracket,
+    val itemDetailsByTournamentItemId: Map<Long, ItemDetail>,
+) {
+    data class ItemDetail(
+        val name: String?,
+        val price: Int?,
+        val currency: String?,
+        val imageUrl: String?,
+    )
+}

--- a/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
@@ -73,13 +73,15 @@ class TournamentControllerTest : IntegrationTestSupport() {
     fun `POST tournaments-id-items 는 참여자이면 200 을 반환한다`() {
         val mockMvc = buildMockMvc()
         val tournamentId = createTournament(mockMvc)
+        val item1Id = saveItem()
+        val item2Id = saveItem()
 
         mockMvc
             .perform(
                 post("/api/v1/tournaments/$tournamentId/items")
                     .header(HttpHeaders.AUTHORIZATION, authHeader(userId))
                     .contentType(MediaType.APPLICATION_JSON)
-                    .content("""{"itemIds":[100,200]}"""),
+                    .content("""{"itemIds":[$item1Id,$item2Id]}"""),
             ).andExpect(status().isOk)
             .andExpect(jsonPath("$.status").value(200))
     }
@@ -88,15 +90,31 @@ class TournamentControllerTest : IntegrationTestSupport() {
     fun `POST tournaments-id-items 는 아이템 1개도 추가할 수 있다`() {
         val mockMvc = buildMockMvc()
         val tournamentId = createTournament(mockMvc)
+        val itemId = saveItem()
 
         mockMvc
             .perform(
                 post("/api/v1/tournaments/$tournamentId/items")
                     .header(HttpHeaders.AUTHORIZATION, authHeader(userId))
                     .contentType(MediaType.APPLICATION_JSON)
-                    .content("""{"itemIds":[100]}"""),
+                    .content("""{"itemIds":[$itemId]}"""),
             ).andExpect(status().isOk)
             .andExpect(jsonPath("$.status").value(200))
+    }
+
+    @Test
+    fun `POST tournaments-id-items 에서 존재하지 않는 아이템 ID 이면 404 를 반환한다`() {
+        val mockMvc = buildMockMvc()
+        val tournamentId = createTournament(mockMvc)
+
+        mockMvc
+            .perform(
+                post("/api/v1/tournaments/$tournamentId/items")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(userId))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"itemIds":[999999]}"""),
+            ).andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.status").value(404))
     }
 
     @Test
@@ -269,7 +287,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
         saveUser(userId, userProfileImage)
         val pendingId = createTournament(mockMvc, "대기중")
         val startedId = createTournament(mockMvc, "진행중")
-        addItemsToTournament(mockMvc, startedId, userId, 100L, 200L)
+        addItemsToTournament(mockMvc, startedId, userId, saveItem(), saveItem())
         mockMvc.perform(
             post("/api/v1/tournaments/$startedId/start")
                 .header(HttpHeaders.AUTHORIZATION, authHeader(userId)),
@@ -291,7 +309,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
         val mockMvc = buildMockMvc()
         val pendingId = createTournament(mockMvc, "대기중")
         val startedId = createTournament(mockMvc, "진행중")
-        addItemsToTournament(mockMvc, startedId, userId, 100L, 200L)
+        addItemsToTournament(mockMvc, startedId, userId, saveItem(), saveItem())
         mockMvc.perform(
             post("/api/v1/tournaments/$startedId/start")
                 .header(HttpHeaders.AUTHORIZATION, authHeader(userId)),
@@ -384,7 +402,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
     fun `DELETE tournaments-id-items-itemId 는 PENDING 토너먼트에서 아이템을 삭제하고 200 을 반환한다`() {
         val mockMvc = buildMockMvc()
         val tournamentId = createTournament(mockMvc)
-        addItemsToTournament(mockMvc, tournamentId, userId, 100L, 200L)
+        addItemsToTournament(mockMvc, tournamentId, userId, saveItem(), saveItem())
         val itemId = tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId).first().getId()
 
         mockMvc
@@ -416,7 +434,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
     fun `DELETE tournaments-id-items-itemId 에서 아이템 추가자가 아니고 소유자도 아니면 403 을 반환한다`() {
         val mockMvc = buildMockMvc()
         val tournamentId = createTournament(mockMvc)
-        addItemsToTournament(mockMvc, tournamentId, userId, 100L, 200L)
+        addItemsToTournament(mockMvc, tournamentId, userId, saveItem(), saveItem())
         val itemId = tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId).first().getId()
 
         mockMvc
@@ -432,7 +450,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
         val mockMvc = buildMockMvc()
         val tournamentId = createTournament(mockMvc)
         tournamentUserJpaRepository.save(TournamentUser(tournamentId = tournamentId, userId = otherUserId))
-        addItemsToTournament(mockMvc, tournamentId, otherUserId, 300L, 400L)
+        addItemsToTournament(mockMvc, tournamentId, otherUserId, saveItem(), saveItem())
         val itemId = tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId).first().getId()
 
         mockMvc
@@ -529,9 +547,12 @@ class TournamentControllerTest : IntegrationTestSupport() {
         val item2Id: Long,
     )
 
+    private fun saveItem(name: String = "테스트 아이템"): Long =
+        itemJpaRepository.save(Item(name = name)).getId()
+
     private fun startTournamentWith2Items(mockMvc: MockMvc): TournamentStart {
         val tournamentId = createTournament(mockMvc)
-        addItemsToTournament(mockMvc, tournamentId, userId, 100L, 200L)
+        addItemsToTournament(mockMvc, tournamentId, userId, saveItem("아이템1"), saveItem("아이템2"))
         mockMvc.perform(
             post("/api/v1/tournaments/$tournamentId/start")
                 .header(HttpHeaders.AUTHORIZATION, authHeader(userId)),

--- a/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
@@ -1,6 +1,8 @@
 package com.depromeet.piki.tournament.controller
 
 import com.depromeet.piki.auth.infrastructure.jwt.JwtProvider
+import com.depromeet.piki.item.domain.Item
+import com.depromeet.piki.item.repository.ItemJpaRepository
 import com.depromeet.piki.support.IntegrationTestSupport
 import com.depromeet.piki.tournament.domain.TournamentItem
 import com.depromeet.piki.tournament.domain.TournamentUser
@@ -39,6 +41,8 @@ class TournamentControllerTest : IntegrationTestSupport() {
     @Autowired private lateinit var tournamentUserJpaRepository: TournamentUserJpaRepository
 
     @Autowired private lateinit var userJpaRepository: UserJpaRepository
+
+    @Autowired private lateinit var itemJpaRepository: ItemJpaRepository
 
     @Autowired private lateinit var jwtProvider: JwtProvider
 
@@ -126,10 +130,12 @@ class TournamentControllerTest : IntegrationTestSupport() {
     }
 
     @Test
-    fun `POST tournaments-id-start 는 아이템이 있는 PENDING 토너먼트를 시작하고 200 을 반환한다`() {
+    fun `POST tournaments-id-start 는 아이템이 있는 PENDING 토너먼트를 시작하고 아이템 상세가 포함된 대진표를 반환한다`() {
         val mockMvc = buildMockMvc()
         val tournamentId = createTournament(mockMvc)
-        addItemsToTournament(mockMvc, tournamentId, userId, 100L, 200L)
+        val item1 = itemJpaRepository.save(Item(name = "나이키 에어맥스", currentPrice = 129_000, currency = "KRW"))
+        val item2 = itemJpaRepository.save(Item(name = "아디다스 울트라부스트", currentPrice = 189_000, currency = "KRW"))
+        addItemsToTournament(mockMvc, tournamentId, userId, item1.getId(), item2.getId())
 
         mockMvc
             .perform(
@@ -137,6 +143,16 @@ class TournamentControllerTest : IntegrationTestSupport() {
                     .header(HttpHeaders.AUTHORIZATION, authHeader(userId)),
             ).andExpect(status().isOk)
             .andExpect(jsonPath("$.status").value(200))
+            .andExpect(jsonPath("$.data.matches").isArray)
+            .andExpect(jsonPath("$.data.matches.length()").value(1))
+            .andExpect(jsonPath("$.data.matches[0].firstItem.tournamentItemId").isNumber)
+            .andExpect(jsonPath("$.data.matches[0].firstItem.name").value("나이키 에어맥스"))
+            .andExpect(jsonPath("$.data.matches[0].firstItem.price").value(129_000))
+            .andExpect(jsonPath("$.data.matches[0].firstItem.currency").value("KRW"))
+            .andExpect(jsonPath("$.data.matches[0].secondItem.tournamentItemId").isNumber)
+            .andExpect(jsonPath("$.data.matches[0].secondItem.name").value("아디다스 울트라부스트"))
+            .andExpect(jsonPath("$.data.matches[0].secondItem.price").value(189_000))
+            .andExpect(jsonPath("$.data.matches[0].secondItem.currency").value("KRW"))
     }
 
     @Test

--- a/src/test/kotlin/com/depromeet/piki/tournament/domain/TournamentBracketTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/domain/TournamentBracketTest.kt
@@ -1,0 +1,98 @@
+package com.depromeet.piki.tournament.domain
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertContains
+import kotlin.test.assertTrue
+
+class TournamentBracketTest {
+    private fun generate(vararg items: Pair<Long, Int?>) =
+        TournamentBracket.generate(items.toList())
+
+    private fun TournamentBracket.allItemIds() =
+        matches.flatMap { listOf(it.firstTournamentItemId, it.secondTournamentItemId) }
+
+    @Test
+    fun `아이템 4개는 가격 오름차순 정렬 후 인접 쌍으로 2개의 매치가 생성된다`() {
+        val bracket = generate(1L to 15_000, 2L to 17_000, 3L to 18_000, 4L to 12_000)
+
+        assertEquals(2, bracket.matches.size)
+        assertEquals(setOf(1L, 2L, 3L, 4L), bracket.allItemIds().toSet())
+    }
+
+    @Test
+    fun `아이템 2개는 1개의 매치가 된다`() {
+        val bracket = generate(1L to 10_000, 2L to 19_000)
+
+        assertEquals(1, bracket.matches.size)
+        assertEquals(setOf(1L, 2L), bracket.allItemIds().toSet())
+    }
+
+    @Test
+    fun `가격 인접한 아이템끼리 쌍을 이루어 4L(21k)은 가장 가까운 3L(18k)과 매칭된다`() {
+        // sorted: 1L(15k), 2L(17k), 3L(18k), 4L(21k) → (1L,2L) 매칭, (3L,4L) 매칭
+        val bracket = generate(1L to 15_000, 2L to 17_000, 3L to 18_000, 4L to 21_000)
+
+        assertEquals(2, bracket.matches.size)
+        assertEquals(setOf(1L, 2L, 3L, 4L), bracket.allItemIds().toSet())
+
+        val matchWith4 = bracket.matches.first { 4L in listOf(it.firstTournamentItemId, it.secondTournamentItemId) }
+        val partner = if (matchWith4.firstTournamentItemId == 4L) matchWith4.secondTournamentItemId else matchWith4.firstTournamentItemId
+        assertEquals(3L, partner)
+    }
+
+    @Test
+    fun `가격 없는 아이템은 마지막에 별도 그룹으로 처리된다`() {
+        val bracket = generate(1L to null, 2L to null, 3L to null, 4L to null)
+
+        assertEquals(2, bracket.matches.size)
+        assertEquals(setOf(1L, 2L, 3L, 4L), bracket.allItemIds().toSet())
+    }
+
+    @Test
+    fun `가격 있는 아이템과 없는 아이템이 섞이면 가격 있는 쪽이 먼저 처리된다`() {
+        // sorted price: [1L(15k), 2L(17k)] → 1개 매치
+        // no-price: [3L, 4L] → 1개 매치
+        val bracket = generate(1L to 15_000, 2L to 17_000, 3L to null, 4L to null)
+
+        assertEquals(2, bracket.matches.size)
+        assertEquals(setOf(1L, 2L, 3L, 4L), bracket.allItemIds().toSet())
+    }
+
+    @Test
+    fun `가격 있는 그룹에서 홀수로 남은 아이템이 가격 없는 그룹과 매칭된다`() {
+        // sorted price: [1L(15k), 2L(17k), 3L(18k)] → (1,2) 매칭, 3L 잔여
+        // no-price: [3L(잔여), 4L] → (3,4) 매칭
+        val bracket = generate(1L to 15_000, 2L to 17_000, 3L to 18_000, 4L to null)
+
+        assertEquals(2, bracket.matches.size)
+        assertEquals(setOf(1L, 2L, 3L, 4L), bracket.allItemIds().toSet())
+    }
+
+    @Test
+    fun `모든 그룹 처리 후 홀수로 남은 아이템은 매치에 포함되지 않는다`() {
+        // sorted price: [1L(15k), 2L(17k), 3L(21k)] → (1,2) 매칭, 3L 잔여 → 이후 그룹 없음 → 미매칭
+        val bracket = generate(1L to 15_000, 2L to 17_000, 3L to 21_000)
+
+        assertEquals(1, bracket.matches.size)
+        assertTrue(3L !in bracket.allItemIds())
+    }
+
+    @Test
+    fun `32개 아이템은 16개의 매치가 생성된다`() {
+        val items = (1L..32L).map { it to (it * 1_000).toInt() }
+        val bracket = TournamentBracket.generate(items)
+
+        assertEquals(16, bracket.matches.size)
+        assertEquals((1L..32L).toSet(), bracket.allItemIds().toSet())
+    }
+
+    @Test
+    fun `각 아이템은 정확히 하나의 매치에만 등장한다`() {
+        val items = (1L..10L).map { it to (it * 3_000).toInt() }
+        val bracket = TournamentBracket.generate(items)
+
+        val allIds = bracket.allItemIds()
+        assertEquals(allIds.size, allIds.toSet().size)
+    }
+}

--- a/src/test/kotlin/com/depromeet/piki/tournament/service/TournamentServiceTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/service/TournamentServiceTest.kt
@@ -57,16 +57,20 @@ class TournamentServiceTest {
     }
 
     private class TestItemRepository : ItemRepository {
+        var validIds: Set<Long>? = null  // null = 모든 ID 유효
+
         override fun save(item: Item): Item = item
         override fun findById(id: Long): Item? = null
-        override fun findByIds(ids: List<Long>): List<Item> =
-            ids.map { id ->
+        override fun findByIds(ids: List<Long>): List<Item> {
+            val effective = validIds?.let { valid -> ids.filter { it in valid } } ?: ids
+            return effective.map { id ->
                 Item().also { item ->
                     val field = LongBaseEntity::class.java.getDeclaredField("id")
                     field.isAccessible = true
                     field.set(item, id)
                 }
             }
+        }
     }
 
     private class TestUserRepository : UserRepository {
@@ -262,6 +266,18 @@ class TournamentServiceTest {
         assertFailsWith<TournamentException> {
             service.addItems(userId, AddTournamentItems(tournamentId, listOf(1L)))
         }
+    }
+
+    @Test
+    fun `addItems 에서 존재하지 않는 itemId 이면 예외가 발생한다`() {
+        testItemRepository.validIds = setOf(1L, 2L)
+        val tournamentId = service.create(userId, CreateTournament("토너먼트"))
+
+        val ex =
+            assertFailsWith<TournamentException> {
+                service.addItems(userId, AddTournamentItems(tournamentId, listOf(1L, 999L)))
+            }
+        assertEquals(HttpStatus.NOT_FOUND, ex.httpStatus)
     }
 
     @Test

--- a/src/test/kotlin/com/depromeet/piki/tournament/service/TournamentServiceTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/service/TournamentServiceTest.kt
@@ -1,6 +1,8 @@
 package com.depromeet.piki.tournament.service
 
 import com.depromeet.piki.common.domain.LongBaseEntity
+import com.depromeet.piki.item.domain.Item
+import com.depromeet.piki.item.repository.ItemRepository
 import com.depromeet.piki.tournament.domain.Tournament
 import com.depromeet.piki.tournament.domain.TournamentHistory
 import com.depromeet.piki.tournament.domain.TournamentItem
@@ -52,6 +54,19 @@ class TournamentServiceTest {
             field.isAccessible = true
             field.set(entity, id)
         }
+    }
+
+    private class TestItemRepository : ItemRepository {
+        override fun save(item: Item): Item = item
+        override fun findById(id: Long): Item? = null
+        override fun findByIds(ids: List<Long>): List<Item> =
+            ids.map { id ->
+                Item().also { item ->
+                    val field = LongBaseEntity::class.java.getDeclaredField("id")
+                    field.isAccessible = true
+                    field.set(item, id)
+                }
+            }
     }
 
     private class TestUserRepository : UserRepository {
@@ -154,7 +169,8 @@ class TournamentServiceTest {
     private val userRepository = TestTournamentUserRepository()
     private val repository = TestTournamentRepository()
     private val testUserRepository = TestUserRepository()
-    private val service = TournamentService(userRepository, repository, itemRepository, testUserRepository)
+    private val testItemRepository = TestItemRepository()
+    private val service = TournamentService(userRepository, repository, itemRepository, testUserRepository, testItemRepository)
     private val userId = UUID.randomUUID()
     private val otherUserId = UUID.randomUUID()
 


### PR DESCRIPTION
## Situation
- 토너먼트 시작 시 참가 아이템들을 대전 페어로 묶는 대진표 생성 로직이 필요했음
- 사용자가 '시작' 버튼을 누르면 로딩 후 첫 매치(두 아이템 이미지·상품명·가격)를 즉시 보여줘야 하는 UX 요구사항이 있었음
- 이를 위해 시작 API 한 번으로 대진표와 아이템 상세 정보를 함께 반환해야 했음

## Task
- 가격이 비슷한 아이템끼리 대전하도록 페어링 알고리즘 설계
- 매치 순서에 랜덤성 부여 (대전 페어는 가격 기준 고정, 노출 순서만 셔플)
- 시작 API 단일 호출로 대진표 + 아이템 상세(name, price, currency, imageUrl)를 모두 반환

## Action

### 알고리즘
- 가격 오름차순 정렬 후 인접 쌍 매칭 — 가장 비슷한 가격끼리 붙도록
- 가격 정보 없는 아이템은 별도 그룹으로 후순위 처리, 가격 있는 그룹의 홀수 잔여 아이템과 자연스럽게 병합
- 페어는 고정, 매치 목록은 `shuffled()`로 순서만 랜덤화

### 레이어 분리
- `TournamentBracket` (도메인): ID 페어만 담는 순수 도메인
- `TournamentBracketResult` (서비스 DTO): 브래킷 + `itemDetailsByTournamentItemId` 맵을 묶어 전달
- `TournamentBracketResponse` (컨트롤러 DTO): 각 매치를 `firstItem` / `secondItem`(name, price, currency, imageUrl 포함)으로 평탄화

### 안전망
- `tournament.start()` 호출을 브래킷 생성 완료 후로 이동 — 아이템 조회·브래킷 생성 실패 시 토너먼트 상태가 `IN_PROGRESS`로 오염되지 않음

### 테스트
- `TournamentBracketTest` 단위 테스트 신규: 가격 인접 페어링, 가격 없는 아이템 처리, 홀수 잔여, 32개 최대치 등 8개 케이스
- 통합 테스트: DB에 실제 Item을 저장하고 시작 응답의 name·price·currency까지 단언

## Result
- 클라이언트가 시작 API 단일 호출로 대진표와 아이템 상세를 모두 수신 — 별도 아이템 조회 API 불필요
- 가격 인접 매칭으로 실질적으로 경쟁력 있는 대진 구성
- 브래킷 생성 실패 시 토너먼트 상태 오염 없음 (안전한 실패)

---
## 연관 이슈

- close #199


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 토너먼트 시작 API가 대진(브래킷) 정보를 반환하도록 변경됨.
  * 아이템을 가격 기준으로 정렬해 자동으로 매칭하고, 각 매치에 항목 상세(이름·가격·통화·이미지)를 포함함.

* **Bug Fixes**
  * 아이템 추가 시 존재하지 않는 ID가 포함되면 404 오류로 응답하도록 검증 강화.

* **Tests**
  * 브래킷 생성 로직에 대한 포괄적 단위/통합 테스트 추가 및 시작 엔드포인트 테스트 강화.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/PIKI-Server/pull/206?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->