### PR TITLE
OpenAPI 문서 description 을 실제 응답·인증 contract 로 정정

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/common/config/OpenApiConfig.kt
+++ b/src/main/kotlin/com/depromeet/piki/common/config/OpenApiConfig.kt
@@ -26,8 +26,8 @@ class OpenApiConfig {
                         """
                         피키(PIKI) 위시리스트 서비스 API 문서.
 
-                        - 모든 응답의 에러 포맷은 RFC 7807 `application/problem+json` 을 따른다.
-                        - 게스트 식별자는 클라이언트가 발급받아 보관하며, 위시리스트 등록 시 함께 전달한다.
+                        - 모든 응답은 공통 래퍼(`ApiResponseBody`)로 `application/json` 으로 내려간다. 필드는 `status`·`code`·`detail`·`data`·`pageResponse` 이며, 성공·실패가 같은 형태다. 실패 시 `data` 는 null 이고 `code`·`detail` 에 사유가 담긴다.
+                        - 인증은 JWT 기반이다. 게스트 생성 또는 소셜 로그인으로 액세스·리프레시 토큰 쌍을 발급받고, 보호된 API 는 액세스 토큰을 `Authorization: Bearer {accessToken}` 헤더로 전달한다. 만료 시 리프레시 토큰으로 갱신한다.
                         """.trimIndent(),
                     ).contact(Contact().name("PIKI").url("https://github.com/depromeet/PIKI-Server"))
                     .license(License().name("Apache-2.0").url("https://www.apache.org/licenses/LICENSE-2.0")),


### PR DESCRIPTION
## Situation
- 운영 docs(Stoplight UI)의 OpenAPI 문서 첫 화면 description 에, 실제 동작과 어긋나는 옛 명세 두 줄이 남아 있었다 (스크린샷에서 발견).
- "RFC 7807 application/problem+json" · "게스트 식별자를 클라이언트가 발급해 위시 등록 body 로 전달" — 둘 다 현재 코드와 맞지 않는다.

## Task
- 문서 description 을 실제 응답 포맷·인증 방식 contract 에 맞게 정정한다.
- 추측이 아니라 실제 코드(GlobalExceptionHandler·ApiResponseBody·AuthApi·JwtAuthenticationFilter)를 근거로 교체한다.

## Action
- **에러/응답 포맷**: "RFC 7807 problem+json" → 성공·실패 모두 공통 래퍼 `ApiResponseBody`(`status`·`code`·`detail`·`data`·`pageResponse`) 로 `application/json` 응답한다는 실제 contract 로 교체. 실패 시 `data=null`, `code`·`detail` 에 사유.
- **인증**: "게스트 식별자 클라이언트 발급·body 전달" → JWT 기반으로 교체. 게스트 생성/소셜 로그인으로 토큰 쌍 발급, 클라이언트는 `Authorization: Bearer` 헤더 전달, 서버가 토큰에서 userId 추출.

## Result
- Swagger/Stoplight 문서 첫 화면이 실제 응답·인증과 일치한다.
- 참고로 같이 점검한 두 건은 이 PR 범위 밖이다:
  - docs 탭 제목 `team3 API Docs` 는 코드상 이미 #203(리브랜딩)에서 `PIKI API Docs` 로 고쳐져 dev 머지 완료 상태. 운영 재배포 시 반영된다.
  - URL 도메인 `api.depromeet18team3.cloud` 는 리브랜딩 때 "유지"로 결정된 운영 도메인이라 손대지 않았다.

---
## 연관 이슈

- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 문서

* **Documentation**
  * OpenAPI 문서가 업데이트되었습니다. JWT 기반 인증 및 액세스·리프레시 토큰 전달 방식, 공통 응답 형식에 대한 설명이 추가되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/PIKI-Server/pull/211?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->