### PR TITLE
런타임 설정(swap·redis·default)을 IaC 프로비저닝 스크립트로 코드화

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,6 +70,61 @@ jobs:
             ${{ secrets.DOCKERHUB_USERNAME }}/team3-server:latest
             ${{ secrets.DOCKERHUB_USERNAME }}/team3-server:${{ github.event.workflow_run.head_sha || github.sha }}
 
+      - name: Upload nginx config
+        uses: appleboy/scp-action@v1
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          source: "infra/nginx/api.depromeet18team3.cloud.conf"
+          target: "/tmp/team3-nginx"
+          strip_components: 2
+
+      - name: Apply nginx config
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            SRC=/tmp/team3-nginx/api.depromeet18team3.cloud.conf
+            DST=/etc/nginx/sites-available/api.depromeet18team3.cloud
+            # api conf 가 include 하는 team3-upstream.conf 가 없으면(새 인스턴스) nginx -t 가 깨진다.
+            # blue-green 전환 전이라도 include 대상이 존재하도록 기본값(8080)으로 초기화한다.
+            # 실제 active 포트 전환은 blue-green(Health check)이 담당하므로 이미 있으면 건드리지 않는다.
+            [ -f /etc/nginx/team3-upstream.conf ] || echo "server localhost:8080;" | sudo tee /etc/nginx/team3-upstream.conf
+            # 현재 설정 백업 후 교체. nginx -t 검증 실패 시 이전 설정으로 롤백하고 배포를 중단한다.
+            sudo cp "$DST" "${DST}.bak" 2>/dev/null || true
+            sudo cp "$SRC" "$DST"
+            if sudo nginx -t; then
+              sudo nginx -s reload
+              echo "nginx config 적용 + reload 완료"
+            else
+              echo "nginx -t 실패 — 이전 설정으로 롤백하고 중단"
+              sudo cp "${DST}.bak" "$DST" 2>/dev/null || true
+              exit 1
+            fi
+
+      - name: Upload provisioning script
+        uses: appleboy/scp-action@v1
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          source: "infra/scripts/provision-runtime.sh"
+          target: "/tmp/team3-provision"
+          strip_components: 2
+
+      - name: Provision runtime (swap·redis·nginx default)
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            chmod +x /tmp/team3-provision/provision-runtime.sh
+            /tmp/team3-provision/provision-runtime.sh
+
       - name: Deploy to EC2
         id: deploy
         uses: appleboy/ssh-action@v1
@@ -153,57 +208,6 @@ jobs:
               -e S3_BUCKET="$S3_BUCKET" \
               -e S3_PUBLIC_BASE_URL="$S3_PUBLIC_BASE_URL" \
               "$IMAGE"
-
-      - name: Upload nginx config
-        uses: appleboy/scp-action@v1
-        with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USER }}
-          key: ${{ secrets.EC2_SSH_KEY }}
-          source: "infra/nginx/api.depromeet18team3.cloud.conf"
-          target: "/tmp/team3-nginx"
-          strip_components: 2
-
-      - name: Apply nginx config
-        uses: appleboy/ssh-action@v1
-        with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USER }}
-          key: ${{ secrets.EC2_SSH_KEY }}
-          script: |
-            SRC=/tmp/team3-nginx/api.depromeet18team3.cloud.conf
-            DST=/etc/nginx/sites-available/api.depromeet18team3.cloud
-            # 현재 설정 백업 후 교체. nginx -t 검증 실패 시 이전 설정으로 롤백하고 배포를 중단한다.
-            sudo cp "$DST" "${DST}.bak" 2>/dev/null || true
-            sudo cp "$SRC" "$DST"
-            if sudo nginx -t; then
-              sudo nginx -s reload
-              echo "nginx config 적용 + reload 완료"
-            else
-              echo "nginx -t 실패 — 이전 설정으로 롤백하고 중단"
-              sudo cp "${DST}.bak" "$DST" 2>/dev/null || true
-              exit 1
-            fi
-
-      - name: Upload provisioning script
-        uses: appleboy/scp-action@v1
-        with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USER }}
-          key: ${{ secrets.EC2_SSH_KEY }}
-          source: "infra/scripts/provision-runtime.sh"
-          target: "/tmp/team3-provision"
-          strip_components: 2
-
-      - name: Provision runtime (swap·redis·nginx default)
-        uses: appleboy/ssh-action@v1
-        with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USER }}
-          key: ${{ secrets.EC2_SSH_KEY }}
-          script: |
-            chmod +x /tmp/team3-provision/provision-runtime.sh
-            /tmp/team3-provision/provision-runtime.sh
 
       - name: Health check and switch
         id: health

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -185,6 +185,26 @@ jobs:
               exit 1
             fi
 
+      - name: Upload provisioning script
+        uses: appleboy/scp-action@v1
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          source: "infra/scripts/provision-runtime.sh"
+          target: "/tmp/team3-provision"
+          strip_components: 2
+
+      - name: Provision runtime (swap·redis·nginx default)
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            chmod +x /tmp/team3-provision/provision-runtime.sh
+            /tmp/team3-provision/provision-runtime.sh
+
       - name: Health check and switch
         id: health
         uses: appleboy/ssh-action@v1

