### PR TITLE
Dev API - 유저 단건 조회 시 AT·RT 함께 발급

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/user/controller/DevUserApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/user/controller/DevUserApi.kt
@@ -1,8 +1,8 @@
 package com.depromeet.piki.user.controller
 
+import com.depromeet.piki.auth.controller.dto.GuestCreateResponse
 import com.depromeet.piki.common.response.ApiResponseBody
 import com.depromeet.piki.user.controller.dto.DevUserSummaryResponse
-import com.depromeet.piki.user.controller.dto.UserResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
@@ -36,13 +36,13 @@ interface DevUserApi {
 
     @Operation(
         summary = "단건 유저 조회",
-        description = "userId 로 유저 전체 정보를 반환한다. 개발 편의용.",
+        description = "userId 로 유저 정보와 AT·RT 를 발급해 반환한다. 개발 편의용.",
     )
     @ApiResponses(
         value = [
             ApiResponse(
                 responseCode = "200",
-                description = "유저 정보 반환",
+                description = "유저 정보 및 AT·RT 반환",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,
@@ -62,5 +62,5 @@ interface DevUserApi {
             ),
         ],
     )
-    fun getUser(userId: UUID): ApiResponseBody<UserResponse>
+    fun getUser(userId: UUID): ApiResponseBody<GuestCreateResponse>
 }

--- a/src/main/kotlin/com/depromeet/piki/user/controller/DevUserController.kt
+++ b/src/main/kotlin/com/depromeet/piki/user/controller/DevUserController.kt
@@ -1,11 +1,11 @@
 package com.depromeet.piki.user.controller
 
+import com.depromeet.piki.auth.controller.dto.GuestCreateResponse
+import com.depromeet.piki.auth.service.AuthService
 import com.depromeet.piki.common.response.ApiResponseBody
 import com.depromeet.piki.common.response.PageResponse
 import com.depromeet.piki.user.controller.dto.DevUserSummaryResponse
-import com.depromeet.piki.user.controller.dto.UserResponse
 import com.depromeet.piki.user.repository.UserJpaRepository
-import com.depromeet.piki.user.service.UserService
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
 import org.springframework.web.bind.annotation.GetMapping
@@ -22,7 +22,7 @@ import java.util.UUID
 @RequestMapping("/api/v1/dev/users")
 class DevUserController(
     private val userJpaRepository: UserJpaRepository,
-    private val userService: UserService,
+    private val authService: AuthService,
 ) : DevUserApi {
     @GetMapping
     override fun listUsers(
@@ -46,6 +46,8 @@ class DevUserController(
     @GetMapping("/{userId}")
     override fun getUser(
         @PathVariable userId: UUID,
-    ): ApiResponseBody<UserResponse> =
-        ApiResponseBody.ok(UserResponse.from(userService.findById(userId)))
+    ): ApiResponseBody<GuestCreateResponse> {
+        val result = authService.issueTokenForExistingUser(userId)
+        return ApiResponseBody.ok(GuestCreateResponse.from(result.tokenPair, result.user))
+    }
 }

--- a/src/test/kotlin/com/depromeet/piki/user/controller/DevUserControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/user/controller/DevUserControllerIntegrationTest.kt
@@ -3,6 +3,7 @@ package com.depromeet.piki.user.controller
 import com.depromeet.piki.support.IntegrationTestSupport
 import com.depromeet.piki.support.uuidToBytes
 import com.depromeet.piki.user.domain.IdentityType
+import org.hamcrest.Matchers.notNullValue
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.jdbc.core.JdbcTemplate
@@ -63,7 +64,7 @@ class DevUserControllerIntegrationTest : IntegrationTestSupport() {
     }
 
     @Test
-    fun `존재하는 userId 로 단건 조회 시 200 과 전체 user 정보가 반환된다`() {
+    fun `존재하는 userId 로 단건 조회 시 200 과 AT·RT·user 정보가 반환된다`() {
         val userId = UUID.randomUUID()
         insertUser(userId, "단건유저", IdentityType.MEMBER)
 
@@ -71,10 +72,11 @@ class DevUserControllerIntegrationTest : IntegrationTestSupport() {
             .perform(get("/api/v1/dev/users/$userId"))
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.status").value(200))
-            .andExpect(jsonPath("$.data.id").value(userId.toString()))
-            .andExpect(jsonPath("$.data.nickname").value("단건유저"))
-            .andExpect(jsonPath("$.data.profileImage").exists())
-            .andExpect(jsonPath("$.data.identityType").value("MEMBER"))
+            .andExpect(jsonPath("$.data.accessToken", notNullValue()))
+            .andExpect(jsonPath("$.data.refreshToken", notNullValue()))
+            .andExpect(jsonPath("$.data.user.id").value(userId.toString()))
+            .andExpect(jsonPath("$.data.user.nickname").value("단건유저"))
+            .andExpect(jsonPath("$.data.user.identityType").value("MEMBER"))
     }
 
     @Test


### PR DESCRIPTION
## Situation

- PR #239 (`GET /api/v1/dev/users/{userId}`) 머지 후, 응답에 AT·RT 가 없어 FE 가 별도 토큰 발급 요청을 추가로 해야 하는 불편이 있었음

## Task

- `GET /api/v1/dev/users/{userId}` 응답을 guest 로그인·승격 응답과 동일한 구조로 변경

## Action

- 응답 타입을 `UserResponse` → `GuestCreateResponse` (accessToken, refreshToken, user) 로 교체
- `authService.issueTokenForExistingUser` 재사용 — `DevAuthController.issueTokenForUser` 와 같은 메서드
- 기존 단건 조회 테스트를 AT·RT 검증으로 갱신

## Result

- `GET /api/v1/dev/users/{userId}` 한 번으로 유저 정보 + AT·RT 를 함께 받아 즉시 사용 가능

---
## 연관 이슈

- #238