### PR TITLE
Dev API 에 user ID 로 토큰 발급 endpoint 추가 — 임의 user 가장

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/auth/controller/AuthApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/controller/AuthApiExamples.kt
@@ -120,8 +120,47 @@ class AuthApiExamples(
                                     detail = "nickname: must not be blank",
                                 ),
                         )
-                        // 401(GUEST 토큰 누락)은 Security 필터 단계 거부라 본문이 ApiResponseBody 가 아닌
-                        // Spring 기본 /error 응답이다. 거짓 example 을 박지 않기 위해 의도적으로 생략한다.
+                    }
+
+                handlerMethod.binds(DevAuthController::issueTokenForUser) ->
+                    operation.examples(openApiObjectMapper.delegate) {
+                        add(
+                            status = HttpStatus.CREATED,
+                            name = "토큰 발급 성공",
+                            payload =
+                                ApiResponseBody.created(
+                                    GuestCreateResponse(
+                                        accessToken = "eyJhbGciOiJIUzI1NiJ9.access",
+                                        refreshToken = "eyJhbGciOiJIUzI1NiJ9.refresh",
+                                        user =
+                                            UserResponse(
+                                                id = UUID.fromString("3b9c1d2e-4f5a-4b6c-8d7e-9f0a1b2c3d4e"),
+                                                nickname = "홍길동",
+                                                profileImage =
+                                                    "https://api.dicebear.com/9.x/bottts/svg?seed=3b9c1d2e-4f5a-4b6c-8d7e-9f0a1b2c3d4e",
+                                                identityType = IdentityType.MEMBER,
+                                            ),
+                                    ),
+                                ),
+                        )
+                        add(
+                            status = HttpStatus.NOT_FOUND,
+                            name = "userId 에 해당하는 user 없음",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.NOT_FOUND,
+                                    status = HttpStatus.NOT_FOUND,
+                                ),
+                        )
+                        add(
+                            status = HttpStatus.CONFLICT,
+                            name = "탈퇴된 user",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.CONFLICT,
+                                    status = HttpStatus.CONFLICT,
+                                ),
+                        )
                     }
             }
             operation

--- a/src/main/kotlin/com/depromeet/piki/auth/controller/DevAuthApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/controller/DevAuthApi.kt
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.MediaType
+import java.util.UUID
 
 @Tag(name = "Dev", description = "개발·테스트 전용 API (운영 환경 비활성화)")
 interface DevAuthApi {
@@ -42,4 +43,46 @@ interface DevAuthApi {
         ],
     )
     fun createDevUser(request: DevUserCreateRequest): ApiResponseBody<GuestCreateResponse>
+
+    @Operation(
+        summary = "기존 user 의 토큰 발급 (임의 user 가장)",
+        description = "이미 존재하는 user (GUEST·MEMBER 모두) 의 access·refresh 토큰을 발급한다. " +
+            "개발·테스트에서 특정 user 시나리오를 재현할 때 사용. GUEST 토큰으로 호출해야 한다. " +
+            "OAuth 통합 전까지의 임시 endpoint 로, 다른 dev API 들과 함께 운영에서 차단 예정.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "201",
+                description = "토큰 발급 성공",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "userId 에 해당하는 user 없음",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "409",
+                description = "탈퇴(soft delete) 된 user — 토큰 발급 거부",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun issueTokenForUser(userId: UUID): ApiResponseBody<GuestCreateResponse>
 }

--- a/src/main/kotlin/com/depromeet/piki/auth/controller/DevAuthController.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/controller/DevAuthController.kt
@@ -6,11 +6,13 @@ import com.depromeet.piki.auth.service.AuthService
 import com.depromeet.piki.common.response.ApiResponseBody
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
 
 @RestController
 @RequestMapping("/api/v1/dev")
