### PR TITLE
SG·RDS drift 를 ignore_changes 로 정합성 확보

### DIFF
--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -48,6 +48,13 @@ resource "aws_db_instance" "mysql" {
   deletion_protection        = false # dev 단계에서는 false, prod 에서는 true 로 전환
   skip_final_snapshot        = true  # dev 단계에서만 true
 
+  # 실제 비밀번호는 콘솔/운영에서 바뀔 수 있어 state·var.db_password 와 어긋날 수 있다.
+  # terraform 이 apply 마다 비번을 var.db_password 로 강제 변경해 앱 DB 연결이 끊기는 사고를 막기 위해
+  # password 변경은 무시한다. 비번을 의도적으로 바꿀 때는 콘솔/CLI 로 직접 수행한다.
+  lifecycle {
+    ignore_changes = [password]
+  }
+
   tags = {
     Name = "${local.name_prefix}-mysql"
   }

--- a/terraform/security_groups.tf
+++ b/terraform/security_groups.tf
@@ -43,6 +43,14 @@ resource "aws_security_group" "ec2" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  # SSH(22) 등 ingress 규칙은 PIKI-Infra maintainer 들이 콘솔/cli 로 직접 관리한다.
+  # github actions 배포용 0.0.0.0/0:22, 팀원 SSH IP 등이 콘솔/cli 로 추가돼 있어,
+  # terraform 이 ingress 를 덮어쓰면 그 규칙이 제거돼 배포·팀원 SSH 가 끊긴다.
+  # 위 ingress 블록은 신규 환경의 초기 생성값일 뿐, 이후엔 콘솔이 권위를 가지므로 변경을 무시한다.
+  lifecycle {
+    ignore_changes = [ingress]
+  }
+
   tags = {
     Name = "${local.name_prefix}-ec2-sg"
   }


### PR DESCRIPTION
## Situation
- #200(OCR 이미지 S3) 작업 중 `terraform plan` 에서 SG·RDS 의 drift 를 발견했다. 5/7 S3 backend 이관 이후 state·코드와 실제 AWS 가 어긋난 상태였다.
- **SG**: PIKI-Infra maintainer 들이 콘솔/cli 로 SSH IP(팀원 IP, github actions `0.0.0.0/0:22`)를 직접 관리해, terraform 코드엔 없는 ingress 규칙이 실제 SG 에 존재.
- **RDS**: state 의 비밀번호와 로컬 `terraform.tfvars` 의 `db_password` 가 불일치.
- 실제로 #200 의 `-target apply` 가 EC2 의존성으로 SG 를 함께 건드려 배포용 `0.0.0.0/0:22` 가 제거되는 사고가 났다 (cli 로 임시 복구). 통째 `apply` 하면 배포·팀원 SSH 가 끊기거나 RDS 비번이 리셋된다.

## Task
- 누가 `terraform apply` 해도 SG·RDS 가 의도치 않게 변경되지 않도록 코드 ↔ 실제 정합성을 확보한다 (배포 SSH·팀원 접속·DB 연결이 끊기는 사고 방지).

## Action
- **SG `ec2` 의 ingress 를 `lifecycle { ignore_changes = [ingress] }`** — SSH 규칙은 콘솔/cli(maintainer)가 권위를 갖게 두고, terraform 이 덮어쓰지 않게 함. 코드의 ingress 블록은 신규 환경 초기 생성값 역할만.
- **RDS `mysql` 의 password 를 `ignore_changes = [password]`** — apply 마다 비번을 `var.db_password` 로 강제 변경해 앱 DB 연결이 끊기던 것을 막음. 비번 변경은 콘솔/CLI 로 수행.
- 관리 방식 결정: "콘솔 수동 관리 유지(ignore_changes)" vs "코드에 모두 명시" 중, 팀이 이미 콘솔로 SSH 를 관리하는 현실에 맞춰 ignore_changes 채택.

## Result
- `terraform plan` 결과 **`No changes. Your infrastructure matches the configuration.`** — SG ingress·RDS password 변경이 사라져 drift 가 해소됐다. 이제 누가 apply 해도 SG·db 가 안전하다.
- #200 에서 cli 로 임시 복구한 `0.0.0.0/0:22` 가 더 이상 apply 로 제거되지 않는다 (재발 방지).
- **범위 밖(별도/후속)**: deploy 워크플로우 S3 env fail-fast 검증은 별도 PR 로 분리, `ec2_ami_id`·버킷명 default 의 다중 환경 대응은 단일 환경엔 무해해 도입 시 후속.

---
## 연관 이슈

- close #208


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **Chores**
  * RDS 데이터베이스 인스턴스 구성 업데이트
  * 보안 그룹 인바운드 규칙 구성 업데이트

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/PIKI-Server/pull/209?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->