### PR TITLE
워크트리 작업 흐름에 맞춰 /issue·/pr 스킬 보강

### DIFF
--- a/.claude/commands/issue.md
+++ b/.claude/commands/issue.md
@@ -1,4 +1,4 @@
-이슈를 생성하고, 브랜치를 만들고, 이슈에 매핑하고, 라벨/Project를 설정합니다.
+이슈를 생성하고, 브랜치(또는 워크트리)를 만들고, 이슈에 매핑하고, 라벨/Project를 설정합니다.
 
 ## 원칙
 
@@ -10,9 +10,11 @@
 
 **Epic 과 일반 이슈는 본질이 다르다.** Epic 은 여러 작업의 묶음으로 자체 코드 작업이 없어 브랜치를 만들지 않는다. 일반 이슈는 코드 작업의 단위로 부모 Epic 에 묶일 수 있다. 이 구분만 사용자가 명시하고, 그 외 분류·prefix·상위 Epic 추천은 모델이 본문을 보고 자동 결정한 뒤 검수받는다.
 
+**작업 공간은 워크트리를 기본으로 한다.** 일반 이슈의 브랜치를 만들 때 현재 체크아웃을 그 브랜치로 끌고 가는 대신, `.claude/worktrees/` 에 격리된 워크트리로 분리하는 것을 추천(첫 번째 옵션)한다. 메인 체크아웃이 작업 중 외부에서 바뀌어도 격리되고 CLAUDE.md "별도 작업은 worktree 로 분리" 정책과 맞다. 사용자가 현재 브랜치 작업을 고를 수 있게 묻되 default 는 워크트리. Epic 은 브랜치 자체가 없어 해당 없음.
+
 **라벨은 한 작업 한 개.** type 차원(`feat`/`fix`/`refactor`/`perf`/`chore`) 과 영역 차원(`docs`/`test`/`infra`) 이 한 라벨로 합쳐져 있다. "외부 가시적 변화" 가 본질이면 그 type, 특정 영역만 만지면 그 영역. multi-label 부여하지 않는다.
 
-**채팅 끊김을 최소화한다.** 자유 텍스트는 한 메시지로 일괄 받고, 옵션 결정은 `AskUserQuestion` 으로 묶어 받는다. 사용자 인터랙션은 보통 **3 라운드** (Epic 여부 → 자유 입력 → 검수) 안에 끝난다.
+**채팅 끊김을 최소화한다.** 자유 텍스트는 한 메시지로 일괄 받고, 옵션 결정은 `AskUserQuestion` 으로 묶어 받는다. 사용자 인터랙션은 보통 **3~4 라운드** (Epic 여부 → 자유 입력 → 검수 → [일반 이슈] 작업 위치) 안에 끝난다.
 
 ## 절차
 
