### PR TITLE
fix: CORS allowedOrigins 에 www 서브도메인 추가

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/common/config/CorsConfig.kt
+++ b/src/main/kotlin/com/depromeet/piki/common/config/CorsConfig.kt
@@ -19,6 +19,7 @@ class CorsConfig {
                 allowedOrigins =
                     listOf(
                         "https://depromeet18team3.cloud",
+                        "https://www.depromeet18team3.cloud",
                         "https://depromeet.vercel.app",
                         // 우리 서버 자체 origin — Stoplight UI (/docs/index.html) 의 try-it 이
                         // 브라우저 fetch(mode=cors) 로 호출 시 same-origin 이어도 Origin 헤더가 박혀


### PR DESCRIPTION
## Summary
- `CorsConfig.kt` allowedOrigins 에 `https://www.depromeet18team3.cloud` 추가
- #269 에서 루트 도메인만 추가했는데, FE origin 이 `www.` 포함 시 CORS 403 발생

Closes #268