### PR TITLE
Spring Security 필터 단계 인증·인가 예외를 ApiResponseBody contract 로 통일

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/auth/config/ApiResponseSecurityErrorHandlers.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/config/ApiResponseSecurityErrorHandlers.kt
@@ -1,0 +1,67 @@
+package com.depromeet.piki.auth.config
+
+import com.depromeet.piki.common.exception.ErrorCategory
+import com.depromeet.piki.common.response.ApiResponseBody
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.web.AuthenticationEntryPoint
+import org.springframework.security.web.access.AccessDeniedHandler
+import org.springframework.stereotype.Component
+import tools.jackson.databind.ObjectMapper
+
+// Security 필터 체인은 DispatcherServlet 이전 단계라 @RestControllerAdvice 의 GlobalExceptionHandler 가
+// 잡지 못한다. 인증·인가 거부 응답도 다른 엔드포인트와 같은 ApiResponseBody contract 로 내려가도록
+// EntryPoint·AccessDeniedHandler 를 여기에 직접 구현한다.
+//
+// detail 은 ErrorCategory.description 의 고정 사용자 대면 문구로 채워, 토큰 파싱 사유 등 내부 정보가
+// 응답으로 새지 않게 한다 (CLAUDE.md 의 "클라이언트 응답에 내부 정보 노출 안 함" 정책).
+
+@Component
+class ApiResponseAuthenticationEntryPoint(
+    private val objectMapper: ObjectMapper,
+) : AuthenticationEntryPoint {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    override fun commence(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        authException: AuthenticationException,
+    ) {
+        log.info("[AuthenticationEntryPoint] {} {} - {}", request.method, request.requestURI, authException.message)
+        writeApiResponseBody(response, HttpStatus.UNAUTHORIZED, ErrorCategory.UNAUTHORIZED, objectMapper)
+    }
+}
+
+@Component
+class ApiResponseAccessDeniedHandler(
+    private val objectMapper: ObjectMapper,
+) : AccessDeniedHandler {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    override fun handle(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        accessDeniedException: AccessDeniedException,
+    ) {
+        log.info("[AccessDeniedHandler] {} {} - {}", request.method, request.requestURI, accessDeniedException.message)
+        writeApiResponseBody(response, HttpStatus.FORBIDDEN, ErrorCategory.FORBIDDEN, objectMapper)
+    }
+}
+
+private fun writeApiResponseBody(
+    response: HttpServletResponse,
+    status: HttpStatus,
+    category: ErrorCategory,
+    objectMapper: ObjectMapper,
+) {
+    response.status = status.value()
+    response.contentType = MediaType.APPLICATION_JSON_VALUE
+    response.characterEncoding = Charsets.UTF_8.name()
+    val body = ApiResponseBody.fail<Nothing>(category, status)
+    response.writer.write(objectMapper.writeValueAsString(body))
+}

--- a/src/main/kotlin/com/depromeet/piki/auth/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/config/SecurityConfig.kt
@@ -2,7 +2,6 @@ package com.depromeet.piki.auth.config
 
 import com.depromeet.piki.auth.filter.JwtAuthenticationFilter
 import com.depromeet.piki.user.domain.IdentityType
