### PR TITLE
deploy-manual.yml 의 concurrency group 을 deploy.yml 과 통일해 EC2 race 차단

### DIFF
--- a/.github/workflows/deploy-manual.yml
+++ b/.github/workflows/deploy-manual.yml
@@ -8,8 +8,12 @@ on:
         required: true
         default: 'dev'
 
+# 자동 deploy (deploy.yml) 와 같은 EC2 한 대를 공유하므로 group 을 통일해
+# 두 워크플로우가 동시에 컨테이너를 조작하는 race 를 차단한다. cancel-in-progress: false
+# 로 두어 새 deploy 가 옛 deploy 를 죽이지 않고 대기 — 롤백 가능성을 줄이는 안전 정책.
+# 향후 진짜 staging 환경이 분리되면 deploy-staging.yml 신규 + 자기 group 으로 다시 분리한다.
 concurrency:
-  group: deploy-staging
+  group: deploy-ec2-dev
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Situation

- `deploy.yml` (자동, dev push 시 발동) 과 `deploy-manual.yml` (수동, workflow_dispatch) 둘 다 같은 EC2 한 대 (`secrets.EC2_HOST`) 에 배포한다. 원래는 환경별 (dev / staging) 동시 배포를 막으려고 concurrency group 을 `deploy-ec2-dev` vs `deploy-staging` 으로 분리해뒀음.
- 그런데 실제로는 staging 환경을 따로 구축하지 않고 EC2 한 대만 운영 중이라 group 분리가 의미를 잃었다. GitHub Actions 는 group 이 다르면 동시 실행을 막지 않으므로, 자동 deploy 의 blue/green 토글 중에 수동 deploy 가 발동되면 같은 EC2 의 컨테이너 조작이 race 가능.
- epic #231 (5/25 작업 묶음) 의 두 번째 항목 — "지금까지 그냥 굴러갔지만 자세히 들여다보면 깨질 수 있는 흐름" 결.

## Task

- 두 workflow 의 concurrency group 을 같게 만들어 GitHub Actions 가 동시 실행을 자연스럽게 차단하도록 정합.
- 향후 진짜 staging 환경이 분리될 가능성도 코드 주석에 같이 짚어, 다음 사람이 group 명을 만지기 전에 의도와 배경을 코드만 보고 잡을 수 있게.

## Action

- `deploy-manual.yml` 의 group 값을 `deploy-staging` → `deploy-ec2-dev` 로 변경. `deploy.yml` 과 동일.
- `cancel-in-progress: false` 는 그대로 유지. 새 deploy 가 옛 deploy 를 죽이지 않고 대기시키는 안전 정책 — 인터럽트로 인한 롤백 가능성을 차단.
- concurrency 블록 위에 4줄 주석을 추가해 (a) 통일 결정 이유, (b) cancel-in-progress 의도, (c) 향후 staging 환경이 진짜로 분리되면 `deploy-staging.yml` 신규 + 자기 group 으로 다시 쪼개라는 안내를 같이 박음.

## Result

- 통일 후엔 자동 deploy 진행 중 수동 deploy 가 발동되면 GitHub Actions UI 에서 "Waiting for the deploy-ec2-dev group" 으로 대기, 앞선 deploy 가 끝나야 시작 → EC2 race 차단.
- 변경 범위가 GitHub Actions workflow 한 줄(+주석) 이라 단위 테스트 영향 없음. 실제 동작은 다음 자동 + 수동 deploy 겹치는 시점에 GitHub Actions UI 의 대기 표시로 검증된다.

---
## 연관 이슈

- close #227
