### PR TITLE
위시리스트 단건 조회 API 추가

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/wishlist/controller/WishlistApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/wishlist/controller/WishlistApi.kt
@@ -89,6 +89,53 @@ interface WishlistApi {
     ): ApiResponseBody<List<WishItemResponse>>
 
     @Operation(
+        summary = "위시리스트 단건 조회",
+        description = """
+            wishId 로 위시 항목 하나를 조회한다. 응답 모양은 목록 조회 항목과 같은 WishItemResponse(wish + item).
+            본인 위시만 조회 가능하며, item 을 직접 노출하지 않고 위시 소유 단위로 권한을 검증한다.
+            item.status 로 파싱 상태(PROCESSING/READY/FAILED)를 구분한다 — 상세 화면 진입 시 단건 폴링에 쓸 수 있다.
+        """,
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "조회 성공",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "403",
+                description = "본인 위시가 아님",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "존재하지 않는 위시 항목",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun getWish(
+        @Parameter(hidden = true) userId: UUID,
+        @Parameter(description = "위시 항목 ID", example = "1024") wishId: Long,
+    ): ApiResponseBody<WishItemResponse>
+
+    @Operation(
         summary = "위시리스트 수정",
         description = """
             위시 항목에 연결된 상품(item)의 이름·현재가·이미지·통화를 수정한다. 들어온 필드만 갱신한다.

--- a/src/main/kotlin/com/depromeet/piki/wishlist/controller/WishlistApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/wishlist/controller/WishlistApiExamples.kt
@@ -72,6 +72,35 @@ class WishlistApiExamples(
                     )
                 }
             }
+            if (handlerMethod.binds(WishlistController::getWish)) {
+                operation.examples(openApiObjectMapper.delegate) {
+                    add(
+                        status = HttpStatus.OK,
+                        name = "조회 성공",
+                        payload = ApiResponseBody.ok(sampleEntry),
+                    )
+                    add(
+                        status = HttpStatus.FORBIDDEN,
+                        name = "본인 위시 아님",
+                        payload =
+                            ApiResponseBody.fail<Unit>(
+                                category = ErrorCategory.FORBIDDEN,
+                                status = HttpStatus.FORBIDDEN,
+                                detail = "해당 위시 아이템에 접근할 권한이 없습니다.",
+                            ),
+                    )
+                    add(
+                        status = HttpStatus.NOT_FOUND,
+                        name = "존재하지 않는 위시 항목",
+                        payload =
+                            ApiResponseBody.fail<Unit>(
+                                category = ErrorCategory.NOT_FOUND,
+                                status = HttpStatus.NOT_FOUND,
+                                detail = "존재하지 않는 위시리스트 항목입니다.",
+                            ),
+                    )
+                }
+            }
             if (handlerMethod.binds(WishlistController::updateWish)) {
                 operation.examples(openApiObjectMapper.delegate) {
                     add(

--- a/src/main/kotlin/com/depromeet/piki/wishlist/controller/WishlistController.kt
+++ b/src/main/kotlin/com/depromeet/piki/wishlist/controller/WishlistController.kt
@@ -62,6 +62,15 @@ class WishlistController(
         )
     }
 
+    @GetMapping("/{wishId}")
+    override fun getWish(
+        @AuthenticationPrincipal userId: UUID,
+        @PathVariable wishId: Long,
+    ): ApiResponseBody<WishItemResponse> {
+        val result = wishlistService.getWish(userId = userId, wishId = wishId)
+        return ApiResponseBody.ok(WishItemResponse.from(result.wish, result.item))
+    }
+
     @PatchMapping("/{wishId}")
     override fun updateWish(
         @AuthenticationPrincipal userId: UUID,

--- a/src/main/kotlin/com/depromeet/piki/wishlist/service/WishlistService.kt
+++ b/src/main/kotlin/com/depromeet/piki/wishlist/service/WishlistService.kt
@@ -104,6 +104,20 @@ class WishlistService(
         return WishlistPage(entries = entries, nextCursor = nextCursor, hasNext = hasNext)
     }
 
+    // wishId 로 단건 조회. 본인 위시만 볼 수 있고, 권한 검증은 도메인(verifyOwnedBy)에 맡긴다.
+    // findById 가 deletedAt IS NULL 만 보므로 삭제된 위시는 notFound(404)로 떨어진다.
+    @Transactional(readOnly = true)
+    fun getWish(
+        userId: UUID,
+        wishId: Long,
+    ): WishWithItem {
+        val wish = wishRepository.findById(wishId) ?: throw WishException.notFound()
+        wish.verifyOwnedBy(userId)
+        // wish 가 가리키는 item 은 반드시 존재한다. 없으면 영속화 경로가 깨진 코드 버그다.
+        val item = itemRepository.findById(wish.itemId) ?: error("wish ${wish.getId()} 의 item ${wish.itemId} 가 없다")
+        return WishWithItem(wish = wish, item = item)
+    }
+
     // item 의 name·currentPrice 를 수정한다. 변경은 @Transactional 커밋 시 dirty checking 으로 반영.
     @Transactional
     fun updateWish(

--- a/src/test/kotlin/com/depromeet/piki/wishlist/controller/WishlistControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/wishlist/controller/WishlistControllerIntegrationTest.kt
@@ -223,6 +223,89 @@ class WishlistControllerIntegrationTest : IntegrationTestSupport() {
     }
 
     @Test
+    fun `위시를 단건 조회하면 200 과 wish·item 이 함께 반환된다`() {
+        val mockMvc = buildMockMvc()
+        val userId = UUID.randomUUID()
+        insertMember(userId)
+        val wishId =
+            seedReadyWish(
+                userId,
+                "https://shop.example.com/products/1",
+                name = "에어 조던 1 미드",
+                currentPrice = 119_000,
+                currency = "KRW",
+                imageUrl = "https://cdn.example.com/p/1.jpg",
+            )
+
+        mockMvc
+            .perform(
+                get("/api/v1/wishlists/$wishId")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer ${memberToken(userId)}"),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.status").value(200))
+            .andExpect(jsonPath("$.code").value("OK"))
+            .andExpect(jsonPath("$.data.wish.id").value(wishId))
+            .andExpect(jsonPath("$.data.item.name").value("에어 조던 1 미드"))
+            .andExpect(jsonPath("$.data.item.currentPrice").value(119_000))
+            .andExpect(jsonPath("$.data.item.currency").value("KRW"))
+            .andExpect(jsonPath("$.data.item.imageUrl").value("https://cdn.example.com/p/1.jpg"))
+            .andExpect(jsonPath("$.data.item.status").value("READY"))
+    }
+
+    @Test
+    fun `남의 위시를 단건 조회하면 403 이 반환된다`() {
+        val mockMvc = buildMockMvc()
+        val ownerId = UUID.randomUUID()
+        val otherId = UUID.randomUUID()
+        insertMember(ownerId)
+        insertMember(otherId)
+        val wishId = seedReadyWish(ownerId, "https://shop.example.com/products/1", "내 상품")
+
+        mockMvc
+            .perform(
+                get("/api/v1/wishlists/$wishId")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer ${memberToken(otherId)}"),
+            ).andExpect(status().isForbidden)
+            .andExpect(jsonPath("$.status").value(403))
+            .andExpect(jsonPath("$.code").value("FORBIDDEN"))
+    }
+
+    @Test
+    fun `존재하지 않는 위시를 단건 조회하면 404 가 반환된다`() {
+        val mockMvc = buildMockMvc()
+        val userId = UUID.randomUUID()
+        insertMember(userId)
+
+        mockMvc
+            .perform(
+                get("/api/v1/wishlists/99999999")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer ${memberToken(userId)}"),
+            ).andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.status").value(404))
+            .andExpect(jsonPath("$.code").value("NOT_FOUND"))
+    }
+
+    @Test
+    fun `삭제된 위시를 단건 조회하면 404 가 반환된다`() {
+        val mockMvc = buildMockMvc()
+        val userId = UUID.randomUUID()
+        insertMember(userId)
+        val authHeader = "Bearer ${memberToken(userId)}"
+        val wishId = seedReadyWish(userId, "https://shop.example.com/products/1", "지울 상품")
+
+        mockMvc
+            .perform(delete("/api/v1/wishlists/$wishId").header(HttpHeaders.AUTHORIZATION, authHeader))
+            .andExpect(status().isOk)
+
+        // soft delete 된 위시는 findById(deletedAt IS NULL)에서 제외되어 단건 조회 시 404.
+        mockMvc
+            .perform(get("/api/v1/wishlists/$wishId").header(HttpHeaders.AUTHORIZATION, authHeader))
+            .andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.status").value(404))
+            .andExpect(jsonPath("$.code").value("NOT_FOUND"))
+    }
+
+    @Test
     fun `위시 item 의 이름·가격·이미지·통화를 수정하면 200 과 갱신된 값이 반환된다`() {
         val mockMvc = buildMockMvc()
         val userId = UUID.randomUUID()


### PR DESCRIPTION
## Situation
- 위시리스트 조회는 목록(`GET /api/v1/wishlists`, cursor 페이지네이션)만 제공해, wishId 로 항목 하나를 직접 가져오는 수단이 없었다.
- 이미 `PATCH /{wishId}`, `DELETE /{wishId}` 가 있는데 `GET /{wishId}` 만 없어 같은 리소스에 대한 조회·수정·삭제가 비대칭이었다.

## Task
- "단건 조회를 굳이 둘 필요가 있나 — 다건 조회 후 클라이언트에서 필터링하면 안 되나" 라는 논의가 있었다.
- 결론: 목록에서 항목을 탭하는 시나리오는 누른 시점에 이미 데이터가 로드돼 있어 다건으로 충분하다. 다만 목록을 거치지 않고 wishId 로 직접 진입하는 경로(딥링크·푸시·앱 상태 복원)와, 등록 직후 PROCESSING→READY 전이를 상세 화면에서 단건 폴링·최신화하는 케이스는 다건으로 풀 수 없다. REST 정합성까지 고려해 단건 API 를 두기로 했다.
- 페이지네이션을 없애거나 size 를 키워 다건으로 덮는 우회는 위시 수가 많아지면 페이로드·렌더링 비용이 커져 방향이 맞지 않다고 판단했다.

## Action

### 구현
- `GET /api/v1/wishlists/{wishId}` 추가. 응답은 목록 항목과 동일한 `WishItemResponse(wish + item)` 로 통일.
- `WishlistService.getWish` 는 기존 `updateWish`/`deleteWish` 의 `findById ?: notFound()` → `verifyOwnedBy` 패턴을 그대로 재사용한 읽기 전용 버전. 외부 호출이 없어 `@Transactional(readOnly = true)`.
- 권한 위반은 도메인 `verifyOwnedBy` 가 403, 미존재는 `WishException.notFound()` 가 404.
- `findById` 가 `deletedAt IS NULL` 만 조회하므로 soft-delete 된 위시는 추가 분기 없이 404 로 떨어진다 — Repository 변경 불필요.

### 문서·테스트
- OpenAPI 인터페이스(`WishlistApi`)와 example 빈(`WishlistApiExamples`)에 200/403/404 를 함께 추가.
- 통합 테스트 4건: 정상 200(wish+item), 남의 위시 403, 미존재 404, soft-delete 된 위시 404.

## Result
- 단위+통합 함께 실행해 `WishlistControllerIntegrationTest` tests=23(신규 4), failures=0 통과.
- 신규 도메인·마이그레이션·FK 없이 기존 패턴 재사용으로 서비스 14줄 + 매핑·문서·테스트만 추가했다.

---
## 연관 이슈

- close #253


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 위시리스트 아이템 단건 조회 엔드포인트 추가 - 특정 위시 항목의 상세 정보와 아이템 정보를 함께 조회할 수 있습니다. 본인 소유 위시만 접근 가능하며, 존재하지 않거나 삭제된 항목에 대해 적절한 오류 응답을 반환합니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/PIKI-Server/pull/256?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->