### PR TITLE
위시리스트 등록 비동기화 및 아이템 파싱 상태 도입

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/PikiApplication.kt
+++ b/src/main/kotlin/com/depromeet/piki/PikiApplication.kt
@@ -3,9 +3,11 @@ package com.depromeet.piki
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
+import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
+@EnableScheduling
 class PikiApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/com/depromeet/piki/common/config/AsyncConfig.kt
+++ b/src/main/kotlin/com/depromeet/piki/common/config/AsyncConfig.kt
@@ -1,0 +1,30 @@
+package com.depromeet.piki.common.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableAsync
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+import java.util.concurrent.Executor
+
+// 등록 시 item 파싱(외부 LLM 호출, read-timeout 60s)을 HTTP 응답과 분리해 백그라운드로 돌리기 위한 executor.
+// 단일 인스턴스 MVP 기준의 보수적 풀 크기다. 운영 트래픽이 보이면 application.yml 로 빼 튜닝한다.
+@Configuration
+@EnableAsync
+class AsyncConfig {
+    @Bean(ITEM_PARSING_EXECUTOR)
+    fun itemParsingExecutor(): Executor =
+        ThreadPoolTaskExecutor().apply {
+            corePoolSize = 4
+            maxPoolSize = 8
+            queueCapacity = 100
+            setThreadNamePrefix("item-parsing-")
+            // 포화 시 기본 AbortPolicy 로 거부한다. 호출 스레드(톰캣)에서 동기 실행하는 CallerRunsPolicy 는
+            // 외부 LLM 호출(최대 60s)로 톰캣 워커 풀을 고갈시켜 무관한 API 까지 번지므로 쓰지 않는다.
+            // 거부는 WishlistService.register 가 잡아 해당 item 을 즉시 FAILED 로 떨어뜨린다(PROCESSING 방치 금지).
+            initialize()
+        }
+
+    companion object {
+        const val ITEM_PARSING_EXECUTOR = "itemParsingExecutor"
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/item/domain/Item.kt
+++ b/src/main/kotlin/com/depromeet/piki/item/domain/Item.kt
@@ -112,6 +112,10 @@ class Item(
         log.info("item {} 파싱 실패 → FAILED 전이", getIdOrNull())
     }
 
+    // 파싱이 끝나 추출 결과가 채워진 상태인지. 토너먼트 출전처럼 "완성된 상품만" 을 요구하는 곳에서 쓴다.
+    // PROCESSING(파싱 중)·FAILED(실패)는 false — 이름·가격이 비어 있어 출전에 부적합하다.
+    fun isReady(): Boolean = status == ItemStatus.READY
+
     private fun validate(
         name: String?,
         currentPrice: Int?,

--- a/src/main/kotlin/com/depromeet/piki/item/domain/Item.kt
+++ b/src/main/kotlin/com/depromeet/piki/item/domain/Item.kt
@@ -7,6 +7,8 @@ import com.depromeet.piki.product.service.ProductSnapshot
 import jakarta.persistence.Column
 import jakarta.persistence.Convert
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.Table
 import org.slf4j.LoggerFactory
 
@@ -24,6 +26,7 @@ class Item(
     imageUrl: String? = null,
     currentPrice: Int? = null,
     currency: String? = null,
+    status: ItemStatus = ItemStatus.READY,
 ) : LongBaseEntity() {
     // 사용자가 수정하는 필드 — setter 직접 노출 대신 update() 로만 바꾼다.
     @Column(name = "name", length = 512)
@@ -40,6 +43,14 @@ class Item(
 
     @Column(name = "currency", length = 8)
     var currency: String? = currency
+        protected set
+
+    // 파싱 생애주기. 전이는 markReady/markFailed 로만 일어난다 (setter 비노출).
+    // 기본값 READY 는 동기 완성 경로(Item.from)·DB 로딩 행과의 호환을 위한 것이고,
+    // 비동기 등록은 Item.processing 으로 PROCESSING 을 명시한다.
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 16)
+    var status: ItemStatus = status
         protected set
 
     // 엔티티 불변식 — 최후의 보루. 정상 흐름에선 입력 경계(요청 DTO 검증 등)가 먼저
@@ -81,6 +92,26 @@ class Item(
         this.currency = newCurrency
     }
 
+    // PROCESSING → READY. 백그라운드 파싱이 성공해 추출 결과(snapshot)를 채우며 전이한다.
+    // 전이 가능 상태가 아닌데 호출되면 워커가 잘못된 item 을 집은 코드 버그이므로 check(500).
+    fun markReady(snapshot: ProductSnapshot) {
+        check(status == ItemStatus.PROCESSING) { "PROCESSING 이 아닌 item(status=$status)은 READY 로 전이할 수 없다" }
+        update(
+            name = snapshot.name,
+            currentPrice = snapshot.currentPrice,
+            imageUrl = snapshot.imageUrl,
+            currency = snapshot.currency,
+        )
+        status = ItemStatus.READY
+    }
+
+    // PROCESSING → FAILED. 파싱 실패(상품 아님·신뢰 불가·타임아웃)를 동기 400 대신 상태로 남긴다.
+    fun markFailed() {
+        check(status == ItemStatus.PROCESSING) { "PROCESSING 이 아닌 item(status=$status)은 FAILED 로 전이할 수 없다" }
+        status = ItemStatus.FAILED
+        log.info("item {} 파싱 실패 → FAILED 전이", getIdOrNull())
+    }
+
     private fun validate(
         name: String?,
         currentPrice: Int?,
@@ -99,6 +130,7 @@ class Item(
         private const val IMAGE_URL_MAX_LENGTH = 2048
         private const val CURRENCY_MAX_LENGTH = 8
 
+        // 동기 완성 경로 — 이미 추출이 끝난 snapshot 으로 READY 상태 item 을 만든다 (OCR 등록 등).
         // URL 추출이든 OCR 추출이든 ProductSnapshot 으로 통일돼 들어온다. OCR 은 link 가 null 일 뿐.
         fun from(snapshot: ProductSnapshot): Item =
             Item(
@@ -107,6 +139,10 @@ class Item(
                 imageUrl = snapshot.imageUrl,
                 currentPrice = snapshot.currentPrice,
                 currency = snapshot.currency,
+                status = ItemStatus.READY,
             )
+
+        // 비동기 등록 시작점 — link 만 가진 PROCESSING item. 파싱이 끝나면 markReady/markFailed 로 전이한다.
+        fun processing(link: ProductLink): Item = Item(link = link, status = ItemStatus.PROCESSING)
     }
 }

--- a/src/main/kotlin/com/depromeet/piki/item/domain/ItemStatus.kt
+++ b/src/main/kotlin/com/depromeet/piki/item/domain/ItemStatus.kt
@@ -1,0 +1,15 @@
+package com.depromeet.piki.item.domain
+
+// item 의 파싱 생애주기. 등록은 외부 LLM 추출(긴 latency)을 백그라운드로 미루므로,
+// 클라이언트가 "담는 중 / 완성 / 등록 실패" 를 구분할 수 있도록 상태를 서버가 명시적으로 갖는다.
+enum class ItemStatus {
+    // 등록 직후. 파싱이 진행 중이며 name·currentPrice·imageUrl 은 아직 비어 있다.
+    PROCESSING,
+
+    // 파싱 완료. 추출된 상품 정보가 채워졌다.
+    READY,
+
+    // 파싱 실패. 상품 페이지가 아니거나(notProductPage) 추출값을 신뢰할 수 없거나(untrustworthyValue)
+    // 인스턴스 크래시 등으로 타임아웃됐다. 동기 400 이 아니라 상태로 표현해 클라이언트가 폴링으로 인지한다.
+    FAILED,
+}

--- a/src/main/kotlin/com/depromeet/piki/item/repository/ItemJpaRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/item/repository/ItemJpaRepository.kt
@@ -1,6 +1,16 @@
 package com.depromeet.piki.item.repository
 
 import com.depromeet.piki.item.domain.Item
+import com.depromeet.piki.item.domain.ItemStatus
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.time.LocalDateTime
 
-interface ItemJpaRepository : JpaRepository<Item, Long>
+interface ItemJpaRepository : JpaRepository<Item, Long> {
+    @Query("select i.id from Item i where i.status = :status and i.createdAt < :cutoff and i.deletedAt is null")
+    fun findIdsByStatusAndCreatedAtBefore(
+        @Param("status") status: ItemStatus,
+        @Param("cutoff") cutoff: LocalDateTime,
+    ): List<Long>
+}

--- a/src/main/kotlin/com/depromeet/piki/item/repository/ItemRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/item/repository/ItemRepository.kt
@@ -1,6 +1,7 @@
 package com.depromeet.piki.item.repository
 
 import com.depromeet.piki.item.domain.Item
+import java.time.LocalDateTime
 
 interface ItemRepository {
     fun save(item: Item): Item
@@ -8,4 +9,7 @@ interface ItemRepository {
     fun findByIds(ids: List<Long>): List<Item>
 
     fun findById(id: Long): Item?
+
+    // cutoff 이전에 생성됐는데 아직 PROCESSING 인 item — 워커가 죽어 방치된 stale 후보의 id.
+    fun findStaleProcessingIds(cutoff: LocalDateTime): List<Long>
 }

--- a/src/main/kotlin/com/depromeet/piki/item/repository/ItemRepositoryImpl.kt
+++ b/src/main/kotlin/com/depromeet/piki/item/repository/ItemRepositoryImpl.kt
@@ -1,7 +1,9 @@
 package com.depromeet.piki.item.repository
 
 import com.depromeet.piki.item.domain.Item
+import com.depromeet.piki.item.domain.ItemStatus
 import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
 
 @Repository
 class ItemRepositoryImpl(
@@ -12,4 +14,7 @@ class ItemRepositoryImpl(
     override fun findByIds(ids: List<Long>): List<Item> = itemJpaRepository.findAllById(ids)
 
     override fun findById(id: Long): Item? = itemJpaRepository.findById(id).orElse(null)
+
+    override fun findStaleProcessingIds(cutoff: LocalDateTime): List<Long> =
+        itemJpaRepository.findIdsByStatusAndCreatedAtBefore(ItemStatus.PROCESSING, cutoff)
 }

--- a/src/main/kotlin/com/depromeet/piki/item/service/AsyncItemParsingWorker.kt
+++ b/src/main/kotlin/com/depromeet/piki/item/service/AsyncItemParsingWorker.kt
@@ -1,0 +1,73 @@
+package com.depromeet.piki.item.service
+
+import com.depromeet.piki.common.config.AsyncConfig
+import com.depromeet.piki.product.domain.ProductLink
+import com.depromeet.piki.product.service.ProductLinkExtractor
+import com.depromeet.piki.product.service.ProductSnapshot
+import com.depromeet.piki.product.service.ProductSnapshotException
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+
+// itemParsingExecutor 스레드에서 파싱을 수행한다. 외부 호출(extract)은 트랜잭션 바깥에서 끝내고,
+// 상태 전이 영속화만 ItemParsingService(@Transactional) 에 위임해 짧은 트랜잭션으로 묶는다.
+// 전이 호출(markReady/markFailed)은 모두 runCatching 으로 감싸 워커 스레드로 예외가 새지 않게 한다
+// (sweeper 와의 레이스로 이미 전이됐거나, 추출값이 도메인 불변식을 위반하는 경우).
+@Component
+class AsyncItemParsingWorker(
+    private val productLinkExtractor: ProductLinkExtractor,
+    private val itemParsingService: ItemParsingService,
+) : ItemParsingWorker {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Async(AsyncConfig.ITEM_PARSING_EXECUTOR)
+    override fun parse(
+        itemId: Long,
+        link: ProductLink,
+    ) {
+        val started = System.nanoTime()
+        runCatching { productLinkExtractor.extract(link) }
+            .onSuccess { snapshot -> onExtracted(itemId, link, snapshot, started) }
+            .onFailure { e -> onExtractFailed(itemId, link, e) }
+    }
+
+    private fun onExtracted(
+        itemId: Long,
+        link: ProductLink,
+        snapshot: ProductSnapshot,
+        started: Long,
+    ) {
+        val elapsedMs = (System.nanoTime() - started) / 1_000_000
+        // 전이가 실패(추출값 도메인 검증 위반·DB 오류·sweeper 와의 레이스로 이미 전이됨)해도 예외를 흡수한다.
+        runCatching { itemParsingService.markReady(itemId, snapshot) }
+            .onSuccess { log.info("item {} 파싱 완료: latency={}ms url={}", itemId, elapsedMs, link.safeLogString()) }
+            .onFailure { e ->
+                // 추출은 됐으나 값을 신뢰할 수 없어 READY 로 채울 수 없는 경우 → PROCESSING 방치 대신 FAILED 로.
+                log.warn("item {} READY 전이 실패 → FAILED: url={}", itemId, link.safeLogString(), e)
+                markFailedQuietly(itemId)
+            }
+    }
+
+    // 파싱 실패는 동기 400 이 아니라 FAILED 상태로 남긴다. 사유에 따라 로그 레벨만 구분한다.
+    private fun onExtractFailed(
+        itemId: Long,
+        link: ProductLink,
+        e: Throwable,
+    ) {
+        when (e) {
+            // 상품 아님·추출값 신뢰 불가 — 클라이언트 입력 계약 위반이라 서버 입장에선 정상 동작(info).
+            is ProductSnapshotException ->
+                log.info("item {} 파싱 실패(계약): {} url={}", itemId, e.message, link.safeLogString())
+            // 외부 호출 실패(네트워크·timeout 등) — warn.
+            else ->
+                log.warn("item {} 파싱 실패(외부 호출): url={}", itemId, link.safeLogString(), e)
+        }
+        markFailedQuietly(itemId)
+    }
+
+    // FAILED 전이도 sweeper 와의 레이스로 실패할 수 있어(이미 전이됨) 잡아 흡수한다.
+    private fun markFailedQuietly(itemId: Long) {
+        runCatching { itemParsingService.markFailed(itemId) }
+            .onFailure { e -> log.info("item {} 는 이미 전이됨, FAILED 처리 생략: {}", itemId, e.message) }
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/item/service/ItemParsingService.kt
+++ b/src/main/kotlin/com/depromeet/piki/item/service/ItemParsingService.kt
@@ -1,0 +1,30 @@
+package com.depromeet.piki.item.service
+
+import com.depromeet.piki.item.repository.ItemRepository
+import com.depromeet.piki.product.service.ProductSnapshot
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+// 파싱 결과의 상태 전이만 짧은 트랜잭션으로 영속화한다 (전이는 dirty checking 으로 커밋 시 반영).
+// 외부 호출(extract)은 워커가 트랜잭션 바깥에서 끝낸다. 워커(@Async)와 별도 빈으로 두어
+// AOP proxy 를 거치게 한다(self-invocation 회피).
+@Service
+class ItemParsingService(
+    private val itemRepository: ItemRepository,
+) {
+    @Transactional
+    fun markReady(
+        itemId: Long,
+        snapshot: ProductSnapshot,
+    ) {
+        // 워커가 방금 저장한 PROCESSING item 을 전이시킨다. 없으면 영속화 경로가 깨진 코드 버그다.
+        val item = itemRepository.findById(itemId) ?: error("파싱 대상 item $itemId 가 없다")
+        item.markReady(snapshot)
+    }
+
+    @Transactional
+    fun markFailed(itemId: Long) {
+        val item = itemRepository.findById(itemId) ?: error("파싱 대상 item $itemId 가 없다")
+        item.markFailed()
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/item/service/ItemParsingWorker.kt
+++ b/src/main/kotlin/com/depromeet/piki/item/service/ItemParsingWorker.kt
@@ -1,0 +1,14 @@
+package com.depromeet.piki.item.service
+
+import com.depromeet.piki.product.domain.ProductLink
+
+// 등록 직후 PROCESSING item 의 파싱을 백그라운드로 수행하는 경계.
+// 호출 즉시 반환하고 실제 파싱(외부 LLM 호출)은 비동기로 진행되어 item 을 READY/FAILED 로 전이시킨다.
+// 구현(@Async)을 인터페이스 뒤에 두어, 추후 메시지 큐 기반 워커로 교체하더라도
+// 호출부(WishlistService)가 바뀌지 않게 한다.
+interface ItemParsingWorker {
+    fun parse(
+        itemId: Long,
+        link: ProductLink,
+    )
+}

--- a/src/main/kotlin/com/depromeet/piki/item/service/StaleProcessingItemSweeper.kt
+++ b/src/main/kotlin/com/depromeet/piki/item/service/StaleProcessingItemSweeper.kt
@@ -1,0 +1,46 @@
+package com.depromeet.piki.item.service
+
+import com.depromeet.piki.item.repository.ItemRepository
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import java.time.LocalDateTime
+
+// 인스턴스 재시작·크래시로 워커가 죽으면 PROCESSING 으로 영원히 남는 item 이 생긴다.
+// 정상 파싱 시간(외부 LLM read-timeout 60s)을 충분히 넘긴 PROCESSING 을 주기적으로 FAILED 로 쓸어낸다.
+// 단일 인스턴스 기준의 @Scheduled 다. 멀티 인스턴스로 확장되면 중복 실행 방지(ShedLock 등)가 필요하다.
+@Component
+class StaleProcessingItemSweeper(
+    private val itemRepository: ItemRepository,
+    private val itemParsingService: ItemParsingService,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Scheduled(fixedDelay = SWEEP_INTERVAL_MS)
+    fun sweep() {
+        val cutoff = LocalDateTime.now().minusMinutes(STALE_TIMEOUT_MINUTES)
+        val staleIds = itemRepository.findStaleProcessingIds(cutoff)
+        if (staleIds.isEmpty()) return
+        // sweep 이 조회한 직후 워커가 막 READY/FAILED 로 전이했을 수 있다(레이스).
+        // 그 경우 markFailed 의 전이 불변식(check)이 깨지므로 잡아 무시한다 — 이미 정상 종료된 것이다.
+        // 정리/스킵 건수를 분리해 로그하므로 부분 실패가 전체 성공으로 가려지지 않는다.
+        val skipped =
+            staleIds.count { itemId ->
+                runCatching { itemParsingService.markFailed(itemId) }
+                    .onFailure { e -> log.info("item {} 는 이미 전이됨, stale 정리 생략: {}", itemId, e.message) }
+                    .isFailure
+            }
+        log.warn(
+            "stale PROCESSING {}건 중 {}건 FAILED 정리, {}건은 이미 전이됨(레이스)",
+            staleIds.size,
+            staleIds.size - skipped,
+            skipped,
+        )
+    }
+
+    companion object {
+        // 정상 파싱이 끝났어야 할 시간을 넉넉히 넘긴 기준. 이보다 오래 PROCESSING 이면 방치된 것으로 본다.
+        private const val STALE_TIMEOUT_MINUTES = 5L
+        private const val SWEEP_INTERVAL_MS = 60_000L
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
@@ -40,7 +40,9 @@ interface TournamentApi {
 
     @Operation(
         summary = "토너먼트 아이템 추가",
-        description = "PENDING 상태의 토너먼트에 아이템을 추가한다. 토너먼트 참여자만 추가할 수 있다.",
+        description =
+            "PENDING 상태의 토너먼트에 아이템을 추가한다. 토너먼트 참여자만 추가할 수 있다. " +
+                "파싱이 끝난 READY 아이템만 추가할 수 있으며, 아직 파싱 중(PROCESSING)이거나 실패(FAILED)한 아이템은 409 로 거부된다.",
     )
     @ApiResponse(
         responseCode = "200",

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentException.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentException.kt
@@ -88,5 +88,14 @@ class TournamentException private constructor(
                 ErrorCategory.NOT_FOUND,
                 HttpStatus.NOT_FOUND,
             )
+
+        // 비동기 파싱이 끝나지 않은(PROCESSING) 또는 실패한(FAILED) 상품을 토너먼트에 추가하려 한 경우.
+        // 곧 READY 가 되거나 영구 실패라 현재 상태와 충돌 → 409.
+        fun itemNotReady(): TournamentException =
+            TournamentException(
+                "아직 준비되지 않은 상품은 토너먼트에 추가할 수 없습니다.",
+                ErrorCategory.CONFLICT,
+                HttpStatus.CONFLICT,
+            )
     }
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
@@ -68,8 +68,11 @@ class TournamentService(
         if (existingItemIds.size + command.itemIds.size > MAX_ITEM_COUNT) {
             throw TournamentException.tooManyTournamentItems()
         }
-        val foundItemIds = itemRepository.findByIds(command.itemIds).map { it.getId() }.toSet()
+        val foundItems = itemRepository.findByIds(command.itemIds)
+        val foundItemIds = foundItems.map { it.getId() }.toSet()
         if (command.itemIds.any { it !in foundItemIds }) throw TournamentException.notFoundItems()
+        // 비동기 파싱 중(PROCESSING)이거나 실패(FAILED)한 상품은 이름·가격이 비어 출전에 부적합하다. READY 만 허용.
+        if (foundItems.any { !it.isReady() }) throw TournamentException.itemNotReady()
         tournamentItemRepository.saveAll(
             command.itemIds.map { itemId ->
                 TournamentItem(tournamentId = command.tournamentId, itemId = itemId, userId = userId)

--- a/src/main/kotlin/com/depromeet/piki/wishlist/controller/WishlistApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/wishlist/controller/WishlistApi.kt
@@ -20,14 +20,17 @@ interface WishlistApi {
     @Operation(
         summary = "위시리스트 등록",
         description = """
-            상품 페이지 URL 을 받아 메타데이터(이름/가격/이미지 등)를 추출한 뒤 유저의 위시리스트에 등록한다.
+            상품 페이지 URL 을 받아 위시리스트에 등록한다. 메타데이터(이름/가격/이미지) 추출은 외부 LLM 호출이라
+            오래 걸리므로 동기로 기다리지 않는다. 등록 즉시 item.status=PROCESSING 인 항목을 201 로 반환하고,
+            실제 파싱은 백그라운드에서 진행되어 READY(완료) 또는 FAILED(파싱 실패) 로 전이한다.
+            클라이언트는 위시리스트 조회를 폴링해 status 변화를 확인한다. URL 형식 오류는 등록 전에 400 으로 거른다.
         """,
     )
     @ApiResponses(
         value = [
             ApiResponse(
                 responseCode = "201",
-                description = "위시리스트 등록 성공",
+                description = "위시리스트 등록 접수 (item.status=PROCESSING, 파싱은 백그라운드)",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,
@@ -59,6 +62,8 @@ interface WishlistApi {
             cursor 페이지네이션: 직전 응답의 pageResponse.nextCursor 를 다음 요청 cursor 로 그대로 전달한다.
             마지막 페이지면 nextCursor 는 null, hasNext 는 false.
             size 는 미지정 시 20, 1~50 범위를 벗어나면 양 끝으로 보정된다.
+            각 항목의 item.status 로 파싱 상태(PROCESSING/READY/FAILED)를 구분한다 —
+            등록 직후 PROCESSING 인 항목은 이 조회를 폴링해 READY/FAILED 로 전이되는지 확인한다.
         """,
     )
     @ApiResponses(

--- a/src/main/kotlin/com/depromeet/piki/wishlist/controller/WishlistApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/wishlist/controller/WishlistApiExamples.kt
@@ -6,6 +6,7 @@ import com.depromeet.piki.common.openapi.binds
 import com.depromeet.piki.common.openapi.examples
 import com.depromeet.piki.common.response.ApiResponseBody
 import com.depromeet.piki.common.response.PageResponse
+import com.depromeet.piki.item.domain.ItemStatus
 import com.depromeet.piki.ocr.domain.OcrImage
 import com.depromeet.piki.wishlist.controller.dto.WishItemResponse
 import org.springdoc.core.customizers.OperationCustomizer
@@ -25,8 +26,8 @@ class WishlistApiExamples(
                 operation.examples(openApiObjectMapper.delegate) {
                     add(
                         status = HttpStatus.CREATED,
-                        name = "등록 성공",
-                        payload = ApiResponseBody.created(sampleEntry),
+                        name = "등록 접수 (파싱 중)",
+                        payload = ApiResponseBody.created(processingSampleEntry),
                     )
                     add(
                         status = HttpStatus.BAD_REQUEST,
@@ -44,10 +45,10 @@ class WishlistApiExamples(
                 operation.examples(openApiObjectMapper.delegate) {
                     add(
                         status = HttpStatus.OK,
-                        name = "조회 성공 (마지막 페이지)",
+                        name = "조회 성공 (담는 중 + 완성 혼재, 마지막 페이지)",
                         payload =
                             ApiResponseBody.ok(
-                                data = listOf(sampleEntry),
+                                data = listOf(processingSampleEntry, sampleEntry),
                                 pageResponse = PageResponse(nextCursor = null, hasNext = false),
                             ),
                     )
@@ -171,6 +172,7 @@ class WishlistApiExamples(
             operation
         }
 
+    // 파싱이 끝난 완성 항목 (READY).
     private val sampleEntry =
         WishItemResponse(
             wish =
@@ -181,6 +183,7 @@ class WishlistApiExamples(
             item =
                 WishItemResponse.ItemView(
                     id = 512,
+                    status = ItemStatus.READY,
                     name = "에어 조던 1 미드",
                     currentPrice = 119_000,
                     currency = "KRW",
@@ -189,7 +192,27 @@ class WishlistApiExamples(
                 ),
         )
 
-    // OCR 등록 항목 — URL·이미지·통화가 없어 해당 필드가 null 이다.
+    // 등록 직후 파싱 중 항목 (PROCESSING) — link 만 있고 name·가격·이미지는 아직 비어 있다.
+    private val processingSampleEntry =
+        WishItemResponse(
+            wish =
+                WishItemResponse.WishView(
+                    id = 1026,
+                    createdAt = LocalDateTime.of(2026, 5, 21, 10, 10, 0),
+                ),
+            item =
+                WishItemResponse.ItemView(
+                    id = 514,
+                    status = ItemStatus.PROCESSING,
+                    name = null,
+                    currentPrice = null,
+                    currency = null,
+                    imageUrl = null,
+                    sourceUrl = "https://www.example-shop.com/products/67890",
+                ),
+        )
+
+    // OCR 등록 항목 — URL·이미지·통화가 없어 해당 필드가 null 이다. 동기 완성이라 READY.
     private val ocrSampleEntry =
         WishItemResponse(
             wish =
@@ -200,6 +223,7 @@ class WishlistApiExamples(
             item =
                 WishItemResponse.ItemView(
                     id = 513,
+                    status = ItemStatus.READY,
                     name = "에어 조던 1 미드",
                     currentPrice = 119_000,
                     currency = null,

--- a/src/main/kotlin/com/depromeet/piki/wishlist/controller/dto/WishItemResponse.kt
+++ b/src/main/kotlin/com/depromeet/piki/wishlist/controller/dto/WishItemResponse.kt
@@ -1,6 +1,7 @@
 package com.depromeet.piki.wishlist.controller.dto
 
 import com.depromeet.piki.item.domain.Item
+import com.depromeet.piki.item.domain.ItemStatus
 import com.depromeet.piki.wishlist.domain.Wish
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
@@ -43,14 +44,19 @@ data class WishItemResponse(
     data class ItemView(
         @field:Schema(description = "상품 ID", example = "512")
         val id: Long,
-        @field:Schema(description = "상품명 (추출 실패 시 null)", example = "에어 조던 1 미드", nullable = true)
+        @field:Schema(
+            description = "파싱 상태 — PROCESSING(담는 중)/READY(완료)/FAILED(파싱 실패). PROCESSING 동안은 name·currentPrice·imageUrl 이 비어 있다.",
+            example = "READY",
+        )
+        val status: ItemStatus,
+        @field:Schema(description = "상품명 (PROCESSING·실패 시 null)", example = "에어 조던 1 미드", nullable = true)
         val name: String?,
-        @field:Schema(description = "스냅샷 시점의 현재 판매가", example = "119000", nullable = true)
+        @field:Schema(description = "스냅샷 시점의 현재 판매가 (PROCESSING·실패 시 null)", example = "119000", nullable = true)
         val currentPrice: Int?,
         @field:Schema(description = "통화 코드 (ISO 4217)", example = "KRW", nullable = true)
         val currency: String?,
         @field:Schema(
-            description = "상품 대표 이미지 URL",
+            description = "상품 대표 이미지 URL (PROCESSING·실패 시 null)",
             example = "https://cdn.example.com/p/512.jpg",
             nullable = true,
         )
@@ -66,6 +72,7 @@ data class WishItemResponse(
             fun from(item: Item): ItemView =
                 ItemView(
                     id = item.getId(),
+                    status = item.status,
                     name = item.name,
                     currentPrice = item.currentPrice,
                     currency = item.currency,

--- a/src/main/kotlin/com/depromeet/piki/wishlist/service/WishlistService.kt
+++ b/src/main/kotlin/com/depromeet/piki/wishlist/service/WishlistService.kt
@@ -3,12 +3,12 @@ package com.depromeet.piki.wishlist.service
 import com.depromeet.piki.common.storage.ImageStorage
 import com.depromeet.piki.item.domain.Item
 import com.depromeet.piki.item.repository.ItemRepository
+import com.depromeet.piki.item.service.ItemParsingService
+import com.depromeet.piki.item.service.ItemParsingWorker
 import com.depromeet.piki.ocr.domain.OcrImage
 import com.depromeet.piki.ocr.service.ImageCropper
 import com.depromeet.piki.ocr.service.ProductImageExtractor
 import com.depromeet.piki.product.domain.ProductLink
-import com.depromeet.piki.product.service.ProductLinkExtractor
-import com.depromeet.piki.product.service.ProductSnapshot
 import com.depromeet.piki.wishlist.domain.WishCursor
 import com.depromeet.piki.wishlist.domain.WishException
 import com.depromeet.piki.wishlist.domain.WishlistSize
@@ -23,26 +23,34 @@ import java.util.UUID
 
 @Service
 class WishlistService(
-    private val productLinkExtractor: ProductLinkExtractor,
     private val productImageExtractor: ProductImageExtractor,
     private val imageCropper: ImageCropper,
     private val imageStorage: ImageStorage,
+    private val itemParsingWorker: ItemParsingWorker,
+    private val itemParsingService: ItemParsingService,
     private val wishPersistenceService: WishPersistenceService,
     private val wishRepository: WishRepository,
     private val itemRepository: ItemRepository,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
-    // register 전체를 @Transactional 로 묶으면 외부 fetch + Gemini 호출 (read-timeout 60s)
-    // 동안 DB 커넥션이 잡혀 풀 고갈 → 다른 API 까지 latency 폭증으로 번진다.
-    // 외부 호출은 트랜잭션 바깥에서 끝내고, 영속화는 별도 빈에 위임해 proxy 를 통해 호출.
+    // register 는 외부 LLM 호출(read-timeout 60s)을 동기로 기다리지 않는다.
+    // link 만 가진 PROCESSING item 을 즉시 저장해 응답을 돌려주고(클라이언트는 "담는 중" 표시),
+    // 실제 파싱은 itemParsingWorker 가 백그라운드에서 수행해 READY/FAILED 로 전이시킨다.
+    // URL 형식 같은 계약 위반은 ProductLink.parse 가 동기로 거른다(400). 파싱 결과 실패만 FAILED 로 간다.
     fun register(
         rawUrl: String,
         userId: UUID,
     ): WishWithItem {
         val link = ProductLink.parse(rawUrl)
-        val snapshot = extractWithLatencyLog(link)
-        return wishPersistenceService.persist(userId, Item.from(snapshot))
+        val result = wishPersistenceService.persist(userId, Item.processing(link))
+        // 워커 디스패치가 큐 포화 등으로 거부되면 PROCESSING 으로 방치하지 않고 즉시 FAILED 로 떨어뜨린다.
+        runCatching { itemParsingWorker.parse(result.item.getId(), link) }
+            .onFailure { e ->
+                log.warn("파싱 워커 디스패치 실패, item {} 를 FAILED 처리: {}", result.item.getId(), e.message)
+                itemParsingService.markFailed(result.item.getId())
+            }
+        return result
     }
 
     // OCR 등록도 link 와 같은 흐름 — 입력이 이미지일 뿐. 외부 추출·크롭·S3 업로드는 트랜잭션 바깥, 영속화만 위임.
@@ -122,13 +130,5 @@ class WishlistService(
         val wish = wishRepository.findById(wishId) ?: throw WishException.notFound()
         wish.verifyOwnedBy(userId)
         wish.delete()
-    }
-
-    private fun extractWithLatencyLog(link: ProductLink): ProductSnapshot {
-        val started = System.nanoTime()
-        val snapshot = productLinkExtractor.extract(link)
-        val elapsedMs = (System.nanoTime() - started) / 1_000_000
-        log.info("extract latency: total={}ms url={}", elapsedMs, link.safeLogString())
-        return snapshot
     }
 }

--- a/src/main/resources/db/migration/V20260525202913__add_status_to_items.sql
+++ b/src/main/resources/db/migration/V20260525202913__add_status_to_items.sql
@@ -1,0 +1,5 @@
+-- items 에 파싱 상태(status) 컬럼 추가.
+-- PROCESSING(등록 직후 파싱 중) / READY(파싱 완료) / FAILED(파싱 실패) 를 ItemStatus enum 의 name 으로 저장한다.
+-- 기존 행은 모두 추출이 끝난 완성 상품이므로 READY 로 backfill 한다 (DEFAULT 'READY').
+ALTER TABLE items
+    ADD COLUMN status VARCHAR(16) NOT NULL DEFAULT 'READY';

--- a/src/test/kotlin/com/depromeet/piki/item/domain/ItemTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/item/domain/ItemTest.kt
@@ -157,4 +157,74 @@ class ItemTest {
         assertEquals("KRW", item.currency)
         assertNull(item.imageUrl)
     }
+
+    @Test
+    fun `from 으로 만든 item 은 READY 상태다`() {
+        val item = Item.from(ProductSnapshot(link = link, name = "나이키"))
+
+        assertEquals(ItemStatus.READY, item.status)
+    }
+
+    @Test
+    fun `processing 으로 만든 item 은 PROCESSING 상태이며 추출 필드가 비어 있다`() {
+        val item = Item.processing(link)
+
+        assertEquals(ItemStatus.PROCESSING, item.status)
+        assertEquals(link, item.link)
+        assertNull(item.name)
+        assertNull(item.currentPrice)
+        assertNull(item.imageUrl)
+        assertNull(item.currency)
+    }
+
+    @Test
+    fun `PROCESSING item 을 markReady 하면 READY 로 전이하며 추출 결과가 채워진다`() {
+        val item = Item.processing(link)
+
+        item.markReady(
+            ProductSnapshot(
+                link = link,
+                name = "나이키 에어포스",
+                currentPrice = 99_000,
+                currency = "KRW",
+                imageUrl = "https://cdn.example.com/p/42.jpg",
+            ),
+        )
+
+        assertEquals(ItemStatus.READY, item.status)
+        assertEquals("나이키 에어포스", item.name)
+        assertEquals(99_000, item.currentPrice)
+        assertEquals("KRW", item.currency)
+        assertEquals("https://cdn.example.com/p/42.jpg", item.imageUrl)
+    }
+
+    @Test
+    fun `PROCESSING item 을 markFailed 하면 FAILED 로 전이한다`() {
+        val item = Item.processing(link)
+
+        item.markFailed()
+
+        assertEquals(ItemStatus.FAILED, item.status)
+    }
+
+    @Test
+    fun `이미 READY 인 item 을 다시 markReady 하면 전이 불변식 위반으로 거부된다`() {
+        val item = Item.from(ProductSnapshot(link = link, name = "나이키"))
+
+        assertFailsWith<IllegalStateException> { item.markReady(ProductSnapshot(link = link, name = "변경")) }
+    }
+
+    @Test
+    fun `READY 인 item 을 markFailed 하면 전이 불변식 위반으로 거부된다`() {
+        val item = Item.from(ProductSnapshot(link = link, name = "나이키"))
+
+        assertFailsWith<IllegalStateException> { item.markFailed() }
+    }
+
+    @Test
+    fun `FAILED 인 item 을 markReady 하면 전이 불변식 위반으로 거부된다`() {
+        val item = Item.processing(link).apply { markFailed() }
+
+        assertFailsWith<IllegalStateException> { item.markReady(ProductSnapshot(link = link, name = "나이키")) }
+    }
 }

--- a/src/test/kotlin/com/depromeet/piki/item/domain/ItemTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/item/domain/ItemTest.kt
@@ -5,7 +5,9 @@ import com.depromeet.piki.product.service.ProductSnapshot
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class ItemTest {
     private val link = ProductLink.parse("https://shop.example.com/products/42")
@@ -226,5 +228,12 @@ class ItemTest {
         val item = Item.processing(link).apply { markFailed() }
 
         assertFailsWith<IllegalStateException> { item.markReady(ProductSnapshot(link = link, name = "나이키")) }
+    }
+
+    @Test
+    fun `isReady 는 READY 일 때만 true 다`() {
+        assertTrue(Item.from(ProductSnapshot(link = link, name = "나이키")).isReady())
+        assertFalse(Item.processing(link).isReady())
+        assertFalse(Item.processing(link).apply { markFailed() }.isReady())
     }
 }

--- a/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
@@ -2,6 +2,7 @@ package com.depromeet.piki.tournament.controller
 
 import com.depromeet.piki.auth.infrastructure.jwt.JwtProvider
 import com.depromeet.piki.item.domain.Item
+import com.depromeet.piki.item.domain.ItemStatus
 import com.depromeet.piki.item.repository.ItemJpaRepository
 import com.depromeet.piki.support.IntegrationTestSupport
 import com.depromeet.piki.tournament.domain.TournamentItem
@@ -115,6 +116,22 @@ class TournamentControllerTest : IntegrationTestSupport() {
                     .content("""{"itemIds":[999999]}"""),
             ).andExpect(status().isNotFound)
             .andExpect(jsonPath("$.status").value(404))
+    }
+
+    @Test
+    fun `POST tournaments-id-items 에서 아직 파싱 중(PROCESSING)인 아이템이면 409 를 반환한다`() {
+        val mockMvc = buildMockMvc()
+        val tournamentId = createTournament(mockMvc)
+        val processingItemId = itemJpaRepository.save(Item(status = ItemStatus.PROCESSING)).getId()
+
+        mockMvc
+            .perform(
+                post("/api/v1/tournaments/$tournamentId/items")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(userId))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"itemIds":[$processingItemId]}"""),
+            ).andExpect(status().isConflict)
+            .andExpect(jsonPath("$.status").value(409))
     }
 
     @Test

--- a/src/test/kotlin/com/depromeet/piki/tournament/service/TournamentServiceTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/service/TournamentServiceTest.kt
@@ -71,6 +71,8 @@ class TournamentServiceTest {
                 }
             }
         }
+
+        override fun findStaleProcessingIds(cutoff: java.time.LocalDateTime): List<Long> = emptyList()
     }
 
     private class TestUserRepository : UserRepository {

--- a/src/test/kotlin/com/depromeet/piki/wishlist/controller/WishlistControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/wishlist/controller/WishlistControllerIntegrationTest.kt
@@ -1,16 +1,18 @@
 package com.depromeet.piki.wishlist.controller
 
 import com.depromeet.piki.auth.infrastructure.jwt.JwtProvider
+import com.depromeet.piki.item.domain.Item
 import com.depromeet.piki.ocr.domain.BoundingBox
 import com.depromeet.piki.ocr.service.OcrExtraction
+import com.depromeet.piki.product.domain.ProductLink
 import com.depromeet.piki.product.service.ProductSnapshot
 import com.depromeet.piki.product.service.gemini.GeminiApiException
 import com.depromeet.piki.support.IntegrationTestSupport
 import com.depromeet.piki.support.StubImageStorage
 import com.depromeet.piki.support.StubProductImageExtractor
-import com.depromeet.piki.support.StubProductLinkExtractor
 import com.depromeet.piki.support.uuidToBytes
 import com.depromeet.piki.user.domain.IdentityType
+import com.depromeet.piki.wishlist.service.WishPersistenceService
 import org.hamcrest.Matchers.nullValue
 import org.hamcrest.Matchers.startsWith
 import java.awt.image.BufferedImage
@@ -38,6 +40,9 @@ import org.springframework.web.context.WebApplicationContext
 import tools.jackson.databind.ObjectMapper
 import java.util.UUID
 
+// 조회·수정·삭제 contract 검증. 이 시나리오들의 본질은 "완성된 위시가 있을 때의 동작"이라
+// 등록(비동기) 경로를 거치지 않고 seedReadyWish 로 READY 상태를 시딩한다.
+// 등록 PROCESSING 응답·파싱 전이는 WishlistRegisterAsyncIntegrationTest 가 검증한다.
 @Transactional
 class WishlistControllerIntegrationTest : IntegrationTestSupport() {
     @Autowired
@@ -47,10 +52,10 @@ class WishlistControllerIntegrationTest : IntegrationTestSupport() {
     private lateinit var objectMapper: ObjectMapper
 
     @Autowired
-    private lateinit var stubProductLinkExtractor: StubProductLinkExtractor
+    private lateinit var stubProductImageExtractor: StubProductImageExtractor
 
     @Autowired
-    private lateinit var stubProductImageExtractor: StubProductImageExtractor
+    private lateinit var wishPersistenceService: WishPersistenceService
 
     @Autowired
     private lateinit var jdbcTemplate: JdbcTemplate
@@ -75,149 +80,34 @@ class WishlistControllerIntegrationTest : IntegrationTestSupport() {
             .apply<DefaultMockMvcBuilder>(springSecurity())
             .build()
 
-    // POST 로 위시 한 건 등록하고 생성된 wishId 를 돌려준다. 조회 시나리오의 데이터 세팅용.
-    private fun registerWish(
-        mockMvc: MockMvc,
-        authHeader: String,
+    // 조회·수정·삭제 시나리오의 데이터 시딩. 등록 API(비동기)를 거치지 않고 영속화 빈으로 READY item+wish 를
+    // 바로 만든다 — 이 테스트들의 관심사는 "완성된 위시가 있을 때"이지 등록 흐름이 아니기 때문.
+    private fun seedReadyWish(
+        userId: UUID,
         url: String,
         name: String,
-    ): Long {
-        stubProductLinkExtractor.build = { ProductSnapshot(link = it, name = name) }
-        val body = objectMapper.writeValueAsString(mapOf("url" to url))
-        val response =
-            mockMvc
-                .perform(
-                    post("/api/v1/wishlists")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .header(HttpHeaders.AUTHORIZATION, authHeader)
-                        .content(body),
-                ).andExpect(status().isCreated)
-                .andReturn()
-                .response
-                .getContentAsString(Charsets.UTF_8)
-        return objectMapper
-            .readTree(response)
-            .path("data")
-            .path("wish")
-            .path("id")
-            .asLong()
-    }
-
-    @Test
-    fun `정상 등록 - 201 과 함께 추출 결과가 응답에 박힌다`() {
-        val mockMvc =
-            MockMvcBuilders
-                .webAppContextSetup(
-                    webApplicationContext,
-                ).apply<DefaultMockMvcBuilder>(springSecurity())
-                .build()
-        val url = "https://shop.example.com/products/42"
-        val userId = UUID.randomUUID()
-        insertMember(userId)
-        stubProductLinkExtractor.build = { link ->
-            ProductSnapshot(
-                link = link,
-                name = "나이키 에어포스",
-                currentPrice = 99_000,
-                currency = "KRW",
-                imageUrl = "https://cdn.example.com/p/42.jpg",
-            )
-        }
-        val body = objectMapper.writeValueAsString(mapOf("url" to url))
-
-        mockMvc
-            .perform(
-                post("/api/v1/wishlists")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .header(HttpHeaders.AUTHORIZATION, "Bearer ${memberToken(userId)}")
-                    .content(body),
-            ).andExpect(status().isCreated)
-            .andExpect(jsonPath("$.status").value(201))
-            .andExpect(jsonPath("$.code").value("CREATED"))
-            .andExpect(jsonPath("$.data.wish.id").isNumber)
-            .andExpect(jsonPath("$.data.wish.createdAt").exists())
-            .andExpect(jsonPath("$.data.item.name").value("나이키 에어포스"))
-            .andExpect(jsonPath("$.data.item.currentPrice").value(99_000))
-            .andExpect(jsonPath("$.data.item.currency").value("KRW"))
-            .andExpect(jsonPath("$.data.item.imageUrl").value("https://cdn.example.com/p/42.jpg"))
-            .andExpect(jsonPath("$.data.item.sourceUrl").value(url))
-    }
-
-    @Test
-    fun `같은 유저가 같은 URL 을 두 번 등록해도 둘 다 201 로 등록된다`() {
-        // dedup 정책은 #134 (item 독립 엔티티 분리) 에서 제거됨. wish 는 user 가 item 을 위시한 사건으로
-        // 보는 multi-record 모델이라 같은 URL 을 반복 등록해도 별개의 wish row 로 쌓인다.
-        val mockMvc =
-            MockMvcBuilders
-                .webAppContextSetup(
-                    webApplicationContext,
-                ).apply<DefaultMockMvcBuilder>(springSecurity())
-                .build()
-        val url = "https://shop.example.com/products/42"
-        val userId = UUID.randomUUID()
-        insertMember(userId)
-        stubProductLinkExtractor.build = { ProductSnapshot(link = it, name = "기본 상품") }
-        val body = objectMapper.writeValueAsString(mapOf("url" to url))
-        val authHeader = "Bearer ${memberToken(userId)}"
-
-        mockMvc
-            .perform(
-                post("/api/v1/wishlists")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .header(HttpHeaders.AUTHORIZATION, authHeader)
-                    .content(body),
-            ).andExpect(status().isCreated)
-
-        mockMvc
-            .perform(
-                post("/api/v1/wishlists")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .header(HttpHeaders.AUTHORIZATION, authHeader)
-                    .content(body),
-            ).andExpect(status().isCreated)
-    }
-
-    @Test
-    fun `다른 유저가 같은 URL 을 등록하면 둘 다 201 로 등록된다`() {
-        val mockMvc =
-            MockMvcBuilders
-                .webAppContextSetup(
-                    webApplicationContext,
-                ).apply<DefaultMockMvcBuilder>(springSecurity())
-                .build()
-        val url = "https://shop.example.com/products/42"
-        stubProductLinkExtractor.build = { ProductSnapshot(link = it, name = "기본 상품") }
-        val firstUserId = UUID.randomUUID()
-        val secondUserId = UUID.randomUUID()
-        insertMember(firstUserId)
-        insertMember(secondUserId)
-        val body = objectMapper.writeValueAsString(mapOf("url" to url))
-
-        mockMvc
-            .perform(
-                post("/api/v1/wishlists")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .header(HttpHeaders.AUTHORIZATION, "Bearer ${memberToken(firstUserId)}")
-                    .content(body),
-            ).andExpect(status().isCreated)
-
-        mockMvc
-            .perform(
-                post("/api/v1/wishlists")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .header(HttpHeaders.AUTHORIZATION, "Bearer ${memberToken(secondUserId)}")
-                    .content(body),
-            ).andExpect(status().isCreated)
-    }
+        currentPrice: Int? = null,
+        currency: String? = null,
+        imageUrl: String? = null,
+    ): Long =
+        wishPersistenceService
+            .persist(
+                userId,
+                Item.from(
+                    ProductSnapshot(
+                        link = ProductLink.parse(url),
+                        name = name,
+                        currentPrice = currentPrice,
+                        currency = currency,
+                        imageUrl = imageUrl,
+                    ),
+                ),
+            ).wish
+            .getId()
 
     @Test
     fun `url 이 빈 문자열이면 400 BAD_REQUEST 가 반환된다`() {
-        val mockMvc =
-            MockMvcBuilders
-                .webAppContextSetup(
-                    webApplicationContext,
-                ).apply<DefaultMockMvcBuilder>(springSecurity())
-                .build()
+        val mockMvc = buildMockMvc()
         val userId = UUID.randomUUID()
         insertMember(userId)
         val body = objectMapper.writeValueAsString(mapOf("url" to ""))
@@ -235,13 +125,8 @@ class WishlistControllerIntegrationTest : IntegrationTestSupport() {
     fun `잘못된 형식의 url 은 400 BAD_REQUEST 로 응답되며 detail 에 원본 url 이 새지 않는다`() {
         // GlobalExceptionHandler 가 IllegalArgumentException_message 를 응답 detail 에 그대로 박는 구조라
         // ProductLink_parse 가 원본을 메시지에 담으면 쿼리스트링 토큰이 클라이언트 응답으로 새어 나간다.
-        // ProductLink_parse 의 message 정책과 contract 양 끝을 함께 묶어 회귀를 잡는다.
-        val mockMvc =
-            MockMvcBuilders
-                .webAppContextSetup(
-                    webApplicationContext,
-                ).apply<DefaultMockMvcBuilder>(springSecurity())
-                .build()
+        // URL 형식 위반은 등록 전(ProductLink.parse) 동기로 거르므로 백그라운드 파싱에 닿지 않는다.
+        val mockMvc = buildMockMvc()
         val userId = UUID.randomUUID()
         insertMember(userId)
         val rawWithSecret = "data:text/html,<token=SHOULD_NOT_LEAK>"
@@ -278,26 +163,26 @@ class WishlistControllerIntegrationTest : IntegrationTestSupport() {
     }
 
     @Test
-    fun `본인 위시만 최신 등록순으로 반환하고 다른 유저 wish 는 섞이지 않는다`() {
+    fun `본인 위시만 최신 등록순으로 반환하고 다른 유저 wish 는 섞이지 않으며 status 가 함께 내려간다`() {
         val mockMvc = buildMockMvc()
         val ownerId = UUID.randomUUID()
         val otherId = UUID.randomUUID()
         insertMember(ownerId)
         insertMember(otherId)
-        val ownerAuth = "Bearer ${memberToken(ownerId)}"
-        registerWish(mockMvc, ownerAuth, "https://shop.example.com/products/1", "첫 상품")
-        val secondWishId = registerWish(mockMvc, ownerAuth, "https://shop.example.com/products/2", "둘째 상품")
-        registerWish(mockMvc, "Bearer ${memberToken(otherId)}", "https://shop.example.com/products/3", "남의 상품")
+        seedReadyWish(ownerId, "https://shop.example.com/products/1", "첫 상품")
+        val secondWishId = seedReadyWish(ownerId, "https://shop.example.com/products/2", "둘째 상품")
+        seedReadyWish(otherId, "https://shop.example.com/products/3", "남의 상품")
 
         mockMvc
             .perform(
                 get("/api/v1/wishlists")
-                    .header(HttpHeaders.AUTHORIZATION, ownerAuth),
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer ${memberToken(ownerId)}"),
             ).andExpect(status().isOk)
             .andExpect(jsonPath("$.data.length()").value(2))
             // 최신 등록(둘째)이 맨 앞 (id desc)
             .andExpect(jsonPath("$.data[0].wish.id").value(secondWishId))
             .andExpect(jsonPath("$.data[0].item.name").value("둘째 상품"))
+            .andExpect(jsonPath("$.data[0].item.status").value("READY"))
             .andExpect(jsonPath("$.data[1].item.name").value("첫 상품"))
             .andExpect(jsonPath("$.pageResponse.hasNext").value(false))
     }
@@ -307,10 +192,10 @@ class WishlistControllerIntegrationTest : IntegrationTestSupport() {
         val mockMvc = buildMockMvc()
         val userId = UUID.randomUUID()
         insertMember(userId)
+        val firstWishId = seedReadyWish(userId, "https://shop.example.com/products/1", "상품1")
+        val secondWishId = seedReadyWish(userId, "https://shop.example.com/products/2", "상품2")
+        seedReadyWish(userId, "https://shop.example.com/products/3", "상품3")
         val authHeader = "Bearer ${memberToken(userId)}"
-        val firstWishId = registerWish(mockMvc, authHeader, "https://shop.example.com/products/1", "상품1")
-        val secondWishId = registerWish(mockMvc, authHeader, "https://shop.example.com/products/2", "상품2")
-        registerWish(mockMvc, authHeader, "https://shop.example.com/products/3", "상품3")
 
         // 첫 페이지: 최신 2건 + 다음 페이지 존재
         mockMvc
@@ -343,7 +228,7 @@ class WishlistControllerIntegrationTest : IntegrationTestSupport() {
         val userId = UUID.randomUUID()
         insertMember(userId)
         val authHeader = "Bearer ${memberToken(userId)}"
-        val wishId = registerWish(mockMvc, authHeader, "https://shop.example.com/products/1", "잘못 읽힌 이름")
+        val wishId = seedReadyWish(userId, "https://shop.example.com/products/1", "잘못 읽힌 이름")
         val body =
             objectMapper.writeValueAsString(
                 mapOf(
@@ -375,33 +260,15 @@ class WishlistControllerIntegrationTest : IntegrationTestSupport() {
         val userId = UUID.randomUUID()
         insertMember(userId)
         val authHeader = "Bearer ${memberToken(userId)}"
-        stubProductLinkExtractor.build = {
-            ProductSnapshot(
-                link = it,
+        val wishId =
+            seedReadyWish(
+                userId,
+                "https://shop.example.com/products/1",
                 name = "원래 이름",
                 currentPrice = 50_000,
                 currency = "KRW",
                 imageUrl = "https://cdn.example.com/orig.jpg",
             )
-        }
-        val registerBody = objectMapper.writeValueAsString(mapOf("url" to "https://shop.example.com/products/1"))
-        val wishId =
-            objectMapper
-                .readTree(
-                    mockMvc
-                        .perform(
-                            post("/api/v1/wishlists")
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .header(HttpHeaders.AUTHORIZATION, authHeader)
-                                .content(registerBody),
-                        ).andExpect(status().isCreated)
-                        .andReturn()
-                        .response
-                        .getContentAsString(Charsets.UTF_8),
-                ).path("data")
-                .path("wish")
-                .path("id")
-                .asLong()
 
         mockMvc
             .perform(
@@ -410,7 +277,7 @@ class WishlistControllerIntegrationTest : IntegrationTestSupport() {
                     .header(HttpHeaders.AUTHORIZATION, authHeader)
                     .content(objectMapper.writeValueAsString(mapOf("name" to "새 이름"))),
             ).andExpect(status().isOk)
-            // name 만 갱신, 나머지는 등록 시점 값 유지
+            // name 만 갱신, 나머지는 시딩 시점 값 유지
             .andExpect(jsonPath("$.data.item.name").value("새 이름"))
             .andExpect(jsonPath("$.data.item.currentPrice").value(50_000))
             .andExpect(jsonPath("$.data.item.currency").value("KRW"))
@@ -424,8 +291,7 @@ class WishlistControllerIntegrationTest : IntegrationTestSupport() {
         val otherId = UUID.randomUUID()
         insertMember(ownerId)
         insertMember(otherId)
-        val wishId =
-            registerWish(mockMvc, "Bearer ${memberToken(ownerId)}", "https://shop.example.com/products/1", "내 상품")
+        val wishId = seedReadyWish(ownerId, "https://shop.example.com/products/1", "내 상품")
         val body = objectMapper.writeValueAsString(mapOf("name" to "남이 바꾼 이름"))
 
         mockMvc
@@ -463,7 +329,7 @@ class WishlistControllerIntegrationTest : IntegrationTestSupport() {
         val userId = UUID.randomUUID()
         insertMember(userId)
         val authHeader = "Bearer ${memberToken(userId)}"
-        val wishId = registerWish(mockMvc, authHeader, "https://shop.example.com/products/1", "상품")
+        val wishId = seedReadyWish(userId, "https://shop.example.com/products/1", "상품")
         val body = objectMapper.writeValueAsString(mapOf("currentPrice" to -1))
 
         mockMvc
@@ -483,8 +349,8 @@ class WishlistControllerIntegrationTest : IntegrationTestSupport() {
         val userId = UUID.randomUUID()
         insertMember(userId)
         val authHeader = "Bearer ${memberToken(userId)}"
-        val keptWishId = registerWish(mockMvc, authHeader, "https://shop.example.com/products/1", "남길 상품")
-        val deletedWishId = registerWish(mockMvc, authHeader, "https://shop.example.com/products/2", "지울 상품")
+        val keptWishId = seedReadyWish(userId, "https://shop.example.com/products/1", "남길 상품")
+        val deletedWishId = seedReadyWish(userId, "https://shop.example.com/products/2", "지울 상품")
 
         mockMvc
             .perform(
@@ -509,8 +375,7 @@ class WishlistControllerIntegrationTest : IntegrationTestSupport() {
         val otherId = UUID.randomUUID()
         insertMember(ownerId)
         insertMember(otherId)
-        val wishId =
-            registerWish(mockMvc, "Bearer ${memberToken(ownerId)}", "https://shop.example.com/products/1", "내 상품")
+        val wishId = seedReadyWish(ownerId, "https://shop.example.com/products/1", "내 상품")
 
         mockMvc
             .perform(
@@ -560,6 +425,8 @@ class WishlistControllerIntegrationTest : IntegrationTestSupport() {
             .andExpect(jsonPath("$.data.item.name").value("나이키 에어포스"))
             .andExpect(jsonPath("$.data.item.currentPrice").value(99_000))
             .andExpect(jsonPath("$.data.item.currency").value("KRW"))
+            // OCR 은 동기 완성이라 status 는 READY.
+            .andExpect(jsonPath("$.data.item.status").value("READY"))
             // bbox 가 없으면 크롭을 건너뛰어 imageUrl 은 null. sourceUrl 도 OCR 이라 null.
             .andExpect(jsonPath("$.data.item.sourceUrl").value(nullValue()))
             .andExpect(jsonPath("$.data.item.imageUrl").value(nullValue()))

--- a/src/test/kotlin/com/depromeet/piki/wishlist/controller/WishlistRegisterAsyncIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/wishlist/controller/WishlistRegisterAsyncIntegrationTest.kt
@@ -1,0 +1,216 @@
+package com.depromeet.piki.wishlist.controller
+
+import com.depromeet.piki.auth.infrastructure.jwt.JwtProvider
+import com.depromeet.piki.item.domain.ItemStatus
+import com.depromeet.piki.item.repository.ItemRepository
+import com.depromeet.piki.product.service.ProductSnapshot
+import com.depromeet.piki.product.service.ProductSnapshotException
+import com.depromeet.piki.support.IntegrationTestSupport
+import com.depromeet.piki.support.StubProductLinkExtractor
+import com.depromeet.piki.support.uuidToBytes
+import com.depromeet.piki.user.domain.IdentityType
+import org.awaitility.Awaitility.await
+import org.hamcrest.Matchers.nullValue
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.web.context.WebApplicationContext
+import tools.jackson.databind.ObjectMapper
+import java.time.Duration
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+// 등록은 비동기(@Async)다. @Transactional 자동 롤백 패턴으로는 워커(별도 스레드·새 트랜잭션)가
+// 미커밋 데이터를 못 보므로, 여기서는 @Transactional 없이 실제 커밋하고 Awaitility 로 상태 전이를 기다린다.
+// (CLAUDE.md '동시성·시간 의존 통합 테스트' 별도 분류.) 자기가 만든 행은 격리 userId 로 구분해 메서드 끝에서 정리한다.
+class WishlistRegisterAsyncIntegrationTest : IntegrationTestSupport() {
+    @Autowired
+    private lateinit var webApplicationContext: WebApplicationContext
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @Autowired
+    private lateinit var stubProductLinkExtractor: StubProductLinkExtractor
+
+    @Autowired
+    private lateinit var itemRepository: ItemRepository
+
+    @Autowired
+    private lateinit var jdbcTemplate: JdbcTemplate
+
+    @Autowired
+    private lateinit var jwtProvider: JwtProvider
+
+    @Test
+    fun `등록하면 추출을 기다리지 않고 PROCESSING 상태로 201 이 즉시 반환된다`() {
+        val mockMvc = buildMockMvc()
+        val userId = UUID.randomUUID()
+        insertMember(userId)
+        try {
+            stubProductLinkExtractor.build = { ProductSnapshot(link = it, name = "나이키 에어포스", currentPrice = 99_000) }
+            val body = objectMapper.writeValueAsString(mapOf("url" to "https://shop.example.com/products/42"))
+
+            mockMvc
+                .perform(
+                    post("/api/v1/wishlists")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer ${memberToken(userId)}")
+                        .content(body),
+                ).andExpect(status().isCreated)
+                .andExpect(jsonPath("$.status").value(201))
+                .andExpect(jsonPath("$.code").value("CREATED"))
+                .andExpect(jsonPath("$.data.wish.id").isNumber)
+                .andExpect(jsonPath("$.data.item.status").value("PROCESSING"))
+                // 파싱 전이라 추출 결과는 아직 비어 있고, 입력으로 받은 sourceUrl 만 채워진다.
+                .andExpect(jsonPath("$.data.item.name").value(nullValue()))
+                .andExpect(jsonPath("$.data.item.currentPrice").value(nullValue()))
+                .andExpect(jsonPath("$.data.item.sourceUrl").value("https://shop.example.com/products/42"))
+        } finally {
+            cleanup(userId)
+        }
+    }
+
+    @Test
+    fun `등록 후 파싱이 성공하면 item 이 READY 로 전이하며 추출 결과가 채워진다`() {
+        val mockMvc = buildMockMvc()
+        val userId = UUID.randomUUID()
+        insertMember(userId)
+        try {
+            stubProductLinkExtractor.build = {
+                ProductSnapshot(link = it, name = "나이키 에어포스", currentPrice = 99_000, currency = "KRW")
+            }
+            val itemId = registerAndGetItemId(mockMvc, userId, "https://shop.example.com/products/42")
+
+            await().atMost(Duration.ofSeconds(5)).until {
+                itemRepository.findById(itemId)?.status == ItemStatus.READY
+            }
+
+            val item = itemRepository.findById(itemId) ?: error("item $itemId 가 없다")
+            assertEquals("나이키 에어포스", item.name)
+            assertEquals(99_000, item.currentPrice)
+            assertEquals("KRW", item.currency)
+        } finally {
+            cleanup(userId)
+        }
+    }
+
+    @Test
+    fun `등록 후 상품 페이지가 아니라고 판정되면 item 이 FAILED 로 전이한다`() {
+        val mockMvc = buildMockMvc()
+        val userId = UUID.randomUUID()
+        insertMember(userId)
+        try {
+            // 파싱 결과 실패는 동기 400 이 아니라 FAILED 상태로 남는다 (등록 응답은 이미 201 로 끝났으므로).
+            stubProductLinkExtractor.build = { throw ProductSnapshotException.notProductPage() }
+            val itemId = registerAndGetItemId(mockMvc, userId, "https://shop.example.com/products/not-a-product")
+
+            await().atMost(Duration.ofSeconds(5)).until {
+                itemRepository.findById(itemId)?.status == ItemStatus.FAILED
+            }
+
+            val item = itemRepository.findById(itemId) ?: error("item $itemId 가 없다")
+            assertEquals(ItemStatus.FAILED, item.status)
+            // 실패 항목은 추출 결과가 비어 있다.
+            assertNull(item.name)
+        } finally {
+            cleanup(userId)
+        }
+    }
+
+    @Test
+    fun `같은 URL 을 두 번 등록해도 dedup 없이 둘 다 201 PROCESSING 으로 별개 등록된다`() {
+        val mockMvc = buildMockMvc()
+        val userId = UUID.randomUUID()
+        insertMember(userId)
+        try {
+            stubProductLinkExtractor.build = { ProductSnapshot(link = it, name = "기본 상품") }
+            val body = objectMapper.writeValueAsString(mapOf("url" to "https://shop.example.com/products/42"))
+            val auth = "Bearer ${memberToken(userId)}"
+
+            repeat(2) {
+                mockMvc
+                    .perform(
+                        post("/api/v1/wishlists")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .header(HttpHeaders.AUTHORIZATION, auth)
+                            .content(body),
+                    ).andExpect(status().isCreated)
+                    .andExpect(jsonPath("$.data.item.status").value("PROCESSING"))
+            }
+
+            // dedup 없는 multi-record 모델 — 같은 URL 이라도 별개 wish 2건이 쌓인다 (persist 는 동기라 즉시 반영).
+            val wishCount =
+                jdbcTemplate.queryForObject(
+                    "SELECT COUNT(*) FROM wishes WHERE user_id = ?",
+                    Int::class.java,
+                    uuidToBytes(userId),
+                )
+            assertEquals(2, wishCount)
+        } finally {
+            cleanup(userId)
+        }
+    }
+
+    private fun registerAndGetItemId(
+        mockMvc: MockMvc,
+        userId: UUID,
+        url: String,
+    ): Long {
+        val body = objectMapper.writeValueAsString(mapOf("url" to url))
+        val response =
+            mockMvc
+                .perform(
+                    post("/api/v1/wishlists")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer ${memberToken(userId)}")
+                        .content(body),
+                ).andExpect(status().isCreated)
+                .andReturn()
+                .response
+                .getContentAsString(Charsets.UTF_8)
+        return objectMapper.readTree(response).path("data").path("item").path("id").asLong()
+    }
+
+    private fun buildMockMvc(): MockMvc =
+        MockMvcBuilders
+            .webAppContextSetup(webApplicationContext)
+            .apply<DefaultMockMvcBuilder>(springSecurity())
+            .build()
+
+    private fun insertMember(userId: UUID) {
+        jdbcTemplate.update(
+            "INSERT INTO users (id, nickname, identity_type, created_at, updated_at) VALUES (?, ?, ?, NOW(6), NOW(6))",
+            uuidToBytes(userId),
+            userId.toString().take(10),
+            "MEMBER",
+        )
+    }
+
+    private fun memberToken(userId: UUID): String = jwtProvider.generateAccessToken(userId, IdentityType.MEMBER)
+
+    // @Transactional 자동 롤백이 없으므로 이 테스트가 만든 user·wish·item 을 직접 정리한다.
+    private fun cleanup(userId: UUID) {
+        val itemIds =
+            jdbcTemplate.queryForList(
+                "SELECT item_id FROM wishes WHERE user_id = ?",
+                Long::class.java,
+                uuidToBytes(userId),
+            )
+        jdbcTemplate.update("DELETE FROM wishes WHERE user_id = ?", uuidToBytes(userId))
+        itemIds.takeIf { it.isNotEmpty() }?.let {
+            jdbcTemplate.update("DELETE FROM items WHERE id IN (${it.joinToString(",")})")
+        }
+        jdbcTemplate.update("DELETE FROM users WHERE id = ?", uuidToBytes(userId))
+    }
+}


### PR DESCRIPTION
## Situation

- 위시리스트 등록(`POST /api/v1/wishlists`)이 완전히 동기라, 요청 안에서 Gemini 파싱(최대 60s)까지 끝낸 뒤 완성된 item 을 201 로 반환했다. 그동안 HTTP 요청이 블로킹된다.
- "상품을 담는 중" 상태가 서버에 존재하지 않고, 클라이언트가 응답을 기다리는 "요청–응답 사이 시간" 으로만 암묵적으로 표현됐다. items 테이블에도 상태 컬럼이 없어 항상 완성으로만 저장됐다.
- 파싱 실패(상품 아님·추출값 신뢰 불가)도 동기 400 으로만 처리돼 비동기 모델과 충돌했다.

## Task

- 파싱 상태를 서버가 명시적으로 갖도록 모델링하고 등록을 비동기화한다.
- 상태 집합이 핵심 결정이었다. "파싱 전/중/후" 3개로는 실패가 빠지는데, 비동기에선 실패를 동기 400 으로 알릴 수 없으므로 실패를 명시 상태로 둬야 한다 → PROCESSING / READY / FAILED.
- 클라이언트는 위시리스트 조회를 폴링해 status 변화를 감지한다 (실시간 푸시 대신 기존 조회 API 재사용).

## Action

### 상태 모델·비동기 흐름
- `ItemStatus`(PROCESSING/READY/FAILED) 와 `Item.processing()` / `markReady()` / `markFailed()` 전이 메서드 추가. 전이 불변식은 `check`(PROCESSING 에서만 전이)로 둬, 잘못된 전이는 코드 버그(500)로 드러나게 했다.
- `register` 는 link 만 가진 PROCESSING item 을 즉시 저장해 201 로 반환하고, `@Async` 워커(`ItemParsingWorker` 인터페이스 뒤 — 추후 메시지 큐 교체 대비)가 백그라운드에서 파싱해 READY/FAILED 로 전이한다.
- 외부 호출(extract)은 트랜잭션 밖에서 끝내고, 상태 전이 영속화만 `ItemParsingService` 의 짧은 트랜잭션으로 묶었다.
- `items.status` 컬럼 마이그레이션 — 기존 행은 `DEFAULT 'READY'` 로 backfill.
- 조회 응답 DTO 에 `status` 노출. URL 형식 위반 등 요청 즉시 판별 가능한 계약 위반은 등록 전 동기 400 으로 유지하고, 파싱해봐야 아는 실패만 FAILED 로 보낸다.

### 안전망 (셀프 리뷰에서 보강)
- executor 포화 시 `CallerRunsPolicy` 는 외부 LLM 호출(최대 60s)을 톰캣 워커 스레드에서 동기 실행해 풀을 고갈시킬 수 있어, `AbortPolicy` 로 두고 디스패치 거부는 `register` 가 잡아 즉시 FAILED 로 처리하도록 바꿨다.
- `markReady` 가 추출값 도메인 검증에 실패하거나 sweeper 와 레이스로 전이가 깨져도 워커 스레드로 예외가 새지 않게 `runCatching` 으로 감싸고 FAILED 로 떨어뜨린다.
- 인스턴스 크래시로 PROCESSING 에 방치된 item 은 `StaleProcessingItemSweeper` 가 5분 후 FAILED 로 정리한다 (단일 인스턴스 기준 `@Scheduled` — 멀티 인스턴스 확장 시 중복 실행 방지 필요).

### 테스트
- 상태 전이는 `ItemTest` 단위 테스트로 망라 (PROCESSING→READY/FAILED, 잘못된 상태 전이 거부).
- 등록 PROCESSING 응답·READY/FAILED 전이·중복 등록은 `@Transactional` 없이 Awaitility 로 검증하는 `WishlistRegisterAsyncIntegrationTest` 신규 — `@Transactional` 자동 롤백 패턴은 `@Async` 워커가 미커밋 데이터를 못 보기 때문.
- 조회·수정·삭제 통합 테스트는 등록 API(비동기) 대신 영속화 빈으로 READY 상태를 시딩(`seedReadyWish`)하도록 재편 — 그 시나리오의 본질이 등록 흐름이 아니라 완성된 위시 상태이기 때문.

## Result

- 전체 313 테스트 통과.
- 클라이언트 계약 변화: 등록 응답이 즉시 완성 데이터 대신 `status=PROCESSING`(name·price·image 는 null)을 반환하고, 조회 폴링으로 READY/FAILED 를 확인한다.
- 범위는 URL 등록 한정. OCR 등록 비동기화, FAILED→재시도 API, FAILED 사유 구분(상품 아님 vs 일시 실패)은 후속 이슈 후보.
- 머지 직전 마이그레이션 timestamp 를 dev 최신 기준으로 재발급 필요 (현재 origin/dev 가 #222 로 앞서감).

---
## 연관 이슈

- close #221


## Updates

### 토너먼트 아이템 추가에 READY 상태 검증 (비동기 도입 회귀 방지)

- "토너먼트 아이템 등록도 이 비동기 플로우를 따라야 하는지" 직접 검사한 결과, 현재 토너먼트는 새 상품을 추출하지 않고 `addItems` 가 `itemIds` 로 기존 item 을 참조만 한다 — 비동기 워커 자체는 토너먼트에 불필요. (`ca7978d`)
- 다만 비동기 도입으로 `PROCESSING`·`FAILED` item 이 존재하게 되면서, `addItems` 가 itemId 존재만 검증해 미완성 상품이 토너먼트에 출전될 수 있는 회귀가 생겨, `Item.isReady()` + `TournamentException.itemNotReady()`(409)로 READY 아이템만 출전 허용하도록 막았다. (`ca7978d`)
- PROCESSING item 을 `addItems` 하면 409 가 반환되는 통합 테스트와 `Item.isReady()` 단위 테스트를 추가했다. 전체 315 테스트 통과. (`d511d0c`)
- 토너먼트가 직접 URL/이미지로 상품을 추출하는 "후보 등록" 경로(보드 예정 기능)가 생기면, 같은 `Item.processing()` + `itemParsingWorker.parse()` 플로우를 재사용해야 한다 — 후속.
