### PR TITLE
이미지 업로드 크기 제한 5MB로 통일

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,8 +5,8 @@ spring:
     import: optional:file:.env[.properties]
   servlet:
     multipart:
-      max-file-size: 10MB
-      max-request-size: 10MB
+      max-file-size: 5MB
+      max-request-size: 5MB
   datasource:
     url: jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_NAME:piki}?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC&characterEncoding=UTF-8
     username: ${DB_USERNAME:piki}


### PR DESCRIPTION
## Situation
- 이미지 업로드 시 앞단 nginx 에 client_max_body_size 가 설정돼 있지 않아 기본값 1MB 가 적용 중이었고, 1MB 를 넘는 정상 사진이 백엔드에 닿기 전 413 으로 막히고 있었음
- Spring 쪽 multipart 한계는 10MB 로 열려 있어 두 계층 값이 어긋나 있었음 (실질 게이트는 더 작은 nginx 1MB)
- 10MB 는 Spring 기본값을 그대로 둔 값이라 업로드 특성에 맞춘 값이 아니었고, 100장이면 1GB 라 과하다는 판단

## Task
- 이미지 업로드 크기 한계를 합리적 값으로 정하고 nginx ↔ Spring 두 계층을 같은 값으로 통일

## Action
- application.yml 의 max-file-size·max-request-size 를 10MB → 5MB 로 축소
- 값 결정: 1MB 로 더 조이면 압축 안 한 스크린샷(최대 ~3MB)이 막혀 클라 압축이 선결 조건이 되므로 제외. 정상 최대치(~3MB)에 여유를 둔 5MB 로 결정
- 클라 압축은 OCR 정확도(과압축 시 텍스트 뭉개짐) 트레이드오프가 있어 이번 스코프에서 분리, 서버 한계만 조정

## Result
- 서버 업로드 한계 5MB 로 통일 — 압축 안 한 정상 스크린샷(~3MB)도 통과
- nginx client_max_body_size 5M 은 이 repo 밖(EC2)이라 1회 수동 적용 필요
- 후속: nginx 설정을 GitHub 단일 진실(IaC)로 두는 플로우를 별도 이슈로 분리 예정

---
## 연관 이슈

- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경사항

* **설정 변경**
  * 파일 업로드 크기 제한이 10MB에서 5MB로 조정되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/PIKI-Server/pull/215?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->