@@ -226,9 +228,37 @@ gh api graphql \
   -F typeId={매핑된 type ID}
 ```
 
-### B-6. 브랜치 생성 + 매핑
+### B-6. 작업 위치 선택 + 브랜치/워크트리 생성
 
-브랜치명 슬러그는 분해된 제목에서 영문 kebab-case 로 생성 (한국어면 의미 보존하며 영문 의역).
+브랜치명 슬러그는 분해된 제목에서 영문 kebab-case 로 생성 (한국어면 의미 보존하며 영문 의역). 브랜치명은 `{prefix}/{이슈번호}-{slug}`, 워크트리 디렉토리명은 `{slug}` (prefix·번호 없이).
+
+브랜치를 어디서 작업할지 `AskUserQuestion` (single-select) 으로 묻는다. **워크트리를 추천(첫 번째)으로 둔다**:
+
+- `워크트리로 분리 (Recommended)` — 현재 체크아웃은 그대로 두고 `.claude/worktrees/{slug}` 에 격리된 작업 공간을 만든다.
+- `현재 브랜치에서 작업` — 현재 디렉토리를 새 브랜치로 전환한다 (기존 동작).
+
+#### 워크트리 선택 시
+
+1. **stale 워크트리 정리** (생성 직전 — CLAUDE.md "worktree 정리는 ... 이벤트에 얹는다"). `git worktree prune` 후 머지·삭제(gone)된 브랜치의 워크트리만 제거. **clean 한 것만, `--force` 금지** — dirty 면 작업 중일 수 있으므로 건드리지 않고 넘어간다.
+
+2. GitHub 브랜치 생성 + 이슈 연결. **`--checkout` 을 주지 않는다** — 현재 디렉토리를 끌고 가면 같은 브랜치를 워크트리에서 다시 체크아웃할 수 없어 충돌한다.
+   ```bash
+   gh issue develop {이슈번호} \
+     --repo depromeet/18th-team3-server \
+     --base dev \
+     --name "{prefix}/{이슈번호}-{slug}"
+   ```
+
+3. `gh` 가 만든 원격 브랜치를 가져와 워크트리로 분리한다 (로컬 브랜치는 워크트리에서 생성):
+   ```bash
+   git fetch origin "{prefix}/{이슈번호}-{slug}":"refs/remotes/origin/{prefix}/{이슈번호}-{slug}"
+   git worktree add ".claude/worktrees/{slug}" "{prefix}/{이슈번호}-{slug}"
+   ```
+   `git worktree add <path> <branch>` 는 로컬에 `{branch}` 가 없고 `origin/{branch}` 가 정확히 하나면 DWIM 으로 추적 브랜치를 만들어 붙인다. DWIM 이 안 되면 명시형으로 fallback: `git worktree add --track -b "{prefix}/{이슈번호}-{slug}" ".claude/worktrees/{slug}" "origin/{prefix}/{이슈번호}-{slug}"`.
+
+4. 세션을 워크트리로 진입시킨다 — `EnterWorktree` 도구를 **`path=".claude/worktrees/{slug}"`** 로 호출 (이미 만든 워크트리에 진입). `name=` 으로 새로 만들지 않는다 — 브랜치는 `gh issue develop` 이 base `dev` 로 이미 만들었고, `EnterWorktree(name=...)` 의 baseRef 기본값(`fresh`=origin/default-branch)은 이 레포에선 `main` 을 가리켜 CLAUDE.md(dev 분기) 와 어긋나기 때문. 이후 작업·커밋·`/pr` 은 이 워크트리에서 진행된다.
+
+#### 현재 브랜치 선택 시 (기존 동작)
 
 ```bash
 gh issue develop {이슈번호} \
@@ -249,7 +279,9 @@ gh project item-add 99 --owner depromeet --url {이슈 URL}
 ### B-8. 결과 출력
 
 - 이슈 URL
-- 브랜치명 + 현재 체크아웃된 브랜치 확인
+- 브랜치명
+- **워크트리 선택 시**: 워크트리 경로(`.claude/worktrees/{slug}`) + "세션이 워크트리로 전환됐고 현재 체크아웃(`dev` 등)은 그대로 유지됩니다" + "작업·커밋·`/pr` 은 이 워크트리에서 진행됩니다"
+- **현재 브랜치 선택 시**: 현재 체크아웃된 브랜치 확인
 - "우선순위 / 일정은 필요시 GitHub Project 보드에서 채우세요."
 - 다음 단계 안내 (작업 시작 → 커밋 → PR)
 
@@ -261,7 +293,9 @@ gh project item-add 99 --owner depromeet --url {이슈 URL}
 - **모델 분해 결과는 검수 필수.** 사용자가 거부하면 즉시 부분 수정 또는 원본 그대로.
 - 분류 자동 결정은 시그널이 명확할 때만. 모호하면 `chore` fallback (보수적).
 - 라벨이 레포에 없어 `gh issue create` 가 실패하면 에러 그대로 보고.
