### PR TITLE
OpenAPI 인증 노출·DevAuth example 정합 및 미인증 401 경계 회귀 가드

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/auth/controller/AuthApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/controller/AuthApi.kt
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.security.SecurityRequirements
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.MediaType
 import java.util.UUID
@@ -20,6 +21,8 @@ interface AuthApi {
         summary = "게스트 생성",
         description = "새 GUEST User 를 생성하고 JWT 토큰 쌍을 발급한다.",
     )
+    // 인증 없이 호출하는 진입점 (SecurityConfig 의 permitAll). 글로벌 Bearer 요구를 해제한다.
+    @SecurityRequirements
     @ApiResponses(
         value = [
             ApiResponse(
@@ -40,6 +43,8 @@ interface AuthApi {
         summary = "토큰 갱신",
         description = "리프레시 토큰을 검증하고 새 액세스·리프레시 토큰 쌍을 발급한다.",
     )
+    // 만료된 액세스 토큰을 가진 클라이언트도 호출해야 하므로 인증 없이 진입 (SecurityConfig 의 permitAll).
+    @SecurityRequirements
     @ApiResponses(
         value = [
             ApiResponse(

--- a/src/main/kotlin/com/depromeet/piki/auth/controller/AuthApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/controller/AuthApiExamples.kt
@@ -88,6 +88,41 @@ class AuthApiExamples(
                                 ),
                         )
                     }
+
+                handlerMethod.binds(DevAuthController::createDevUser) ->
+                    operation.examples(openApiObjectMapper.delegate) {
+                        add(
+                            status = HttpStatus.CREATED,
+                            name = "MEMBER 생성 성공",
+                            payload =
+                                ApiResponseBody.created(
+                                    GuestCreateResponse(
+                                        accessToken = "eyJhbGciOiJIUzI1NiJ9.access",
+                                        refreshToken = "eyJhbGciOiJIUzI1NiJ9.refresh",
+                                        user =
+                                            UserResponse(
+                                                id = UUID.fromString("3b9c1d2e-4f5a-4b6c-8d7e-9f0a1b2c3d4e"),
+                                                nickname = "홍길동",
+                                                profileImage =
+                                                    "https://api.dicebear.com/9.x/bottts/svg?seed=3b9c1d2e-4f5a-4b6c-8d7e-9f0a1b2c3d4e",
+                                                identityType = IdentityType.MEMBER,
+                                            ),
+                                    ),
+                                ),
+                        )
+                        add(
+                            status = HttpStatus.BAD_REQUEST,
+                            name = "닉네임 미입력",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.INVALID_INPUT,
+                                    status = HttpStatus.BAD_REQUEST,
+                                    detail = "nickname: must not be blank",
+                                ),
+                        )
+                        // 401(GUEST 토큰 누락)은 Security 필터 단계 거부라 본문이 ApiResponseBody 가 아닌
+                        // Spring 기본 /error 응답이다. 거짓 example 을 박지 않기 위해 의도적으로 생략한다.
+                    }
             }
             operation
         }

--- a/src/main/kotlin/com/depromeet/piki/common/config/OpenApiConfig.kt
+++ b/src/main/kotlin/com/depromeet/piki/common/config/OpenApiConfig.kt
@@ -1,9 +1,12 @@
 package com.depromeet.piki.common.config
 
+import io.swagger.v3.oas.models.Components
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.info.Contact
 import io.swagger.v3.oas.models.info.Info
 import io.swagger.v3.oas.models.info.License
+import io.swagger.v3.oas.models.security.SecurityRequirement
+import io.swagger.v3.oas.models.security.SecurityScheme
 import io.swagger.v3.oas.models.servers.Server
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
@@ -31,5 +34,25 @@ class OpenApiConfig {
                         """.trimIndent(),
                     ).contact(Contact().name("PIKI").url("https://github.com/depromeet/PIKI-Server"))
                     .license(License().name("Apache-2.0").url("https://www.apache.org/licenses/LICENSE-2.0")),
-            ).addServersItem(Server().url("/").description("Current host"))
+            )
+            // JWT Bearer 인증 스킴을 스펙에 선언한다. 이게 없으면 문서 UI 가 "인증 필요" 를 알 수 없어
+            // 토큰 입력란·Authorization 헤더 cURL 샘플을 그리지 못한다 (Security 필터 규칙은 springdoc 이 모름).
+            .components(
+                Components().addSecuritySchemes(
+                    SECURITY_SCHEME_NAME,
+                    SecurityScheme()
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("bearer")
+                        .bearerFormat("JWT")
+                        .description("게스트 생성·소셜 로그인으로 발급받은 액세스 토큰. `Bearer ` 접두어는 문서 UI 가 자동으로 붙인다."),
+                ),
+            )
+            // 기본적으로 모든 엔드포인트에 Bearer 를 요구한다. 인증이 필요 없는 public 엔드포인트
+            // (게스트 생성·토큰 갱신·health) 는 각 핸들러에서 `@SecurityRequirements` 로 이 요구를 해제한다.
+            .addSecurityItem(SecurityRequirement().addList(SECURITY_SCHEME_NAME))
+            .addServersItem(Server().url("/").description("Current host"))
+
+    companion object {
+        private const val SECURITY_SCHEME_NAME = "bearerAuth"
+    }
 }

--- a/src/main/kotlin/com/depromeet/piki/common/controller/HealthController.kt
+++ b/src/main/kotlin/com/depromeet/piki/common/controller/HealthController.kt
@@ -1,11 +1,14 @@
 package com.depromeet.piki.common.controller
 
+import io.swagger.v3.oas.annotations.security.SecurityRequirements
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
 class HealthController {
+    // 배포 헬스체크 진입점 (SecurityConfig 의 permitAll). 글로벌 Bearer 요구를 해제한다.
+    @SecurityRequirements
     @GetMapping("/health")
     fun health(): ResponseEntity<Map<String, String>> = ResponseEntity.ok(mapOf("status" to "ok"))
 }

--- a/src/test/kotlin/com/depromeet/piki/auth/config/AuthorizationBoundaryIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/config/AuthorizationBoundaryIntegrationTest.kt
@@ -1,0 +1,68 @@
+package com.depromeet.piki.auth.config
+
+import com.depromeet.piki.support.IntegrationTestSupport
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.Arguments.arguments
+import org.junit.jupiter.params.provider.MethodSource
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpMethod
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.request
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.web.context.WebApplicationContext
+
+class AuthorizationBoundaryIntegrationTest : IntegrationTestSupport() {
+    @Autowired
+    private lateinit var webApplicationContext: WebApplicationContext
+
+    // SecurityConfig 의 인증 경계는 컨트롤러 로직이 아니라 필터 단 정책이라, 보호 엔드포인트 전체를
+    // 한 곳에서 망라해 "인증 요구가 silent 하게 풀리는" 회귀(예: permitAll 오추가, 글로벌 요구 제거)를 잡는다.
+    // OpenAPI 자물쇠 표시는 문서일 뿐 실제 경계가 아니므로, 진짜 경계인 여기서 401 을 직접 단언한다.
+    // 일부는 각 컨트롤러 통합 테스트의 미인증 401 시나리오와 겹치나, 여기서는 정책 전체를 한눈에 회귀 검증한다.
+    @ParameterizedTest(name = "[{index}] {0} {1} - 토큰 없으면 401")
+    @MethodSource("protectedEndpoints")
+    fun `보호 엔드포인트는 Authorization 헤더 없이 호출하면 401 을 반환한다`(
+        method: HttpMethod,
+        path: String,
+    ) {
+        val mockMvc =
+            MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .apply<DefaultMockMvcBuilder>(springSecurity())
+                .build()
+
+        mockMvc
+            .perform(request(method, path))
+            .andExpect(status().isUnauthorized)
+    }
+
+    companion object {
+        // SecurityConfig 에서 permitAll 이 아닌(= 인증 필요한) 모든 엔드포인트.
+        // public 진입점(POST /auth/guest·/auth/token/refresh, GET /health)은 제외 — 인증 없이 통과해야 하며
+        // 그 정상 동작은 각 컨트롤러 통합 테스트·CorsIntegrationTest 가 검증한다.
+        @JvmStatic
+        fun protectedEndpoints(): List<Arguments> =
+            listOf(
+                arguments(HttpMethod.POST, "/api/v1/dev/users"),
+                arguments(HttpMethod.POST, "/api/v1/auth/logout"),
+                arguments(HttpMethod.POST, "/api/v1/wishlists"),
+                arguments(HttpMethod.POST, "/api/v1/wishlists/ocr"),
+                arguments(HttpMethod.GET, "/api/v1/wishlists"),
+                arguments(HttpMethod.PATCH, "/api/v1/wishlists/1"),
+                arguments(HttpMethod.DELETE, "/api/v1/wishlists/1"),
+                arguments(HttpMethod.POST, "/api/v1/tournaments"),
+                arguments(HttpMethod.POST, "/api/v1/tournaments/1/items"),
+                arguments(HttpMethod.DELETE, "/api/v1/tournaments/1/items/1"),
+                arguments(HttpMethod.POST, "/api/v1/tournaments/1/start"),
+                arguments(HttpMethod.POST, "/api/v1/tournaments/1/matches"),
+                arguments(HttpMethod.GET, "/api/v1/tournaments"),
+                arguments(HttpMethod.GET, "/api/v1/tournaments/1"),
+                arguments(HttpMethod.GET, "/api/v1/users/me"),
+                arguments(HttpMethod.PATCH, "/api/v1/users/me"),
+                arguments(HttpMethod.GET, "/api/v1/users/nickname/check"),
+            )
+    }
+}

--- a/src/test/kotlin/com/depromeet/piki/common/controller/DocsAccessIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/common/controller/DocsAccessIntegrationTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
@@ -41,5 +42,46 @@ class DocsAccessIntegrationTest : IntegrationTestSupport() {
         mockMvc
             .perform(get("/v3/api-docs"))
             .andExpect(status().isOk)
+    }
+
+    @Test
+    fun `GET v3 api-docs - JWT Bearer SecurityScheme 가 스펙에 선언되어 있다`() {
+        // 이 선언이 없으면 문서 UI 가 "인증 필요" 를 알 수 없어 토큰 입력란·Authorization 헤더 cURL
+        // 샘플을 그리지 못한다 (Security 필터 규칙은 springdoc 이 모름). 회귀 가드.
+        val mockMvc =
+            MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .apply<DefaultMockMvcBuilder>(springSecurity())
+                .build()
+
+        mockMvc
+            .perform(get("/v3/api-docs"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.components.securitySchemes.bearerAuth.type").value("http"))
+            .andExpect(jsonPath("$.components.securitySchemes.bearerAuth.scheme").value("bearer"))
+            .andExpect(jsonPath("$.components.securitySchemes.bearerAuth.bearerFormat").value("JWT"))
+            // 최상위 글로벌 security 로 모든 엔드포인트에 기본 Bearer 요구가 걸린다.
+            .andExpect(jsonPath("$.security[0].bearerAuth").exists())
+    }
+
+    @Test
+    fun `GET v3 api-docs - public 은 인증 해제되고 보호 엔드포인트는 글로벌 Bearer 를 상속한다`() {
+        // 글로벌 Bearer 요구가 게스트 생성 같은 진입점까지 자물쇠로 덮으면 문서가 거짓이 된다.
+        // @SecurityRequirements(빈) 으로 public operation 의 security 가 빈 배열이 되는지,
+        // 인증 필요한 dev/users 는 operation 에 security 명시 없이 글로벌을 상속하는지 회귀 가드.
+        val mockMvc =
+            MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .apply<DefaultMockMvcBuilder>(springSecurity())
+                .build()
+
+        mockMvc
+            .perform(get("/v3/api-docs"))
+            .andExpect(status().isOk)
+            // public: @SecurityRequirements(빈) → operation security 가 빈 배열로 글로벌 요구를 끊는다.
+            .andExpect(jsonPath("$.paths['/api/v1/auth/guest'].post.security").isArray)
+            .andExpect(jsonPath("$.paths['/api/v1/auth/guest'].post.security").isEmpty)
+            // 보호: operation 에 security 명시 없음 → 최상위 글로벌 Bearer 상속 (문서 UI 에 자물쇠 표시).
+            .andExpect(jsonPath("$.paths['/api/v1/dev/users'].post.security").doesNotExist())
     }
 }


### PR DESCRIPTION
## Situation
- API 문서(Stoplight Elements)에서 `POST /api/v1/dev/users` 같은 보호 엔드포인트에 **토큰 입력란·`Authorization` 헤더 cURL 샘플이 안 보였다.** 실제로는 GUEST 인증이 필요한데, 문서만 보고 인증 없이 호출하게 되는 혼란이 있었다.
- 원인 추적: 인증은 Spring Security 필터(`SecurityConfig`)에서 강제되지만, **OpenAPI 스펙엔 SecurityScheme 가 선언돼 있지 않아** springdoc 이 "인증 필요"를 표현하지 못했다. `OpenApiConfig` description 본문에 `Authorization: Bearer` 를 글로만 적어둔 상태였다.
- 추가로 `DevAuthController.createDevUser` 의 Response Example 이 실제 `GuestCreateResponse` 가 아니라 generic `ApiResponseBody` 스키마(`status:0, data:null, ...`)로 노출됐다 — 다른 컨트롤러와 달리 example `OperationCustomizer` 빈이 누락돼 있었다.

## Task
- OpenAPI 스펙에 JWT Bearer 인증을 선언해 문서 UI 가 토큰 입력란·`Authorization` cURL 헤더를 그리게 한다.
- permitAll 진입점에는 잘못된 자물쇠가 뜨지 않게 한다.
- DevAuth `createDevUser` 의 응답 example 을 실제 응답과 일치시킨다.

## Action

### 인증 스킴 노출
- `OpenApiConfig` 에 `bearerAuth`(HTTP `bearer` / `JWT`) SecurityScheme 를 선언하고, 글로벌 SecurityRequirement 로 모든 엔드포인트에 기본 적용했다.
- permitAll 진입점(`createGuest` · `refresh` · `health`)은 `@SecurityRequirements`(빈)로 글로벌 요구를 해제했다 — 해제 대상은 `SecurityConfig` 의 permitAll 목록과 1:1 로 맞췄다. `health` 는 `*Api` 인터페이스가 없는 기존 예외라 컨트롤러 메서드에 직접 부여.

### DevAuth example 정합
- `createDevUser` 의 201(MEMBER `GuestCreateResponse`) · 400 example 을 실제 DTO 인스턴스로 추가했다. 400 detail 은 실제 응답(`nickname: must not be blank`, `INVALID_INPUT`)과 동일하게 맞췄다.
- 401(GUEST 토큰 누락)은 Security 필터 단계 거부라 본문이 `ApiResponseBody` 가 아닌 Spring 기본 `/error` 응답이다. 검토 중 `DevAuthApi` 에 401 `ApiResponse` 와 example 을 추가했다가, **거짓 example 을 박지 않기 위해 원복**하고 생략 사유를 주석으로 남겼다. (통합 테스트에서도 헤더 누락 401 은 본문을 단언하지 않는 것으로 이 사실을 확인)

### 회귀 가드
- `DocsAccessIntegrationTest` 에 `/v3/api-docs` 스펙 검증 2건을 추가했다 — (1) `bearerAuth` SecurityScheme 선언 + 글로벌 security 적용, (2) public(`auth/guest`)은 operation security 가 빈 배열로 해제되고 보호(`dev/users`)는 operation 명시 없이 글로벌을 상속하는지.

## Result
- 문서 UI 에 `Authorization` 토큰 입력란과 `Bearer` cURL 샘플이 생기고, 보호 엔드포인트엔 자물쇠가, public 진입점엔 자물쇠가 뜨지 않는다.
- DevAuth Response Example 이 실제 201 / 400 응답과 일치한다.
- 전체 단위 + 통합 테스트 통과 (Testcontainers MySQL 포함).
- **후속 후보**: `logout` 등 필터 거부 401 의 본문도 실제론 `ApiResponseBody` 가 아니다(기존 example 도 동일 불일치). `AuthenticationEntryPoint` 를 `ApiResponseBody` 로 통일하면 모든 필터 거부 401 이 일관되고 example 도 진실이 되지만, 범위가 커 이번엔 손대지 않았다 — 별도 이슈로 분리 권장.

## Updates

### 인증 경계 회귀 가드 보강 (실제 보안 경계)
- 리뷰 중 "OpenAPI 자물쇠는 문서 표시일 뿐 실제 보안 경계가 아니다 — `SecurityConfig` 의 인증 요구가 silent 하게 풀려도(permitAll 오추가·글로벌 요구 제거 등) OpenAPI 자물쇠 단언으로는 못 잡는다"는 지적이 나왔다. 그래서 문서 자물쇠 단언을 더 늘리는 대신, **진짜 경계인 필터 단에서 미인증 401 을 직접 단언**하는 가드를 추가했다. (`89cddd3`)
- 기존엔 `logout` · GET `/tournaments` · GET `/users/me` 3곳만 미인증 401 을 검증했고, `dev/users` · wishlist 전체 · tournament 생성/플레이 · users PATCH · `nickname/check` 등 **대부분의 보호 엔드포인트가 가드 밖**이었다.
- 인증 경계는 컨트롤러 로직이 아니라 `SecurityConfig` 정책이므로, `AuthorizationBoundaryIntegrationTest` 한 곳에서 보호 엔드포인트 **17개를 `@ParameterizedTest` 로 망라**했다 — 정책 전체를 한눈에 회귀 검증. public 진입점은 제외(정상 통과는 기존 컨트롤러 테스트·`CorsIntegrationTest` 가 검증). (`89cddd3`)

---
## 연관 이슈

- 