--- a/infra/scripts/provision-runtime.sh
+++ b/infra/scripts/provision-runtime.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# EC2 런타임 프로비저닝 — 멱등(idempotent). 배포 때 실행되어 박스 안 런타임 설정
+# (swap / redis / nginx default 사이트)이 레포 정의 상태가 되도록 보장한다.
+# 이미 있는 자원은 건드리지 않고 skip 한다 — 기존 인스턴스엔 영향 0, 새 인스턴스에서만 생성. (#217)
+#
+# docker 명령은 sudo 없이(ubuntu 가 docker 그룹), 시스템·nginx 는 sudo 로 — deploy.yml 기존 패턴과 동일.
+set -euo pipefail
+
+# 1) swap — 메모리 906Mi 라 1G swap 이 필수다. 없을 때만 생성하고 fstab 에 등록해 재부팅에도 유지되게 한다.
+if sudo swapon --show | grep -q '/swapfile'; then
+  echo "[swap] 이미 활성 — skip"
+else
+  echo "[swap] /swapfile 1G 생성"
+  sudo fallocate -l 1G /swapfile || sudo dd if=/dev/zero of=/swapfile bs=1M count=1024
+  sudo chmod 600 /swapfile
+  sudo mkswap /swapfile
+  sudo swapon /swapfile
+  grep -q '/swapfile' /etc/fstab || echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab
+fi
+
+# 2) redis — RefreshToken 저장소(RedisRefreshTokenStore). 없을 때만 named 볼륨(team3-redis-data)으로 기동.
+#    기존 컨테이너(익명 볼륨 포함)는 보존한다 — 멱등 skip. 새 인스턴스에서만 named 볼륨으로 생성돼,
+#    이후 컨테이너 재생성에도 refresh token 이 유지된다.
+if docker ps -a --format '{{.Names}}' | grep -qx 'team3-redis'; then
+  echo "[redis] team3-redis 이미 존재 — skip"
+else
+  echo "[redis] team3-redis named 볼륨으로 기동"
+  docker run -d \
+    --name team3-redis \
+    --restart unless-stopped \
+    -p 172.17.0.1:6379:6379 \
+    -v team3-redis-data:/data \
+    redis:7-alpine
+fi
+
+# 3) nginx default 사이트 — 불필요한 stock catch-all 노출. 있으면 제거하고 reload.
+if [ -e /etc/nginx/sites-enabled/default ]; then
+  echo "[nginx] sites-enabled/default 제거"
+  sudo rm -f /etc/nginx/sites-enabled/default
+  sudo nginx -t && sudo nginx -s reload
+else
+  echo "[nginx] default 없음 — skip"
+fi
+
+echo "런타임 프로비저닝 완료"


### PR DESCRIPTION
## Situation
- EC2 박스 안 런타임 설정(swap · redis 컨테이너 · nginx default 사이트)이 SSH 수동 셋업이라 git 어디에도 없었다. 인스턴스가 죽으면 재현 불가, 수동 편집이 drift 의 근원이다. #217 의 nginx(#274 완료)에 이은 나머지 3항목.

## Task
- swap · redis · default 를 코드화해 #217 을 완결한다. 기존 운영 인스턴스를 깨지 않으면서(멱등) 새 인스턴스 재현성을 확보한다.

## Action
### 멱등 프로비저닝 스크립트
- `infra/scripts/provision-runtime.sh` 신규 — 셋 다 "없을 때만" 처리. 기존 인스턴스는 전부 skip(영향 0), 새 인스턴스에서만 생성된다.
  - swap: `/swapfile` 1G 없으면 생성 + fstab 등록(재부팅 survive). 메모리 906Mi 라 필수.
  - redis: `team3-redis` 없으면 named 볼륨(`team3-redis-data`)으로 기동. RefreshToken 저장소(`RedisRefreshTokenStore`)라 컨테이너 재생성 시 토큰 유실(전체 재로그인)을 막기 위함. 기존 익명 볼륨 컨테이너는 멱등 skip 으로 보존.
  - nginx default: `sites-enabled/default` 있으면 제거 + reload (불필요한 stock catch-all).

### 배포 연결
- `deploy.yml` 에 Upload(scp)+Provision(실행) 스텝 추가 — nginx conf 이관과 같은 패턴. 머지 시 스크립트가 EC2 에서 멱등 실행된다.

### 검토 후 회피한 안
- swap 을 terraform user-data 로 두는 안은 회피했다 — user_data 변경이 인스턴스 replace 를 유발해 운영 EC2 재생성(데이터 손실) 위험이 있다. 배포 스크립트 멱등 실행이 안전하다.

## Result
- 박스 안 런타임 설정이 git 단일 진실이 되어, 인스턴스 재생성 시 swap · redis · default 정리가 자동 재현된다.
- 멱등이라 기존 운영 인스턴스엔 영향이 없다(전부 skip). 실제 동작은 dev 머지 후 배포 시 확인된다.
- #217 의 4항목(nginx / redis / swap / default)이 모두 완료돼 이슈를 닫는다.

---
## 연관 이슈

- close #217


## Updates
### 배포 순서 재편 — 정적 프로비저닝과 blue-green 분리 (self code-review 대응)
- 정적 상태 보장(nginx 설정 · swap · redis · default 제거)을 앱 컨테이너 기동 앞으로, blue-green(컨테이너 기동 + upstream 전환)을 뒤로 재배치했다. 전제(redis · swap)가 앱보다 먼저 갖춰지고, 프로비저닝 실패 시 트래픽 전환 전에 배포가 중단된다 — 부가 작업이 전환만 골라 막던 구조를 제거. api conf 가 include 하는 team3-upstream.conf 를 Apply 단계에서 없으면 8080 으로 초기화해, 정적 nginx 가 앞으로 가며 include 대상 부재로 nginx -t 가 깨지던 것도 막았다 (`e0408e2`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 배포 워크플로우의 설정 검증 기능 강화 및 오류 발생 시 자동 복구 기능 추가
  * EC2 인스턴스 런타임 자동 프로비저닝 스크립트 신규 추가
  * 배포 프로세스 안정성 및 자동화 수준 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/PIKI-Server/pull/279?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->