-- `gh issue develop` 은 `--name` (브랜치 이름 옵션) + `--checkout` 둘 다 명시 (인터랙티브 회피). `--branch-name` 은 존재하지 않는 옵션이니 주의.
+- `gh issue develop` 은 `--name` (브랜치 이름 옵션) 을 명시 (인터랙티브 회피). `--branch-name` 은 존재하지 않는 옵션이니 주의. `--checkout` 은 **현재 브랜치 작업을 고른 경우에만** 붙인다 — 워크트리 작업이면 현재 디렉토리가 끌려가 충돌하므로 빼고, 체크아웃은 `EnterWorktree` 가 대신한다.
+- **워크트리 진입은 `EnterWorktree(path=...)` 로만.** `git worktree add` 로 먼저 만든 뒤 `path` 로 진입한다. `EnterWorktree(name=...)` 는 새 브랜치를 자체 생성하며 baseRef 기본값이 이 레포의 git default branch(`main`)를 가리켜 `dev` 분기 정책과 어긋난다. `path` 로 진입한 워크트리는 `ExitWorktree` 가 제거하지 않으므로, 정리는 `/session-close` 나 다음 `/issue` 의 stale prune 에 맡긴다.
+- **워크트리 stale prune 안전 가드.** 생성 직전 정리는 clean(커밋 안 된 변경 없음) + 머지·삭제(gone)된 브랜치의 워크트리만 제거한다. `--force` 절대 금지, dirty 면 그냥 둔다.
 - `gh project item-add` 권한 부족 시 사용자에게 `gh auth refresh -h github.com -s project` 안내 (인터랙티브 디바이스 인증, 일회성).
 - 본문에 `#{epic 번호}` 가 들어가면 GitHub 가 자동 cross-reference 링크 — 별도 sub-issue API 불필요.
 - 중복 이슈 검사 false positive 가능성 인지. 사용자가 "다른 이슈" 라 답하면 그대로 진행.

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -6,7 +6,34 @@
 
 ## 절차
 
-### 0단계: 모드 결정 + base branch 자동 감지
+### 0단계: 작업 위치 가드 + 모드 결정 + base branch 자동 감지
+
+**0-A. 작업 위치 가드 (워크트리 감지)** — `/pr` 의 모든 git/gh 명령은 현재 작업 디렉토리(cwd) 기준으로 돈다. 세션이 워크트리 안에 있으면 git worktree 특성상 자동으로 그 워크트리 브랜치를 바라보므로 별도 처리가 필요 없다. 문제는 cwd 가 작업 브랜치와 어긋난 경우 — 워크트리에서 작업해놓고 메인 체크아웃(base 브랜치)에서 `/pr` 을 부르면 조용히 틀린 PR(또는 "변경 없음")이 만들어진다. 이를 먼저 거른다.
+
+```bash
+CURRENT_BRANCH=$(git branch --show-current)
+# base 후보 (아래 0-B 의 $BASE 결정과 동일 우선순위: origin/dev → 레포 default → main)
+if git rev-parse --verify origin/dev >/dev/null 2>&1; then
+  BASE_GUESS=dev
+else
+  BASE_GUESS=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || echo main)
+fi
+```
+
+`$CURRENT_BRANCH` 가 `$BASE_GUESS` 와 **다르면** 정상(작업 브랜치) — 가드를 통과해 0-B 로 넘어간다.
+
+`$CURRENT_BRANCH` 가 `$BASE_GUESS` 와 **같으면** PR 을 올릴 작업 브랜치가 아니다. 작업은 다른 워크트리에 있을 가능성이 크다:
+
+```bash
+git worktree list --porcelain   # base 가 아닌 브랜치를 가진 워크트리 = 작업 후보
+```
+
+- **작업 후보 워크트리가 있으면** `AskUserQuestion` (single-select) 으로 "그 워크트리로 진입해 `/pr` 을 이어갈까요?" 를 묻는다 (**진입 = Recommended, 첫 번째**). 후보가 여럿이면 각 워크트리(경로 + 브랜치)를 옵션으로 나열한다.
+  - **진입 동의** → `EnterWorktree` 도구를 `path={선택한 워크트리 경로}` 로 호출해 세션을 옮긴 뒤, **0단계를 처음부터 다시 시작**한다 (이제 cwd 가 워크트리라 `CURRENT_BRANCH` 가 feature 브랜치 → 가드 통과).
+  - **거부** → 멈춘다. "작업 워크트리에서 직접 `/pr` 을 불러주세요" 안내.
+- **작업 후보 워크트리가 없으면** (다른 워크트리도 전부 base 이거나 워크트리가 메인뿐) — base 브랜치에서 `/pr` 을 부른 셈이라 올릴 작업 브랜치가 안 보인다. 그 사실을 알리고 멈춘다 (`$ARGUMENTS` 로 다른 base 를 명시한 의도적 dev→main 류 PR 이면 사용자가 다시 알려준다).
+
+**0-B. 모드 결정 + $BASE 자동 감지**
 
 **현재 브랜치의 PR 존재 여부 확인** — update 모드 vs create 모드 결정:
 
@@ -19,15 +46,7 @@ gh pr view --json url,number,body,baseRefName 2>/dev/null
 
 **`$BASE` 결정**:
 