-import jakarta.servlet.http.HttpServletResponse
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpMethod
@@ -14,7 +13,10 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 @EnableWebSecurity
-class SecurityConfig {
+class SecurityConfig(
+    private val authenticationEntryPoint: ApiResponseAuthenticationEntryPoint,
+    private val accessDeniedHandler: ApiResponseAccessDeniedHandler,
+) {
     @Bean
     fun securityFilterChain(
         http: HttpSecurity,
@@ -60,10 +62,11 @@ class SecurityConfig {
                     .anyRequest()
                     .authenticated()
             }.exceptionHandling {
-                // 미인증 요청은 401, 인증됐지만 권한 없으면 403
-                it.authenticationEntryPoint { _, response, _ ->
-                    response.sendError(HttpServletResponse.SC_UNAUTHORIZED)
-                }
+                // 미인증 요청은 401, 인증됐지만 권한 없으면 403.
+                // Security 필터 체인은 DispatcherServlet 이전이라 GlobalExceptionHandler 가 잡지 못하므로,
+                // 두 경로 모두 ApiResponseBody contract 로 응답을 직접 작성하는 핸들러를 꽂는다.
+                it.authenticationEntryPoint(authenticationEntryPoint)
+                it.accessDeniedHandler(accessDeniedHandler)
             }.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
             .build()
 }

--- a/src/test/kotlin/com/depromeet/piki/auth/config/SecurityErrorResponseIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/config/SecurityErrorResponseIntegrationTest.kt
@@ -1,0 +1,76 @@
+package com.depromeet.piki.auth.config
+
+import com.depromeet.piki.auth.infrastructure.jwt.JwtProvider
+import com.depromeet.piki.support.IntegrationTestSupport
+import com.depromeet.piki.user.domain.IdentityType
+import org.hamcrest.Matchers.notNullValue
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpHeaders
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.web.context.WebApplicationContext
+import java.util.UUID
+
+// Spring Security 필터 체인은 DispatcherServlet 이전이라 GlobalExceptionHandler 가 잡지 못하고,
+// 401·403 응답은 EntryPoint·AccessDeniedHandler 에서만 작성된다. 본문이 빈 채로 내려가던 회귀
+// (#213) 가 다시 새지 않도록, 필터 단 401·403 응답이 다른 엔드포인트와 같은 ApiResponseBody
+// contract (status·code·detail) 로 내려가는지 한 자리에서 검증한다.
+class SecurityErrorResponseIntegrationTest : IntegrationTestSupport() {
+    @Autowired
+    private lateinit var webApplicationContext: WebApplicationContext
+
+    @Autowired
+    private lateinit var jwtProvider: JwtProvider
+
+    @Test
+    fun `토큰 없이 보호 엔드포인트 호출 시 401 응답이 ApiResponseBody contract 로 내려간다`() {
+        buildMockMvc()
+            .perform(post("/api/v1/wishlists"))
+            .andExpect(status().isUnauthorized)
+            .andExpect(content().contentTypeCompatibleWith("application/json"))
+            .andExpect(jsonPath("$.status").value(401))
+            .andExpect(jsonPath("$.code").value("UNAUTHORIZED"))
+            .andExpect(jsonPath("$.detail", notNullValue()))
+    }
+
+    @Test
+    fun `위조된 Bearer 토큰으로 보호 엔드포인트 호출 시 401 응답이 ApiResponseBody contract 로 내려간다`() {
+        buildMockMvc()
+            .perform(
+                post("/api/v1/wishlists")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer invalid.token.value"),
+            ).andExpect(status().isUnauthorized)
+            .andExpect(content().contentTypeCompatibleWith("application/json"))
+            .andExpect(jsonPath("$.status").value(401))
+            .andExpect(jsonPath("$.code").value("UNAUTHORIZED"))
+            .andExpect(jsonPath("$.detail", notNullValue()))
+    }
+
+    @Test
+    fun `MEMBER 권한 토큰으로 GUEST 전용 dev 엔드포인트 호출 시 403 응답이 ApiResponseBody contract 로 내려간다`() {
+        val memberToken = jwtProvider.generateAccessToken(UUID.randomUUID(), IdentityType.MEMBER)
+
+        buildMockMvc()
+            .perform(
+                post("/api/v1/dev/users")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer $memberToken"),
+            ).andExpect(status().isForbidden)
+            .andExpect(content().contentTypeCompatibleWith("application/json"))
+            .andExpect(jsonPath("$.status").value(403))
+            .andExpect(jsonPath("$.code").value("FORBIDDEN"))
+            .andExpect(jsonPath("$.detail", notNullValue()))
+    }
+
+    private fun buildMockMvc(): MockMvc =
+        MockMvcBuilders
+            .webAppContextSetup(webApplicationContext)
+            .apply<DefaultMockMvcBuilder>(springSecurity())
+            .build()
+}


### PR DESCRIPTION
## Situation

- 보호 엔드포인트에 토큰 없이·만료된 토큰·위조 토큰으로 요청하면 401 이 빈 body 로 내려가고, 권한 부족 시 403 도 동일하게 깨져 있었다. 정상 endpoint 는 모두 `ApiResponseBody` (`status`/`code`/`detail`/`data`) 래퍼를 거치는데 인증·인가 거부만 contract 가 어긋나, 클라이언트 공통 파싱 코드가 깨지고 사유를 알 수 없는 상태.
- 원인은 Spring Security 필터 체인이 DispatcherServlet 이전 단계라는 점. `@RestControllerAdvice` 의 `GlobalExceptionHandler` 가 아예 호출되지 않아 응답 셰이핑이 누락된다. `AuthenticationEntryPoint` 는 `sendError` 만 호출하는 lambda 였고 `AccessDeniedHandler` 는 아예 미설정이라 Spring Security 의 기본 `sendError` 가 깔린 상태.
- epic #231 (5/25 작업 묶음) 의 "지금까지 그냥 굴러갔지만 자세히 들여다보면 깨질 수 있는 흐름" 결로 정리된 4건 중 하나.

## Task

- 필터 단 401·403 응답을 정상 endpoint 와 동일한 `ApiResponseBody` contract 로 내려보낸다.
- 응답 `detail` 에는 토큰 파싱 사유·내부 식별자 같은 민감 정보를 절대 노출하지 않는다 (CLAUDE.md "클라이언트 응답에 내부 정보 노출 안 함" 정책).
- 응답 contract 가 다시 어긋나는 회귀를 잡을 통합 테스트를 한 자리에 둔다.

## Action

### 두 가지 접근 사이에서 직접 작성 안 선택

- **안 A: HandlerExceptionResolver 위임** — EntryPoint/Handler 는 2줄 shim 으로 두고 `GlobalExceptionHandler` 에 `@ExceptionHandler(AuthenticationException, AccessDeniedException)` 를 추가해 응답 셰이핑을 한 자리에 모은다.
- **안 B: EntryPoint/Handler 안에서 직접 JSON body 작성** (채택) — `ObjectMapper` 로 `ApiResponseBody.fail` 을 직접 직렬화.
- 결정 이유: 응답 contract 의 진짜 단일 소스는 이미 `ApiResponseBody.fail` 자체라 위임으로 얻는 이득이 작다. Security 예외를 MVC 의 `HandlerExceptionResolver` 로 돌리는 cross-layer 결합이 생기고, Spring Security 표준 idiom 도 직접 작성 쪽이라 가독성이 더 자연스럽다.

### 구현

- 신규 `auth/config/ApiResponseSecurityErrorHandlers.kt` 에 두 `@Component` 추가:
  - `ApiResponseAuthenticationEntryPoint` — 401 응답 작성
  - `ApiResponseAccessDeniedHandler` — 403 응답 작성
  - 공통 plumbing (status·Content-Type·UTF-8·writeValueAsString) 은 동 파일의 private 헬퍼로 추출.
- `detail` 은 `ErrorCategory.UNAUTHORIZED.description` / `ErrorCategory.FORBIDDEN.description` 고정 문구로 채워, 호출부가 임의 문자열을 실어 응답으로 새는 통로를 차단.
- `SecurityConfig` 의 `.exceptionHandling` 의 inline lambda 를 위 두 빈으로 교체. 생성자에서 두 핸들러를 주입.

### 회귀 가드

- 신규 `SecurityErrorResponseIntegrationTest` — 한 자리에서 필터 단 401·403 의 body contract 를 망라:
  - 토큰 없이 보호 endpoint 호출 → 401, body 는 `status`·`code`·`detail` 포함
  - 위조된 Bearer 토큰 → 401
  - MEMBER 권한 토큰으로 GUEST 전용 dev endpoint 호출 → 403
- `IntegrationTestSupport` 를 그대로 상속해 컨텍스트 캐시 보존.

## Result

- 필터 단 401·403 도 정상 endpoint 와 같은 `ApiResponseBody` 래퍼로 내려간다. 클라이언트 공통 파싱 코드가 일관되게 동작.
- `detail` 은 `ErrorCategory.description` 의 고정 사용자 대면 문구만 노출 — 토큰 파싱 사유·내부 식별자가 응답으로 새지 않는다.

### 테스트

전체: total **331**, failures **0**, errors **0**, skipped **2** (환경 의존 기존 테스트)

신규 테스트 (`SecurityErrorResponseIntegrationTest`):

| # | 시나리오 | Status | Time |
|---|---|---|---|
| 1 | 토큰 없이 보호 endpoint → 401, ApiResponseBody contract | PASS | 0.013s |
| 2 | 위조된 Bearer 토큰 → 401, ApiResponseBody contract | PASS | 0.002s |
| 3 | MEMBER 권한 토큰으로 GUEST 전용 dev endpoint → 403, ApiResponseBody contract | PASS | 0.032s |

---
## 연관 이슈

- close #213


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * API 인증 실패(401) 및 권한 부족(403) 오류 응답이 표준화된 JSON 형식으로 일관되게 제공되도록 개선했습니다.

* **테스트**
  * 인증 및 권한 관련 오류 응답이 정상적으로 작동하는지 검증하는 통합 테스트를 추가했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/PIKI-Server/pull/232?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->