### PR TITLE
토너먼트 아이템 추가 경로 분리 및 비동기 처리 전환

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/common/config/AsyncConfig.kt
+++ b/src/main/kotlin/com/depromeet/piki/common/config/AsyncConfig.kt
@@ -20,7 +20,8 @@ class AsyncConfig {
             setThreadNamePrefix("item-parsing-")
             // 포화 시 기본 AbortPolicy 로 거부한다. 호출 스레드(톰캣)에서 동기 실행하는 CallerRunsPolicy 는
             // 외부 LLM 호출(최대 60s)로 톰캣 워커 풀을 고갈시켜 무관한 API 까지 번지므로 쓰지 않는다.
-            // 거부는 WishlistService.register 가 잡아 해당 item 을 즉시 FAILED 로 떨어뜨린다(PROCESSING 방치 금지).
+            // 거부는 호출부(WishlistService.register, TournamentItemService.addItemsFromImages 등)가 잡아
+            // 해당 item 을 즉시 FAILED 로 떨어뜨린다(PROCESSING 방치 금지).
             initialize()
         }
 

--- a/src/main/kotlin/com/depromeet/piki/item/repository/ItemRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/item/repository/ItemRepository.kt
@@ -6,6 +6,8 @@ import java.time.LocalDateTime
 interface ItemRepository {
     fun save(item: Item): Item
 
+    fun saveAll(items: List<Item>): List<Item>
+
     fun findByIds(ids: List<Long>): List<Item>
 
     fun findById(id: Long): Item?

--- a/src/main/kotlin/com/depromeet/piki/item/repository/ItemRepositoryImpl.kt
+++ b/src/main/kotlin/com/depromeet/piki/item/repository/ItemRepositoryImpl.kt
@@ -11,6 +11,8 @@ class ItemRepositoryImpl(
 ) : ItemRepository {
     override fun save(item: Item): Item = itemJpaRepository.save(item)
 
+    override fun saveAll(items: List<Item>): List<Item> = itemJpaRepository.saveAll(items)
+
     override fun findByIds(ids: List<Long>): List<Item> = itemJpaRepository.findAllById(ids)
 
     override fun findById(id: Long): Item? = itemJpaRepository.findById(id).orElse(null)

--- a/src/main/kotlin/com/depromeet/piki/item/service/AsyncImageParsingWorker.kt
+++ b/src/main/kotlin/com/depromeet/piki/item/service/AsyncImageParsingWorker.kt
@@ -1,0 +1,62 @@
+package com.depromeet.piki.item.service
+
+import com.depromeet.piki.common.config.AsyncConfig
+import com.depromeet.piki.common.storage.ImageStorage
+import com.depromeet.piki.ocr.domain.OcrImage
+import com.depromeet.piki.ocr.service.ImageCropper
+import com.depromeet.piki.ocr.service.ProductImageExtractor
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+// itemParsingExecutor 스레드에서 OCR 파싱을 수행한다.
+// 외부 호출(extract, crop, upload)은 트랜잭션 바깥에서 끝내고,
+// 상태 전이 영속화만 ItemParsingService(@Transactional) 에 위임해 짧은 트랜잭션으로 묶는다.
+// AsyncItemParsingWorker(URL 기반) 와 동일한 패턴 — 실패는 모두 FAILED 전이로 흡수한다.
+@Component
+class AsyncImageParsingWorker(
+    private val productImageExtractor: ProductImageExtractor,
+    private val imageCropper: ImageCropper,
+    private val imageStorage: ImageStorage,
+    private val itemParsingService: ItemParsingService,
+) : ImageParsingWorker {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Async(AsyncConfig.ITEM_PARSING_EXECUTOR)
+    override fun parse(
+        itemId: Long,
+        image: OcrImage,
+    ) {
+        runCatching {
+            val extraction = productImageExtractor.extract(image)
+            val imageUrl =
+                extraction.boundingBox
+                    ?.let { imageCropper.crop(image.bytes, it) }
+                    ?.let { cropped ->
+                        runCatching {
+                            imageStorage.upload(cropped, "items/${UUID.randomUUID()}.png", "image/png")
+                        }.getOrElse { e ->
+                            log.warn("item {} 크롭 이미지 S3 업로드 실패, imageUrl 없이 등록: {}", itemId, e.message)
+                            null
+                        }
+                    }
+            extraction.snapshot.copy(imageUrl = imageUrl)
+        }.onSuccess { snapshot ->
+            runCatching { itemParsingService.markReady(itemId, snapshot) }
+                .onSuccess { log.info("item {} OCR 파싱 완료 → READY", itemId) }
+                .onFailure { e ->
+                    log.warn("item {} READY 전이 실패 → FAILED: {}", itemId, e.message)
+                    markFailedQuietly(itemId)
+                }
+        }.onFailure { e ->
+            log.warn("item {} OCR 파싱 실패: {}", itemId, e.message)
+            markFailedQuietly(itemId)
+        }
+    }
+
+    private fun markFailedQuietly(itemId: Long) {
+        runCatching { itemParsingService.markFailed(itemId) }
+            .onFailure { e -> log.info("item {} 는 이미 전이됨, FAILED 처리 생략: {}", itemId, e.message) }
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/item/service/AsyncImageParsingWorker.kt
+++ b/src/main/kotlin/com/depromeet/piki/item/service/AsyncImageParsingWorker.kt
@@ -57,6 +57,11 @@ class AsyncImageParsingWorker(
 
     private fun markFailedQuietly(itemId: Long) {
         runCatching { itemParsingService.markFailed(itemId) }
-            .onFailure { e -> log.info("item {} 는 이미 전이됨, FAILED 처리 생략: {}", itemId, e.message) }
+            .onFailure { e ->
+                when (e) {
+                    is IllegalStateException -> log.info("item {} 는 이미 전이됨, FAILED 처리 생략: {}", itemId, e.message)
+                    else -> log.error("item {} FAILED 전이 실패, PROCESSING 방치 위험", itemId, e)
+                }
+            }
     }
 }

--- a/src/main/kotlin/com/depromeet/piki/item/service/AsyncItemParsingWorker.kt
+++ b/src/main/kotlin/com/depromeet/piki/item/service/AsyncItemParsingWorker.kt
@@ -68,6 +68,11 @@ class AsyncItemParsingWorker(
     // FAILED 전이도 sweeper 와의 레이스로 실패할 수 있어(이미 전이됨) 잡아 흡수한다.
     private fun markFailedQuietly(itemId: Long) {
         runCatching { itemParsingService.markFailed(itemId) }
-            .onFailure { e -> log.info("item {} 는 이미 전이됨, FAILED 처리 생략: {}", itemId, e.message) }
+            .onFailure { e ->
+                when (e) {
+                    is IllegalStateException -> log.info("item {} 는 이미 전이됨, FAILED 처리 생략: {}", itemId, e.message)
+                    else -> log.error("item {} FAILED 전이 실패, PROCESSING 방치 위험", itemId, e)
+                }
+            }
     }
 }

--- a/src/main/kotlin/com/depromeet/piki/item/service/ImageParsingWorker.kt
+++ b/src/main/kotlin/com/depromeet/piki/item/service/ImageParsingWorker.kt
@@ -1,0 +1,13 @@
+package com.depromeet.piki.item.service
+
+import com.depromeet.piki.ocr.domain.OcrImage
+
+// PROCESSING item 의 OCR 파싱을 백그라운드로 수행하는 경계.
+// 호출 즉시 반환하고 실제 파싱(외부 LLM 호출)은 비동기로 진행되어 item 을 READY/FAILED 로 전이시킨다.
+// ItemParsingWorker(URL 기반) 와 분리해 두어, OCR 경로가 URL 경로와 독립적으로 교체·확장 가능하다.
+interface ImageParsingWorker {
+    fun parse(
+        itemId: Long,
+        image: OcrImage,
+    )
+}

--- a/src/main/kotlin/com/depromeet/piki/item/service/StaleProcessingItemSweeper.kt
+++ b/src/main/kotlin/com/depromeet/piki/item/service/StaleProcessingItemSweeper.kt
@@ -27,7 +27,12 @@ class StaleProcessingItemSweeper(
         val skipped =
             staleIds.count { itemId ->
                 runCatching { itemParsingService.markFailed(itemId) }
-                    .onFailure { e -> log.info("item {} 는 이미 전이됨, stale 정리 생략: {}", itemId, e.message) }
+                    .onFailure { e ->
+                        when (e) {
+                            is IllegalStateException -> log.info("item {} 는 이미 전이됨, stale 정리 생략: {}", itemId, e.message)
+                            else -> log.error("item {} stale FAILED 전이 실패", itemId, e)
+                        }
+                    }
                     .isFailure
             }
         log.warn(

--- a/src/main/kotlin/com/depromeet/piki/item/service/StaleProcessingItemSweeper.kt
+++ b/src/main/kotlin/com/depromeet/piki/item/service/StaleProcessingItemSweeper.kt
@@ -23,23 +23,31 @@ class StaleProcessingItemSweeper(
         if (staleIds.isEmpty()) return
         // sweep 이 조회한 직후 워커가 막 READY/FAILED 로 전이했을 수 있다(레이스).
         // 그 경우 markFailed 의 전이 불변식(check)이 깨지므로 잡아 무시한다 — 이미 정상 종료된 것이다.
-        // 정리/스킵 건수를 분리해 로그하므로 부분 실패가 전체 성공으로 가려지지 않는다.
-        val skipped =
-            staleIds.count { itemId ->
-                runCatching { itemParsingService.markFailed(itemId) }
-                    .onFailure { e ->
-                        when (e) {
-                            is IllegalStateException -> log.info("item {} 는 이미 전이됨, stale 정리 생략: {}", itemId, e.message)
-                            else -> log.error("item {} stale FAILED 전이 실패", itemId, e)
+        // 레이스(이미 전이됨)와 실제 전이 실패를 분리 집계해 요약 로그에서 오판을 막는다.
+        var alreadyTransitioned = 0
+        var transitionFailed = 0
+        for (itemId in staleIds) {
+            runCatching { itemParsingService.markFailed(itemId) }
+                .onFailure { e ->
+                    when (e) {
+                        is IllegalStateException -> {
+                            alreadyTransitioned++
+                            log.info("item {} 는 이미 전이됨, stale 정리 생략: {}", itemId, e.message)
+                        }
+                        else -> {
+                            transitionFailed++
+                            log.error("item {} stale FAILED 전이 실패", itemId, e)
                         }
                     }
-                    .isFailure
-            }
+                }
+        }
+        val succeeded = staleIds.size - alreadyTransitioned - transitionFailed
         log.warn(
-            "stale PROCESSING {}건 중 {}건 FAILED 정리, {}건은 이미 전이됨(레이스)",
+            "stale PROCESSING {}건 — FAILED 정리 {}건, 이미 전이됨(레이스) {}건, 전이 실패 {}건",
             staleIds.size,
-            staleIds.size - skipped,
-            skipped,
+            succeeded,
+            alreadyTransitioned,
+            transitionFailed,
         )
     }
 

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
@@ -83,14 +83,17 @@ interface TournamentApi {
 
     @Operation(
         summary = "이미지로 토너먼트 아이템 추가",
-        description = "PENDING 상태의 토너먼트에 이미지 OCR을 통해 아이템을 추가한다. 1~5장까지 한 번에 추가 가능하다. 토너먼트 참여자만 추가할 수 있다.",
+        description = "PENDING 상태의 토너먼트에 이미지 OCR을 통해 아이템을 추가한다. 이미지 1~5장을 전달하면 아이템이 PROCESSING 상태로 즉시 생성되어 itemIds가 반환된다. " +
+            "OCR 파싱은 비동기로 진행되며 완료 시 READY 또는 FAILED 상태로 전환된다. " +
+            "클라이언트는 아이템 상태를 실시간으로 반영하기 위해 itemId로 상태를 폴링한다(친구가 담은 아이템도 동일하게 폴링으로 실시간 반영). " +
+            "토너먼트 참여자만 추가할 수 있다.",
     )
     @ApiResponse(
         responseCode = "200",
         description = "아이템 추가 성공",
         content = [
             Content(
-                mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                mediaType = MediaType.APPLICATION_JSON_VALUE,
                 schema = Schema(implementation = ApiResponseBody::class),
             ),
         ],

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
@@ -1,6 +1,8 @@
 package com.depromeet.piki.tournament.controller
 
 import com.depromeet.piki.common.response.ApiResponseBody
+import com.depromeet.piki.tournament.controller.dto.AddTournamentItemFromLinkRequest
+import com.depromeet.piki.tournament.controller.dto.AddTournamentItemsFromImagesResponse
 import com.depromeet.piki.tournament.controller.dto.AddTournamentItemsRequest
 import com.depromeet.piki.tournament.controller.dto.CreateTournamentRequest
 import com.depromeet.piki.tournament.controller.dto.CreateTournamentResponse
@@ -15,6 +17,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.MediaType
+import org.springframework.web.multipart.MultipartFile
 import java.util.UUID
 
 @Tag(name = "Tournament", description = "토너먼트 API")
@@ -39,10 +42,8 @@ interface TournamentApi {
     ): ApiResponseBody<CreateTournamentResponse>
 
     @Operation(
-        summary = "토너먼트 아이템 추가",
-        description =
-            "PENDING 상태의 토너먼트에 아이템을 추가한다. 토너먼트 참여자만 추가할 수 있다. " +
-                "파싱이 끝난 READY 아이템만 추가할 수 있으며, 아직 파싱 중(PROCESSING)이거나 실패(FAILED)한 아이템은 409 로 거부된다.",
+        summary = "위시에서 토너먼트 아이템 추가",
+        description = "PENDING 상태의 토너먼트에 이미 저장된 아이템을 위시 목록에서 추가한다. 토너먼트 참여자만 추가할 수 있다.",
     )
     @ApiResponse(
         responseCode = "200",
@@ -54,11 +55,51 @@ interface TournamentApi {
             ),
         ],
     )
-    fun addItems(
+    fun addItemsFromWish(
         userId: UUID,
         tournamentId: Long,
         request: AddTournamentItemsRequest,
     ): ApiResponseBody<Unit>
+
+    @Operation(
+        summary = "URL 링크로 토너먼트 아이템 추가",
+        description = "PENDING 상태의 토너먼트에 URL 링크를 파싱해 아이템을 추가한다. 토너먼트 참여자만 추가할 수 있다.",
+    )
+    @ApiResponse(
+        responseCode = "200",
+        description = "아이템 추가 성공",
+        content = [
+            Content(
+                mediaType = MediaType.APPLICATION_JSON_VALUE,
+                schema = Schema(implementation = ApiResponseBody::class),
+            ),
+        ],
+    )
+    fun addItemFromLink(
+        userId: UUID,
+        tournamentId: Long,
+        request: AddTournamentItemFromLinkRequest,
+    ): ApiResponseBody<Unit>
+
+    @Operation(
+        summary = "이미지로 토너먼트 아이템 추가",
+        description = "PENDING 상태의 토너먼트에 이미지 OCR을 통해 아이템을 추가한다. 1~5장까지 한 번에 추가 가능하다. 토너먼트 참여자만 추가할 수 있다.",
+    )
+    @ApiResponse(
+        responseCode = "200",
+        description = "아이템 추가 성공",
+        content = [
+            Content(
+                mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                schema = Schema(implementation = ApiResponseBody::class),
+            ),
+        ],
+    )
+    fun addItemsFromImages(
+        userId: UUID,
+        tournamentId: Long,
+        images: List<MultipartFile>,
+    ): ApiResponseBody<AddTournamentItemsFromImagesResponse>
 
     @Operation(
         summary = "토너먼트 아이템 삭제",

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
@@ -2,6 +2,7 @@ package com.depromeet.piki.tournament.controller
 
 import com.depromeet.piki.common.response.ApiResponseBody
 import com.depromeet.piki.tournament.controller.dto.AddTournamentItemFromLinkRequest
+import com.depromeet.piki.tournament.controller.dto.AddTournamentItemFromLinkResponse
 import com.depromeet.piki.tournament.controller.dto.AddTournamentItemsFromImagesResponse
 import com.depromeet.piki.tournament.controller.dto.AddTournamentItemsRequest
 import com.depromeet.piki.tournament.controller.dto.CreateTournamentRequest
@@ -63,7 +64,9 @@ interface TournamentApi {
 
     @Operation(
         summary = "URL 링크로 토너먼트 아이템 추가",
-        description = "PENDING 상태의 토너먼트에 URL 링크를 파싱해 아이템을 추가한다. 토너먼트 참여자만 추가할 수 있다.",
+        description = "PENDING 상태의 토너먼트에 URL 링크를 통해 아이템을 추가한다. 아이템이 PROCESSING 상태로 즉시 생성되어 itemId가 반환된다. " +
+            "파싱은 비동기로 진행되며 완료 시 READY 또는 FAILED 상태로 전환된다. " +
+            "클라이언트는 itemId로 상태를 폴링한다. 토너먼트 참여자만 추가할 수 있다.",
     )
     @ApiResponse(
         responseCode = "200",
@@ -79,7 +82,7 @@ interface TournamentApi {
         userId: UUID,
         tournamentId: Long,
         request: AddTournamentItemFromLinkRequest,
-    ): ApiResponseBody<Unit>
+    ): ApiResponseBody<AddTournamentItemFromLinkResponse>
 
     @Operation(
         summary = "이미지로 토너먼트 아이템 추가",

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApiExamples.kt
@@ -4,6 +4,7 @@ import com.depromeet.piki.common.openapi.OpenApiObjectMapper
 import com.depromeet.piki.common.openapi.binds
 import com.depromeet.piki.common.openapi.examples
 import com.depromeet.piki.common.response.ApiResponseBody
+import com.depromeet.piki.tournament.controller.dto.AddTournamentItemsFromImagesResponse
 import com.depromeet.piki.tournament.controller.dto.CreateTournamentResponse
 import com.depromeet.piki.tournament.controller.dto.TournamentBracketResponse
 import com.depromeet.piki.tournament.controller.dto.TournamentHistoryInfoResponse
@@ -89,21 +90,10 @@ class TournamentApiExamples(
                     operation.examples(openApiObjectMapper.delegate) {
                         add(
                             status = HttpStatus.OK,
-                            name = "이미지 아이템 추가 성공 (일부 실패 없음)",
+                            name = "이미지 아이템 추가 성공",
                             payload = ApiResponseBody.ok(
-                                com.depromeet.piki.tournament.controller.dto.AddTournamentItemsFromImagesResponse(
-                                    failedCount = 0,
-                                    failedIndices = emptyList(),
-                                ),
-                            ),
-                        )
-                        add(
-                            status = HttpStatus.OK,
-                            name = "이미지 아이템 추가 성공 (일부 실패)",
-                            payload = ApiResponseBody.ok(
-                                com.depromeet.piki.tournament.controller.dto.AddTournamentItemsFromImagesResponse(
-                                    failedCount = 1,
-                                    failedIndices = listOf(2),
+                                AddTournamentItemsFromImagesResponse(
+                                    itemIds = listOf(1L, 2L, 3L),
                                 ),
                             ),
                         )

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApiExamples.kt
@@ -67,12 +67,45 @@ class TournamentApiExamples(
                         )
                     }
 
-                handlerMethod.binds(TournamentController::addItems) ->
+                handlerMethod.binds(TournamentController::addItemsFromWish) ->
                     operation.examples(openApiObjectMapper.delegate) {
                         add(
                             status = HttpStatus.OK,
-                            name = "아이템 추가 성공",
+                            name = "위시 아이템 추가 성공",
                             payload = ApiResponseBody.ok<Unit>(),
+                        )
+                    }
+
+                handlerMethod.binds(TournamentController::addItemFromLink) ->
+                    operation.examples(openApiObjectMapper.delegate) {
+                        add(
+                            status = HttpStatus.OK,
+                            name = "링크 아이템 추가 성공",
+                            payload = ApiResponseBody.ok<Unit>(),
+                        )
+                    }
+
+                handlerMethod.binds(TournamentController::addItemsFromImages) ->
+                    operation.examples(openApiObjectMapper.delegate) {
+                        add(
+                            status = HttpStatus.OK,
+                            name = "이미지 아이템 추가 성공 (일부 실패 없음)",
+                            payload = ApiResponseBody.ok(
+                                com.depromeet.piki.tournament.controller.dto.AddTournamentItemsFromImagesResponse(
+                                    failedCount = 0,
+                                    failedIndices = emptyList(),
+                                ),
+                            ),
+                        )
+                        add(
+                            status = HttpStatus.OK,
+                            name = "이미지 아이템 추가 성공 (일부 실패)",
+                            payload = ApiResponseBody.ok(
+                                com.depromeet.piki.tournament.controller.dto.AddTournamentItemsFromImagesResponse(
+                                    failedCount = 1,
+                                    failedIndices = listOf(2),
+                                ),
+                            ),
                         )
                     }
 

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApiExamples.kt
@@ -4,6 +4,7 @@ import com.depromeet.piki.common.openapi.OpenApiObjectMapper
 import com.depromeet.piki.common.openapi.binds
 import com.depromeet.piki.common.openapi.examples
 import com.depromeet.piki.common.response.ApiResponseBody
+import com.depromeet.piki.tournament.controller.dto.AddTournamentItemFromLinkResponse
 import com.depromeet.piki.tournament.controller.dto.AddTournamentItemsFromImagesResponse
 import com.depromeet.piki.tournament.controller.dto.CreateTournamentResponse
 import com.depromeet.piki.tournament.controller.dto.TournamentBracketResponse
@@ -82,7 +83,7 @@ class TournamentApiExamples(
                         add(
                             status = HttpStatus.OK,
                             name = "링크 아이템 추가 성공",
-                            payload = ApiResponseBody.ok<Unit>(),
+                            payload = ApiResponseBody.ok(AddTournamentItemFromLinkResponse(itemId = 1L)),
                         )
                     }
 

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentController.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentController.kt
@@ -1,6 +1,8 @@
 package com.depromeet.piki.tournament.controller
 
 import com.depromeet.piki.common.response.ApiResponseBody
+import com.depromeet.piki.tournament.controller.dto.AddTournamentItemFromLinkRequest
+import com.depromeet.piki.tournament.controller.dto.AddTournamentItemsFromImagesResponse
 import com.depromeet.piki.tournament.controller.dto.AddTournamentItemsRequest
 import com.depromeet.piki.tournament.controller.dto.CreateTournamentRequest
 import com.depromeet.piki.tournament.controller.dto.CreateTournamentResponse
@@ -9,9 +11,11 @@ import com.depromeet.piki.tournament.controller.dto.TournamentBracketResponse
 import com.depromeet.piki.tournament.controller.dto.TournamentInfoResponse
 import com.depromeet.piki.tournament.controller.dto.TournamentSummaryResponse
 import com.depromeet.piki.tournament.domain.TournamentStatus
+import com.depromeet.piki.tournament.service.TournamentItemService
 import com.depromeet.piki.tournament.service.TournamentService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
@@ -22,12 +26,14 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
 import java.util.UUID
 
 @RestController
 @RequestMapping("/api/v1/tournaments")
 class TournamentController(
     private val tournamentService: TournamentService,
+    private val tournamentItemService: TournamentItemService,
 ) : TournamentApi {
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
@@ -39,14 +45,34 @@ class TournamentController(
         return ApiResponseBody.created(CreateTournamentResponse(tournamentId))
     }
 
-    @PostMapping("/{tournamentId}/items")
-    override fun addItems(
+    @PostMapping("/{tournamentId}/items/wish")
+    override fun addItemsFromWish(
         @AuthenticationPrincipal userId: UUID,
         @PathVariable tournamentId: Long,
         @Valid @RequestBody request: AddTournamentItemsRequest,
     ): ApiResponseBody<Unit> {
-        tournamentService.addItems(userId, request.toAddTournamentItems(tournamentId))
+        tournamentService.addItemsFromWish(userId, request.toAddTournamentItemsFromWish(tournamentId))
         return ApiResponseBody.ok()
+    }
+
+    @PostMapping("/{tournamentId}/items/link")
+    override fun addItemFromLink(
+        @AuthenticationPrincipal userId: UUID,
+        @PathVariable tournamentId: Long,
+        @Valid @RequestBody request: AddTournamentItemFromLinkRequest,
+    ): ApiResponseBody<Unit> {
+        tournamentItemService.addItemFromLink(userId, tournamentId, request.url)
+        return ApiResponseBody.ok()
+    }
+
+    @PostMapping("/{tournamentId}/items/images", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
+    override fun addItemsFromImages(
+        @AuthenticationPrincipal userId: UUID,
+        @PathVariable tournamentId: Long,
+        @RequestParam("images") images: List<MultipartFile>,
+    ): ApiResponseBody<AddTournamentItemsFromImagesResponse> {
+        val result = tournamentItemService.addItemsFromImages(userId, tournamentId, images)
+        return ApiResponseBody.ok(AddTournamentItemsFromImagesResponse.from(result))
     }
 
     @DeleteMapping("/{tournamentId}/items/{tournamentItemId}")

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentController.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentController.kt
@@ -71,8 +71,8 @@ class TournamentController(
         @PathVariable tournamentId: Long,
         @RequestParam("images") images: List<MultipartFile>,
     ): ApiResponseBody<AddTournamentItemsFromImagesResponse> {
-        val result = tournamentItemService.addItemsFromImages(userId, tournamentId, images)
-        return ApiResponseBody.ok(AddTournamentItemsFromImagesResponse.from(result))
+        val itemIds = tournamentItemService.addItemsFromImages(userId, tournamentId, images)
+        return ApiResponseBody.ok(AddTournamentItemsFromImagesResponse(itemIds))
     }
 
     @DeleteMapping("/{tournamentId}/items/{tournamentItemId}")

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentController.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentController.kt
@@ -2,6 +2,7 @@ package com.depromeet.piki.tournament.controller
 
 import com.depromeet.piki.common.response.ApiResponseBody
 import com.depromeet.piki.tournament.controller.dto.AddTournamentItemFromLinkRequest
+import com.depromeet.piki.tournament.controller.dto.AddTournamentItemFromLinkResponse
 import com.depromeet.piki.tournament.controller.dto.AddTournamentItemsFromImagesResponse
 import com.depromeet.piki.tournament.controller.dto.AddTournamentItemsRequest
 import com.depromeet.piki.tournament.controller.dto.CreateTournamentRequest
@@ -60,9 +61,9 @@ class TournamentController(
         @AuthenticationPrincipal userId: UUID,
         @PathVariable tournamentId: Long,
         @Valid @RequestBody request: AddTournamentItemFromLinkRequest,
-    ): ApiResponseBody<Unit> {
-        tournamentItemService.addItemFromLink(userId, tournamentId, request.url)
-        return ApiResponseBody.ok()
+    ): ApiResponseBody<AddTournamentItemFromLinkResponse> {
+        val itemId = tournamentItemService.addItemFromLink(userId, tournamentId, request.url)
+        return ApiResponseBody.ok(AddTournamentItemFromLinkResponse(itemId))
     }
 
     @PostMapping("/{tournamentId}/items/images", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/dto/AddTournamentItemFromLinkRequest.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/dto/AddTournamentItemFromLinkRequest.kt
@@ -1,8 +1,17 @@
 package com.depromeet.piki.tournament.controller.dto
 
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode
 import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
 
 data class AddTournamentItemFromLinkRequest(
     @field:NotBlank
+    @field:Size(max = 2048)
+    @field:Schema(
+        description = "등록할 상품 페이지 URL",
+        example = "https://www.example-shop.com/products/12345",
+        requiredMode = RequiredMode.REQUIRED,
+    )
     val url: String,
 )

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/dto/AddTournamentItemFromLinkRequest.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/dto/AddTournamentItemFromLinkRequest.kt
@@ -1,0 +1,8 @@
+package com.depromeet.piki.tournament.controller.dto
+
+import jakarta.validation.constraints.NotBlank
+
+data class AddTournamentItemFromLinkRequest(
+    @field:NotBlank
+    val url: String,
+)

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/dto/AddTournamentItemFromLinkResponse.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/dto/AddTournamentItemFromLinkResponse.kt
@@ -1,0 +1,5 @@
+package com.depromeet.piki.tournament.controller.dto
+
+data class AddTournamentItemFromLinkResponse(
+    val itemId: Long,
+)

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/dto/AddTournamentItemsFromImagesResponse.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/dto/AddTournamentItemsFromImagesResponse.kt
@@ -1,0 +1,16 @@
+package com.depromeet.piki.tournament.controller.dto
+
+import com.depromeet.piki.tournament.service.dto.AddTournamentItemsFromImagesResult
+
+data class AddTournamentItemsFromImagesResponse(
+    val failedCount: Int,
+    val failedIndices: List<Int>,
+) {
+    companion object {
+        fun from(result: AddTournamentItemsFromImagesResult): AddTournamentItemsFromImagesResponse =
+            AddTournamentItemsFromImagesResponse(
+                failedCount = result.failedIndices.size,
+                failedIndices = result.failedIndices,
+            )
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/dto/AddTournamentItemsFromImagesResponse.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/dto/AddTournamentItemsFromImagesResponse.kt
@@ -1,16 +1,5 @@
 package com.depromeet.piki.tournament.controller.dto
 
-import com.depromeet.piki.tournament.service.dto.AddTournamentItemsFromImagesResult
-
 data class AddTournamentItemsFromImagesResponse(
-    val failedCount: Int,
-    val failedIndices: List<Int>,
-) {
-    companion object {
-        fun from(result: AddTournamentItemsFromImagesResult): AddTournamentItemsFromImagesResponse =
-            AddTournamentItemsFromImagesResponse(
-                failedCount = result.failedIndices.size,
-                failedIndices = result.failedIndices,
-            )
-    }
-}
+    val itemIds: List<Long>,
+)

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/dto/AddTournamentItemsRequest.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/dto/AddTournamentItemsRequest.kt
@@ -1,14 +1,14 @@
 package com.depromeet.piki.tournament.controller.dto
 
-import com.depromeet.piki.tournament.service.dto.AddTournamentItems
+import com.depromeet.piki.tournament.service.dto.AddTournamentItemsFromWish
 import jakarta.validation.constraints.Size
 
 data class AddTournamentItemsRequest(
     @field:Size(min = 1, max = 32)
     val itemIds: List<Long>,
 ) {
-    fun toAddTournamentItems(tournamentId: Long): AddTournamentItems =
-        AddTournamentItems(
+    fun toAddTournamentItemsFromWish(tournamentId: Long): AddTournamentItemsFromWish =
+        AddTournamentItemsFromWish(
             tournamentId = tournamentId,
             itemIds = itemIds,
         )

--- a/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentItemJpaRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentItemJpaRepository.kt
@@ -8,6 +8,8 @@ import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 
 interface TournamentItemJpaRepository : JpaRepository<TournamentItem, Long> {
+    fun countByTournamentId(tournamentId: Long): Int
+
     fun findAllByTournamentIdOrderByIdAsc(tournamentId: Long): List<TournamentItem>
 
     @Modifying

--- a/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentItemRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentItemRepository.kt
@@ -5,6 +5,8 @@ import com.depromeet.piki.tournament.domain.TournamentItem
 interface TournamentItemRepository {
     fun saveAll(items: List<TournamentItem>): List<TournamentItem>
 
+    fun countByTournamentId(tournamentId: Long): Int
+
     fun findAllByTournamentId(tournamentId: Long): List<TournamentItem>
 
     fun findById(id: Long): TournamentItem?

--- a/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentItemRepositoryImpl.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentItemRepositoryImpl.kt
@@ -10,6 +10,8 @@ class TournamentItemRepositoryImpl(
 ) : TournamentItemRepository {
     override fun saveAll(items: List<TournamentItem>): List<TournamentItem> = tournamentItemJpaRepository.saveAll(items)
 
+    override fun countByTournamentId(tournamentId: Long): Int = tournamentItemJpaRepository.countByTournamentId(tournamentId)
+
     override fun findAllByTournamentId(tournamentId: Long): List<TournamentItem> =
         tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId)
 

--- a/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentJpaRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentJpaRepository.kt
@@ -2,9 +2,15 @@ package com.depromeet.piki.tournament.repository
 
 import com.depromeet.piki.tournament.domain.Tournament
 import com.depromeet.piki.tournament.domain.TournamentStatus
+import jakarta.persistence.LockModeType
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
+import org.springframework.data.jpa.repository.Query
 
 interface TournamentJpaRepository : JpaRepository<Tournament, Long> {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT t FROM Tournament t WHERE t.id = :id")
+    fun findByIdForUpdate(id: Long): Tournament?
     fun findByIdInAndStatusInOrderByCreatedAtDesc(
         ids: List<Long>,
         statuses: List<TournamentStatus>,

--- a/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentRepository.kt
@@ -11,6 +11,8 @@ interface TournamentRepository {
 
     fun findTournamentById(tournamentId: Long): Tournament?
 
+    fun findTournamentByIdForUpdate(tournamentId: Long): Tournament?
+
     fun findTournamentHistoriesByTournamentId(tournamentId: Long): List<TournamentHistory>
 
     fun findByIdsAndStatuses(

--- a/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentRepositoryImpl.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentRepositoryImpl.kt
@@ -20,6 +20,9 @@ class TournamentRepositoryImpl(
     override fun findTournamentById(tournamentId: Long): Tournament? =
         tournamentJpaRepository.findByIdOrNull(tournamentId)
 
+    override fun findTournamentByIdForUpdate(tournamentId: Long): Tournament? =
+        tournamentJpaRepository.findByIdForUpdate(tournamentId)
+
     override fun findTournamentHistoriesByTournamentId(tournamentId: Long): List<TournamentHistory> =
         tournamentHistoryJpaRepository.findAllByTournamentIdOrderByCurrentRoundAscIdAsc(tournamentId)
 

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentConstants.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentConstants.kt
@@ -1,0 +1,4 @@
+package com.depromeet.piki.tournament.service
+
+internal const val TOURNAMENT_MAX_ITEM_COUNT = 32
+internal const val TOURNAMENT_MIN_ITEM_COUNT = 2

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentException.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentException.kt
@@ -97,5 +97,12 @@ class TournamentException private constructor(
                 ErrorCategory.CONFLICT,
                 HttpStatus.CONFLICT,
             )
+
+        fun invalidImageCount(): TournamentException =
+            TournamentException(
+                "이미지는 최소 1개, 최대 5개까지 전송할 수 있습니다.",
+                ErrorCategory.INVALID_INPUT,
+                HttpStatus.BAD_REQUEST,
+            )
     }
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentException.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentException.kt
@@ -89,11 +89,19 @@ class TournamentException private constructor(
                 HttpStatus.NOT_FOUND,
             )
 
-        // 비동기 파싱이 끝나지 않은(PROCESSING) 또는 실패한(FAILED) 상품을 토너먼트에 추가하려 한 경우.
+        // 비동기 파싱이 끝나지 않은(PROCESSING) 또는 실패한(FAILED) 상품을 위시에서 토너먼트에 추가하려 한 경우.
         // 곧 READY 가 되거나 영구 실패라 현재 상태와 충돌 → 409.
         fun itemNotReady(): TournamentException =
             TournamentException(
                 "아직 준비되지 않은 상품은 토너먼트에 추가할 수 없습니다.",
+                ErrorCategory.CONFLICT,
+                HttpStatus.CONFLICT,
+            )
+
+        // 토너먼트 시작 시 PROCESSING·FAILED 아이템이 포함된 경우.
+        fun itemNotReadyToStart(): TournamentException =
+            TournamentException(
+                "아직 준비되지 않은 상품이 포함되어 있어 토너먼트를 시작할 수 없습니다.",
                 ErrorCategory.CONFLICT,
                 HttpStatus.CONFLICT,
             )
@@ -103,6 +111,13 @@ class TournamentException private constructor(
                 "이미지는 최소 1개, 최대 5개까지 전송할 수 있습니다.",
                 ErrorCategory.INVALID_INPUT,
                 HttpStatus.BAD_REQUEST,
+            )
+
+        fun itemNotInWishlist(): TournamentException =
+            TournamentException(
+                "위시리스트에 없는 아이템은 토너먼트에 추가할 수 없습니다.",
+                ErrorCategory.FORBIDDEN,
+                HttpStatus.FORBIDDEN,
             )
     }
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentItemPersistenceService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentItemPersistenceService.kt
@@ -1,6 +1,7 @@
 package com.depromeet.piki.tournament.service
 
 import com.depromeet.piki.item.domain.Item
+import com.depromeet.piki.item.domain.ItemStatus
 import com.depromeet.piki.item.repository.ItemRepository
 import com.depromeet.piki.tournament.domain.TournamentItem
 import com.depromeet.piki.tournament.repository.TournamentItemRepository
@@ -26,6 +27,32 @@ class TournamentItemPersistenceService(
         tournamentId: Long,
         items: List<Item>,
     ) {
+        validateAndCheckCapacity(userId, tournamentId, items.size)
+        val savedItems = itemRepository.saveAll(items)
+        tournamentItemRepository.saveAll(
+            savedItems.map { TournamentItem(tournamentId = tournamentId, itemId = it.getId(), userId = userId) },
+        )
+    }
+
+    @Transactional
+    fun persistProcessingItems(
+        userId: UUID,
+        tournamentId: Long,
+        count: Int,
+    ): List<Long> {
+        validateAndCheckCapacity(userId, tournamentId, count)
+        val items = itemRepository.saveAll(List(count) { Item(status = ItemStatus.PROCESSING) })
+        tournamentItemRepository.saveAll(
+            items.map { TournamentItem(tournamentId = tournamentId, itemId = it.getId(), userId = userId) },
+        )
+        return items.map { it.getId() }
+    }
+
+    private fun validateAndCheckCapacity(
+        userId: UUID,
+        tournamentId: Long,
+        incomingCount: Int,
+    ) {
         val tournament =
             tournamentRepository.findTournamentById(tournamentId)
                 ?: throw TournamentException.notFoundTournament()
@@ -33,11 +60,6 @@ class TournamentItemPersistenceService(
         tournamentUserRepository.findByTournamentIdAndUserId(tournamentId, userId)
             ?: throw TournamentException.forbiddenTournament()
         val existing = tournamentItemRepository.findAllByTournamentId(tournamentId)
-        if (existing.size + items.size > TOURNAMENT_MAX_ITEM_COUNT) throw TournamentException.tooManyTournamentItems()
-
-        val savedItems = itemRepository.saveAll(items)
-        tournamentItemRepository.saveAll(
-            savedItems.map { TournamentItem(tournamentId = tournamentId, itemId = it.getId(), userId = userId) },
-        )
+        if (existing.size + incomingCount > TOURNAMENT_MAX_ITEM_COUNT) throw TournamentException.tooManyTournamentItems()
     }
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentItemPersistenceService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentItemPersistenceService.kt
@@ -1,0 +1,43 @@
+package com.depromeet.piki.tournament.service
+
+import com.depromeet.piki.item.domain.Item
+import com.depromeet.piki.item.repository.ItemRepository
+import com.depromeet.piki.tournament.domain.TournamentItem
+import com.depromeet.piki.tournament.repository.TournamentItemRepository
+import com.depromeet.piki.tournament.repository.TournamentRepository
+import com.depromeet.piki.tournament.repository.TournamentUserRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+// TournamentItemService 의 외부 호출(링크 추출·OCR)이 트랜잭션 밖에 있도록
+// 아이템 저장과 토너먼트 아이템 등록만 별도 빈으로 분리한다.
+// 같은 빈에서 @Transactional 메서드를 직접 호출하면 Spring AOP proxy 를 거치지 않아 트랜잭션이 무력화된다.
+@Service
+class TournamentItemPersistenceService(
+    private val tournamentRepository: TournamentRepository,
+    private val tournamentUserRepository: TournamentUserRepository,
+    private val tournamentItemRepository: TournamentItemRepository,
+    private val itemRepository: ItemRepository,
+) {
+    @Transactional
+    fun persistItems(
+        userId: UUID,
+        tournamentId: Long,
+        items: List<Item>,
+    ) {
+        val tournament =
+            tournamentRepository.findTournamentById(tournamentId)
+                ?: throw TournamentException.notFoundTournament()
+        if (!tournament.isPending()) throw TournamentException.notPendingTournament()
+        tournamentUserRepository.findByTournamentIdAndUserId(tournamentId, userId)
+            ?: throw TournamentException.forbiddenTournament()
+        val existing = tournamentItemRepository.findAllByTournamentId(tournamentId)
+        if (existing.size + items.size > TOURNAMENT_MAX_ITEM_COUNT) throw TournamentException.tooManyTournamentItems()
+
+        val savedItems = itemRepository.saveAll(items)
+        tournamentItemRepository.saveAll(
+            savedItems.map { TournamentItem(tournamentId = tournamentId, itemId = it.getId(), userId = userId) },
+        )
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentItemPersistenceService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentItemPersistenceService.kt
@@ -3,6 +3,7 @@ package com.depromeet.piki.tournament.service
 import com.depromeet.piki.item.domain.Item
 import com.depromeet.piki.item.domain.ItemStatus
 import com.depromeet.piki.item.repository.ItemRepository
+import com.depromeet.piki.product.domain.ProductLink
 import com.depromeet.piki.tournament.domain.TournamentItem
 import com.depromeet.piki.tournament.repository.TournamentItemRepository
 import com.depromeet.piki.tournament.repository.TournamentRepository
@@ -32,6 +33,18 @@ class TournamentItemPersistenceService(
         tournamentItemRepository.saveAll(
             savedItems.map { TournamentItem(tournamentId = tournamentId, itemId = it.getId(), userId = userId) },
         )
+    }
+
+    @Transactional
+    fun persistLinkItem(
+        userId: UUID,
+        tournamentId: Long,
+        link: ProductLink,
+    ): Long {
+        validateAndCheckCapacity(userId, tournamentId, 1)
+        val item = itemRepository.save(Item.processing(link))
+        tournamentItemRepository.saveAll(listOf(TournamentItem(tournamentId = tournamentId, itemId = item.getId(), userId = userId)))
+        return item.getId()
     }
 
     @Transactional

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentItemPersistenceService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentItemPersistenceService.kt
@@ -23,19 +23,6 @@ class TournamentItemPersistenceService(
     private val itemRepository: ItemRepository,
 ) {
     @Transactional
-    fun persistItems(
-        userId: UUID,
-        tournamentId: Long,
-        items: List<Item>,
-    ) {
-        validateAndCheckCapacity(userId, tournamentId, items.size)
-        val savedItems = itemRepository.saveAll(items)
-        tournamentItemRepository.saveAll(
-            savedItems.map { TournamentItem(tournamentId = tournamentId, itemId = it.getId(), userId = userId) },
-        )
-    }
-
-    @Transactional
     fun persistLinkItem(
         userId: UUID,
         tournamentId: Long,

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentItemPersistenceService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentItemPersistenceService.kt
@@ -59,7 +59,7 @@ class TournamentItemPersistenceService(
         if (!tournament.isPending()) throw TournamentException.notPendingTournament()
         tournamentUserRepository.findByTournamentIdAndUserId(tournamentId, userId)
             ?: throw TournamentException.forbiddenTournament()
-        val existing = tournamentItemRepository.findAllByTournamentId(tournamentId)
-        if (existing.size + incomingCount > TOURNAMENT_MAX_ITEM_COUNT) throw TournamentException.tooManyTournamentItems()
+        val existingCount = tournamentItemRepository.countByTournamentId(tournamentId)
+        if (existingCount + incomingCount > TOURNAMENT_MAX_ITEM_COUNT) throw TournamentException.tooManyTournamentItems()
     }
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentItemPersistenceService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentItemPersistenceService.kt
@@ -54,7 +54,7 @@ class TournamentItemPersistenceService(
         incomingCount: Int,
     ) {
         val tournament =
-            tournamentRepository.findTournamentById(tournamentId)
+            tournamentRepository.findTournamentByIdForUpdate(tournamentId)
                 ?: throw TournamentException.notFoundTournament()
         if (!tournament.isPending()) throw TournamentException.notPendingTournament()
         tournamentUserRepository.findByTournamentIdAndUserId(tournamentId, userId)

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentItemService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentItemService.kt
@@ -32,11 +32,13 @@ class TournamentItemService(
         val link = ProductLink.parse(url)
         validateTournamentAccess(userId, tournamentId)
         val itemId = tournamentItemPersistenceService.persistLinkItem(userId, tournamentId, link)
-        runCatching { itemParsingWorker.parse(itemId, link) }
-            .onFailure { e ->
-                log.warn("item {} async 디스패치 거부 → FAILED 처리", itemId, e)
-                runCatching { itemParsingService.markFailed(itemId) }
-            }
+        try {
+            itemParsingWorker.parse(itemId, link)
+        } catch (e: TaskRejectedException) {
+            log.warn("item {} async 디스패치 거부 → FAILED 처리", itemId, e)
+            runCatching { itemParsingService.markFailed(itemId) }
+                .onFailure { ex -> log.error("item {} FAILED 전이 실패, PROCESSING 방치 위험", itemId, ex) }
+        }
         return itemId
     }
 
@@ -54,8 +56,9 @@ class TournamentItemService(
             try {
                 imageParsingWorker.parse(itemId, ocrImage)
             } catch (e: TaskRejectedException) {
-                log.warn("item {} async 디스패치 거부 → FAILED 처리", itemId)
+                log.warn("item {} async 디스패치 거부 → FAILED 처리", itemId, e)
                 runCatching { itemParsingService.markFailed(itemId) }
+                    .onFailure { ex -> log.error("item {} FAILED 전이 실패, PROCESSING 방치 위험", itemId, ex) }
             }
         }
         return itemIds

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentItemService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentItemService.kt
@@ -1,0 +1,108 @@
+package com.depromeet.piki.tournament.service
+
+import com.depromeet.piki.common.storage.ImageStorage
+import com.depromeet.piki.item.domain.Item
+import com.depromeet.piki.ocr.domain.OcrImage
+import com.depromeet.piki.ocr.service.ImageCropper
+import com.depromeet.piki.ocr.service.ProductImageExtractor
+import com.depromeet.piki.product.domain.ProductLink
+import com.depromeet.piki.product.service.ProductLinkExtractor
+import com.depromeet.piki.product.service.ProductSnapshot
+import com.depromeet.piki.tournament.repository.TournamentRepository
+import com.depromeet.piki.tournament.service.dto.AddTournamentItemsFromImagesResult
+import com.depromeet.piki.tournament.repository.TournamentUserRepository
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.web.multipart.MultipartFile
+import java.util.UUID
+
+@Service
+class TournamentItemService(
+    private val tournamentRepository: TournamentRepository,
+    private val tournamentUserRepository: TournamentUserRepository,
+    private val productLinkExtractor: ProductLinkExtractor,
+    private val productImageExtractor: ProductImageExtractor,
+    private val imageCropper: ImageCropper,
+    private val imageStorage: ImageStorage,
+    private val tournamentItemPersistenceService: TournamentItemPersistenceService,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    fun addItemFromLink(
+        userId: UUID,
+        tournamentId: Long,
+        url: String,
+    ) {
+        validateTournamentAccess(userId, tournamentId)
+        val link = ProductLink.parse(url)
+        val snapshot = extractWithLatencyLog(link)
+        tournamentItemPersistenceService.persistItems(userId, tournamentId, listOf(Item.from(snapshot)))
+    }
+
+    fun addItemsFromImages(
+        userId: UUID,
+        tournamentId: Long,
+        images: List<MultipartFile>,
+    ): AddTournamentItemsFromImagesResult {
+        if (images.size !in MIN_IMAGE_COUNT..MAX_IMAGE_COUNT) throw TournamentException.invalidImageCount()
+        validateTournamentAccess(userId, tournamentId)
+
+        val failedIndices = mutableListOf<Int>()
+        val successfulItems = mutableListOf<Item>()
+
+        images.forEachIndexed { index, image ->
+            runCatching {
+                val ocrImage = OcrImage.of(image.bytes, image.contentType)
+                val extraction = productImageExtractor.extract(ocrImage)
+                val imageUrl =
+                    extraction.boundingBox
+                        ?.let { imageCropper.crop(ocrImage.bytes, it) }
+                        ?.let { cropped ->
+                            runCatching {
+                                imageStorage.upload(cropped, "items/${UUID.randomUUID()}.png", "image/png")
+                            }.getOrElse { e ->
+                                log.warn("크롭 이미지 S3 업로드 실패, imageUrl 없이 등록 진행: {}", e.message)
+                                null
+                            }
+                        }
+                Item.from(extraction.snapshot.copy(imageUrl = imageUrl))
+            }.onSuccess { item ->
+                successfulItems.add(item)
+            }.onFailure { e ->
+                log.warn("이미지[{}] 처리 실패, 해당 이미지 건너뜀: {}", index, e.message)
+                failedIndices.add(index)
+            }
+        }
+
+        if (successfulItems.isNotEmpty()) {
+            tournamentItemPersistenceService.persistItems(userId, tournamentId, successfulItems)
+        }
+
+        return AddTournamentItemsFromImagesResult(failedIndices = failedIndices)
+    }
+
+    private fun extractWithLatencyLog(link: ProductLink): ProductSnapshot {
+        val started = System.nanoTime()
+        val snapshot = productLinkExtractor.extract(link)
+        val elapsedMs = (System.nanoTime() - started) / 1_000_000
+        log.info("extract latency: total={}ms url={}", elapsedMs, link.safeLogString())
+        return snapshot
+    }
+
+    private fun validateTournamentAccess(
+        userId: UUID,
+        tournamentId: Long,
+    ) {
+        val tournament =
+            tournamentRepository.findTournamentById(tournamentId)
+                ?: throw TournamentException.notFoundTournament()
+        if (!tournament.isPending()) throw TournamentException.notPendingTournament()
+        tournamentUserRepository.findByTournamentIdAndUserId(tournamentId, userId)
+            ?: throw TournamentException.forbiddenTournament()
+    }
+
+    companion object {
+        private const val MIN_IMAGE_COUNT = 1
+        private const val MAX_IMAGE_COUNT = 5
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentItemService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentItemService.kt
@@ -1,12 +1,10 @@
 package com.depromeet.piki.tournament.service
 
-import com.depromeet.piki.item.domain.Item
 import com.depromeet.piki.item.service.ImageParsingWorker
 import com.depromeet.piki.item.service.ItemParsingService
+import com.depromeet.piki.item.service.ItemParsingWorker
 import com.depromeet.piki.ocr.domain.OcrImage
 import com.depromeet.piki.product.domain.ProductLink
-import com.depromeet.piki.product.service.ProductLinkExtractor
-import com.depromeet.piki.product.service.ProductSnapshot
 import com.depromeet.piki.tournament.repository.TournamentRepository
 import com.depromeet.piki.tournament.repository.TournamentUserRepository
 import org.slf4j.LoggerFactory
@@ -19,7 +17,7 @@ import java.util.UUID
 class TournamentItemService(
     private val tournamentRepository: TournamentRepository,
     private val tournamentUserRepository: TournamentUserRepository,
-    private val productLinkExtractor: ProductLinkExtractor,
+    private val itemParsingWorker: ItemParsingWorker,
     private val imageParsingWorker: ImageParsingWorker,
     private val itemParsingService: ItemParsingService,
     private val tournamentItemPersistenceService: TournamentItemPersistenceService,
@@ -30,11 +28,16 @@ class TournamentItemService(
         userId: UUID,
         tournamentId: Long,
         url: String,
-    ) {
-        validateTournamentAccess(userId, tournamentId)
+    ): Long {
         val link = ProductLink.parse(url)
-        val snapshot = extractWithLatencyLog(link)
-        tournamentItemPersistenceService.persistItems(userId, tournamentId, listOf(Item.from(snapshot)))
+        validateTournamentAccess(userId, tournamentId)
+        val itemId = tournamentItemPersistenceService.persistLinkItem(userId, tournamentId, link)
+        runCatching { itemParsingWorker.parse(itemId, link) }
+            .onFailure { e ->
+                log.warn("item {} async 디스패치 거부 → FAILED 처리", itemId, e)
+                runCatching { itemParsingService.markFailed(itemId) }
+            }
+        return itemId
     }
 
     fun addItemsFromImages(
@@ -56,14 +59,6 @@ class TournamentItemService(
             }
         }
         return itemIds
-    }
-
-    private fun extractWithLatencyLog(link: ProductLink): ProductSnapshot {
-        val started = System.nanoTime()
-        val snapshot = productLinkExtractor.extract(link)
-        val elapsedMs = (System.nanoTime() - started) / 1_000_000
-        log.info("extract latency: total={}ms url={}", elapsedMs, link.safeLogString())
-        return snapshot
     }
 
     private fun validateTournamentAccess(

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentItemService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentItemService.kt
@@ -1,17 +1,16 @@
 package com.depromeet.piki.tournament.service
 
-import com.depromeet.piki.common.storage.ImageStorage
 import com.depromeet.piki.item.domain.Item
+import com.depromeet.piki.item.service.ImageParsingWorker
+import com.depromeet.piki.item.service.ItemParsingService
 import com.depromeet.piki.ocr.domain.OcrImage
-import com.depromeet.piki.ocr.service.ImageCropper
-import com.depromeet.piki.ocr.service.ProductImageExtractor
 import com.depromeet.piki.product.domain.ProductLink
 import com.depromeet.piki.product.service.ProductLinkExtractor
 import com.depromeet.piki.product.service.ProductSnapshot
 import com.depromeet.piki.tournament.repository.TournamentRepository
-import com.depromeet.piki.tournament.service.dto.AddTournamentItemsFromImagesResult
 import com.depromeet.piki.tournament.repository.TournamentUserRepository
 import org.slf4j.LoggerFactory
+import org.springframework.core.task.TaskRejectedException
 import org.springframework.stereotype.Service
 import org.springframework.web.multipart.MultipartFile
 import java.util.UUID
@@ -21,9 +20,8 @@ class TournamentItemService(
     private val tournamentRepository: TournamentRepository,
     private val tournamentUserRepository: TournamentUserRepository,
     private val productLinkExtractor: ProductLinkExtractor,
-    private val productImageExtractor: ProductImageExtractor,
-    private val imageCropper: ImageCropper,
-    private val imageStorage: ImageStorage,
+    private val imageParsingWorker: ImageParsingWorker,
+    private val itemParsingService: ItemParsingService,
     private val tournamentItemPersistenceService: TournamentItemPersistenceService,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
@@ -43,42 +41,21 @@ class TournamentItemService(
         userId: UUID,
         tournamentId: Long,
         images: List<MultipartFile>,
-    ): AddTournamentItemsFromImagesResult {
+    ): List<Long> {
         if (images.size !in MIN_IMAGE_COUNT..MAX_IMAGE_COUNT) throw TournamentException.invalidImageCount()
         validateTournamentAccess(userId, tournamentId)
-
-        val failedIndices = mutableListOf<Int>()
-        val successfulItems = mutableListOf<Item>()
-
-        images.forEachIndexed { index, image ->
-            runCatching {
-                val ocrImage = OcrImage.of(image.bytes, image.contentType)
-                val extraction = productImageExtractor.extract(ocrImage)
-                val imageUrl =
-                    extraction.boundingBox
-                        ?.let { imageCropper.crop(ocrImage.bytes, it) }
-                        ?.let { cropped ->
-                            runCatching {
-                                imageStorage.upload(cropped, "items/${UUID.randomUUID()}.png", "image/png")
-                            }.getOrElse { e ->
-                                log.warn("크롭 이미지 S3 업로드 실패, imageUrl 없이 등록 진행: {}", e.message)
-                                null
-                            }
-                        }
-                Item.from(extraction.snapshot.copy(imageUrl = imageUrl))
-            }.onSuccess { item ->
-                successfulItems.add(item)
-            }.onFailure { e ->
-                log.warn("이미지[{}] 처리 실패, 해당 이미지 건너뜀: {}", index, e.message)
-                failedIndices.add(index)
+        // 형식 검증(빈 바이트·미지원 MIME) — 실패 시 즉시 400. 유효한 이미지만 PROCESSING 으로 등록한다.
+        val ocrImages = images.map { OcrImage.of(it.bytes, it.contentType) }
+        val itemIds = tournamentItemPersistenceService.persistProcessingItems(userId, tournamentId, ocrImages.size)
+        itemIds.zip(ocrImages).forEach { (itemId, ocrImage) ->
+            try {
+                imageParsingWorker.parse(itemId, ocrImage)
+            } catch (e: TaskRejectedException) {
+                log.warn("item {} async 디스패치 거부 → FAILED 처리", itemId)
+                runCatching { itemParsingService.markFailed(itemId) }
             }
         }
-
-        if (successfulItems.isNotEmpty()) {
-            tournamentItemPersistenceService.persistItems(userId, tournamentId, successfulItems)
-        }
-
-        return AddTournamentItemsFromImagesResult(failedIndices = failedIndices)
+        return itemIds
     }
 
     private fun extractWithLatencyLog(link: ProductLink): ProductSnapshot {

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentItemService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentItemService.kt
@@ -5,8 +5,6 @@ import com.depromeet.piki.item.service.ItemParsingService
 import com.depromeet.piki.item.service.ItemParsingWorker
 import com.depromeet.piki.ocr.domain.OcrImage
 import com.depromeet.piki.product.domain.ProductLink
-import com.depromeet.piki.tournament.repository.TournamentRepository
-import com.depromeet.piki.tournament.repository.TournamentUserRepository
 import org.slf4j.LoggerFactory
 import org.springframework.core.task.TaskRejectedException
 import org.springframework.stereotype.Service
@@ -15,8 +13,6 @@ import java.util.UUID
 
 @Service
 class TournamentItemService(
-    private val tournamentRepository: TournamentRepository,
-    private val tournamentUserRepository: TournamentUserRepository,
     private val itemParsingWorker: ItemParsingWorker,
     private val imageParsingWorker: ImageParsingWorker,
     private val itemParsingService: ItemParsingService,
@@ -30,7 +26,6 @@ class TournamentItemService(
         url: String,
     ): Long {
         val link = ProductLink.parse(url)
-        validateTournamentAccess(userId, tournamentId)
         val itemId = tournamentItemPersistenceService.persistLinkItem(userId, tournamentId, link)
         try {
             itemParsingWorker.parse(itemId, link)
@@ -48,7 +43,6 @@ class TournamentItemService(
         images: List<MultipartFile>,
     ): List<Long> {
         if (images.size !in MIN_IMAGE_COUNT..MAX_IMAGE_COUNT) throw TournamentException.invalidImageCount()
-        validateTournamentAccess(userId, tournamentId)
         // 형식 검증(빈 바이트·미지원 MIME) — 실패 시 즉시 400. 유효한 이미지만 PROCESSING 으로 등록한다.
         val ocrImages = images.map { OcrImage.of(it.bytes, it.contentType) }
         val itemIds = tournamentItemPersistenceService.persistProcessingItems(userId, tournamentId, ocrImages.size)
@@ -62,18 +56,6 @@ class TournamentItemService(
             }
         }
         return itemIds
-    }
-
-    private fun validateTournamentAccess(
-        userId: UUID,
-        tournamentId: Long,
-    ) {
-        val tournament =
-            tournamentRepository.findTournamentById(tournamentId)
-                ?: throw TournamentException.notFoundTournament()
-        if (!tournament.isPending()) throw TournamentException.notPendingTournament()
-        tournamentUserRepository.findByTournamentIdAndUserId(tournamentId, userId)
-            ?: throw TournamentException.forbiddenTournament()
     }
 
     companion object {

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
@@ -17,6 +17,7 @@ import com.depromeet.piki.tournament.service.dto.TournamentBracketResult
 import com.depromeet.piki.tournament.service.dto.TournamentInfo
 import com.depromeet.piki.tournament.service.dto.TournamentSummary
 import com.depromeet.piki.user.repository.UserRepository
+import com.depromeet.piki.wishlist.repository.WishRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
@@ -28,6 +29,7 @@ class TournamentService(
     private val tournamentItemRepository: TournamentItemRepository,
     private val userRepository: UserRepository,
     private val itemRepository: ItemRepository,
+    private val wishRepository: WishRepository,
 ) {
     @Transactional
     fun create(
@@ -65,6 +67,8 @@ class TournamentService(
         val hasDuplicate =
             command.itemIds.toSet().size != command.itemIds.size || command.itemIds.any { it in existingItemIds }
         if (hasDuplicate) throw TournamentException.duplicateTournamentItem()
+        val wishCount = wishRepository.countByItemIdsAndUserId(command.itemIds, userId)
+        if (wishCount < command.itemIds.size) throw TournamentException.itemNotInWishlist()
         if (existingItemIds.size + command.itemIds.size > TOURNAMENT_MAX_ITEM_COUNT) {
             throw TournamentException.tooManyTournamentItems()
         }
@@ -99,6 +103,7 @@ class TournamentService(
             .findByIds(tournamentItems.map { it.itemId })
             .associate { it.getId() to it }
         if (tournamentItems.any { it.itemId !in itemById }) throw TournamentException.notFoundItems()
+        if (itemById.values.any { !it.isReady() }) throw TournamentException.itemNotReadyToStart()
         val itemsWithPrice = tournamentItems.map { it.getId() to itemById[it.itemId]?.currentPrice }
         val bracket = TournamentBracket.generate(itemsWithPrice)
 

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
@@ -64,11 +64,11 @@ class TournamentService(
                 .findAllByTournamentId(command.tournamentId)
                 .map { it.itemId }
                 .toSet()
-        val hasDuplicate =
-            command.itemIds.toSet().size != command.itemIds.size || command.itemIds.any { it in existingItemIds }
-        if (hasDuplicate) throw TournamentException.duplicateTournamentItem()
+        // 요청 내 중복 확인 — wishCount 는 unique itemId 기준이라 먼저 걸러야 정확하다
+        if (command.itemIds.toSet().size != command.itemIds.size) throw TournamentException.duplicateTournamentItem()
         val wishCount = wishRepository.countByItemIdsAndUserId(command.itemIds, userId)
         if (wishCount < command.itemIds.size) throw TournamentException.itemNotInWishlist()
+        if (command.itemIds.any { it in existingItemIds }) throw TournamentException.duplicateTournamentItem()
         if (existingItemIds.size + command.itemIds.size > TOURNAMENT_MAX_ITEM_COUNT) {
             throw TournamentException.tooManyTournamentItems()
         }

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
@@ -10,7 +10,7 @@ import com.depromeet.piki.tournament.domain.TournamentUser
 import com.depromeet.piki.tournament.repository.TournamentItemRepository
 import com.depromeet.piki.tournament.repository.TournamentRepository
 import com.depromeet.piki.tournament.repository.TournamentUserRepository
-import com.depromeet.piki.tournament.service.dto.AddTournamentItems
+import com.depromeet.piki.tournament.service.dto.AddTournamentItemsFromWish
 import com.depromeet.piki.tournament.service.dto.CreateTournament
 import com.depromeet.piki.tournament.service.dto.RecordMatch
 import com.depromeet.piki.tournament.service.dto.TournamentBracketResult
@@ -47,9 +47,9 @@ class TournamentService(
     }
 
     @Transactional
-    fun addItems(
+    fun addItemsFromWish(
         userId: UUID,
-        command: AddTournamentItems,
+        command: AddTournamentItemsFromWish,
     ) {
         val tournament =
             tournamentRepository.findTournamentById(command.tournamentId)
@@ -65,7 +65,7 @@ class TournamentService(
         val hasDuplicate =
             command.itemIds.toSet().size != command.itemIds.size || command.itemIds.any { it in existingItemIds }
         if (hasDuplicate) throw TournamentException.duplicateTournamentItem()
-        if (existingItemIds.size + command.itemIds.size > MAX_ITEM_COUNT) {
+        if (existingItemIds.size + command.itemIds.size > TOURNAMENT_MAX_ITEM_COUNT) {
             throw TournamentException.tooManyTournamentItems()
         }
         val foundItems = itemRepository.findByIds(command.itemIds)
@@ -94,7 +94,7 @@ class TournamentService(
                 ?: throw TournamentException.forbiddenTournament()
         if (owner.getId() != tournament.ownerTournamentUserId) throw TournamentException.forbiddenTournament()
         val tournamentItems = tournamentItemRepository.findAllByTournamentId(tournamentId)
-        if (tournamentItems.size !in MIN_ITEM_COUNT..MAX_ITEM_COUNT) throw TournamentException.invalidItemCount()
+        if (tournamentItems.size !in TOURNAMENT_MIN_ITEM_COUNT..TOURNAMENT_MAX_ITEM_COUNT) throw TournamentException.invalidItemCount()
         val itemById = itemRepository
             .findByIds(tournamentItems.map { it.itemId })
             .associate { it.getId() to it }
@@ -227,8 +227,4 @@ class TournamentService(
         if (deleted == 0) throw TournamentException.notPendingTournament()
     }
 
-    companion object {
-        private const val MIN_ITEM_COUNT = 2
-        private const val MAX_ITEM_COUNT = 32
-    }
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/dto/AddTournamentItems.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/dto/AddTournamentItems.kt
@@ -1,6 +1,6 @@
 package com.depromeet.piki.tournament.service.dto
 
-data class AddTournamentItems(
+data class AddTournamentItemsFromWish(
     val tournamentId: Long,
     val itemIds: List<Long>,
 )

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/dto/AddTournamentItemsFromImagesResult.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/dto/AddTournamentItemsFromImagesResult.kt
@@ -1,0 +1,5 @@
+package com.depromeet.piki.tournament.service.dto
+
+data class AddTournamentItemsFromImagesResult(
+    val failedIndices: List<Int>,
+)

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/dto/AddTournamentItemsFromImagesResult.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/dto/AddTournamentItemsFromImagesResult.kt
@@ -1,5 +1,0 @@
-package com.depromeet.piki.tournament.service.dto
-
-data class AddTournamentItemsFromImagesResult(
-    val failedIndices: List<Int>,
-)

--- a/src/main/kotlin/com/depromeet/piki/wishlist/repository/WishJpaRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/wishlist/repository/WishJpaRepository.kt
@@ -11,6 +11,11 @@ interface WishJpaRepository : JpaRepository<Wish, Long> {
         userId: UUID,
     ): Long
 
+    fun countByItemIdInAndUserIdAndDeletedAtIsNull(
+        itemIds: Collection<Long>,
+        userId: UUID,
+    ): Long
+
     fun findByUserIdAndDeletedAtIsNullOrderByIdDesc(
         userId: UUID,
         limit: Limit,

--- a/src/main/kotlin/com/depromeet/piki/wishlist/repository/WishRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/wishlist/repository/WishRepository.kt
@@ -12,6 +12,11 @@ interface WishRepository {
         userId: UUID,
     ): Long
 
+    fun countByItemIdsAndUserId(
+        itemIds: List<Long>,
+        userId: UUID,
+    ): Long
+
     // id desc 정렬로 최대 limit 건. cursor 가 있으면 그 id 미만만(다음 페이지). 삭제된 행은 제외.
     fun findPage(
         userId: UUID,

--- a/src/main/kotlin/com/depromeet/piki/wishlist/repository/WishRepositoryImpl.kt
+++ b/src/main/kotlin/com/depromeet/piki/wishlist/repository/WishRepositoryImpl.kt
@@ -17,6 +17,11 @@ class WishRepositoryImpl(
         userId: UUID,
     ): Long = wishJpaRepository.countByIdInAndUserId(ids, userId)
 
+    override fun countByItemIdsAndUserId(
+        itemIds: List<Long>,
+        userId: UUID,
+    ): Long = wishJpaRepository.countByItemIdInAndUserIdAndDeletedAtIsNull(itemIds, userId)
+
     override fun findPage(
         userId: UUID,
         cursor: WishCursor?,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
   servlet:
     multipart:
       max-file-size: 5MB
-      max-request-size: 5MB
+      max-request-size: 25MB
   datasource:
     url: jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_NAME:piki}?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC&characterEncoding=UTF-8
     username: ${DB_USERNAME:piki}

--- a/src/test/kotlin/com/depromeet/piki/support/IntegrationStubs.kt
+++ b/src/test/kotlin/com/depromeet/piki/support/IntegrationStubs.kt
@@ -1,6 +1,8 @@
 package com.depromeet.piki.support
 
 import com.depromeet.piki.auth.infrastructure.oauth.OAuthProvider
+import com.depromeet.piki.item.service.AsyncImageParsingWorker
+import com.depromeet.piki.item.service.AsyncItemParsingWorker
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Primary
@@ -25,6 +27,20 @@ class IntegrationStubs {
     @Bean
     @Primary
     fun imageStorage(): StubImageStorage = StubImageStorage()
+
+    // ItemParsingWorker·ImageParsingWorker 는 내부 비동기 워커를 래핑한 configurable stub.
+    // enabled=true (기본): 실제 워커로 위임 — WishlistRegisterAsyncIntegrationTest 는 이 경로를 사용한다.
+    // enabled=false: no-op — @Transactional 통합 테스트에서 미커밋 item 접근으로 발생하는 warn 로그 노이즈를
+    //   없애려면 테스트 본문에서 false 로 설정한다(설정한 테스트가 직접 복원한다).
+    @Bean
+    @Primary
+    fun itemParsingWorker(asyncItemParsingWorker: AsyncItemParsingWorker): StubItemParsingWorker =
+        StubItemParsingWorker(asyncItemParsingWorker)
+
+    @Bean
+    @Primary
+    fun imageParsingWorker(asyncImageParsingWorker: AsyncImageParsingWorker): StubImageParsingWorker =
+        StubImageParsingWorker(asyncImageParsingWorker)
 
     // OAuth client 는 운영에서 아직 Bean 으로 등록되지 않은 상태 (Task 6 에서 OAuthClient
     // Bean 등록 예정 — epic #122). 주입 후보가 stub 하나뿐이라 @Primary 불필요.

--- a/src/test/kotlin/com/depromeet/piki/support/StubImageParsingWorker.kt
+++ b/src/test/kotlin/com/depromeet/piki/support/StubImageParsingWorker.kt
@@ -1,0 +1,17 @@
+package com.depromeet.piki.support
+
+import com.depromeet.piki.item.service.ImageParsingWorker
+import com.depromeet.piki.ocr.domain.OcrImage
+
+// ImageParsingWorker 를 래핑해 테스트별로 활성화/비활성화한다.
+// StubItemParsingWorker 와 동일 정책.
+class StubImageParsingWorker(private val delegate: ImageParsingWorker) : ImageParsingWorker {
+    @Volatile var enabled: Boolean = true
+
+    override fun parse(
+        itemId: Long,
+        image: OcrImage,
+    ) {
+        if (enabled) delegate.parse(itemId, image)
+    }
+}

--- a/src/test/kotlin/com/depromeet/piki/support/StubItemParsingWorker.kt
+++ b/src/test/kotlin/com/depromeet/piki/support/StubItemParsingWorker.kt
@@ -1,0 +1,20 @@
+package com.depromeet.piki.support
+
+import com.depromeet.piki.item.service.ItemParsingWorker
+import com.depromeet.piki.product.domain.ProductLink
+
+// ItemParsingWorker 를 래핑해 테스트별로 활성화/비활성화한다.
+// enabled=true (기본): 실제 AsyncItemParsingWorker 에 위임 — WishlistRegisterAsyncIntegrationTest 처럼
+//   실제 상태 전이를 검증하는 테스트는 그대로 동작한다.
+// enabled=false: no-op — @Transactional 통합 테스트에서 미커밋 item 에 접근해 warn 로그가 찍히는
+//   노이즈를 없애려면 해당 테스트 본문에서 false 로 설정한다.
+class StubItemParsingWorker(private val delegate: ItemParsingWorker) : ItemParsingWorker {
+    @Volatile var enabled: Boolean = true
+
+    override fun parse(
+        itemId: Long,
+        link: ProductLink,
+    ) {
+        if (enabled) delegate.parse(itemId, link)
+    }
+}

--- a/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
@@ -4,9 +4,7 @@ import com.depromeet.piki.auth.infrastructure.jwt.JwtProvider
 import com.depromeet.piki.item.domain.Item
 import com.depromeet.piki.item.domain.ItemStatus
 import com.depromeet.piki.item.repository.ItemJpaRepository
-import com.depromeet.piki.product.service.ProductSnapshot
 import com.depromeet.piki.support.IntegrationTestSupport
-import com.depromeet.piki.support.StubProductLinkExtractor
 import com.depromeet.piki.tournament.domain.TournamentItem
 import com.depromeet.piki.tournament.domain.TournamentUser
 import com.depromeet.piki.tournament.repository.TournamentItemJpaRepository
@@ -53,8 +51,6 @@ class TournamentControllerTest : IntegrationTestSupport() {
     @Autowired private lateinit var itemJpaRepository: ItemJpaRepository
 
     @Autowired private lateinit var jwtProvider: JwtProvider
-
-    @Autowired private lateinit var stubProductLinkExtractor: StubProductLinkExtractor
 
     @Autowired private lateinit var wishPersistenceService: WishPersistenceService
 
@@ -532,12 +528,9 @@ class TournamentControllerTest : IntegrationTestSupport() {
     }
 
     @Test
-    fun `POST tournaments-id-items-link 는 참여자이면 아이템을 추가하고 200 을 반환한다`() {
+    fun `POST tournaments-id-items-link 는 참여자이면 PROCESSING 아이템을 생성하고 itemId 를 반환한다`() {
         val mockMvc = buildMockMvc()
         val tournamentId = createTournament(mockMvc)
-        stubProductLinkExtractor.build = { _ ->
-            ProductSnapshot(name = "테스트 상품", currentPrice = 10_000, currency = "KRW")
-        }
 
         mockMvc
             .perform(
@@ -547,6 +540,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
                     .content("""{"url":"https://example.com/product"}"""),
             ).andExpect(status().isOk)
             .andExpect(jsonPath("$.status").value(200))
+            .andExpect(jsonPath("$.data.itemId").isNumber)
 
         assertEquals(1, tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId).size)
     }
@@ -670,9 +664,6 @@ class TournamentControllerTest : IntegrationTestSupport() {
         val tournamentId = createTournament(mockMvc)
         val full32 = (1..32).map { saveWishItem() }.toLongArray()
         addItemsToTournament(mockMvc, tournamentId, userId, *full32)
-        stubProductLinkExtractor.build = { _ ->
-            ProductSnapshot(name = "상품", currentPrice = 1_000, currency = "KRW")
-        }
 
         mockMvc
             .perform(

--- a/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
@@ -540,17 +540,21 @@ class TournamentControllerTest : IntegrationTestSupport() {
             val mockMvc = buildMockMvc()
             val tournamentId = createTournament(mockMvc)
 
-            mockMvc
-                .perform(
-                    post("/api/v1/tournaments/$tournamentId/items/link")
-                        .header(HttpHeaders.AUTHORIZATION, authHeader(userId))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""{"url":"https://example.com/product"}"""),
-                ).andExpect(status().isOk)
-                .andExpect(jsonPath("$.status").value(200))
-                .andExpect(jsonPath("$.data.itemId").isNumber)
+            val result =
+                mockMvc
+                    .perform(
+                        post("/api/v1/tournaments/$tournamentId/items/link")
+                            .header(HttpHeaders.AUTHORIZATION, authHeader(userId))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""{"url":"https://example.com/product"}"""),
+                    ).andExpect(status().isOk)
+                    .andExpect(jsonPath("$.status").value(200))
+                    .andExpect(jsonPath("$.data.itemId").isNumber)
+                    .andReturn()
 
+            val itemId = objectMapper.readTree(result.response.contentAsString)["data"]["itemId"].asLong()
             assertEquals(1, tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId).size)
+            assertEquals(ItemStatus.PROCESSING, itemJpaRepository.findById(itemId).orElseThrow().status)
         } finally {
             stubItemParsingWorker.enabled = true
         }

--- a/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
@@ -4,11 +4,8 @@ import com.depromeet.piki.auth.infrastructure.jwt.JwtProvider
 import com.depromeet.piki.item.domain.Item
 import com.depromeet.piki.item.domain.ItemStatus
 import com.depromeet.piki.item.repository.ItemJpaRepository
-import com.depromeet.piki.ocr.domain.OcrImage
-import com.depromeet.piki.ocr.service.OcrExtraction
 import com.depromeet.piki.product.service.ProductSnapshot
 import com.depromeet.piki.support.IntegrationTestSupport
-import com.depromeet.piki.support.StubProductImageExtractor
 import com.depromeet.piki.support.StubProductLinkExtractor
 import com.depromeet.piki.tournament.domain.TournamentItem
 import com.depromeet.piki.tournament.domain.TournamentUser
@@ -17,6 +14,9 @@ import com.depromeet.piki.tournament.repository.TournamentUserJpaRepository
 import com.depromeet.piki.user.domain.IdentityType
 import com.depromeet.piki.user.domain.User
 import com.depromeet.piki.user.repository.UserJpaRepository
+import com.depromeet.piki.wishlist.domain.Wish
+import com.depromeet.piki.wishlist.repository.WishJpaRepository
+import com.depromeet.piki.wishlist.service.WishPersistenceService
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpHeaders
@@ -56,7 +56,9 @@ class TournamentControllerTest : IntegrationTestSupport() {
 
     @Autowired private lateinit var stubProductLinkExtractor: StubProductLinkExtractor
 
-    @Autowired private lateinit var stubProductImageExtractor: StubProductImageExtractor
+    @Autowired private lateinit var wishPersistenceService: WishPersistenceService
+
+    @Autowired private lateinit var wishJpaRepository: WishJpaRepository
 
     private val userId: UUID = UUID.fromString("11111111-2222-3333-4444-555555555555")
     private val otherUserId: UUID = UUID.fromString("99999999-8888-7777-6666-555555555555")
@@ -85,8 +87,8 @@ class TournamentControllerTest : IntegrationTestSupport() {
     fun `POST tournaments-id-items 는 참여자이면 200 을 반환한다`() {
         val mockMvc = buildMockMvc()
         val tournamentId = createTournament(mockMvc)
-        val item1Id = saveItem()
-        val item2Id = saveItem()
+        val item1Id = saveWishItem()
+        val item2Id = saveWishItem()
 
         mockMvc
             .perform(
@@ -102,7 +104,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
     fun `POST tournaments-id-items 는 아이템 1개도 추가할 수 있다`() {
         val mockMvc = buildMockMvc()
         val tournamentId = createTournament(mockMvc)
-        val itemId = saveItem()
+        val itemId = saveWishItem()
 
         mockMvc
             .perform(
@@ -118,6 +120,8 @@ class TournamentControllerTest : IntegrationTestSupport() {
     fun `POST tournaments-id-items 에서 존재하지 않는 아이템 ID 이면 404 를 반환한다`() {
         val mockMvc = buildMockMvc()
         val tournamentId = createTournament(mockMvc)
+        // 위시에는 등록되어 있지만 item 테이블에는 없는 ID — wish 확인 통과 후 item 존재 확인에서 404
+        wishJpaRepository.save(Wish(userId = userId, itemId = 999999L))
 
         mockMvc
             .perform(
@@ -134,10 +138,12 @@ class TournamentControllerTest : IntegrationTestSupport() {
         val mockMvc = buildMockMvc()
         val tournamentId = createTournament(mockMvc)
         val processingItemId = itemJpaRepository.save(Item(status = ItemStatus.PROCESSING)).getId()
+        // 위시에도 등록 — wish 확인 통과 후 READY 상태 확인에서 409
+        wishJpaRepository.save(Wish(userId = userId, itemId = processingItemId))
 
         mockMvc
             .perform(
-                post("/api/v1/tournaments/$tournamentId/items")
+                post("/api/v1/tournaments/$tournamentId/items/wish")
                     .header(HttpHeaders.AUTHORIZATION, authHeader(userId))
                     .contentType(MediaType.APPLICATION_JSON)
                     .content("""{"itemIds":[$processingItemId]}"""),
@@ -179,9 +185,9 @@ class TournamentControllerTest : IntegrationTestSupport() {
     fun `POST tournaments-id-start 는 아이템이 있는 PENDING 토너먼트를 시작하고 아이템 상세가 포함된 대진표를 반환한다`() {
         val mockMvc = buildMockMvc()
         val tournamentId = createTournament(mockMvc)
-        val item1 = itemJpaRepository.save(Item(name = "나이키 에어맥스", currentPrice = 129_000, currency = "KRW"))
-        val item2 = itemJpaRepository.save(Item(name = "아디다스 울트라부스트", currentPrice = 189_000, currency = "KRW"))
-        addItemsToTournament(mockMvc, tournamentId, userId, item1.getId(), item2.getId())
+        val item1Id = wishPersistenceService.persist(userId, Item(name = "나이키 에어맥스", currentPrice = 129_000, currency = "KRW")).item.getId()
+        val item2Id = wishPersistenceService.persist(userId, Item(name = "아디다스 울트라부스트", currentPrice = 189_000, currency = "KRW")).item.getId()
+        addItemsToTournament(mockMvc, tournamentId, userId, item1Id, item2Id)
 
         mockMvc
             .perform(
@@ -315,7 +321,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
         saveUser(userId, userProfileImage)
         val pendingId = createTournament(mockMvc, "대기중")
         val startedId = createTournament(mockMvc, "진행중")
-        addItemsToTournament(mockMvc, startedId, userId, saveItem(), saveItem())
+        addItemsToTournament(mockMvc, startedId, userId, saveWishItem(), saveWishItem())
         mockMvc.perform(
             post("/api/v1/tournaments/$startedId/start")
                 .header(HttpHeaders.AUTHORIZATION, authHeader(userId)),
@@ -337,7 +343,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
         val mockMvc = buildMockMvc()
         val pendingId = createTournament(mockMvc, "대기중")
         val startedId = createTournament(mockMvc, "진행중")
-        addItemsToTournament(mockMvc, startedId, userId, saveItem(), saveItem())
+        addItemsToTournament(mockMvc, startedId, userId, saveWishItem(), saveWishItem())
         mockMvc.perform(
             post("/api/v1/tournaments/$startedId/start")
                 .header(HttpHeaders.AUTHORIZATION, authHeader(userId)),
@@ -430,7 +436,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
     fun `DELETE tournaments-id-items-itemId 는 PENDING 토너먼트에서 아이템을 삭제하고 200 을 반환한다`() {
         val mockMvc = buildMockMvc()
         val tournamentId = createTournament(mockMvc)
-        addItemsToTournament(mockMvc, tournamentId, userId, saveItem(), saveItem())
+        addItemsToTournament(mockMvc, tournamentId, userId, saveWishItem(), saveWishItem())
         val itemId = tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId).first().getId()
 
         mockMvc
@@ -462,7 +468,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
     fun `DELETE tournaments-id-items-itemId 에서 아이템 추가자가 아니고 소유자도 아니면 403 을 반환한다`() {
         val mockMvc = buildMockMvc()
         val tournamentId = createTournament(mockMvc)
-        addItemsToTournament(mockMvc, tournamentId, userId, saveItem(), saveItem())
+        addItemsToTournament(mockMvc, tournamentId, userId, saveWishItem(), saveWishItem())
         val itemId = tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId).first().getId()
 
         mockMvc
@@ -478,7 +484,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
         val mockMvc = buildMockMvc()
         val tournamentId = createTournament(mockMvc)
         tournamentUserJpaRepository.save(TournamentUser(tournamentId = tournamentId, userId = otherUserId))
-        addItemsToTournament(mockMvc, tournamentId, otherUserId, saveItem(), saveItem())
+        addItemsToTournament(mockMvc, tournamentId, otherUserId, saveWishItem(otherUserId), saveWishItem(otherUserId))
         val itemId = tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId).first().getId()
 
         mockMvc
@@ -590,43 +596,9 @@ class TournamentControllerTest : IntegrationTestSupport() {
     }
 
     @Test
-    fun `POST tournaments-id-items-images 는 참여자이면 이미지를 추가하고 200 과 failedCount 0 을 반환한다`() {
+    fun `POST tournaments-id-items-images 는 참여자이면 PROCESSING 아이템을 생성하고 itemIds 를 반환한다`() {
         val mockMvc = buildMockMvc()
         val tournamentId = createTournament(mockMvc)
-        stubProductImageExtractor.build = { _ ->
-            OcrExtraction(
-                snapshot = ProductSnapshot(name = "이미지 상품", currentPrice = 50_000, currency = "KRW"),
-                boundingBox = null,
-            )
-        }
-        val image = MockMultipartFile("images", "test.jpg", "image/jpeg", ByteArray(100) { 1 })
-
-        mockMvc
-            .perform(
-                multipart("/api/v1/tournaments/$tournamentId/items/images")
-                    .file(image)
-                    .header(HttpHeaders.AUTHORIZATION, authHeader(userId)),
-            ).andExpect(status().isOk)
-            .andExpect(jsonPath("$.status").value(200))
-            .andExpect(jsonPath("$.data.failedCount").value(0))
-            .andExpect(jsonPath("$.data.failedIndices").isEmpty)
-
-        assertEquals(1, tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId).size)
-    }
-
-    @Test
-    fun `POST tournaments-id-items-images 에서 일부 이미지 처리 실패 시 성공한 이미지는 저장되고 failedIndices 를 반환한다`() {
-        val mockMvc = buildMockMvc()
-        val tournamentId = createTournament(mockMvc)
-        var callCount = 0
-        stubProductImageExtractor.build = { _ ->
-            val current = ++callCount
-            if (current == 2) error("OCR 실패 시뮬레이션")
-            OcrExtraction(
-                snapshot = ProductSnapshot(name = "이미지 상품 $current", currentPrice = 10_000 * current, currency = "KRW"),
-                boundingBox = null,
-            )
-        }
         val image1 = MockMultipartFile("images", "img1.jpg", "image/jpeg", ByteArray(100) { 1 })
         val image2 = MockMultipartFile("images", "img2.jpg", "image/jpeg", ByteArray(100) { 2 })
 
@@ -638,10 +610,10 @@ class TournamentControllerTest : IntegrationTestSupport() {
                     .header(HttpHeaders.AUTHORIZATION, authHeader(userId)),
             ).andExpect(status().isOk)
             .andExpect(jsonPath("$.status").value(200))
-            .andExpect(jsonPath("$.data.failedCount").value(1))
-            .andExpect(jsonPath("$.data.failedIndices[0]").value(1))
+            .andExpect(jsonPath("$.data.itemIds").isArray)
+            .andExpect(jsonPath("$.data.itemIds.length()").value(2))
 
-        assertEquals(1, tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId).size)
+        assertEquals(2, tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId).size)
     }
 
     @Test
@@ -672,6 +644,60 @@ class TournamentControllerTest : IntegrationTestSupport() {
         mockMvc
             .perform(request)
             .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.status").value(400))
+    }
+
+    @Test
+    fun `POST tournaments-id-items 에서 위시리스트에 없는 아이템이면 403 을 반환한다`() {
+        val mockMvc = buildMockMvc()
+        val tournamentId = createTournament(mockMvc)
+        // saveItem 은 위시 없이 아이템만 저장 — wish 소유 확인에서 실패해야 한다
+        val itemId = saveItem()
+
+        mockMvc
+            .perform(
+                post("/api/v1/tournaments/$tournamentId/items/wish")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(userId))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"itemIds":[$itemId]}"""),
+            ).andExpect(status().isForbidden)
+            .andExpect(jsonPath("$.status").value(403))
+    }
+
+    @Test
+    fun `POST tournaments-id-items-link 에서 32개 초과 시 400 을 반환한다`() {
+        val mockMvc = buildMockMvc()
+        val tournamentId = createTournament(mockMvc)
+        val full32 = (1..32).map { saveWishItem() }.toLongArray()
+        addItemsToTournament(mockMvc, tournamentId, userId, *full32)
+        stubProductLinkExtractor.build = { _ ->
+            ProductSnapshot(name = "상품", currentPrice = 1_000, currency = "KRW")
+        }
+
+        mockMvc
+            .perform(
+                post("/api/v1/tournaments/$tournamentId/items/link")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(userId))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"url":"https://example.com/product"}"""),
+            ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.status").value(400))
+    }
+
+    @Test
+    fun `POST tournaments-id-items-images 에서 32개 초과 시 400 을 반환한다`() {
+        val mockMvc = buildMockMvc()
+        val tournamentId = createTournament(mockMvc)
+        val full32 = (1..32).map { saveWishItem() }.toLongArray()
+        addItemsToTournament(mockMvc, tournamentId, userId, *full32)
+        val image = MockMultipartFile("images", "img.jpg", "image/jpeg", ByteArray(100) { 1 })
+
+        mockMvc
+            .perform(
+                multipart("/api/v1/tournaments/$tournamentId/items/images")
+                    .file(image)
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(userId)),
+            ).andExpect(status().isBadRequest)
             .andExpect(jsonPath("$.status").value(400))
     }
 
@@ -728,9 +754,13 @@ class TournamentControllerTest : IntegrationTestSupport() {
     private fun saveItem(name: String = "테스트 아이템"): Long =
         itemJpaRepository.save(Item(name = name)).getId()
 
+    // 위시리스트에도 등록된 READY 아이템 생성 — /items/wish 엔드포인트용
+    private fun saveWishItem(owner: UUID = userId, name: String = "테스트 아이템"): Long =
+        wishPersistenceService.persist(owner, Item(name = name)).item.getId()
+
     private fun startTournamentWith2Items(mockMvc: MockMvc): TournamentStart {
         val tournamentId = createTournament(mockMvc)
-        addItemsToTournament(mockMvc, tournamentId, userId, saveItem("아이템1"), saveItem("아이템2"))
+        addItemsToTournament(mockMvc, tournamentId, userId, saveWishItem(name = "아이템1"), saveWishItem(name = "아이템2"))
         mockMvc.perform(
             post("/api/v1/tournaments/$tournamentId/start")
                 .header(HttpHeaders.AUTHORIZATION, authHeader(userId)),

--- a/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
@@ -4,7 +4,12 @@ import com.depromeet.piki.auth.infrastructure.jwt.JwtProvider
 import com.depromeet.piki.item.domain.Item
 import com.depromeet.piki.item.domain.ItemStatus
 import com.depromeet.piki.item.repository.ItemJpaRepository
+import com.depromeet.piki.ocr.domain.OcrImage
+import com.depromeet.piki.ocr.service.OcrExtraction
+import com.depromeet.piki.product.service.ProductSnapshot
 import com.depromeet.piki.support.IntegrationTestSupport
+import com.depromeet.piki.support.StubProductImageExtractor
+import com.depromeet.piki.support.StubProductLinkExtractor
 import com.depromeet.piki.tournament.domain.TournamentItem
 import com.depromeet.piki.tournament.domain.TournamentUser
 import com.depromeet.piki.tournament.repository.TournamentItemJpaRepository
@@ -16,10 +21,12 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
+import org.springframework.mock.web.MockMultipartFile
 import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -46,6 +53,10 @@ class TournamentControllerTest : IntegrationTestSupport() {
     @Autowired private lateinit var itemJpaRepository: ItemJpaRepository
 
     @Autowired private lateinit var jwtProvider: JwtProvider
+
+    @Autowired private lateinit var stubProductLinkExtractor: StubProductLinkExtractor
+
+    @Autowired private lateinit var stubProductImageExtractor: StubProductImageExtractor
 
     private val userId: UUID = UUID.fromString("11111111-2222-3333-4444-555555555555")
     private val otherUserId: UUID = UUID.fromString("99999999-8888-7777-6666-555555555555")
@@ -79,7 +90,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
 
         mockMvc
             .perform(
-                post("/api/v1/tournaments/$tournamentId/items")
+                post("/api/v1/tournaments/$tournamentId/items/wish")
                     .header(HttpHeaders.AUTHORIZATION, authHeader(userId))
                     .contentType(MediaType.APPLICATION_JSON)
                     .content("""{"itemIds":[$item1Id,$item2Id]}"""),
@@ -95,7 +106,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
 
         mockMvc
             .perform(
-                post("/api/v1/tournaments/$tournamentId/items")
+                post("/api/v1/tournaments/$tournamentId/items/wish")
                     .header(HttpHeaders.AUTHORIZATION, authHeader(userId))
                     .contentType(MediaType.APPLICATION_JSON)
                     .content("""{"itemIds":[$itemId]}"""),
@@ -110,7 +121,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
 
         mockMvc
             .perform(
-                post("/api/v1/tournaments/$tournamentId/items")
+                post("/api/v1/tournaments/$tournamentId/items/wish")
                     .header(HttpHeaders.AUTHORIZATION, authHeader(userId))
                     .contentType(MediaType.APPLICATION_JSON)
                     .content("""{"itemIds":[999999]}"""),
@@ -141,7 +152,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
 
         mockMvc
             .perform(
-                post("/api/v1/tournaments/$tournamentId/items")
+                post("/api/v1/tournaments/$tournamentId/items/wish")
                     .header(HttpHeaders.AUTHORIZATION, authHeader(userId))
                     .contentType(MediaType.APPLICATION_JSON)
                     .content("""{"itemIds":[]}"""),
@@ -156,7 +167,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
 
         mockMvc
             .perform(
-                post("/api/v1/tournaments/$tournamentId/items")
+                post("/api/v1/tournaments/$tournamentId/items/wish")
                     .header(HttpHeaders.AUTHORIZATION, authHeader(otherUserId))
                     .contentType(MediaType.APPLICATION_JSON)
                     .content("""{"itemIds":[100,200]}"""),
@@ -514,6 +525,156 @@ class TournamentControllerTest : IntegrationTestSupport() {
             .andExpect(jsonPath("$.status").value(404))
     }
 
+    @Test
+    fun `POST tournaments-id-items-link 는 참여자이면 아이템을 추가하고 200 을 반환한다`() {
+        val mockMvc = buildMockMvc()
+        val tournamentId = createTournament(mockMvc)
+        stubProductLinkExtractor.build = { _ ->
+            ProductSnapshot(name = "테스트 상품", currentPrice = 10_000, currency = "KRW")
+        }
+
+        mockMvc
+            .perform(
+                post("/api/v1/tournaments/$tournamentId/items/link")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(userId))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"url":"https://example.com/product"}"""),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.status").value(200))
+
+        assertEquals(1, tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId).size)
+    }
+
+    @Test
+    fun `POST tournaments-id-items-link 에서 url 이 빈 값이면 400 을 반환한다`() {
+        val mockMvc = buildMockMvc()
+        val tournamentId = createTournament(mockMvc)
+
+        mockMvc
+            .perform(
+                post("/api/v1/tournaments/$tournamentId/items/link")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(userId))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"url":""}"""),
+            ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.status").value(400))
+    }
+
+    @Test
+    fun `POST tournaments-id-items-link 에서 토너먼트 참여자가 아니면 403 을 반환한다`() {
+        val mockMvc = buildMockMvc()
+        val tournamentId = createTournament(mockMvc)
+
+        mockMvc
+            .perform(
+                post("/api/v1/tournaments/$tournamentId/items/link")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(otherUserId))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"url":"https://example.com/product"}"""),
+            ).andExpect(status().isForbidden)
+            .andExpect(jsonPath("$.status").value(403))
+    }
+
+    @Test
+    fun `POST tournaments-id-items-link 에서 토너먼트가 없으면 404 를 반환한다`() {
+        val mockMvc = buildMockMvc()
+
+        mockMvc
+            .perform(
+                post("/api/v1/tournaments/999999/items/link")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(userId))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"url":"https://example.com/product"}"""),
+            ).andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.status").value(404))
+    }
+
+    @Test
+    fun `POST tournaments-id-items-images 는 참여자이면 이미지를 추가하고 200 과 failedCount 0 을 반환한다`() {
+        val mockMvc = buildMockMvc()
+        val tournamentId = createTournament(mockMvc)
+        stubProductImageExtractor.build = { _ ->
+            OcrExtraction(
+                snapshot = ProductSnapshot(name = "이미지 상품", currentPrice = 50_000, currency = "KRW"),
+                boundingBox = null,
+            )
+        }
+        val image = MockMultipartFile("images", "test.jpg", "image/jpeg", ByteArray(100) { 1 })
+
+        mockMvc
+            .perform(
+                multipart("/api/v1/tournaments/$tournamentId/items/images")
+                    .file(image)
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(userId)),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.status").value(200))
+            .andExpect(jsonPath("$.data.failedCount").value(0))
+            .andExpect(jsonPath("$.data.failedIndices").isEmpty)
+
+        assertEquals(1, tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId).size)
+    }
+
+    @Test
+    fun `POST tournaments-id-items-images 에서 일부 이미지 처리 실패 시 성공한 이미지는 저장되고 failedIndices 를 반환한다`() {
+        val mockMvc = buildMockMvc()
+        val tournamentId = createTournament(mockMvc)
+        var callCount = 0
+        stubProductImageExtractor.build = { _ ->
+            val current = ++callCount
+            if (current == 2) error("OCR 실패 시뮬레이션")
+            OcrExtraction(
+                snapshot = ProductSnapshot(name = "이미지 상품 $current", currentPrice = 10_000 * current, currency = "KRW"),
+                boundingBox = null,
+            )
+        }
+        val image1 = MockMultipartFile("images", "img1.jpg", "image/jpeg", ByteArray(100) { 1 })
+        val image2 = MockMultipartFile("images", "img2.jpg", "image/jpeg", ByteArray(100) { 2 })
+
+        mockMvc
+            .perform(
+                multipart("/api/v1/tournaments/$tournamentId/items/images")
+                    .file(image1)
+                    .file(image2)
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(userId)),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.status").value(200))
+            .andExpect(jsonPath("$.data.failedCount").value(1))
+            .andExpect(jsonPath("$.data.failedIndices[0]").value(1))
+
+        assertEquals(1, tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId).size)
+    }
+
+    @Test
+    fun `POST tournaments-id-items-images 에서 토너먼트 참여자가 아니면 403 을 반환한다`() {
+        val mockMvc = buildMockMvc()
+        val tournamentId = createTournament(mockMvc)
+        val image = MockMultipartFile("images", "test.jpg", "image/jpeg", ByteArray(100) { 1 })
+
+        mockMvc
+            .perform(
+                multipart("/api/v1/tournaments/$tournamentId/items/images")
+                    .file(image)
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(otherUserId)),
+            ).andExpect(status().isForbidden)
+            .andExpect(jsonPath("$.status").value(403))
+    }
+
+    @Test
+    fun `POST tournaments-id-items-images 에서 이미지 6개 이상이면 400 을 반환한다`() {
+        val mockMvc = buildMockMvc()
+        val tournamentId = createTournament(mockMvc)
+        val images = (1..6).map { i -> MockMultipartFile("images", "img$i.jpg", "image/jpeg", ByteArray(100) { 1 }) }
+
+        val request = images.fold(multipart("/api/v1/tournaments/$tournamentId/items/images")) { req, file ->
+            req.file(file)
+        }.header(HttpHeaders.AUTHORIZATION, authHeader(userId))
+
+        mockMvc
+            .perform(request)
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.status").value(400))
+    }
+
     private fun buildMockMvc(): MockMvc =
         MockMvcBuilders
             .webAppContextSetup(webApplicationContext)
@@ -551,7 +712,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
         vararg itemIds: Long,
     ) {
         mockMvc.perform(
-            post("/api/v1/tournaments/$tournamentId/items")
+            post("/api/v1/tournaments/$tournamentId/items/wish")
                 .header(HttpHeaders.AUTHORIZATION, authHeader(owner))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("""{"itemIds":${itemIds.joinToString(",", "[", "]")}}"""),

--- a/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
@@ -5,6 +5,8 @@ import com.depromeet.piki.item.domain.Item
 import com.depromeet.piki.item.domain.ItemStatus
 import com.depromeet.piki.item.repository.ItemJpaRepository
 import com.depromeet.piki.support.IntegrationTestSupport
+import com.depromeet.piki.support.StubImageParsingWorker
+import com.depromeet.piki.support.StubItemParsingWorker
 import com.depromeet.piki.tournament.domain.TournamentItem
 import com.depromeet.piki.tournament.domain.TournamentUser
 import com.depromeet.piki.tournament.repository.TournamentItemJpaRepository
@@ -55,6 +57,10 @@ class TournamentControllerTest : IntegrationTestSupport() {
     @Autowired private lateinit var wishPersistenceService: WishPersistenceService
 
     @Autowired private lateinit var wishJpaRepository: WishJpaRepository
+
+    @Autowired private lateinit var stubItemParsingWorker: StubItemParsingWorker
+
+    @Autowired private lateinit var stubImageParsingWorker: StubImageParsingWorker
 
     private val userId: UUID = UUID.fromString("11111111-2222-3333-4444-555555555555")
     private val otherUserId: UUID = UUID.fromString("99999999-8888-7777-6666-555555555555")
@@ -529,20 +535,25 @@ class TournamentControllerTest : IntegrationTestSupport() {
 
     @Test
     fun `POST tournaments-id-items-link 는 참여자이면 PROCESSING 아이템을 생성하고 itemId 를 반환한다`() {
-        val mockMvc = buildMockMvc()
-        val tournamentId = createTournament(mockMvc)
+        stubItemParsingWorker.enabled = false
+        try {
+            val mockMvc = buildMockMvc()
+            val tournamentId = createTournament(mockMvc)
 
-        mockMvc
-            .perform(
-                post("/api/v1/tournaments/$tournamentId/items/link")
-                    .header(HttpHeaders.AUTHORIZATION, authHeader(userId))
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content("""{"url":"https://example.com/product"}"""),
-            ).andExpect(status().isOk)
-            .andExpect(jsonPath("$.status").value(200))
-            .andExpect(jsonPath("$.data.itemId").isNumber)
+            mockMvc
+                .perform(
+                    post("/api/v1/tournaments/$tournamentId/items/link")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader(userId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""{"url":"https://example.com/product"}"""),
+                ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data.itemId").isNumber)
 
-        assertEquals(1, tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId).size)
+            assertEquals(1, tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId).size)
+        } finally {
+            stubItemParsingWorker.enabled = true
+        }
     }
 
     @Test
@@ -591,23 +602,28 @@ class TournamentControllerTest : IntegrationTestSupport() {
 
     @Test
     fun `POST tournaments-id-items-images 는 참여자이면 PROCESSING 아이템을 생성하고 itemIds 를 반환한다`() {
-        val mockMvc = buildMockMvc()
-        val tournamentId = createTournament(mockMvc)
-        val image1 = MockMultipartFile("images", "img1.jpg", "image/jpeg", ByteArray(100) { 1 })
-        val image2 = MockMultipartFile("images", "img2.jpg", "image/jpeg", ByteArray(100) { 2 })
+        stubImageParsingWorker.enabled = false
+        try {
+            val mockMvc = buildMockMvc()
+            val tournamentId = createTournament(mockMvc)
+            val image1 = MockMultipartFile("images", "img1.jpg", "image/jpeg", ByteArray(100) { 1 })
+            val image2 = MockMultipartFile("images", "img2.jpg", "image/jpeg", ByteArray(100) { 2 })
 
-        mockMvc
-            .perform(
-                multipart("/api/v1/tournaments/$tournamentId/items/images")
-                    .file(image1)
-                    .file(image2)
-                    .header(HttpHeaders.AUTHORIZATION, authHeader(userId)),
-            ).andExpect(status().isOk)
-            .andExpect(jsonPath("$.status").value(200))
-            .andExpect(jsonPath("$.data.itemIds").isArray)
-            .andExpect(jsonPath("$.data.itemIds.length()").value(2))
+            mockMvc
+                .perform(
+                    multipart("/api/v1/tournaments/$tournamentId/items/images")
+                        .file(image1)
+                        .file(image2)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader(userId)),
+                ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data.itemIds").isArray)
+                .andExpect(jsonPath("$.data.itemIds.length()").value(2))
 
-        assertEquals(2, tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId).size)
+            assertEquals(2, tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId).size)
+        } finally {
+            stubImageParsingWorker.enabled = true
+        }
     }
 
     @Test

--- a/src/test/kotlin/com/depromeet/piki/tournament/service/TournamentServiceTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/service/TournamentServiceTest.kt
@@ -11,7 +11,7 @@ import com.depromeet.piki.tournament.domain.TournamentUser
 import com.depromeet.piki.tournament.repository.TournamentItemRepository
 import com.depromeet.piki.tournament.repository.TournamentRepository
 import com.depromeet.piki.tournament.repository.TournamentUserRepository
-import com.depromeet.piki.tournament.service.dto.AddTournamentItems
+import com.depromeet.piki.tournament.service.dto.AddTournamentItemsFromWish
 import com.depromeet.piki.tournament.service.dto.CreateTournament
 import com.depromeet.piki.tournament.service.dto.RecordMatch
 import com.depromeet.piki.user.domain.IdentityType
@@ -60,6 +60,7 @@ class TournamentServiceTest {
         var validIds: Set<Long>? = null  // null = 모든 ID 유효
 
         override fun save(item: Item): Item = item
+        override fun saveAll(items: List<Item>): List<Item> = items
         override fun findById(id: Long): Item? = null
         override fun findByIds(ids: List<Long>): List<Item> {
             val effective = validIds?.let { valid -> ids.filter { it in valid } } ?: ids
@@ -185,7 +186,7 @@ class TournamentServiceTest {
         name: String = "토너먼트",
     ): Long {
         val tournamentId = service.create(userId, CreateTournament(name))
-        service.addItems(userId, AddTournamentItems(tournamentId, itemIds))
+        service.addItemsFromWish(userId, AddTournamentItemsFromWish(tournamentId, itemIds))
         service.start(userId, tournamentId)
         return tournamentId
     }
@@ -202,7 +203,7 @@ class TournamentServiceTest {
     fun `addItems 는 PENDING 토너먼트에 아이템을 추가한다`() {
         val tournamentId = service.create(userId, CreateTournament("내 토너먼트"))
 
-        service.addItems(userId, AddTournamentItems(tournamentId, (1L..8L).toList()))
+        service.addItemsFromWish(userId, AddTournamentItemsFromWish(tournamentId, (1L..8L).toList()))
 
         assertEquals(8, itemRepository.findAllByTournamentId(tournamentId).size)
     }
@@ -213,7 +214,7 @@ class TournamentServiceTest {
 
         val ex =
             assertFailsWith<TournamentException> {
-                service.addItems(otherUserId, AddTournamentItems(tournamentId, (1L..4L).toList()))
+                service.addItemsFromWish(otherUserId, AddTournamentItemsFromWish(tournamentId, (1L..4L).toList()))
             }
         assertEquals(HttpStatus.FORBIDDEN, ex.httpStatus)
     }
@@ -221,11 +222,11 @@ class TournamentServiceTest {
     @Test
     fun `addItems 에서 토너먼트 참여자가 아니면 중복 아이템이어도 권한 예외가 발생한다`() {
         val tournamentId = service.create(userId, CreateTournament("토너먼트"))
-        service.addItems(userId, AddTournamentItems(tournamentId, listOf(1L)))
+        service.addItemsFromWish(userId, AddTournamentItemsFromWish(tournamentId, listOf(1L)))
 
         val ex =
             assertFailsWith<TournamentException> {
-                service.addItems(otherUserId, AddTournamentItems(tournamentId, listOf(1L)))
+                service.addItemsFromWish(otherUserId, AddTournamentItemsFromWish(tournamentId, listOf(1L)))
             }
         assertEquals(HttpStatus.FORBIDDEN, ex.httpStatus)
     }
@@ -233,11 +234,11 @@ class TournamentServiceTest {
     @Test
     fun `addItems 에서 기존 아이템과 합산해 32개를 초과하면 예외가 발생한다`() {
         val tournamentId = service.create(userId, CreateTournament("토너먼트"))
-        service.addItems(userId, AddTournamentItems(tournamentId, (1L..32L).toList()))
+        service.addItemsFromWish(userId, AddTournamentItemsFromWish(tournamentId, (1L..32L).toList()))
 
         val ex =
             assertFailsWith<TournamentException> {
-                service.addItems(userId, AddTournamentItems(tournamentId, listOf(33L)))
+                service.addItemsFromWish(userId, AddTournamentItemsFromWish(tournamentId, listOf(33L)))
             }
         assertEquals(HttpStatus.BAD_REQUEST, ex.httpStatus)
     }
@@ -247,7 +248,7 @@ class TournamentServiceTest {
         val tournamentId = createAndStart(listOf(1L, 2L))
 
         assertFailsWith<TournamentException> {
-            service.addItems(userId, AddTournamentItems(tournamentId, listOf(3L, 4L)))
+            service.addItemsFromWish(userId, AddTournamentItemsFromWish(tournamentId, listOf(3L, 4L)))
         }
     }
 
@@ -256,17 +257,17 @@ class TournamentServiceTest {
         val tournamentId = service.create(userId, CreateTournament("토너먼트"))
 
         assertFailsWith<TournamentException> {
-            service.addItems(userId, AddTournamentItems(tournamentId, listOf(1L, 1L, 2L)))
+            service.addItemsFromWish(userId, AddTournamentItemsFromWish(tournamentId, listOf(1L, 1L, 2L)))
         }
     }
 
     @Test
     fun `addItems 에서 이미 등록된 itemId 를 다시 추가하면 예외가 발생한다`() {
         val tournamentId = service.create(userId, CreateTournament("토너먼트"))
-        service.addItems(userId, AddTournamentItems(tournamentId, listOf(1L, 2L)))
+        service.addItemsFromWish(userId, AddTournamentItemsFromWish(tournamentId, listOf(1L, 2L)))
 
         assertFailsWith<TournamentException> {
-            service.addItems(userId, AddTournamentItems(tournamentId, listOf(1L)))
+            service.addItemsFromWish(userId, AddTournamentItemsFromWish(tournamentId, listOf(1L)))
         }
     }
 
@@ -277,7 +278,7 @@ class TournamentServiceTest {
 
         val ex =
             assertFailsWith<TournamentException> {
-                service.addItems(userId, AddTournamentItems(tournamentId, listOf(1L, 999L)))
+                service.addItemsFromWish(userId, AddTournamentItemsFromWish(tournamentId, listOf(1L, 999L)))
             }
         assertEquals(HttpStatus.NOT_FOUND, ex.httpStatus)
     }
@@ -285,7 +286,7 @@ class TournamentServiceTest {
     @Test
     fun `start 는 PENDING 토너먼트를 IN_PROGRESS 로 전환한다`() {
         val tournamentId = service.create(userId, CreateTournament("토너먼트"))
-        service.addItems(userId, AddTournamentItems(tournamentId, listOf(1L, 2L)))
+        service.addItemsFromWish(userId, AddTournamentItemsFromWish(tournamentId, listOf(1L, 2L)))
 
         service.start(userId, tournamentId)
 
@@ -295,7 +296,7 @@ class TournamentServiceTest {
     @Test
     fun `start 에서 소유자가 아니면 예외가 발생한다`() {
         val tournamentId = service.create(userId, CreateTournament("토너먼트"))
-        service.addItems(userId, AddTournamentItems(tournamentId, listOf(1L, 2L)))
+        service.addItemsFromWish(userId, AddTournamentItemsFromWish(tournamentId, listOf(1L, 2L)))
 
         assertFailsWith<TournamentException> {
             service.start(otherUserId, tournamentId)
@@ -323,7 +324,7 @@ class TournamentServiceTest {
     @Test
     fun `start 에서 아이템이 1개면 예외가 발생한다`() {
         val tournamentId = service.create(userId, CreateTournament("토너먼트"))
-        service.addItems(userId, AddTournamentItems(tournamentId, listOf(1L)))
+        service.addItemsFromWish(userId, AddTournamentItemsFromWish(tournamentId, listOf(1L)))
 
         assertFailsWith<TournamentException> {
             service.start(userId, tournamentId)
@@ -333,7 +334,7 @@ class TournamentServiceTest {
     @Test
     fun `start 에서 아이템이 32개면 정상적으로 시작된다`() {
         val tournamentId = service.create(userId, CreateTournament("토너먼트"))
-        service.addItems(userId, AddTournamentItems(tournamentId, (1L..32L).toList()))
+        service.addItemsFromWish(userId, AddTournamentItemsFromWish(tournamentId, (1L..32L).toList()))
 
         service.start(userId, tournamentId)
 
@@ -386,7 +387,7 @@ class TournamentServiceTest {
     @Test
     fun `recordMatch 에서 PENDING 토너먼트면 예외가 발생한다`() {
         val tournamentId = service.create(userId, CreateTournament("토너먼트"))
-        service.addItems(userId, AddTournamentItems(tournamentId, listOf(1L, 2L)))
+        service.addItemsFromWish(userId, AddTournamentItemsFromWish(tournamentId, listOf(1L, 2L)))
 
         assertFailsWith<TournamentException> {
             service.recordMatch(
@@ -558,7 +559,7 @@ class TournamentServiceTest {
     fun `getTournaments 에서 status 필터가 주어지면 해당 상태만 반환한다`() {
         service.create(userId, CreateTournament("대기중"))
         val startedId = service.create(userId, CreateTournament("진행중"))
-        service.addItems(userId, AddTournamentItems(startedId, listOf(1L, 2L)))
+        service.addItemsFromWish(userId, AddTournamentItemsFromWish(startedId, listOf(1L, 2L)))
         service.start(userId, startedId)
 
         val result = service.getTournaments(userId, listOf(TournamentStatus.PENDING))
@@ -571,10 +572,10 @@ class TournamentServiceTest {
     fun `getTournaments 에서 복수 status 필터가 주어지면 해당 상태들만 반환한다`() {
         service.create(userId, CreateTournament("대기중"))
         val startedId = service.create(userId, CreateTournament("진행중"))
-        service.addItems(userId, AddTournamentItems(startedId, listOf(1L, 2L)))
+        service.addItemsFromWish(userId, AddTournamentItemsFromWish(startedId, listOf(1L, 2L)))
         service.start(userId, startedId)
         val completedId = service.create(userId, CreateTournament("완료됨"))
-        service.addItems(userId, AddTournamentItems(completedId, listOf(3L, 4L)))
+        service.addItemsFromWish(userId, AddTournamentItemsFromWish(completedId, listOf(3L, 4L)))
         service.start(userId, completedId)
         val completedItems = itemRepository.findAllByTournamentId(completedId)
         service.recordMatch(
@@ -615,7 +616,7 @@ class TournamentServiceTest {
     @Test
     fun `deleteItem 은 PENDING 토너먼트에서 아이템을 삭제한다`() {
         val tournamentId = service.create(userId, CreateTournament("토너먼트"))
-        service.addItems(userId, AddTournamentItems(tournamentId, listOf(1L, 2L)))
+        service.addItemsFromWish(userId, AddTournamentItemsFromWish(tournamentId, listOf(1L, 2L)))
         val item = itemRepository.findAllByTournamentId(tournamentId).first()
 
         service.deleteItem(userId, tournamentId, item.getId())
@@ -627,7 +628,7 @@ class TournamentServiceTest {
     fun `deleteItem 에서 토너먼트 소유자도 다른 사람이 추가한 아이템을 삭제할 수 있다`() {
         val tournamentId = service.create(userId, CreateTournament("토너먼트"))
         userRepository.save(TournamentUser(tournamentId = tournamentId, userId = otherUserId))
-        service.addItems(otherUserId, AddTournamentItems(tournamentId, listOf(1L)))
+        service.addItemsFromWish(otherUserId, AddTournamentItemsFromWish(tournamentId, listOf(1L)))
         val item = itemRepository.findAllByTournamentId(tournamentId).first()
 
         service.deleteItem(userId, tournamentId, item.getId())
@@ -658,8 +659,8 @@ class TournamentServiceTest {
     fun `deleteItem 에서 다른 토너먼트 아이템이면 예외가 발생한다`() {
         val tournamentId1 = service.create(userId, CreateTournament("토너먼트1"))
         val tournamentId2 = service.create(userId, CreateTournament("토너먼트2"))
-        service.addItems(userId, AddTournamentItems(tournamentId1, listOf(1L)))
-        service.addItems(userId, AddTournamentItems(tournamentId2, listOf(2L)))
+        service.addItemsFromWish(userId, AddTournamentItemsFromWish(tournamentId1, listOf(1L)))
+        service.addItemsFromWish(userId, AddTournamentItemsFromWish(tournamentId2, listOf(2L)))
         val itemOfTournament2 = itemRepository.findAllByTournamentId(tournamentId2).first()
 
         assertFailsWith<TournamentException> {
@@ -670,7 +671,7 @@ class TournamentServiceTest {
     @Test
     fun `deleteItem 에서 아이템을 추가하지 않은 타인이면 예외가 발생한다`() {
         val tournamentId = service.create(userId, CreateTournament("토너먼트"))
-        service.addItems(userId, AddTournamentItems(tournamentId, listOf(1L)))
+        service.addItemsFromWish(userId, AddTournamentItemsFromWish(tournamentId, listOf(1L)))
         val item = itemRepository.findAllByTournamentId(tournamentId).first()
 
         assertFailsWith<TournamentException> {

--- a/src/test/kotlin/com/depromeet/piki/tournament/service/TournamentServiceTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/service/TournamentServiceTest.kt
@@ -361,6 +361,17 @@ class TournamentServiceTest {
     }
 
     @Test
+    fun `start 에서 FAILED 아이템이 있으면 409 예외가 발생한다`() {
+        val tournamentId = service.create(userId, CreateTournament("토너먼트"))
+        testWishRepository.addWish(userId, 1L, 2L)
+        service.addItemsFromWish(userId, AddTournamentItemsFromWish(tournamentId, listOf(1L, 2L)))
+        testItemRepository.statusOverrides[1L] = ItemStatus.FAILED
+
+        val ex = assertFailsWith<TournamentException> { service.start(userId, tournamentId) }
+        assertEquals(HttpStatus.CONFLICT, ex.httpStatus)
+    }
+
+    @Test
     fun `start 에서 아이템이 없으면 예외가 발생한다`() {
         val tournamentId = service.create(userId, CreateTournament("토너먼트"))
 

--- a/src/test/kotlin/com/depromeet/piki/tournament/service/TournamentServiceTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/service/TournamentServiceTest.kt
@@ -176,6 +176,8 @@ class TournamentServiceTest {
 
         override fun findTournamentById(tournamentId: Long): Tournament? = tournaments[tournamentId]
 
+        override fun findTournamentByIdForUpdate(tournamentId: Long): Tournament? = tournaments[tournamentId]
+
         override fun findTournamentHistoriesByTournamentId(tournamentId: Long): List<TournamentHistory> =
             histories.filter { it.tournamentId == tournamentId }
 

--- a/src/test/kotlin/com/depromeet/piki/tournament/service/TournamentServiceTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/service/TournamentServiceTest.kt
@@ -2,6 +2,7 @@ package com.depromeet.piki.tournament.service
 
 import com.depromeet.piki.common.domain.LongBaseEntity
 import com.depromeet.piki.item.domain.Item
+import com.depromeet.piki.item.domain.ItemStatus
 import com.depromeet.piki.item.repository.ItemRepository
 import com.depromeet.piki.tournament.domain.Tournament
 import com.depromeet.piki.tournament.domain.TournamentHistory
@@ -17,6 +18,9 @@ import com.depromeet.piki.tournament.service.dto.RecordMatch
 import com.depromeet.piki.user.domain.IdentityType
 import com.depromeet.piki.user.domain.User
 import com.depromeet.piki.user.repository.UserRepository
+import com.depromeet.piki.wishlist.domain.WishCursor
+import com.depromeet.piki.wishlist.domain.Wish
+import com.depromeet.piki.wishlist.repository.WishRepository
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
 import java.util.UUID
@@ -58,6 +62,7 @@ class TournamentServiceTest {
 
     private class TestItemRepository : ItemRepository {
         var validIds: Set<Long>? = null  // null = 모든 ID 유효
+        val statusOverrides: MutableMap<Long, ItemStatus> = mutableMapOf()
 
         override fun save(item: Item): Item = item
         override fun saveAll(items: List<Item>): List<Item> = items
@@ -65,7 +70,7 @@ class TournamentServiceTest {
         override fun findByIds(ids: List<Long>): List<Item> {
             val effective = validIds?.let { valid -> ids.filter { it in valid } } ?: ids
             return effective.map { id ->
-                Item().also { item ->
+                Item(status = statusOverrides[id] ?: ItemStatus.READY).also { item ->
                     val field = LongBaseEntity::class.java.getDeclaredField("id")
                     field.isAccessible = true
                     field.set(item, id)
@@ -74,6 +79,24 @@ class TournamentServiceTest {
         }
 
         override fun findStaleProcessingIds(cutoff: java.time.LocalDateTime): List<Long> = emptyList()
+    }
+
+    private class TestWishRepository : WishRepository {
+        // userId → itemIds 매핑. 위시에 등록된 것만 카운트된다.
+        val wishItemIdsByUser: MutableMap<UUID, MutableSet<Long>> = mutableMapOf()
+
+        fun addWish(userId: UUID, vararg itemIds: Long) {
+            wishItemIdsByUser.getOrPut(userId) { mutableSetOf() }.addAll(itemIds.toList())
+        }
+
+        override fun save(wish: Wish): Wish = wish
+        override fun countByIdsAndUserId(ids: List<Long>, userId: UUID): Long = 0L
+        override fun countByItemIdsAndUserId(itemIds: List<Long>, userId: UUID): Long {
+            val owned = wishItemIdsByUser[userId] ?: emptySet()
+            return itemIds.count { it in owned }.toLong()
+        }
+        override fun findPage(userId: UUID, cursor: WishCursor?, limit: Int): List<Wish> = emptyList()
+        override fun findById(id: Long): Wish? = null
     }
 
     private class TestUserRepository : UserRepository {
@@ -177,7 +200,8 @@ class TournamentServiceTest {
     private val repository = TestTournamentRepository()
     private val testUserRepository = TestUserRepository()
     private val testItemRepository = TestItemRepository()
-    private val service = TournamentService(userRepository, repository, itemRepository, testUserRepository, testItemRepository)
+    private val testWishRepository = TestWishRepository()
+    private val service = TournamentService(userRepository, repository, itemRepository, testUserRepository, testItemRepository, testWishRepository)
     private val userId = UUID.randomUUID()
     private val otherUserId = UUID.randomUUID()
 
@@ -186,6 +210,7 @@ class TournamentServiceTest {
         name: String = "토너먼트",
     ): Long {
         val tournamentId = service.create(userId, CreateTournament(name))
+        testWishRepository.addWish(userId, *itemIds.toLongArray())
         service.addItemsFromWish(userId, AddTournamentItemsFromWish(tournamentId, itemIds))
         service.start(userId, tournamentId)
         return tournamentId
@@ -202,6 +227,7 @@ class TournamentServiceTest {
     @Test
     fun `addItems 는 PENDING 토너먼트에 아이템을 추가한다`() {
         val tournamentId = service.create(userId, CreateTournament("내 토너먼트"))
+        testWishRepository.addWish(userId, *(1L..8L).toList().toLongArray())
 
         service.addItemsFromWish(userId, AddTournamentItemsFromWish(tournamentId, (1L..8L).toList()))
 
@@ -222,6 +248,7 @@ class TournamentServiceTest {
     @Test
     fun `addItems 에서 토너먼트 참여자가 아니면 중복 아이템이어도 권한 예외가 발생한다`() {
         val tournamentId = service.create(userId, CreateTournament("토너먼트"))
+        testWishRepository.addWish(userId, 1L)
         service.addItemsFromWish(userId, AddTournamentItemsFromWish(tournamentId, listOf(1L)))
 
         val ex =
@@ -234,6 +261,7 @@ class TournamentServiceTest {
     @Test
     fun `addItems 에서 기존 아이템과 합산해 32개를 초과하면 예외가 발생한다`() {
         val tournamentId = service.create(userId, CreateTournament("토너먼트"))
+        testWishRepository.addWish(userId, *(1L..33L).toList().toLongArray())
         service.addItemsFromWish(userId, AddTournamentItemsFromWish(tournamentId, (1L..32L).toList()))
 
         val ex =
@@ -264,6 +292,7 @@ class TournamentServiceTest {
     @Test
     fun `addItems 에서 이미 등록된 itemId 를 다시 추가하면 예외가 발생한다`() {
         val tournamentId = service.create(userId, CreateTournament("토너먼트"))
+        testWishRepository.addWish(userId, 1L, 2L)
         service.addItemsFromWish(userId, AddTournamentItemsFromWish(tournamentId, listOf(1L, 2L)))
 
         assertFailsWith<TournamentException> {
@@ -274,6 +303,7 @@ class TournamentServiceTest {
     @Test
     fun `addItems 에서 존재하지 않는 itemId 이면 예외가 발생한다`() {
         testItemRepository.validIds = setOf(1L, 2L)
+        testWishRepository.addWish(userId, 1L, 999L)
         val tournamentId = service.create(userId, CreateTournament("토너먼트"))
 
         val ex =
@@ -286,6 +316,7 @@ class TournamentServiceTest {
     @Test
     fun `start 는 PENDING 토너먼트를 IN_PROGRESS 로 전환한다`() {
         val tournamentId = service.create(userId, CreateTournament("토너먼트"))
+        testWishRepository.addWish(userId, 1L, 2L)
         service.addItemsFromWish(userId, AddTournamentItemsFromWish(tournamentId, listOf(1L, 2L)))
 
         service.start(userId, tournamentId)
@@ -296,6 +327,7 @@ class TournamentServiceTest {
     @Test
     fun `start 에서 소유자가 아니면 예외가 발생한다`() {
         val tournamentId = service.create(userId, CreateTournament("토너먼트"))
+        testWishRepository.addWish(userId, 1L, 2L)
         service.addItemsFromWish(userId, AddTournamentItemsFromWish(tournamentId, listOf(1L, 2L)))
 
         assertFailsWith<TournamentException> {
@@ -313,6 +345,17 @@ class TournamentServiceTest {
     }
 
     @Test
+    fun `start 에서 PROCESSING 아이템이 있으면 409 예외가 발생한다`() {
+        val tournamentId = service.create(userId, CreateTournament("토너먼트"))
+        testWishRepository.addWish(userId, 1L, 2L)
+        service.addItemsFromWish(userId, AddTournamentItemsFromWish(tournamentId, listOf(1L, 2L)))
+        testItemRepository.statusOverrides[1L] = ItemStatus.PROCESSING
+
+        val ex = assertFailsWith<TournamentException> { service.start(userId, tournamentId) }
+        assertEquals(HttpStatus.CONFLICT, ex.httpStatus)
+    }
+
+    @Test
     fun `start 에서 아이템이 없으면 예외가 발생한다`() {
         val tournamentId = service.create(userId, CreateTournament("토너먼트"))
 
@@ -324,6 +367,7 @@ class TournamentServiceTest {
     @Test
     fun `start 에서 아이템이 1개면 예외가 발생한다`() {
         val tournamentId = service.create(userId, CreateTournament("토너먼트"))
+        testWishRepository.addWish(userId, 1L)
         service.addItemsFromWish(userId, AddTournamentItemsFromWish(tournamentId, listOf(1L)))
 
         assertFailsWith<TournamentException> {
@@ -334,6 +378,7 @@ class TournamentServiceTest {
     @Test
     fun `start 에서 아이템이 32개면 정상적으로 시작된다`() {
         val tournamentId = service.create(userId, CreateTournament("토너먼트"))
+        testWishRepository.addWish(userId, *(1L..32L).toList().toLongArray())
         service.addItemsFromWish(userId, AddTournamentItemsFromWish(tournamentId, (1L..32L).toList()))
 
         service.start(userId, tournamentId)
@@ -387,6 +432,7 @@ class TournamentServiceTest {
     @Test
     fun `recordMatch 에서 PENDING 토너먼트면 예외가 발생한다`() {
         val tournamentId = service.create(userId, CreateTournament("토너먼트"))
+        testWishRepository.addWish(userId, 1L, 2L)
         service.addItemsFromWish(userId, AddTournamentItemsFromWish(tournamentId, listOf(1L, 2L)))
 
         assertFailsWith<TournamentException> {
@@ -559,6 +605,7 @@ class TournamentServiceTest {
     fun `getTournaments 에서 status 필터가 주어지면 해당 상태만 반환한다`() {
         service.create(userId, CreateTournament("대기중"))
         val startedId = service.create(userId, CreateTournament("진행중"))
+        testWishRepository.addWish(userId, 1L, 2L)
         service.addItemsFromWish(userId, AddTournamentItemsFromWish(startedId, listOf(1L, 2L)))
         service.start(userId, startedId)
 
@@ -572,6 +619,7 @@ class TournamentServiceTest {
     fun `getTournaments 에서 복수 status 필터가 주어지면 해당 상태들만 반환한다`() {
         service.create(userId, CreateTournament("대기중"))
         val startedId = service.create(userId, CreateTournament("진행중"))
+        testWishRepository.addWish(userId, 1L, 2L, 3L, 4L)
         service.addItemsFromWish(userId, AddTournamentItemsFromWish(startedId, listOf(1L, 2L)))
         service.start(userId, startedId)
         val completedId = service.create(userId, CreateTournament("완료됨"))
@@ -616,6 +664,7 @@ class TournamentServiceTest {
     @Test
     fun `deleteItem 은 PENDING 토너먼트에서 아이템을 삭제한다`() {
         val tournamentId = service.create(userId, CreateTournament("토너먼트"))
+        testWishRepository.addWish(userId, 1L, 2L)
         service.addItemsFromWish(userId, AddTournamentItemsFromWish(tournamentId, listOf(1L, 2L)))
         val item = itemRepository.findAllByTournamentId(tournamentId).first()
 
@@ -628,6 +677,7 @@ class TournamentServiceTest {
     fun `deleteItem 에서 토너먼트 소유자도 다른 사람이 추가한 아이템을 삭제할 수 있다`() {
         val tournamentId = service.create(userId, CreateTournament("토너먼트"))
         userRepository.save(TournamentUser(tournamentId = tournamentId, userId = otherUserId))
+        testWishRepository.addWish(otherUserId, 1L)
         service.addItemsFromWish(otherUserId, AddTournamentItemsFromWish(tournamentId, listOf(1L)))
         val item = itemRepository.findAllByTournamentId(tournamentId).first()
 
@@ -659,6 +709,7 @@ class TournamentServiceTest {
     fun `deleteItem 에서 다른 토너먼트 아이템이면 예외가 발생한다`() {
         val tournamentId1 = service.create(userId, CreateTournament("토너먼트1"))
         val tournamentId2 = service.create(userId, CreateTournament("토너먼트2"))
+        testWishRepository.addWish(userId, 1L, 2L)
         service.addItemsFromWish(userId, AddTournamentItemsFromWish(tournamentId1, listOf(1L)))
         service.addItemsFromWish(userId, AddTournamentItemsFromWish(tournamentId2, listOf(2L)))
         val itemOfTournament2 = itemRepository.findAllByTournamentId(tournamentId2).first()
@@ -671,11 +722,34 @@ class TournamentServiceTest {
     @Test
     fun `deleteItem 에서 아이템을 추가하지 않은 타인이면 예외가 발생한다`() {
         val tournamentId = service.create(userId, CreateTournament("토너먼트"))
+        testWishRepository.addWish(userId, 1L)
         service.addItemsFromWish(userId, AddTournamentItemsFromWish(tournamentId, listOf(1L)))
         val item = itemRepository.findAllByTournamentId(tournamentId).first()
 
         assertFailsWith<TournamentException> {
             service.deleteItem(otherUserId, tournamentId, item.getId())
         }
+    }
+
+    @Test
+    fun `addItems 에서 위시에 없는 아이템이면 403 예외가 발생한다`() {
+        val tournamentId = service.create(userId, CreateTournament("토너먼트"))
+        // 위시에 1L만 등록하고 2L은 없는 상태
+
+        val ex = assertFailsWith<TournamentException> {
+            service.addItemsFromWish(userId, AddTournamentItemsFromWish(tournamentId, listOf(1L, 2L)))
+        }
+        assertEquals(HttpStatus.FORBIDDEN, ex.httpStatus)
+    }
+
+    @Test
+    fun `addItems 에서 일부 아이템이 위시에 없으면 403 예외가 발생한다`() {
+        testWishRepository.addWish(userId, 1L) // 1L만 위시에 있음
+        val tournamentId = service.create(userId, CreateTournament("토너먼트"))
+
+        val ex = assertFailsWith<TournamentException> {
+            service.addItemsFromWish(userId, AddTournamentItemsFromWish(tournamentId, listOf(1L, 2L)))
+        }
+        assertEquals(HttpStatus.FORBIDDEN, ex.httpStatus)
     }
 }

--- a/src/test/kotlin/com/depromeet/piki/tournament/service/TournamentServiceTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/service/TournamentServiceTest.kt
@@ -127,6 +127,9 @@ class TournamentServiceTest {
                 item
             }
 
+        override fun countByTournamentId(tournamentId: Long): Int =
+            items.count { it.tournamentId == tournamentId }
+
         override fun findAllByTournamentId(tournamentId: Long): List<TournamentItem> =
             items.filter { it.tournamentId == tournamentId }
 


### PR DESCRIPTION
## Situation
- 기존 단일 엔드포인트(`POST /tournaments/{id}/items`)가 위시·링크·이미지 세 경로를 하나로 처리했으나, 각 경로의 특성(즉시 완료 vs 비동기, 요청 형식)이 달라 분리가 필요했다
- 링크·이미지 경로에서 외부 LLM 호출(최대 60s)이 트랜잭션 안에 묶여 DB 커넥션을 오래 점유, 커넥션 풀 고갈 위험이 있었다
- 위시에서 아이템 추가 시 소유권 검증이 없어 다른 유저의 아이템도 등록 가능한 보안 허점이 있었다

## Task
- 위시·링크·이미지 세 경로를 별도 엔드포인트로 분리하고, 링크·이미지는 비동기 처리로 전환
- 외부 호출을 트랜잭션 밖으로 꺼내 DB 커넥션 고갈 방지
- 위시 소유권 검증 추가, 토너먼트 시작 시 PROCESSING 아이템 차단

## Action

### 엔드포인트 분리
- `POST /tournaments/{id}/items/wish` — 위시리스트 아이템 추가 (최대 32개, 즉시 처리)
- `POST /tournaments/{id}/items/link` — URL 링크 추가 (1개, PROCESSING 즉시 반환 후 비동기 파싱)
- `POST /tournaments/{id}/items/images` — 이미지 OCR 추가 (1–5개, PROCESSING 즉시 반환 후 비동기 파싱)

### 비동기 처리 구조
- `TournamentItemPersistenceService`: 외부 호출 전에 Item + TournamentItem을 PROCESSING 상태로 먼저 커밋. self-invocation AOP 우회를 위해 별도 빈으로 분리해 트랜잭션 경계를 짧게 유지
- `AsyncImageParsingWorker`: 이미지 OCR 경로 전용 비동기 워커. `AsyncItemParsingWorker`(링크)와 대칭 구조로 설계해 경로별 독립 교체 가능
- 큐 포화(`TaskRejectedException`) 시 해당 아이템을 즉시 FAILED로 전이해 PROCESSING 방치 방지

### 검증 강화
- 위시 추가 시 `WishRepository.countByItemIdsAndUserId`로 소유권 일괄 확인
- 토너먼트 시작 시 등록된 아이템 중 PROCESSING·FAILED가 있으면 409 차단 (`itemNotReadyToStart`)
- 이미지 추가 시 MIME 형식·바이트 유효성을 트랜잭션 진입 전에 먼저 검증

### 쿼리 최적화
- 용량 체크를 `findAllByTournamentId`(전체 조회) → `countByTournamentId`(COUNT 쿼리)로 교체
- 링크·이미지 경로의 중복 tournament·user 검증 제거 — 파싱 비동기화 이후 "외부 IO 전 빠른 실패" 명분이 사라졌고 `validateAndCheckCapacity`가 트랜잭션 내에서 동일 검증을 담당하므로 성공 경로 5→3 쿼리 절감

### 테스트
- `StubItemParsingWorker` · `StubImageParsingWorker`: `enabled` 플래그로 활성화/비활성화 가능한 래퍼 추가. `@Transactional` 통합 테스트에서 미커밋 Item에 비동기 워커가 접근해 발생하던 warn 로그 노이즈 제거 — `WishlistRegisterAsyncIntegrationTest`(실제 커밋 + Awaitility)는 그대로 동작
- `multipart max-request-size` 5MB → 25MB (이미지 5장 동시 업로드 수용)

## Result
- 링크·이미지 추가: 클라이언트가 itemId(s)를 즉시 받아 폴링 가능, LLM 호출이 HTTP 응답과 분리되어 타임아웃 위험 제거
- 위시 추가: 소유권 미검증 보안 허점 수정
- 토너먼트 시작: PROCESSING·FAILED 아이템이 섞인 채 시작되는 케이스 차단

---
## 연관 이슈
- close #254


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 토너먼트에 이미지 업로드로 아이템 추가
  * 토너먼트에 상품 링크(URL)로 아이템 추가
  * 토너먼트에 위시리스트 기반 아이템 추가

* **Refactor**
  * 아이템 추가 API를 위시/링크/이미지 3가지 경로로 분리

* **Chores**
  * 파일 업로드 최대 허용 크기 25MB로 상향

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/PIKI-Server/pull/255?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->