### PR TITLE
닉네임 중복 검사에서 본인 닉네임 제외 — 게스트→유저 승격 흐름 정합

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/user/controller/UserApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/user/controller/UserApi.kt
@@ -106,7 +106,9 @@ interface UserApi {
 
     @Operation(
         summary = "닉네임 중복 체크",
-        description = "닉네임이 이미 다른 유저에게 점유됐는지 확인한다. 회원 전환 / 닉네임 수정 전 사전 확인용.",
+        description =
+            "닉네임이 이미 다른 유저에게 점유됐는지 확인한다. 회원 전환 / 닉네임 수정 전 사전 확인용. " +
+                "본인의 현재 닉네임은 중복으로 잡지 않는다 — 자기 닉네임 유지 / 자기 닉네임으로 재확인 흐름이 자연스럽게 통과.",
     )
     @ApiResponses(
         value = [
@@ -142,5 +144,8 @@ interface UserApi {
             ),
         ],
     )
-    fun checkNickname(request: NicknameCheckRequest): ApiResponseBody<NicknameCheckResponse>
+    fun checkNickname(
+        @Parameter(hidden = true) userId: UUID,
+        request: NicknameCheckRequest,
+    ): ApiResponseBody<NicknameCheckResponse>
 }

--- a/src/main/kotlin/com/depromeet/piki/user/controller/UserController.kt
+++ b/src/main/kotlin/com/depromeet/piki/user/controller/UserController.kt
@@ -41,7 +41,10 @@ class UserController(
 
     @GetMapping("/nickname/check")
     override fun checkNickname(
+        @AuthenticationPrincipal userId: UUID,
         @Valid request: NicknameCheckRequest,
     ): ApiResponseBody<NicknameCheckResponse> =
-        ApiResponseBody.ok(NicknameCheckResponse(available = userService.isNicknameAvailable(request.nickname)))
+        ApiResponseBody.ok(
+            NicknameCheckResponse(available = userService.isNicknameAvailable(request.nickname, userId)),
+        )
 }

--- a/src/main/kotlin/com/depromeet/piki/user/repository/UserJpaRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/user/repository/UserJpaRepository.kt
@@ -6,4 +6,9 @@ import java.util.UUID
 
 interface UserJpaRepository : JpaRepository<User, UUID> {
     fun existsByNickname(nickname: String): Boolean
+
+    fun existsByNicknameAndIdNot(
+        nickname: String,
+        id: UUID,
+    ): Boolean
 }

--- a/src/main/kotlin/com/depromeet/piki/user/repository/UserRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/user/repository/UserRepository.kt
@@ -11,4 +11,11 @@ interface UserRepository {
     fun findByIds(ids: Collection<UUID>): List<User>
 
     fun existsByNickname(nickname: String): Boolean
+
+    // 본인 user 를 제외한 중복 검사. 닉네임 유지·자기 닉네임으로 다시 변경하는 흐름에서
+    // 본인까지 잡아 409 를 내던 결을 막기 위한 변형 (#230).
+    fun existsByNicknameAndIdNot(
+        nickname: String,
+        excludeUserId: UUID,
+    ): Boolean
 }

--- a/src/main/kotlin/com/depromeet/piki/user/repository/UserRepositoryImpl.kt
+++ b/src/main/kotlin/com/depromeet/piki/user/repository/UserRepositoryImpl.kt
@@ -16,4 +16,9 @@ class UserRepositoryImpl(
     override fun findByIds(ids: Collection<UUID>): List<User> = userJpaRepository.findAllById(ids)
 
     override fun existsByNickname(nickname: String): Boolean = userJpaRepository.existsByNickname(nickname)
+
+    override fun existsByNicknameAndIdNot(
+        nickname: String,
+        excludeUserId: UUID,
+    ): Boolean = userJpaRepository.existsByNicknameAndIdNot(nickname, excludeUserId)
 }

--- a/src/main/kotlin/com/depromeet/piki/user/service/UserService.kt
+++ b/src/main/kotlin/com/depromeet/piki/user/service/UserService.kt
@@ -103,7 +103,14 @@ class UserService(
             throw UserException.duplicateNickname()
         }
         user.updateNickname(newNickname)
-        return userRepository.save(user)
+        // existsByNicknameAndIdNot 체크와 save 사이에 다른 트랜잭션이 같은 nickname 으로
+        // update / insert 하면 DB unique constraint (uq_users_nickname) 위반이 떠 race 케이스에서
+        // 500 이 새어나갈 수 있다. createMember 와 같은 패턴으로 catch → 409 로 매핑.
+        return try {
+            userRepository.save(user)
+        } catch (e: DataIntegrityViolationException) {
+            throw UserException.duplicateNickname()
+        }
     }
 
     @Transactional

