### PR TITLE
배포 워크플로우에 필수 환경변수 fail-fast 검증 추가

### DIFF
--- a/.github/workflows/deploy-manual.yml
+++ b/.github/workflows/deploy-manual.yml
@@ -102,10 +102,12 @@ jobs:
           key: ${{ secrets.EC2_SSH_KEY }}
           envs: GEMINI_API_KEY,DB_HOST,DB_PORT,DB_NAME,DB_USERNAME,DB_PASSWORD,JWT_SECRET,REDIS_HOST,REDIS_PORT,KAKAO_CLIENT_ID,KAKAO_CLIENT_SECRET,KAKAO_REDIRECT_URI,GOOGLE_CLIENT_ID,GOOGLE_CLIENT_SECRET,GOOGLE_REDIRECT_URI,S3_BUCKET,S3_PUBLIC_BASE_URL,DOCKERHUB_USERNAME,IMAGE_TAG
           script: |
-            # 필수 S3 환경변수 검증 — docker stop 으로 기존 컨테이너를 내리기 전에 먼저 실패시킨다.
-            # (단순 교체 방식이라 검증 없이 내리면 새 컨테이너 부팅 실패 시 서비스가 다운된다)
-            : "${S3_BUCKET:?S3_BUCKET 이 비어 있습니다. repo secret 을 확인하세요}"
-            : "${S3_PUBLIC_BASE_URL:?S3_PUBLIC_BASE_URL 이 비어 있습니다. repo secret 을 확인하세요}"
+            # 앱 부팅 필수 환경변수 검증 — docker stop 으로 기존 컨테이너를 내리기 전에 먼저 실패시킨다.
+            # (단순 교체 방식이라 검증 없이 내리면 새 컨테이너 부팅 실패 시 서비스가 다운된다.
+            #  KAKAO/GOOGLE OAuth·*_EXPIRY 등 기본값/선택값은 제외 — 비어도 부팅되므로)
+            for v in JWT_SECRET GEMINI_API_KEY S3_BUCKET S3_PUBLIC_BASE_URL DB_HOST DB_PORT DB_NAME DB_USERNAME DB_PASSWORD REDIS_HOST REDIS_PORT; do
+              if [ -z "${!v:-}" ]; then echo "ERROR: 필수 환경변수 $v 가 비어 있습니다 — repo secret 을 확인하세요" >&2; exit 1; fi
+            done
 
             IMAGE="$DOCKERHUB_USERNAME/team3-server:$IMAGE_TAG"
             docker pull "$IMAGE"

--- a/.github/workflows/deploy-manual.yml
+++ b/.github/workflows/deploy-manual.yml
@@ -102,10 +102,10 @@ jobs:
           key: ${{ secrets.EC2_SSH_KEY }}
           envs: GEMINI_API_KEY,DB_HOST,DB_PORT,DB_NAME,DB_USERNAME,DB_PASSWORD,JWT_SECRET,REDIS_HOST,REDIS_PORT,KAKAO_CLIENT_ID,KAKAO_CLIENT_SECRET,KAKAO_REDIRECT_URI,GOOGLE_CLIENT_ID,GOOGLE_CLIENT_SECRET,GOOGLE_REDIRECT_URI,S3_BUCKET,S3_PUBLIC_BASE_URL,DOCKERHUB_USERNAME,IMAGE_TAG
           script: |
