### PR TITLE
user_details 의 email 컬럼 제거 — OAuth 에서 email 받지 않기로 결정

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/user/domain/UserDetail.kt
+++ b/src/main/kotlin/com/depromeet/piki/user/domain/UserDetail.kt
@@ -11,7 +11,6 @@ import java.util.UUID
 @Table(name = "user_details")
 class UserDetail(
     userId: UUID,
-    email: String,
     provider: String,
     socialId: String,
 ) : BaseEntity<UUID>() {
@@ -21,10 +20,6 @@ class UserDetail(
 
     override fun getIdOrNull(): UUID = userId
 
-    @Column(nullable = false)
-    var email: String = email
-        protected set
-
     @Column(nullable = false, length = 20)
     var provider: String = provider
         protected set
@@ -32,8 +27,4 @@ class UserDetail(
     @Column(name = "social_id", nullable = false)
     var socialId: String = socialId
         protected set
-
-    fun updateEmail(newEmail: String) {
-        email = newEmail
-    }
 }

--- a/src/main/resources/db/migration/V20260527011356__drop_user_details_email.sql
+++ b/src/main/resources/db/migration/V20260527011356__drop_user_details_email.sql
@@ -1,0 +1,7 @@
+-- OAuth 통합 (epic #122) 진행 전 schema 정합. email 결을 OAuth 에서 받지 않기로 결정한 정합:
+--   - Kakao 이메일 동의 항목 받으면 검수 1-2주 → 동의 항목 0 으로 면제
+--   - Google·Apple 도 email scope 빼면 검수 결 가벼움
+--   - 마케팅·인증·복구 메일 어떤 용도로도 안 받음 — dead column
+-- DB 영향 0 (user_details 행 0 rows empirical 확인). 미래 필요 시 ADD COLUMN 으로 재추가 (backfill 0).
+
+ALTER TABLE user_details DROP COLUMN email;


### PR DESCRIPTION
## Situation

- `user_details.email` 컬럼이 NOT NULL 로 박혀 있으나 실제로는 **dead column** — 운영 RDS 의 `user_details` 0 rows + production 코드 `email` 참조 0 건 (정적 분석 + DB empirical 양쪽 확인).
- `user_details` 0 rows 인 이유 — dev API (`POST /api/v1/dev/users`) 로 만든 MEMBER 들은 **`users` 행만 INSERT 하고 `user_details` 는 안 만지는 설계** 였음. OAuth 통합 (#122 Task 8) 전까지의 임시 결로, dev MEMBER 가 OAuth 없이 만들어지므로 social_id 가 없는 상태. 결과적으로 마이그레이션이 건드릴 데이터가 0.
- OAuth 통합 (epic #122 Task 8) 진행 전 schema 정합 결. 정책 변경 — **email 받지 않기로 결정**.

## Task

- email 결을 OAuth 에서 받지 않기로 결정한 이유:
  - **사용처 0** — 마케팅·인증·복구 메일 어떤 용도로도 안 받음
  - **Kakao 검수 lead time 0** — "이메일" 동의 항목을 받으면 검수 (1-2주) 필요한데, 동의 항목을 비우면 즉시 면제
  - **Google 도 결 가벼움** — email scope 빼면 "unverified app" 경고 없음, 검수 lead time 0
  - **Apple 은 본래 검수 없음** — Apple Developer Program 만 가입돼 있으면 즉시 사용
- 즉 셋 다 검수 lead time 0 으로 OAuth 출시 가능. 이걸 가능하게 만들려면 `email NOT NULL` 제약을 풀어야 함.

## Action

- `V20260527011356__drop_user_details_email.sql` — `ALTER TABLE user_details DROP COLUMN email` (forward-only, CLAUDE.md 의 마이그레이션 컨벤션 준수).
- `UserDetail` 엔티티에서 `email` 필드 + `updateEmail()` 메서드 제거. 생성자 인자도 정리.
- NULL 허용 vs DROP 사이에서 **DROP 채택**. NULL 허용은 hedge 인데 dead 컬럼이 남으면 "왜 안 쓰지?" 라는 질문을 만들고 우리의 명시적 결정 ("email 받지 않기로") 이 코드에 안 드러남. CLAUDE.md YAGNI 결과 일치. 미래에 email 결이 필요해지면 ADD COLUMN 으로 추가 (backfill 0, cost 거의 0).
- 데이터 영향 0 — 운영 RDS `team3.user_details` 0 rows 직접 SELECT 로 empirical 확인 후 진행. CLAUDE.md "DROP 류 destructive 작업은 단계적으로" 경고는 데이터·코드 의존이 있을 때 결인데 둘 다 0 이라 단계 분리 불필요.

## Result

- OAuth 통합 진행 시 Kakao·Google·Apple 셋 다 **검수 lead time 0** 으로 출시 가능.
- production 코드 / DB 영향 0 — 전체 테스트 **375 PASS** (failures 0, errors 0, skipped 2).
- 미래에 email 결이 필요해지면 `ADD COLUMN` 마이그레이션으로 즉시 복구 가능 (지금 데이터 없으니 backfill cost 0).

---
## 연관 이슈

- close #262


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **리팩토링**
  * 사용자 상세 정보에서 이메일 저장 및 수정 기능이 제거되었습니다. 계정 정보는 이제 소셜 인증 제공자 기반 필드만으로 관리됩니다.
* **Chores**
  * 기존 이메일 컬럼을 제거하는 데이터베이스 마이그레이션이 추가되어 스키마에서 이메일 필드가 삭제됩니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/PIKI-Server/pull/263?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->