-- **create 모드** — 우선순위로 자동 감지:
-  ```bash
-  # 우선순위: origin/dev → 레포 default branch → main
-  if git rev-parse --verify origin/dev >/dev/null 2>&1; then
-    BASE=dev
-  else
-    BASE=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || echo main)
-  fi
-  ```
+- **create 모드** — 0-A 에서 계산한 `$BASE_GUESS` 를 그대로 쓴다 (`BASE=$BASE_GUESS`). 우선순위: origin/dev → 레포 default branch → main.
 - **update 모드** — 기존 PR 의 base 사용:
   ```bash
   BASE=$(gh pr view --json baseRefName --jq '.baseRefName')


### PR DESCRIPTION
## Situation
- `/issue` 는 이슈마다 현재 체크아웃을 새 브랜치로 전환(`gh issue develop --checkout`)했는데, 실제 작업은 워크트리로 분리하는 경우가 잦았다.
- 이 레포는 메인 체크아웃의 브랜치가 작업 중 외부(다른 세션/사용자)에서 바뀌는 환경이라, 워크트리로 격리하지 않으면 변경이 엉뚱한 브랜치에 얹힌다. (이번 작업 중에도 메인 체크아웃이 `dev` → `infra/214` 로 바뀌어 변경이 잘못 얹히는 함정을 실제로 겪었다.)

## Task
- `/issue` 와 `/pr` 이 워크트리를 1급으로 다루게 만든다 — 브랜치냐 워크트리냐를 묻되 워크트리를 기본(추천)으로 두고, `/pr` 이 잘못된 위치에서 불릴 때를 거른다.

## Action

### `/issue` — 작업 위치 선택 (B-6)
- "워크트리로 분리 / 현재 브랜치에서 작업" 을 `AskUserQuestion` 으로 묻고 워크트리를 첫 번째(Recommended)로 둔다.
- 워크트리 경로: `gh issue develop` 을 `--checkout` 없이 호출해 `dev` base 브랜치만 만들고, `git worktree add` 로 분리한 뒤 `EnterWorktree(path=...)` 로 진입.
- `EnterWorktree(name=...)` 를 쓰지 않은 이유: baseRef 기본값(`fresh`)이 레포 default(`main`)를 가리켜 `dev` 분기 정책과 어긋난다. 브랜치는 `gh` 가 `dev` 로 만들고, 워크트리는 `path` 진입만 담당.

### `/pr` — 작업 위치 가드 (0-A)
- 현재 브랜치가 base(`dev`)와 같으면 작업 브랜치가 아니라고 보고, `git worktree list` 로 작업 워크트리 후보를 찾아 "그 워크트리로 진입해 이어갈까?" 를 묻는다. 동의하면 `EnterWorktree(path)` 로 옮겨 0단계 재시작.
- `/pr` 은 cwd 기반이라 워크트리 안에서는 이미 자동으로 그 브랜치를 바라본다. 가드는 "메인 체크아웃(base)에서 잘못 부른 경우" 만 거른다.

### 검증·점검
- `git worktree add <path> <branch>` 의 DWIM(로컬에 없는 브랜치를 `origin` 추적으로 자동 생성)을 임시 워크트리로 실제 검증한 뒤 채택.
- 전체 스킬 audit — 이동 지시가 있는 `issue`·`pr`·`session-check`·`session-close` 가 모두 워크트리를 다루는지 확인. `coderabbit`·`commit`·`notion-board` 는 이동 지시가 없어 가드 불필요.

## Result
- `/issue`·`/pr` 이 워크트리를 기본으로 다뤄, 메인 체크아웃이 외부에서 바뀌어도 작업이 격리된다.
- 후속(이번 범위 제외):
  - `pre-pr` 은 위치 가드가 없고 base 가 `main` 으로 하드코딩(`git diff main...HEAD`)돼 있다. 빌드·테스트·커밋을 `/pr` 가드보다 먼저 하므로 별도 보강 후보.
  - `/pr` 의 base 비교가 로컬 `dev` 를 쓰는데 로컬이 stale 이면 남의 커밋을 끌어온다. 이 PR 작성 중 실제로 겪어 `origin/dev` 기준으로 우회했다 — `$BASE` 를 `origin/dev` 로 비교하는 개선 후보.

---
## 연관 이슈

- 
