### PR TITLE
OCR Gemini 응답시간 안정화 및 read-timeout 500 누수 차단

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -96,6 +96,7 @@ ISSUE_LABELS=$(gh issue view {번호} --json labels --jq '[.labels[].name] | joi
 - diff에서만 보이는 기계적 변경 나열은 최소화
 - Task 섹션은 Slack PR 봇이 읽으므로, 핵심 작업을 간결하게 요약
 - 한국어로 작성, 기술 용어는 영어 허용
+- **본문에 `~` 를 쓰지 않는다** — GitHub-flavored markdown 이 `~text~` 를 취소선(strikethrough)으로 렌더링해, approximately/범위 의도로 쓴 물결이 두 개 사이 텍스트를 통째로 줄 그어버린다. approximately 는 "약", 범위는 en dash(–) 나 "에서"로 표현.
 - **1단계에서 수집한 `git log` 의 모든 커밋이 STAR(특히 Action)에 빠짐없이 반영됐는지 최종 점검한다.** 해시 명기는 update 모드 전용이지만, "누락된 커밋이 없는지" 점검은 create 모드도 같은 레벨로 거친다 — 기억·추측이 아니라 로그와 대조한다.
 
 **Action 섹션 그룹화 가이드:**

--- a/src/main/kotlin/com/depromeet/piki/ocr/service/gemini/GeminiOcrRequest.kt
+++ b/src/main/kotlin/com/depromeet/piki/ocr/service/gemini/GeminiOcrRequest.kt
@@ -1,5 +1,10 @@
 package com.depromeet.piki.ocr.service.gemini
 
+import com.fasterxml.jackson.annotation.JsonInclude
+
+// Gemini JSON Schema 파서는 `"properties": null` 같은 잉여 null 필드를 스키마 위반으로 취급한다.
+// (GeminiExtractionRequest 와 동일 정책) 직렬화 단계에서 null 필드를 전부 생략한다.
+@JsonInclude(JsonInclude.Include.NON_NULL)
 data class GeminiOcrRequest(
     val generationConfig: GenerationConfig,
     val contents: List<Content>,
@@ -7,6 +12,14 @@ data class GeminiOcrRequest(
     data class GenerationConfig(
         val responseMimeType: String,
         val responseSchema: Schema,
+        // gemini-3.1-flash-lite 는 thinkingLevel 을 명시하지 않으면 dynamic thinking 이 붙어
+        // OCR 같은 단순 추출에도 응답이 간헐적으로 ~20s 까지 튄다 (read-timeout 초과 → 호출 실패).
+        // OCR 은 이미지에서 직접 읽는 작업이라 깊은 추론이 불필요하므로 minimal 로 고정해 ~3s 로 안정화한다.
+        val thinkingConfig: ThinkingConfig,
+    )
+
+    data class ThinkingConfig(
+        val thinkingLevel: String,
     )
 
     data class Content(
@@ -23,6 +36,7 @@ data class GeminiOcrRequest(
         val data: String,
     )
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     data class Schema(
         val type: SchemaType,
         val properties: Map<String, Schema>? = null,
@@ -39,6 +53,9 @@ data class GeminiOcrRequest(
     }
 
     companion object {
+        // OCR 은 이미지에서 직접 정보를 읽는 작업이라 깊은 추론이 불필요하다. dynamic thinking 비활성.
+        private const val MINIMAL_THINKING = "minimal"
+
         private val SYSTEM_PROMPT = """
             You are a product information extractor. The user captured a product page to identify the product they are interested in.
 
@@ -81,6 +98,7 @@ data class GeminiOcrRequest(
                 generationConfig = GenerationConfig(
                     responseMimeType = "application/json",
                     responseSchema = PRODUCT_SCHEMA,
+                    thinkingConfig = ThinkingConfig(thinkingLevel = MINIMAL_THINKING),
                 ),
                 contents = listOf(
                     Content(

--- a/src/main/kotlin/com/depromeet/piki/product/service/gemini/GeminiHttpClient.kt
+++ b/src/main/kotlin/com/depromeet/piki/product/service/gemini/GeminiHttpClient.kt
@@ -5,6 +5,7 @@ import org.springframework.http.client.SimpleClientHttpRequestFactory
 import org.springframework.stereotype.Component
 import org.springframework.web.client.ResourceAccessException
 import org.springframework.web.client.RestClient
+import org.springframework.web.client.RestClientException
 import org.springframework.web.client.RestClientResponseException
 import tools.jackson.databind.ObjectMapper
 
@@ -61,6 +62,11 @@ class GeminiHttpClient(
                 } catch (e: RestClientResponseException) {
                     throw GeminiApiException.fromResponseError(e)
                 } catch (e: ResourceAccessException) {
+                    throw GeminiApiException.upstreamError(e)
+                } catch (e: RestClientException) {
+                    // 응답 본문 추출 중 read-timeout 등은 RestClientResponseException 도 ResourceAccessException 도
+                    // 아닌 raw RestClientException("Error while extracting response", content-type octet-stream)으로 온다.
+                    // 위 두 catch 를 빠져나가 500 으로 새던 것을 막고, transport 장애로 보고 retryable(502)로 분류한다.
                     throw GeminiApiException.upstreamError(e)
                 } ?: throw GeminiApiException.emptyResponse()
 

--- a/src/test/kotlin/com/depromeet/piki/ocr/service/gemini/GeminiOcrRequestTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/ocr/service/gemini/GeminiOcrRequestTest.kt
@@ -1,0 +1,66 @@
+package com.depromeet.piki.ocr.service.gemini
+
+import org.junit.jupiter.api.Test
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.module.kotlin.jacksonObjectMapper
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class GeminiOcrRequestTest {
+    private val objectMapper: ObjectMapper = jacksonObjectMapper()
+
+    @Test
+    fun `forImageAnalysis 요청은 thinkingLevel 을 minimal 로 명시한다`() {
+        // 명시하지 않으면 gemini-3.1-flash-lite 에 dynamic thinking 이 붙어 응답이 ~20s 까지 튄다.
+        val json =
+            objectMapper.writeValueAsString(
+                GeminiOcrRequest.forImageAnalysis(base64Image = "AAAA", mimeType = "image/png"),
+            )
+
+        assertTrue(
+            json.contains("\"thinkingConfig\":{\"thinkingLevel\":\"minimal\"}"),
+            "thinkingLevel minimal 이 직렬화되지 않았다: $json",
+        )
+    }
+
+    @Test
+    fun `요청에 null 값 필드는 직렬화되지 않는다`() {
+        // Gemini JSON Schema 파서는 STRING 타입에 붙은 "items":null 같은 잉여 null 을 스키마 위반으로 취급한다.
+        val json =
+            objectMapper.writeValueAsString(
+                GeminiOcrRequest.forImageAnalysis(base64Image = "AAAA", mimeType = "image/png"),
+            )
+
+        assertFalse(
+            json.contains(":null"),
+            "NON_NULL 정책인데 null 값이 직렬화됐다: $json",
+        )
+    }
+
+    @Test
+    fun `nullable 이 명시된 스키마 필드는 직렬화에 포함된다`() {
+        // null 값 생략(NON_NULL)과 별개로, 의도적으로 박은 nullable=true 는 보존되어야 한다.
+        val json =
+            objectMapper.writeValueAsString(
+                GeminiOcrRequest.forImageAnalysis(base64Image = "AAAA", mimeType = "image/png"),
+            )
+
+        assertTrue(
+            json.contains("\"nullable\":true"),
+            "스키마의 nullable=true 가 누락됐다: $json",
+        )
+    }
+
+    @Test
+    fun `이미지 part 는 inlineData 의 mimeType·data 를 그대로 싣는다`() {
+        val json =
+            objectMapper.writeValueAsString(
+                GeminiOcrRequest.forImageAnalysis(base64Image = "BASE64DATA", mimeType = "image/jpeg"),
+            )
+
+        assertTrue(
+            json.contains("\"inlineData\":{\"mimeType\":\"image/jpeg\",\"data\":\"BASE64DATA\"}"),
+            "inlineData 적재가 어긋났다: $json",
+        )
+    }
+}


### PR DESCRIPTION
## Situation
- 운영 OCR 등록(`POST /api/v1/wishlists/ocr`)이 계속 502 를 반환. 처음엔 OOM·nginx `proxy_read_timeout` 을 의심했으나, 운영 로그(컨테이너 정상 생존 + `GeminiApiException`)로 둘 다 기각
- 502 의 실체는 Gemini API 가 4xx 를 돌려준 것(`GeminiApiException.httpStatus = BAD_GATEWAY`). 원인은 운영 Gemini API 키 문제였고, 키 교체 후 502 는 사라졌으나 이번엔 500 이 드러남
- 500 의 정체는 read-timeout — 키가 유효해지자 Gemini 가 실제 이미지 추론을 시작했는데 30s read-timeout 을 초과. 운영 스택트레이스에서 `SocketTimeoutException: Read timed out` 확인

## Task
- 키 교체로 드러난 OCR read-timeout 을 근본 해결하고, 타임아웃이 500 으로 새던 예외 분류를 정정

## Action
### 근본 — 응답시간 안정화
- 실측: 같은 OCR 요청이 `thinkingLevel` 미명시 시 1.4–19.6s 로 크게 변동(가끔 30s 초과), `thinkingLevel: minimal` 명시 시 1.4–3.1s 로 안정. 문서상 minimal 이 flash-lite 기본이라지만 미명시 시 dynamic thinking 이 붙어 튄다
- `GeminiOcrRequest` 에 `thinkingConfig.thinkingLevel = "minimal"` 명시 — OCR 은 이미지에서 직접 읽어 깊은 추론이 불필요하다

### 안전망 — 타임아웃 예외 분류
- 응답 본문 추출 단계의 read-timeout 은 `RestClientResponseException`·`ResourceAccessException` 이 아닌 raw `RestClientException`("Error while extracting response", content-type `octet-stream`)으로 와서 `GeminiHttpClient` 의 기존 두 catch 를 빠져나가 500 으로 샜다. 원래 의도(read-timeout = retryable → 502)를 우회한 버그
- `RestClientException` catch 를 추가해 transport 장애로 보고 retryable(502)로 일관 분류 + 재시도 경로 진입

### 부수 정정
- `GeminiOcrRequest` 에 `@JsonInclude(NON_NULL)` 누락 발견 — `GeminiExtractionRequest` 와 달리 잉여 null(`properties`/`items` 등)을 그대로 보내고 있었고, Gemini JSON Schema 파서는 이를 위반으로 취급한다. 동일 정책으로 정정

## Result
- OCR Gemini 응답이 약 3s 로 안정화돼 30s read-timeout 초과가 사실상 소멸
- 만일의 타임아웃도 500 이 아닌 502(retryable)로 일관 처리
- 단위 테스트 4건 추가(직렬화: thinkingLevel 명시 · NON_NULL 잉여 null 생략 · nullable 보존 · inlineData 적재), 단위+통합 전체 통과
- 주의: 코드 변경이라 `dev` 머지·배포 후에야 운영 OCR 에 반영된다 (현재 운영 500 은 배포 파이프라인을 타야 해소)

---
## 연관 이슈

- 


## Updates
### PR 스킬 보강
- 본문 작성 시 물결(`~`) 사용 금지 규칙을 `/pr` 스킬 작성 지침에 추가 — GitHub 가 `~text~` 를 취소선으로 렌더링해, approximately/범위 의도의 물결이 두 텍스트 사이를 줄 그어버리는 문제(이 PR 초기 본문에서 실제 발생) (`9114c8d`)