-            # 앱 부팅 필수 환경변수 검증 — docker stop 으로 기존 컨테이너를 내리기 전에 먼저 실패시킨다.
-            # (단순 교체 방식이라 검증 없이 내리면 새 컨테이너 부팅 실패 시 서비스가 다운된다.
-            #  KAKAO/GOOGLE OAuth·*_EXPIRY 등 기본값/선택값은 제외 — 비어도 부팅되므로)
-            for v in JWT_SECRET GEMINI_API_KEY S3_BUCKET S3_PUBLIC_BASE_URL DB_HOST DB_PORT DB_NAME DB_USERNAME DB_PASSWORD REDIS_HOST REDIS_PORT; do
+            # 배포에 필요한 환경변수 검증 — docker stop 으로 기존 컨테이너를 내리기 전에 먼저 실패시킨다.
+            # 위 envs 로 넘기는 값 전부를 검사한다. (OAuth secret 이 비면 부팅은 되지만 소셜 로그인이
+            #  조용히 깨지므로 포함. 단순 교체라 검증 없이 내리면 새 컨테이너 실패 시 다운)
+            for v in GEMINI_API_KEY DB_HOST DB_PORT DB_NAME DB_USERNAME DB_PASSWORD JWT_SECRET REDIS_HOST REDIS_PORT KAKAO_CLIENT_ID KAKAO_CLIENT_SECRET KAKAO_REDIRECT_URI GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET GOOGLE_REDIRECT_URI S3_BUCKET S3_PUBLIC_BASE_URL DOCKERHUB_USERNAME IMAGE_TAG; do
               if [ -z "${!v:-}" ]; then echo "ERROR: 필수 환경변수 $v 가 비어 있습니다 — repo secret 을 확인하세요" >&2; exit 1; fi
             done
 

--- a/.github/workflows/deploy-manual.yml
+++ b/.github/workflows/deploy-manual.yml
@@ -102,6 +102,11 @@ jobs:
           key: ${{ secrets.EC2_SSH_KEY }}
           envs: GEMINI_API_KEY,DB_HOST,DB_PORT,DB_NAME,DB_USERNAME,DB_PASSWORD,JWT_SECRET,REDIS_HOST,REDIS_PORT,KAKAO_CLIENT_ID,KAKAO_CLIENT_SECRET,KAKAO_REDIRECT_URI,GOOGLE_CLIENT_ID,GOOGLE_CLIENT_SECRET,GOOGLE_REDIRECT_URI,S3_BUCKET,S3_PUBLIC_BASE_URL,DOCKERHUB_USERNAME,IMAGE_TAG
           script: |
+            # 필수 S3 환경변수 검증 — docker stop 으로 기존 컨테이너를 내리기 전에 먼저 실패시킨다.
+            # (단순 교체 방식이라 검증 없이 내리면 새 컨테이너 부팅 실패 시 서비스가 다운된다)
+            : "${S3_BUCKET:?S3_BUCKET 이 비어 있습니다. repo secret 을 확인하세요}"
+            : "${S3_PUBLIC_BASE_URL:?S3_PUBLIC_BASE_URL 이 비어 있습니다. repo secret 을 확인하세요}"
+
             IMAGE="$DOCKERHUB_USERNAME/team3-server:$IMAGE_TAG"
             docker pull "$IMAGE"
             docker stop team3-server || true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -102,10 +102,10 @@ jobs:
           key: ${{ secrets.EC2_SSH_KEY }}
           envs: GEMINI_API_KEY,DB_HOST,DB_PORT,DB_NAME,DB_USERNAME,DB_PASSWORD,JWT_SECRET,REDIS_HOST,REDIS_PORT,KAKAO_CLIENT_ID,KAKAO_CLIENT_SECRET,KAKAO_REDIRECT_URI,GOOGLE_CLIENT_ID,GOOGLE_CLIENT_SECRET,GOOGLE_REDIRECT_URI,S3_BUCKET,S3_PUBLIC_BASE_URL,DOCKERHUB_USERNAME,IMAGE_TAG
           script: |