@@ -23,6 +25,15 @@ class DevAuthController(
         @Valid @RequestBody request: DevUserCreateRequest,
     ): ApiResponseBody<GuestCreateResponse> {
         val result = authService.createMember(request.nickname)
+        return ApiResponseBody.created(GuestCreateResponse.from(result.tokenPair, result.user))
+    }
+
+    @PostMapping("/{userId}/token")
+    @ResponseStatus(HttpStatus.CREATED)
+    override fun issueTokenForUser(
+        @PathVariable userId: UUID,
+    ): ApiResponseBody<GuestCreateResponse> {
+        val result = authService.issueTokenForExistingUser(userId)
         return ApiResponseBody.created(GuestCreateResponse.from(result.tokenPair, result.user))
     }
 }

--- a/src/main/kotlin/com/depromeet/piki/auth/service/AuthService.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/service/AuthService.kt
@@ -6,6 +6,7 @@ import com.depromeet.piki.auth.infrastructure.redis.RefreshTokenStore
 import com.depromeet.piki.auth.service.dto.SignupResult
 import com.depromeet.piki.auth.service.dto.TokenPair
 import com.depromeet.piki.user.domain.User
+import com.depromeet.piki.user.domain.UserException
 import com.depromeet.piki.user.service.UserService
 import org.springframework.stereotype.Service
 import java.util.UUID
