### PR TITLE
전체 API 실패 응답 코드 문서화 및 CLAUDE.md 규칙 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -404,6 +404,33 @@ race · 동시성 · timeout 처럼 일반 통합 테스트 패턴(`@Transaction
 - example payload 는 실제 DTO 인스턴스를 만들어 `ApiResponseBody.ok/created/fail` 로 감싸 넘긴다. `@ExampleObject(value = "...JSON 평문...")` 형태 금지 — DTO 시그니처 변경이 컴파일로 추적되지 않는다.
 - 새 엔드포인트 추가 / 시그니처 변경 시 인터페이스 + example 빈을 함께 갱신한다. 한쪽만 바꾸면 OpenAPI 문서가 실제 응답과 어긋난다.
 
+### 실패 응답 코드 필수 문서화
+
+**`*Api.kt` 의 각 메서드는 실제로 발생 가능한 실패 응답 코드를 모두 `@ApiResponses` 에 포함해야 한다.** 성공 코드만 달고 실패를 생략하면 클라이언트가 docs 만 보고 에러 처리를 설계할 수 없다.
+
+조사 대상은 세 군데다.
+
+1. **Spring Security** (`SecurityConfig`) — 엔드포인트에 적용된 권한 설정을 확인한다.
+   - `permitAll()` 이 아닌 경우: **401** (미인증)
+   - `hasAuthority(...)` / `authenticated()` 가 아닌 특정 권한 요구: **403** (권한 없음)
+
+2. **도메인 예외** (`*Exception.kt`) — 서비스·도메인에서 throw 되는 커스텀 예외의 `httpStatus` 를 따른다.
+   - 400 / 403 / 404 / 409 등 예외마다 다르므로 실제 throw 지점을 추적한다.
+
+3. **Bean Validation** — 요청 DTO 의 `@NotBlank` · `@Size` 등 위반은 `MethodArgumentNotValidException` → **400** 으로 매핑된다.
+
+description 은 구체적으로 쓴다. "오류 등" 같은 모호한 표현 대신 실제 원인을 나열한다.
+
+```kotlin
+// 나쁜 예
+ApiResponse(responseCode = "400", description = "잘못된 요청 (오류 등)")
+
+// 좋은 예
+ApiResponse(responseCode = "400", description = "잘못된 요청 (URL 이 비어 있음 · 유효한 URL 형식이 아님 · https 외 스킴)")
+```
+
+새 엔드포인트를 추가하거나 서비스 로직을 변경해 새 예외가 추가됐다면, `*Api.kt` 의 `@ApiResponses` 도 함께 갱신한다.
+
 ### 응답 포맷
 **모든 응답은 `ApiResponseBody` 래퍼로 감싼다.** 컨트롤러 메서드는 항상 `ApiResponseBody<T>` 를 반환하고, 직접 `ResponseEntity` / raw DTO 를 노출하지 않는다.
 

--- a/src/main/kotlin/com/depromeet/piki/auth/controller/AuthApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/controller/AuthApi.kt
@@ -58,8 +58,18 @@ interface AuthApi {
                 ],
             ),
             ApiResponse(
+                responseCode = "400",
+                description = "refreshToken 미입력",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
                 responseCode = "401",
-                description = "유효하지 않은 리프레시 토큰",
+                description = "유효하지 않은 리프레시 토큰 (파싱 불가 · 만료 · Redis 값 불일치 · 탈퇴 유저)",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,
@@ -89,7 +99,7 @@ interface AuthApi {
             ),
             ApiResponse(
                 responseCode = "401",
-                description = "인증 필요",
+                description = "미인증 (JWT 토큰 없음 또는 유효하지 않음)",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,

--- a/src/main/kotlin/com/depromeet/piki/auth/controller/DevAuthApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/controller/DevAuthApi.kt
@@ -40,6 +40,36 @@ interface DevAuthApi {
                     ),
                 ],
             ),
+            ApiResponse(
+                responseCode = "401",
+                description = "미인증 (JWT 토큰 없음 또는 유효하지 않음)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "403",
+                description = "GUEST 권한 없음 (MEMBER 토큰으로 호출 불가 · GUEST 필요)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "409",
+                description = "이미 사용 중인 닉네임",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
         ],
     )
     fun createDevUser(request: DevUserCreateRequest): ApiResponseBody<GuestCreateResponse>
@@ -55,6 +85,26 @@ interface DevAuthApi {
             ApiResponse(
                 responseCode = "201",
                 description = "토큰 발급 성공",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "미인증 (JWT 토큰 없음 또는 유효하지 않음)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "403",
+                description = "GUEST 권한 없음 (MEMBER 토큰으로 호출 불가 · GUEST 필요)",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
@@ -34,7 +34,32 @@ interface TournamentApi {
             ApiResponse(
                 responseCode = "201",
                 description = "토너먼트 생성 성공",
-                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청 (name 미입력)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "미인증 (JWT 토큰 없음 또는 유효하지 않음)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
             ),
         ],
     )
@@ -55,7 +80,62 @@ interface TournamentApi {
             ApiResponse(
                 responseCode = "200",
                 description = "아이템 추가 성공",
-                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청 (itemIds 1~32개 범위 초과 · 아이템 최대 32개 초과)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "미인증 (JWT 토큰 없음 또는 유효하지 않음)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "403",
+                description = "권한 없음 (토너먼트 참여자가 아님 · 위시리스트에 없는 아이템 포함)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "토너먼트를 찾을 수 없음 · 존재하지 않는 아이템 포함",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "409",
+                description = "상태 충돌 (PENDING이 아닌 토너먼트 · 이미 등록된 아이템 · PROCESSING/FAILED 상품 포함)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
             ),
         ],
     )
@@ -79,7 +159,62 @@ interface TournamentApi {
             ApiResponse(
                 responseCode = "200",
                 description = "아이템 추가 성공 (item.status=PROCESSING, 파싱은 백그라운드)",
-                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청 (URL 미입력 · URL 형식 오류(비어 있음/유효하지 않음/https 외 스킴) · URL 2048자 초과 · 아이템 최대 32개 초과)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "미인증 (JWT 토큰 없음 또는 유효하지 않음)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "403",
+                description = "권한 없음 (토너먼트 참여자가 아님)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "토너먼트를 찾을 수 없음",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "409",
+                description = "상태 충돌 (PENDING이 아닌 토너먼트)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
             ),
         ],
     )
@@ -103,7 +238,62 @@ interface TournamentApi {
             ApiResponse(
                 responseCode = "200",
                 description = "아이템 추가 성공 (item.status=PROCESSING, 파싱은 백그라운드)",
-                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청 (이미지 1~5장 범위 초과 · 빈 이미지 · 이미지 타입 미지정 · 지원하지 않는 이미지 형식(png/jpeg/webp/heic/heif만 허용) · 아이템 최대 32개 초과)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "미인증 (JWT 토큰 없음 또는 유효하지 않음)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "403",
+                description = "권한 없음 (토너먼트 참여자가 아님)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "토너먼트를 찾을 수 없음",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "409",
+                description = "상태 충돌 (PENDING이 아닌 토너먼트)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
             ),
         ],
     )
@@ -122,7 +312,52 @@ interface TournamentApi {
             ApiResponse(
                 responseCode = "200",
                 description = "아이템 삭제 성공",
-                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "미인증 (JWT 토큰 없음 또는 유효하지 않음)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "403",
+                description = "권한 없음 (아이템을 추가한 본인도 아니고 토너먼트 소유자도 아님)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "토너먼트를 찾을 수 없음 · 토너먼트 아이템을 찾을 수 없음",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "409",
+                description = "상태 충돌 (PENDING이 아닌 토너먼트)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
             ),
         ],
     )
@@ -145,7 +380,62 @@ interface TournamentApi {
             ApiResponse(
                 responseCode = "200",
                 description = "토너먼트 시작 성공 (첫 라운드 대진표 반환)",
-                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "아이템 수 미충족 (최소 2개, 최대 32개)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "미인증 (JWT 토큰 없음 또는 유효하지 않음)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "403",
+                description = "권한 없음 (토너먼트 소유자가 아님)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "토너먼트를 찾을 수 없음 · 존재하지 않는 아이템 포함",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "409",
+                description = "상태 충돌 (PENDING이 아닌 토너먼트 · PROCESSING/FAILED 상품 포함)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
             ),
         ],
     )
@@ -167,7 +457,62 @@ interface TournamentApi {
             ApiResponse(
                 responseCode = "200",
                 description = "매치 결과 기록 성공",
-                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청 (승자가 대결 두 아이템 중 하나가 아님 · 해당 토너먼트에 속하지 않는 아이템)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "미인증 (JWT 토큰 없음 또는 유효하지 않음)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "403",
+                description = "권한 없음 (토너먼트 참여자가 아님)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "토너먼트를 찾을 수 없음",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "409",
+                description = "상태 충돌 (IN_PROGRESS가 아닌 토너먼트)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
             ),
         ],
     )
@@ -190,7 +535,22 @@ interface TournamentApi {
             ApiResponse(
                 responseCode = "200",
                 description = "목록 조회 성공 (참여 토너먼트 없으면 빈 배열 반환)",
-                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "미인증 (JWT 토큰 없음 또는 유효하지 않음)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
             ),
         ],
     )
@@ -215,8 +575,43 @@ interface TournamentApi {
         value = [
             ApiResponse(
                 responseCode = "200",
-                description = "조회 성공",
-                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+                description = "토너먼트 조회 성공",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "미인증 (JWT 토큰 없음 또는 유효하지 않음)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "403",
+                description = "권한 없음 (토너먼트 참여자가 아님)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "토너먼트를 찾을 수 없음",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
             ),
         ],
     )

--- a/src/main/kotlin/com/depromeet/piki/user/controller/DevUserApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/user/controller/DevUserApi.kt
@@ -60,6 +60,16 @@ interface DevUserApi {
                     ),
                 ],
             ),
+            ApiResponse(
+                responseCode = "409",
+                description = "탈퇴(soft delete) 된 유저 — 토큰 발급 거부",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
         ],
     )
     fun getUser(userId: UUID): ApiResponseBody<GuestCreateResponse>

--- a/src/main/kotlin/com/depromeet/piki/user/controller/UserApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/user/controller/UserApi.kt
@@ -35,7 +35,17 @@ interface UserApi {
             ),
             ApiResponse(
                 responseCode = "401",
-                description = "인증 필요",
+                description = "미인증 (JWT 토큰 없음 또는 유효하지 않음)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "유저를 찾을 수 없음 (JWT 유효하지만 DB에서 유저가 삭제된 경우)",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,
@@ -79,7 +89,17 @@ interface UserApi {
             ),
             ApiResponse(
                 responseCode = "401",
-                description = "인증 필요",
+                description = "미인증 (JWT 토큰 없음 또는 유효하지 않음)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "유저를 찾을 수 없음 (JWT 유효하지만 DB에서 유저가 삭제된 경우)",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,
@@ -89,7 +109,7 @@ interface UserApi {
             ),
             ApiResponse(
                 responseCode = "409",
-                description = "닉네임 중복",
+                description = "상태 충돌 (닉네임 중복 · 탈퇴한 유저)",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,
@@ -134,7 +154,7 @@ interface UserApi {
             ),
             ApiResponse(
                 responseCode = "401",
-                description = "인증 필요",
+                description = "미인증 (JWT 토큰 없음 또는 유효하지 않음)",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,

--- a/src/main/kotlin/com/depromeet/piki/wishlist/controller/WishlistApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/wishlist/controller/WishlistApi.kt
@@ -40,7 +40,27 @@ interface WishlistApi {
             ),
             ApiResponse(
                 responseCode = "400",
-                description = "잘못된 요청 (URL 형식 오류 등)",
+                description = "잘못된 요청 (URL 이 비어 있음 · 유효한 URL 형식이 아님 · https 외 스킴)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "미인증 (JWT 토큰 없음 또는 유효하지 않음)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "403",
+                description = "권한 없음 (GUEST 권한으로 접근 불가 · MEMBER 필요)",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,
@@ -71,6 +91,36 @@ interface WishlistApi {
             ApiResponse(
                 responseCode = "200",
                 description = "위시리스트 조회 성공",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "유효하지 않은 cursor 값 (숫자로 변환 불가)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "미인증 (JWT 토큰 없음 또는 유효하지 않음)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "403",
+                description = "권한 없음 (GUEST 권한으로 접근 불가 · MEMBER 필요)",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,
@@ -109,8 +159,18 @@ interface WishlistApi {
                 ],
             ),
             ApiResponse(
+                responseCode = "401",
+                description = "미인증 (JWT 토큰 없음 또는 유효하지 않음)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
                 responseCode = "403",
-                description = "본인 위시가 아님",
+                description = "권한 없음 (GUEST 권한으로 접근 불가 · MEMBER 필요, 또는 본인 위시가 아님)",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,
@@ -120,7 +180,7 @@ interface WishlistApi {
             ),
             ApiResponse(
                 responseCode = "404",
-                description = "존재하지 않는 위시 항목",
+                description = "존재하지 않는 위시 항목 (삭제된 항목 포함)",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,
@@ -156,7 +216,17 @@ interface WishlistApi {
             ),
             ApiResponse(
                 responseCode = "400",
-                description = "잘못된 요청 (가격 음수, 이름 길이 초과 등)",
+                description = "잘못된 요청 (currentPrice 음수 · name/imageUrl/currency 길이 초과)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "미인증 (JWT 토큰 없음 또는 유효하지 않음)",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,
@@ -166,7 +236,7 @@ interface WishlistApi {
             ),
             ApiResponse(
                 responseCode = "403",
-                description = "본인 위시가 아님",
+                description = "권한 없음 (GUEST 권한으로 접근 불가 · MEMBER 필요, 또는 본인 위시가 아님)",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,
@@ -176,7 +246,7 @@ interface WishlistApi {
             ),
             ApiResponse(
                 responseCode = "404",
-                description = "존재하지 않는 위시 항목",
+                description = "존재하지 않는 위시 항목 (삭제된 항목 포함)",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,
@@ -212,8 +282,18 @@ interface WishlistApi {
                 ],
             ),
             ApiResponse(
+                responseCode = "401",
+                description = "미인증 (JWT 토큰 없음 또는 유효하지 않음)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
                 responseCode = "403",
-                description = "본인 위시가 아님",
+                description = "권한 없음 (GUEST 권한으로 접근 불가 · MEMBER 필요, 또는 본인 위시가 아님)",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,
@@ -223,7 +303,7 @@ interface WishlistApi {
             ),
             ApiResponse(
                 responseCode = "404",
-                description = "존재하지 않는 위시 항목",
+                description = "존재하지 않는 위시 항목 (삭제된 항목 포함)",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,
@@ -260,7 +340,27 @@ interface WishlistApi {
             ),
             ApiResponse(
                 responseCode = "400",
-                description = "잘못된 요청 (빈 이미지 / 지원하지 않는 이미지 형식 등)",
+                description = "잘못된 요청 (빈 이미지 · 이미지 타입 미지정 · 지원하지 않는 이미지 형식(png/jpeg/webp/heic/heif만 허용))",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "미인증 (JWT 토큰 없음 또는 유효하지 않음)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "403",
+                description = "권한 없음 (GUEST 권한으로 접근 불가 · MEMBER 필요)",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,


### PR DESCRIPTION
## Situation
- 기존 `*Api.kt` 인터페이스에 성공 응답 코드만 기재돼 있었고, 실패 코드(401·403·404·409 등)는 포함되지 않거나 "오류 등" 수준으로 모호하게만 기술
- 클라이언트가 OpenAPI docs만 보고 에러 처리를 설계하기 어려운 상태였고, 이후 추가되는 엔드포인트에서도 같은 상황이 반복될 구조

## Task
- 패키지(wishlist → auth → tournament → user) 순으로 각 엔드포인트의 실패 응답 코드를 전수 조사해 문서화
- 조사 범위: SecurityConfig 권한 정책(401/403), 도메인 예외 httpStatus(각 `*Exception.kt` throw 지점 추적), Bean Validation(400)
- 향후 같은 상황이 재발하지 않도록 CLAUDE.md에 필수화 규칙 추가

## Action

### 패키지별 변경

- **WishlistApi** — 전 엔드포인트에 401 추가(SecurityConfig: MEMBER 필요), 403 설명에 GUEST 권한 케이스 합산. `GET /wishlists`에는 WishCursor.parse 실패로 인한 400(cursor 숫자 변환 불가) 추가. 400·403·404 description을 ProductLinkException·WishException·Item.validate 실제 사유 기준으로 구체화
- **AuthApi / DevAuthApi** — `POST /auth/token/refresh`에 400 추가(TokenRefreshRequest.refreshToken `@NotBlank` 위반), 401 description 구체화(파싱 불가·만료·Redis 불일치·탈퇴 유저 케이스 명시). DevAuthApi 전 엔드포인트에 401·403(GUEST 권한 필요) 추가, createDevUser에 409(닉네임 중복) 추가
- **TournamentApi** — 단일 `@ApiResponse` → `@ApiResponses` 전환. 전 엔드포인트에 401 추가. 엔드포인트별로 TournamentException 팩토리 메서드와 TournamentItemPersistenceService.validateAndCheckCapacity 경로를 추적해 400·403·404·409 전체 기재. start에 403을 참여자 아님이 아닌 소유자 아님으로 정확히 구분
- **UserApi / DevUserApi** — 401 description 전부 구체화. getMe·updateMe에 404 추가(JWT 유효하지만 DB 삭제 엣지 케이스). updateMe 409 description에 탈퇴 유저(UserException.deletedUser) 케이스 합산. DevUserApi.getUser에 409 추가

### CLAUDE.md 규칙 추가

- `## 컨트롤러 / OpenAPI 문서` 섹션에 `### 실패 응답 코드 필수 문서화` 항목 신설
- 조사 대상 세 곳(SecurityConfig, 도메인 예외, Bean Validation) 명시
- description은 실제 원인 나열 필수, "오류 등" 같은 모호한 표현 금지 — 예시 코드 포함
- 서비스 로직 변경·예외 추가 시 `*Api.kt`도 함께 갱신하도록 명시

## Result
- 클라이언트가 docs만 보고 각 API의 실패 코드와 원인을 모두 파악할 수 있는 상태
- CLAUDE.md 규칙으로 이후 엔드포인트 추가·변경 시에도 동일한 기준으로 관리됨

---
## 연관 이슈

- close #260


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * API 엔드포인트 응답 코드 및 설명을 보다 정확하고 구체적으로 개선했습니다.
  * 인증 오류(401), 권한 오류(403), 유효성 검사 오류(400), 리소스 충돌(409) 등 발생 가능한 모든 응답 케이스를 명시적으로 문서화했습니다.
  * API 문서 가이드라인을 추가하여 향후 변경 시 일관된 문서화를 보장합니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/PIKI-Server/pull/264?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->