### PR TITLE
토너먼트 API OpenAPI description 실제 동작과 일치화

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
@@ -375,7 +375,7 @@ interface TournamentApi {
         value = [
             ApiResponse(
                 responseCode = "200",
-                description = "토너먼트 시작 성공 (첫 라운드 대진표 반환)",
+                description = "토너먼트 시작 성공 (가격 오름차순 정렬 아이템 목록 반환)",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,
@@ -425,7 +425,7 @@ interface TournamentApi {
             ),
             ApiResponse(
                 responseCode = "409",
-                description = "상태 충돌 (PENDING이 아닌 토너먼트 · PROCESSING/FAILED 상품 포함)",
+                description = "상태 충돌 (PENDING이 아닌 토너먼트 · PROCESSING/FAILED 상품 포함 · 가격 정보 없는 상품 포함)",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,
@@ -462,7 +462,7 @@ interface TournamentApi {
             ),
             ApiResponse(
                 responseCode = "400",
-                description = "잘못된 요청 (승자가 대결 두 아이템 중 하나가 아님 · 해당 토너먼트에 속하지 않는 아이템)",
+                description = "잘못된 요청 (승자가 대결 두 아이템 중 하나가 아님 · 해당 토너먼트에 속하지 않는 아이템 · 현재 진행해야 할 라운드가 아님)",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,


### PR DESCRIPTION
## Situation
- `TournamentApi.kt`의 `@ApiResponse` description 일부가 실제 서비스 코드와 어긋나 있었음
- `POST /start` 200 설명이 "대진표 반환"으로 되어 있었으나 실제 응답은 flat list (`items: List<ItemResponse>`)
- `itemPriceRequired()`·`invalidCurrentRound()`가 실제로 throw되는 케이스임에도 description에서 누락

## Task
- `TournamentApi.kt` `@ApiResponse` description을 `TournamentService`·`TournamentException` 코드와 직접 대조해 일치화
- 클라이언트가 OpenAPI 문서만 보고 에러 처리를 설계할 수 있도록 정확한 케이스 보완

## Action
- `POST /start` 200 description: `"대진표 반환"` → `"가격 오름차순 정렬 아이템 목록 반환"`
  - 실제 응답은 `TournamentStartResponse { items: List<ItemResponse> }` flat list
  - 구조화된 대진표(firstItem/secondItem pair)는 `GET /{id}` `inProgress.bracket`에 존재하며 `/start`와 다름
- `POST /start` 409 description에 `가격 정보 없는 상품 포함` 추가
  - `TournamentService.start()`에서 `itemPriceRequired()` → 409 CONFLICT가 throw되지만 description에 없었음
- `POST /matches` 400 description에 `현재 진행해야 할 라운드가 아님` 추가
  - `invalidCurrentRound()` → BAD_REQUEST 케이스가 description에서 빠져 있었음

## Result
- Swagger UI에서 보이는 에러 케이스가 실제 동작과 일치
- 클라이언트가 `/start` 응답을 "대진표" 구조로 오해할 여지 제거

---
## 연관 이슈

- close #266


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * API 응답 설명이 더욱 명확하게 업데이트되었습니다.
  * 토너먼트 시작 API의 정상 응답 및 오류 조건 설명이 개선되었습니다.
  * 매치 결과 기록 API의 오류 조건이 더 구체적으로 문서화되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/PIKI-Server/pull/267?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->