@@ -24,6 +25,15 @@ class AuthService(
 
     fun createMember(nickname: String): SignupResult {
         val user = userService.createMember(nickname)
+        val tokenPair = issueTokenPair(user)
+        return SignupResult(tokenPair = tokenPair, user = user)
+    }
+
+    // Dev 전용. 기존 user 의 token pair 를 발급해 임의 user 시나리오를 재현할 수 있게 한다.
+    // OAuth 통합 (epic #122) 전까지의 임시 endpoint 와 같은 결로 묶여 운영 노출 차단 예정 (#177 후속).
+    fun issueTokenForExistingUser(userId: UUID): SignupResult {
+        val user = userService.findById(userId)
+        user.deletedAt?.let { throw UserException.deletedUser(userId) }
         val tokenPair = issueTokenPair(user)
         return SignupResult(tokenPair = tokenPair, user = user)
     }

--- a/src/test/kotlin/com/depromeet/piki/auth/config/AuthorizationBoundaryIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/config/AuthorizationBoundaryIntegrationTest.kt
@@ -47,6 +47,7 @@ class AuthorizationBoundaryIntegrationTest : IntegrationTestSupport() {
         fun protectedEndpoints(): List<Arguments> =
             listOf(
                 arguments(HttpMethod.POST, "/api/v1/dev/users"),
+                arguments(HttpMethod.POST, "/api/v1/dev/00000000-0000-0000-0000-000000000000/token"),
                 arguments(HttpMethod.POST, "/api/v1/auth/logout"),
                 arguments(HttpMethod.POST, "/api/v1/wishlists"),
                 arguments(HttpMethod.POST, "/api/v1/wishlists/ocr"),

--- a/src/test/kotlin/com/depromeet/piki/auth/controller/DevAuthControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/controller/DevAuthControllerIntegrationTest.kt
@@ -1,0 +1,121 @@
+package com.depromeet.piki.auth.controller
+
+import com.depromeet.piki.auth.infrastructure.jwt.JwtProvider
+import com.depromeet.piki.support.IntegrationTestSupport
+import com.depromeet.piki.support.uuidToBytes
+import com.depromeet.piki.user.domain.IdentityType
+import org.hamcrest.Matchers.notNullValue
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpHeaders
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.context.WebApplicationContext
+import java.util.UUID
+
+@Transactional
+class DevAuthControllerIntegrationTest : IntegrationTestSupport() {
+    @Autowired
+    private lateinit var webApplicationContext: WebApplicationContext
+
+    @Autowired
+    private lateinit var jwtProvider: JwtProvider
+
+    @Autowired
+    private lateinit var jdbcTemplate: JdbcTemplate
+
+    @Test
+    fun `MEMBER user 의 ID 로 토큰 발급 요청 시 201 과 access·refresh 토큰이 반환된다`() {
+        val targetUserId = UUID.randomUUID()
+        insertUser(targetUserId, IdentityType.MEMBER, deleted = false)
+        val guestToken = jwtProvider.generateAccessToken(UUID.randomUUID(), IdentityType.GUEST)
+
+        buildMockMvc()
+            .perform(
+                post("/api/v1/dev/$targetUserId/token")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer $guestToken"),
+            ).andExpect(status().isCreated)
+            .andExpect(jsonPath("$.status").value(201))
+            .andExpect(jsonPath("$.code").value("CREATED"))
+            .andExpect(jsonPath("$.data.accessToken", notNullValue()))
+            .andExpect(jsonPath("$.data.refreshToken", notNullValue()))
+            .andExpect(jsonPath("$.data.user.id").value(targetUserId.toString()))
+            .andExpect(jsonPath("$.data.user.identityType").value("MEMBER"))
+    }
+
+    @Test
+    fun `GUEST user 의 ID 로 토큰 발급 요청 시 201 과 GUEST 권한 토큰 쌍이 반환된다`() {
+        val targetUserId = UUID.randomUUID()
+        insertUser(targetUserId, IdentityType.GUEST, deleted = false)
+        val callerToken = jwtProvider.generateAccessToken(UUID.randomUUID(), IdentityType.GUEST)
+
+        buildMockMvc()
+            .perform(
+                post("/api/v1/dev/$targetUserId/token")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer $callerToken"),
+            ).andExpect(status().isCreated)
+            .andExpect(jsonPath("$.data.user.id").value(targetUserId.toString()))
+            .andExpect(jsonPath("$.data.user.identityType").value("GUEST"))
+    }
+
+    @Test
+    fun `존재하지 않는 userId 로 토큰 발급 요청 시 404 가 ApiResponseBody 로 반환된다`() {
+        val unknownUserId = UUID.randomUUID()
+        val guestToken = jwtProvider.generateAccessToken(UUID.randomUUID(), IdentityType.GUEST)
+
+        buildMockMvc()
+            .perform(
+                post("/api/v1/dev/$unknownUserId/token")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer $guestToken"),
+            ).andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.status").value(404))
+            .andExpect(jsonPath("$.code").value("NOT_FOUND"))
+            .andExpect(jsonPath("$.detail", notNullValue()))
+            .andExpect(jsonPath("$.data").doesNotExist())
+    }
+
+    @Test
+    fun `탈퇴된 user 의 ID 로 토큰 발급 요청 시 409 가 ApiResponseBody 로 반환된다`() {
+        val deletedUserId = UUID.randomUUID()
+        insertUser(deletedUserId, IdentityType.MEMBER, deleted = true)
+        val guestToken = jwtProvider.generateAccessToken(UUID.randomUUID(), IdentityType.GUEST)
+
+        buildMockMvc()
+            .perform(
+                post("/api/v1/dev/$deletedUserId/token")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer $guestToken"),
+            ).andExpect(status().isConflict)
+            .andExpect(jsonPath("$.status").value(409))
+            .andExpect(jsonPath("$.code").value("CONFLICT"))
+            .andExpect(jsonPath("$.detail", notNullValue()))
+            .andExpect(jsonPath("$.data").doesNotExist())
+    }
+
+    private fun buildMockMvc(): MockMvc =
+        MockMvcBuilders
+            .webAppContextSetup(webApplicationContext)
+            .apply<DefaultMockMvcBuilder>(springSecurity())
+            .build()
+
+    private fun insertUser(
+        userId: UUID,
+        identityType: IdentityType,
+        deleted: Boolean,
+    ) {
+        val deletedAtClause = if (deleted) "NOW(6)" else "NULL"
+        jdbcTemplate.update(
+            "INSERT INTO users (id, nickname, identity_type, created_at, updated_at, deleted_at) " +
+                "VALUES (?, ?, ?, NOW(6), NOW(6), $deletedAtClause)",
+            uuidToBytes(userId),
+            userId.toString().take(10),
+            identityType.name,
+        )
+    }
+}


### PR DESCRIPTION
## Situation

- 기존 dev API (POST /api/v1/dev/users) 는 매번 새 MEMBER user 를 만들고 토큰을 발급한다. 개발·테스트 중에 특정 user (게스트든 MEMBER든) 의 시나리오를 재현하려면 그 user 의 토큰이 필요한데 길이 없었음.
- epic #231 (5/25 작업 묶음) 의 세 번째 항목 — "지금까지 그냥 굴러갔지만 자세히 들여다보면 깨질 수 있는 흐름" 중 "개발 편의" 결.

## Task

- 기존 user 의 access·refresh 토큰을 발급해 "임의 user 가장" 을 가능하게 하는 dev endpoint 추가.
- 응답 contract 는 기존 dev create 와 동일하게 유지 — 클라이언트·테스트 파싱 코드가 일관되게 동작하도록.
- 발급 vs 조회 / path 길이 / 회귀 가드 범위 같은 설계 결정을 같이 잡음.

## Action

### 설계 결정

- **발급 vs 조회 — 발급으로 결정.** access token 은 stateless JWT 라 어디에도 저장되지 않아 "조회" 가 본질적으로 불가능. dev 목적 (특정 user 시나리오 재현) 자체가 발급으로만 달성됨. 부작용은 인지: 진짜 그 user 가 동시에 로그인 중이면 Redis 의 refresh 가 덮어써져 다음 refresh 시점에 강제 로그아웃 — dev 환경 가정상 실용상 문제 적음.
- **path 단축.** 처음엔 `/api/v1/dev/users/{userId}/token` 으로 잡았으나 길어서 `/api/v1/dev/{userId}/token` 로 줄임. 기존 `/api/v1/dev/users` (생성) 와 path segment 가 달라 Spring 라우팅 충돌 없음.

### 구현

- `AuthService.issueTokenForExistingUser` — `findById` → `deletedAt` 가드 → `issueTokenPair` 순. 존재 안 함은 `UserException.notFound` (404), 탈퇴는 `UserException.deletedUser` (409) 로 자연스럽게 매핑됨.
- `DevAuthController` 에 `POST /{userId}/token` 핸들러 + `DevAuthApi` 에 OpenAPI 어노테이션 (201 / 404 / 409).
- 응답 DTO 는 `GuestCreateResponse` 그대로 재사용 — `accessToken`·`refreshToken`·`user` 동일 contract. 권한 정책도 `/api/v1/dev/**` 의 `hasAuthority(GUEST)` 유지.

### 회귀 가드

- 신규 `DevAuthControllerIntegrationTest` — happy path MEMBER/GUEST + 404 (없는 userId) + 409 (탈퇴) 4 시나리오 망라.
- `AuthorizationBoundaryIntegrationTest` 의 `protectedEndpoints` 에 신규 path 의 401 진입 가드 1줄 추가 — 인증 요구가 silent 하게 풀리는 회귀를 한 자리에서 잡도록 유지.

### 부수 정리

- `AuthApiExamples` 에 신규 endpoint 의 201·404·409 예시 추가.
- `createDevUser` 쪽에 박혀 있던 "401 은 Spring 기본 /error 라 example 생략" 주석은 #213 머지 후 401 도 `ApiResponseBody` contract 로 통일됐기에 stale 이 되어 함께 제거.

## Result

- `POST /api/v1/dev/{userId}/token` 으로 임의 user (GUEST·MEMBER) 의 토큰 쌍 발급 가능. 응답 contract 는 기존 dev create 와 동일.
- 전체 테스트 **349 / 349 PASS** (failures 0, errors 0, skipped 2 — 기존 환경 의존).

신규 테스트 (`DevAuthControllerIntegrationTest`):

| # | 시나리오 | Status | Time |
|---|---|---|---|
| 1 | MEMBER user ID 로 토큰 발급 → 201 + token pair + user 객체 | PASS | 0.009s |
| 2 | GUEST user ID 로 토큰 발급 → 201 + GUEST 권한 토큰 쌍 | PASS | 0.006s |
| 3 | 존재하지 않는 userId → 404 ApiResponseBody | PASS | 0.004s |
| 4 | 탈퇴된 user → 409 ApiResponseBody | PASS | 0.006s |

### 보안 메모

Dev API 는 현재 운영 환경에도 노출됨 (#177 임시 조치, OAuth 통합 전까지). 이 endpoint 는 사실상 "임의 user 가장" 이므로 dev 전용임이 명확해야 함. epic #122 (OAuth 통합) 시점에 다른 dev API 들과 함께 운영에서 차단되도록 묶을 예정.

---
## 연관 이슈

- close #228
