### PR TITLE
nginx 설정을 레포 IaC로 이관하고 배포 동기화

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -154,6 +154,37 @@ jobs:
               -e S3_PUBLIC_BASE_URL="$S3_PUBLIC_BASE_URL" \
               "$IMAGE"
 
+      - name: Upload nginx config
+        uses: appleboy/scp-action@v1
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          source: "infra/nginx/api.depromeet18team3.cloud.conf"
+          target: "/tmp/team3-nginx"
+          strip_components: 2
+
+      - name: Apply nginx config
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            SRC=/tmp/team3-nginx/api.depromeet18team3.cloud.conf
+            DST=/etc/nginx/sites-available/api.depromeet18team3.cloud
+            # 현재 설정 백업 후 교체. nginx -t 검증 실패 시 이전 설정으로 롤백하고 배포를 중단한다.
+            sudo cp "$DST" "${DST}.bak" 2>/dev/null || true
+            sudo cp "$SRC" "$DST"
+            if sudo nginx -t; then
+              sudo nginx -s reload
+              echo "nginx config 적용 + reload 완료"
+            else
+              echo "nginx -t 실패 — 이전 설정으로 롤백하고 중단"
+              sudo cp "${DST}.bak" "$DST" 2>/dev/null || true
+              exit 1
+            fi
+
       - name: Health check and switch
         id: health
         uses: appleboy/ssh-action@v1

--- a/infra/nginx/api.depromeet18team3.cloud.conf
+++ b/infra/nginx/api.depromeet18team3.cloud.conf
@@ -1,0 +1,49 @@
+# api.depromeet18team3.cloud nginx 설정 — IaC 단일 진실(single source of truth)
+#
+# 이 파일이 배포 시 EC2 /etc/nginx/sites-available/api.depromeet18team3.cloud 로 복사되고,
+# nginx -t 검증을 통과해야 reload 된다 (.github/workflows/deploy.yml).
+#
+# 동적·서버 의존 요소는 이 레포가 관리하지 않고 경로로 참조만 한다:
+#   - /etc/nginx/team3-upstream.conf : deploy.yml 이 blue/green 전환 때 런타임에 생성하는 상태 파일
+#                                      (server localhost:8080 | 8081). IaC 대상 아님.
+#   - /etc/letsencrypt/*             : certbot 이 발급·자동 갱신하는 TLS 키·인증서 (비밀). git 금지.
+
+upstream team3 {
+    include /etc/nginx/team3-upstream.conf;
+}
+
+server {
+    server_name api.depromeet18team3.cloud;
+
+    client_max_body_size 5M;
+
+    location / {
+        proxy_pass http://team3;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # OCR 등 LLM 호출 엔드포인트는 앱이 Gemini read-timeout(30s) + 재시도까지
+        # 최악 약 60s 를 쓸 수 있다. nginx 기본 60s 로는 앱이 502 + 실패 사유를 내려보내기
+        # 직전에 잘려 504(사유 없음)가 클라이언트로 나간다. 앱 최악치보다 여유 있게 두어,
+        # 느린 호출도 앱이 끝까지 응답해 사유를 전달하게 한다.
+        # (근본 단축은 앱 측 read-timeout/재시도 조정 — 별도 작업)
+        proxy_read_timeout 90s;
+    }
+
+    listen 443 ssl;
+    ssl_certificate /etc/letsencrypt/live/api.depromeet18team3.cloud/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/api.depromeet18team3.cloud/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+}
+
+server {
+    if ($host = api.depromeet18team3.cloud) {
+        return 301 https://$host$request_uri;
+    }
+    listen 80;
+    server_name api.depromeet18team3.cloud;
+    return 404;
+}


### PR DESCRIPTION
## Situation
- EC2 nginx 설정(`sites-available/api.depromeet18team3.cloud`)이 SSH 수동 셋업이라 git 어디에도 없었다. 누가 언제 무엇을 바꿨는지 추적 불가, 인스턴스가 죽으면 복구 막막, 수동 편집이 drift 의 근원이었다.
- 특히 OCR 504 디버깅에서 드러난 `proxy_read_timeout` 누락(nginx 기본 60s)도 코드 밖에 있어 리뷰 없이 바뀌는 설정이었다.

## Task
- nginx 설정을 레포 단일 진실로 옮기고, 변경 시 배포가 EC2 에 단방향 반영하는 흐름을 만든다 (#217 의 nginx 항목).
- 이 김에 504 의 직접 원인인 proxy_read_timeout 을 conf 에 명시한다.

## Action
### nginx 설정 IaC 이관
- `infra/nginx/api.depromeet18team3.cloud.conf` 신규 — 현재 EC2 설정을 그대로 옮기되, 동적/서버 의존 요소(`team3-upstream.conf` blue/green 상태, letsencrypt 인증서)는 include 경로 참조만 하고 IaC 대상에서 제외. EC2 현재 conf 와 diff 가 proxy_read_timeout 한 줄뿐임을 대조해 nginx -t 통과를 확인했다.
- `proxy_read_timeout 90s` 명시 — 앱이 Gemini read-timeout(30s) + 재시도로 최악 약 60s 를 쓰는데 nginx 기본 60s 라, 앱이 502 + 실패 사유를 내려보내기 직전에 잘려 504(사유 없음)가 클라이언트로 나가던 것을 막는다. 앱 최악치보다 여유 있게 두었다. (근본 단축은 앱 측 read-timeout/재시도 조정 — 별도 작업)

### 배포 동기화
- `deploy.yml` 에 Upload(scp)+Apply 스텝 추가. Apply 는 백업 → 교체 → nginx -t 검증 → reload, 검증 실패 시 .bak 로 롤백 후 배포 중단. 컨테이너 기동 뒤·헬스체크 앞에 두어 include 대상(`team3-upstream.conf`)이 보장된 시점에 적용한다.
- 이후 nginx 변경은 이 conf 를 PR 로 고치면 머지 → CI → 배포를 타고 EC2 에 단방향 반영된다. EC2 수동 편집은 다음 배포에 덮어써진다(drift 방지).

## Result
- nginx 설정이 git 추적·리뷰·복구 가능해지고, 504 의 직접 원인(timeout 누락)이 해소된다.
- 실제 동작(nginx -t 통과·reload·504 해소)은 dev 머지 후 배포 워크플로가 돌 때 확인된다 — 로컬에서 워크플로 실행은 불가하다.
- 첫 배포 때 EC2 현재 설정이 레포 버전으로 한 번 정렬되고, 이후 레포가 진실이 된다.
- 주의: 이번 PR 은 #217 의 nginx 항목만 다룬다. redis 컨테이너 코드화·swap·`sites-enabled/default` 제거는 이슈에 남아 있어 #217 은 닫지 않는다(refs).

---
## 연관 이슈

- refs #217