-            # 앱 부팅 필수 환경변수 검증 — 누락/오타 시 비활성 슬롯 기동 전에 즉시 실패시켜 배포를 중단한다.
-            # (필수값이 비면 새 컨테이너가 못 떠 배포만 실패한다. KAKAO/GOOGLE OAuth·*_EXPIRY 등
-            #  기본값/선택값은 제외 — 비어도 부팅되므로 가드하면 정상 배포까지 막는다)
-            for v in JWT_SECRET GEMINI_API_KEY S3_BUCKET S3_PUBLIC_BASE_URL DB_HOST DB_PORT DB_NAME DB_USERNAME DB_PASSWORD REDIS_HOST REDIS_PORT; do
+            # 배포에 필요한 환경변수 검증 — 누락/오타 시 비활성 슬롯 기동 전에 즉시 실패시켜 배포를 중단한다.
+            # 위 envs 로 넘기는 값 전부를 검사한다. (KAKAO/GOOGLE 등 OAuth secret 이 비면 부팅은 되지만
+            #  소셜 로그인이 조용히 깨지므로 포함 — "부팅 여부"가 아니라 "운영에 필요한가"로 판단)
+            for v in GEMINI_API_KEY DB_HOST DB_PORT DB_NAME DB_USERNAME DB_PASSWORD JWT_SECRET REDIS_HOST REDIS_PORT KAKAO_CLIENT_ID KAKAO_CLIENT_SECRET KAKAO_REDIRECT_URI GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET GOOGLE_REDIRECT_URI S3_BUCKET S3_PUBLIC_BASE_URL DOCKERHUB_USERNAME IMAGE_TAG; do
               if [ -z "${!v:-}" ]; then echo "ERROR: 필수 환경변수 $v 가 비어 있습니다 — repo secret 을 확인하세요" >&2; exit 1; fi
             done
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -102,10 +102,12 @@ jobs:
           key: ${{ secrets.EC2_SSH_KEY }}
           envs: GEMINI_API_KEY,DB_HOST,DB_PORT,DB_NAME,DB_USERNAME,DB_PASSWORD,JWT_SECRET,REDIS_HOST,REDIS_PORT,KAKAO_CLIENT_ID,KAKAO_CLIENT_SECRET,KAKAO_REDIRECT_URI,GOOGLE_CLIENT_ID,GOOGLE_CLIENT_SECRET,GOOGLE_REDIRECT_URI,S3_BUCKET,S3_PUBLIC_BASE_URL,DOCKERHUB_USERNAME,IMAGE_TAG
           script: |
-            # 필수 S3 환경변수 검증 — 누락/오타 시 컨테이너 교체 전에 즉시 실패시켜 배포를 중단한다.
-            # (앱 부팅 필수값이라, 빠뜨린 채 교체하면 새 컨테이너가 못 떠 배포만 실패한다)
-            : "${S3_BUCKET:?S3_BUCKET 이 비어 있습니다. repo secret 을 확인하세요}"
-            : "${S3_PUBLIC_BASE_URL:?S3_PUBLIC_BASE_URL 이 비어 있습니다. repo secret 을 확인하세요}"
+            # 앱 부팅 필수 환경변수 검증 — 누락/오타 시 비활성 슬롯 기동 전에 즉시 실패시켜 배포를 중단한다.
+            # (필수값이 비면 새 컨테이너가 못 떠 배포만 실패한다. KAKAO/GOOGLE OAuth·*_EXPIRY 등
+            #  기본값/선택값은 제외 — 비어도 부팅되므로 가드하면 정상 배포까지 막는다)
+            for v in JWT_SECRET GEMINI_API_KEY S3_BUCKET S3_PUBLIC_BASE_URL DB_HOST DB_PORT DB_NAME DB_USERNAME DB_PASSWORD REDIS_HOST REDIS_PORT; do
+              if [ -z "${!v:-}" ]; then echo "ERROR: 필수 환경변수 $v 가 비어 있습니다 — repo secret 을 확인하세요" >&2; exit 1; fi
+            done
 
             IMAGE="$DOCKERHUB_USERNAME/team3-server:$IMAGE_TAG"
             docker pull "$IMAGE"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -102,6 +102,11 @@ jobs:
           key: ${{ secrets.EC2_SSH_KEY }}
           envs: GEMINI_API_KEY,DB_HOST,DB_PORT,DB_NAME,DB_USERNAME,DB_PASSWORD,JWT_SECRET,REDIS_HOST,REDIS_PORT,KAKAO_CLIENT_ID,KAKAO_CLIENT_SECRET,KAKAO_REDIRECT_URI,GOOGLE_CLIENT_ID,GOOGLE_CLIENT_SECRET,GOOGLE_REDIRECT_URI,S3_BUCKET,S3_PUBLIC_BASE_URL,DOCKERHUB_USERNAME,IMAGE_TAG
           script: |
