### PR TITLE
fix: CORS allowedOrigins 에 프론트엔드 도메인 추가

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/common/config/CorsConfig.kt
+++ b/src/main/kotlin/com/depromeet/piki/common/config/CorsConfig.kt
@@ -18,6 +18,7 @@ class CorsConfig {
             CorsConfiguration().apply {
                 allowedOrigins =
                     listOf(
+                        "https://depromeet18team3.cloud",
                         "https://depromeet.vercel.app",
                         // 우리 서버 자체 origin — Stoplight UI (/docs/index.html) 의 try-it 이
                         // 브라우저 fetch(mode=cors) 로 호출 시 same-origin 이어도 Origin 헤더가 박혀


### PR DESCRIPTION
## Summary
- `CorsConfig.kt` 의 `allowedOrigins` 에 `https://depromeet18team3.cloud` 추가
- FE가 해당 도메인에서 BE로 요청 시 발생하는 CORS 에러 해소

## Test plan
- [ ] 브라우저에서 `https://depromeet18team3.cloud` origin 으로 API 호출 시 CORS 에러 없이 응답 확인
- [ ] 기존 허용 origin (`https://depromeet.vercel.app`, localhost 등) 정상 동작 확인

Closes #268

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 크로스 오리진 요청 허용 도메인에 새로운 주소가 추가되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/PIKI-Server/pull/269?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->