### PR TITLE
nginx 요청 본문 크기 제한을 25MB로 상향

### DIFF
--- a/infra/nginx/api.depromeet18team3.cloud.conf
+++ b/infra/nginx/api.depromeet18team3.cloud.conf
@@ -15,7 +15,7 @@ upstream team3 {
 server {
     server_name api.depromeet18team3.cloud;
 
-    client_max_body_size 5M;
+    client_max_body_size 25M;
 
     location / {
         proxy_pass http://team3;


### PR DESCRIPTION
## Situation
- nginx `client_max_body_size` 가 5M 로 설정돼 있어, 그보다 큰 요청 본문은 앱에 닿기 전 nginx 단에서 413 Request Entity Too Large 로 거부된다.
- 더 큰 업로드를 허용하기 위해 한도를 25MB 로 올릴 필요가 생겼다.

## Task
- nginx 요청 본문 크기 한도를 5M → 25M 로 상향한다.

## Action
- IaC 단일 진실(single source of truth) conf 인 `infra/nginx/api.depromeet18team3.cloud.conf` 의 `client_max_body_size 5M` 을 `25M` 으로 수정 (`ffe5d8d`).

## Result
- 배포 시 이 conf 가 EC2 `/etc/nginx/sites-available/...` 로 복사되고 `nginx -t` 통과 후 reload 되어, 25MB 까지의 요청 본문이 허용된다 (`.github/workflows/deploy.yml`).
- 앱(Spring) 측 multipart 업로드 한도가 별도로 더 작으면 거기서 다시 막힐 수 있으니, 큰 업로드가 목적이면 앱 설정도 함께 확인 필요.

---
## 연관 이슈

- 