+            # 필수 S3 환경변수 검증 — 누락/오타 시 컨테이너 교체 전에 즉시 실패시켜 배포를 중단한다.
+            # (앱 부팅 필수값이라, 빠뜨린 채 교체하면 새 컨테이너가 못 떠 배포만 실패한다)
+            : "${S3_BUCKET:?S3_BUCKET 이 비어 있습니다. repo secret 을 확인하세요}"
+            : "${S3_PUBLIC_BASE_URL:?S3_PUBLIC_BASE_URL 이 비어 있습니다. repo secret 을 확인하세요}"
+
             IMAGE="$DOCKERHUB_USERNAME/team3-server:$IMAGE_TAG"
             docker pull "$IMAGE"
 


### PR DESCRIPTION
## Situation
- #200(OCR S3)에서 배포 워크플로우에 `S3_BUCKET`·`S3_PUBLIC_BASE_URL` 환경변수를 추가했는데, 이 값은 앱 부팅 필수값이다.
- CodeRabbit 이 #200 리뷰에서 지적: 두 배포 워크플로우가 **컨테이너를 교체(또는 기존 컨테이너를 내림)하기 전에** 이 값들의 누락을 검증하지 않는다. secret 누락/오타 시 새 컨테이너가 못 떠 배포가 실패하고, 특히 단순 교체 방식인 `deploy-manual` 은 **기존 컨테이너를 먼저 내려** 서비스 다운 위험까지 있다.

## Task
- 배포 시작 단계에서 S3 필수 환경변수 누락을 즉시 잡아(fail-fast) 컨테이너 교체 전에 중단한다.

## Action
- `deploy.yml`·`deploy-manual.yml` 의 `script` 맨 앞에 `: "${S3_BUCKET:?...}"` · `: "${S3_PUBLIC_BASE_URL:?...}"` 가드를 추가 — 값이 비어 있으면 그 줄에서 셸이 즉시 종료된다.
- `deploy.yml`(블루그린)은 비활성 슬롯 기동 전, `deploy-manual`(단순 교체)은 `docker stop` 전에 검증해, 기존 서비스를 내리기 전에 막는다.

## Result
- secret 누락/오타로 인한 배포 실패를 컨테이너 교체 **전에** 잡는다 — 특히 deploy-manual 의 "기존 내림 → 새 컨테이너 부팅 실패 → 다운" 시나리오를 방지.
- #200 리뷰의 CodeRabbit nitpick(#8)을 #209(SG/db drift)와 분리해 별도로 반영한 PR.

---
## 연관 이슈

- close #214

## Updates

### fail-fast 검증을 부팅 필수 env 전체로 확장
- 리뷰 중 "S3 만 검사하고 다른 필수값은 안 막나?" 지적 — 일관성상 부팅 필수 env 전체를 검증해야 맞다. S3 만 막던 것을 `JWT_SECRET`·`GEMINI_API_KEY`·`DB_*`·`REDIS_*` 까지 for 루프로 확장했다. (`15ffee7`)
- 대상 기준: placeholder 없거나(`JWT_SECRET`) Properties `require`(Gemini·S3)로 **비면 부팅이 실패하는 값** + 기본값이 `localhost` 라 운영선 필수인 DB·Redis. `KAKAO/GOOGLE` OAuth·`*_EXPIRY` 등은 빈값 허용(부팅됨)이라 제외 — 가드하면 정상 배포까지 막힌다.

### 검사 대상을 `envs` 전체로 확장 (기준 재정의)
- 위 "부팅 필수만 검사" 기준을 폐기하고, `envs` 로 SSH 세션에 넘기는 값 **전부**(19개)를 검사하도록 확장했다. 판단 기준을 "부팅이 실패하는가"에서 **"운영에 필요한가"** 로 바꾼 결과다. (`c464746`)
- 직전 항목에서 제외했던 `KAKAO_*`·`GOOGLE_*` OAuth secret 도 포함 — 비어도 부팅은 되지만 소셜 로그인이 **조용히 깨진다**. "부팅됨 ≠ 정상 동작" 이므로 가드 대상. `DOCKERHUB_USERNAME`·`IMAGE_TAG`(이미지 식별값)까지 포함해 누락 시 엉뚱한/없는 이미지를 끌어오는 사고도 막는다.
- 매번 일부만 막던 반쪽 가드를 없애고, **넘기는 값 = 검사하는 값** 으로 목록을 단일화해 향후 env 추가 시 가드 누락이 생기지 않게 했다.