--- a/src/main/kotlin/com/depromeet/piki/user/service/UserService.kt
+++ b/src/main/kotlin/com/depromeet/piki/user/service/UserService.kt
@@ -84,8 +84,13 @@ class UserService(
     @Transactional(readOnly = true)
     fun findById(userId: UUID): User = userRepository.findById(userId) ?: throw UserException.notFound(userId)
 
+    // 본인 닉네임은 중복으로 잡지 않는다 (#230). 게스트가 자기 닉네임 그대로 유지하거나, 본인이
+    // 자기 닉네임으로 다시 변경하는 흐름이 자연스럽게 통과되도록 본인 제외 후 검사.
     @Transactional(readOnly = true)
-    fun isNicknameAvailable(nickname: String): Boolean = !userRepository.existsByNickname(nickname)
+    fun isNicknameAvailable(
+        nickname: String,
+        userId: UUID,
+    ): Boolean = !userRepository.existsByNicknameAndIdNot(nickname, userId)
 
     @Transactional
     fun updateNickname(
@@ -94,7 +99,7 @@ class UserService(
     ): User {
         val user = findById(userId)
         user.deletedAt?.let { throw UserException.deletedUser(userId) }
-        if (user.nickname != newNickname && userRepository.existsByNickname(newNickname)) {
+        if (userRepository.existsByNicknameAndIdNot(newNickname, userId)) {
             throw UserException.duplicateNickname()
         }
         user.updateNickname(newNickname)

--- a/src/test/kotlin/com/depromeet/piki/tournament/service/TournamentServiceTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/service/TournamentServiceTest.kt
@@ -89,6 +89,11 @@ class TournamentServiceTest {
         override fun findByIds(ids: Collection<UUID>): List<User> = ids.mapNotNull { users[it] }
 
         override fun existsByNickname(nickname: String): Boolean = users.values.any { it.nickname == nickname }
+
+        override fun existsByNicknameAndIdNot(
+            nickname: String,
+            excludeUserId: UUID,
+        ): Boolean = users.values.any { it.nickname == nickname && it.id != excludeUserId }
     }
 
     private class TestTournamentItemRepository : TournamentItemRepository {

--- a/src/test/kotlin/com/depromeet/piki/user/controller/UserControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/user/controller/UserControllerIntegrationTest.kt
@@ -173,22 +173,64 @@ class UserControllerIntegrationTest : IntegrationTestSupport() {
     }
 
     @Test
-    fun `GET users nickname check - 이미 사용 중인 닉네임이면 available false 가 반환된다`() {
+    fun `GET users nickname check - 다른 user 가 이미 점유한 닉네임이면 available false 가 반환된다`() {
+        val mockMvc =
+            MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .apply<DefaultMockMvcBuilder>(springSecurity())
+                .build()
+        val otherUserId = UUID.randomUUID()
+        insertUser(otherUserId, nickname = "점유닉네임")
+        val myUserId = UUID.randomUUID()
+        insertUser(myUserId, nickname = "내닉네임")
+
+        mockMvc
+            .perform(
+                get("/api/v1/users/nickname/check")
+                    .param("nickname", "점유닉네임")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer ${token(myUserId)}"),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.available").value(false))
+    }
+
+    @Test
+    fun `GET users nickname check - 본인이 자기 닉네임으로 호출하면 본인 제외로 available true 가 반환된다`() {
         val mockMvc =
             MockMvcBuilders
                 .webAppContextSetup(webApplicationContext)
                 .apply<DefaultMockMvcBuilder>(springSecurity())
                 .build()
         val userId = UUID.randomUUID()
-        insertUser(userId, nickname = "점유닉네임")
+        insertUser(userId, nickname = "내닉네임")
 
         mockMvc
             .perform(
                 get("/api/v1/users/nickname/check")
-                    .param("nickname", "점유닉네임")
+                    .param("nickname", "내닉네임")
                     .header(HttpHeaders.AUTHORIZATION, "Bearer ${token(userId)}"),
             ).andExpect(status().isOk)
-            .andExpect(jsonPath("$.data.available").value(false))
+            .andExpect(jsonPath("$.data.available").value(true))
+    }
+
+    @Test
+    fun `PATCH users me - 본인이 자기 닉네임 그대로 보내면 200 으로 통과한다`() {
+        val mockMvc =
+            MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .apply<DefaultMockMvcBuilder>(springSecurity())
+                .build()
+        val userId = UUID.randomUUID()
+        insertUser(userId, nickname = "내닉네임")
+        val body = objectMapper.writeValueAsString(mapOf("nickname" to "내닉네임"))
+
+        mockMvc
+            .perform(
+                patch("/api/v1/users/me")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer ${token(userId)}")
+                    .content(body),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.nickname").value("내닉네임"))
     }
 
     @Test


### PR DESCRIPTION
## Situation

- 닉네임 중복 검사가 모든 User 대상으로 동작해 본인까지 포함됐다. 게스트가 자기 닉네임 그대로 유지·재확인하거나, 본인이 자기 닉네임을 다시 입력하는 자연스러운 흐름이 모두 "이미 있는 닉네임" 으로 잡혀 409 가 떴다.
- epic #231 (5/25 작업 묶음) 의 네 번째 항목 — "지금까지 그냥 굴러갔지만 자세히 들여다보면 깨질 수 있는 흐름" 중 "사용자 흐름 정합" 결.

## Task

- 닉네임 중복 검사에서 **요청자 본인의 User 는 제외** (`userId != 본인` 인 User 중에서만 중복 체크).
- 적용 endpoint:
  - `GET /api/v1/users/nickname/check` — 인증된 요청자 본인 제외
  - `PATCH /api/v1/users/me` — 닉네임 변경 시 본인 제외 (같은 정책)
- 두 메서드 사이의 검사 패턴을 한 모양으로 통일.

## Action

### 검사 통일

- `UserRepository.existsByNicknameAndIdNot(nickname, excludeUserId)` 추가. Spring Data JPA 의 derived query naming 으로 매핑되어 별도 `@Query` 불필요.
- `UserService` 의 두 메서드 (`isNicknameAvailable`·`updateNickname`) 모두 같은 self-exclude 패턴으로 통일. `updateNickname` 의 기존 `user.nickname != newNickname` early-return 우회 (의도는 같으나 결이 다르게 보이던 단편) 를 한 모양으로 정리.

### 컨트롤러

- `GET /nickname/check` 가 `@AuthenticationPrincipal userId` 받아 서비스로 전달. `SecurityConfig` 의 매처가 이미 비인증 호출을 차단하고 있어 항상 식별 가능 — 별도 nullable 분기 없음.

### 회귀 가드

- 기존 "이미 사용 중인 닉네임이면 false" 테스트가 본인 닉네임을 본인 토큰으로 체크하던 결이라 self-exclude 후엔 회귀로 깨졌을 것. 다른 user 가 점유한 케이스로 바로잡음.
- 신규 self-exclude 시나리오 2건: (a) `check` 본인 닉네임 → `available true`, (b) `PATCH /me` 본인 닉네임 그대로 → 200.
- `TestUserRepository` (TournamentServiceTest 내부 fake) — UserRepository 인터페이스 확장에 맞춰 1줄 구현 추가.

### 스코프 경계 명시

- 작업 중 사용자가 reproduce 한 경로 — "게스트 토큰 → `POST /api/v1/dev/users` 같은 닉네임으로 MEMBER 생성 → 409" 는 **이 PR scope 밖**. 그건 *새 user 생성* 이라 self-exclude 와 무관 (가드해야 할 "본인" 이 없음). 이슈 본문이 명시한 두 production path 만 다룬다 — dev API 자체 정리는 OAuth 통합 (epic #122) 시 다른 dev API 들과 함께 다룰 결.

## Result

- 본인 닉네임 유지·재확인·재변경 흐름이 자연스럽게 통과.
- 다른 user 점유 닉네임은 그대로 차단 (409 / `available: false`) — 회귀 가드.
- 전체 테스트 **346 / 346 PASS** (failures 0, errors 0, skipped 2 — 기존 환경 의존).

신규·갱신 테스트 (`UserControllerIntegrationTest`):

| # | 시나리오 | Status | Time |
|---|---|---|---|
| 1 | 다른 user 가 점유한 닉네임 → `available false` | PASS | 0.009s |
| 2 | 본인이 자기 닉네임으로 호출 → 본인 제외로 `available true` | PASS | 0.004s |
| 3 | PATCH /me 본인 닉네임 그대로 → 200 통과 | PASS | 0.006s |

---
## 연관 이슈

- close #230


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 닉네임 중복 확인 시 현재 사용자의 기존 닉네임을 중복으로 처리하지 않도록 개선
  * 닉네임 변경 시 본인의 닉네임은 중복 검증에서 제외되도록 수정

* **Tests**
  * 닉네임 중복 확인 테스트 케이스 업데이트 (다른 사용자 닉네임 점유 시나리오 추가)
  * 본인 닉네임 유지 및 변경 시나리오에 대한 테스트 케이스 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/PIKI-Server/pull/235?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->