### PR TITLE
위시리스트 이미지 등록 다건·비동기 전환

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
@@ -300,7 +300,7 @@ interface TournamentApi {
     fun addItemsFromImages(
         @Parameter(hidden = true) userId: UUID,
         @Parameter(description = "토너먼트 ID", example = "1") tournamentId: Long,
-        images: List<MultipartFile>,
+        images: List<MultipartFile>?,
     ): ApiResponseBody<AddTournamentItemsFromImagesResponse>
 
     @Operation(

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentController.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentController.kt
@@ -70,9 +70,11 @@ class TournamentController(
     override fun addItemsFromImages(
         @AuthenticationPrincipal userId: UUID,
         @PathVariable tournamentId: Long,
-        @RequestParam("images") images: List<MultipartFile>,
+        @RequestParam("images", required = false) images: List<MultipartFile>?,
     ): ApiResponseBody<AddTournamentItemsFromImagesResponse> {
-        val itemIds = tournamentItemService.addItemsFromImages(userId, tournamentId, images)
+        // images 파트 미첨부(0장)는 Spring 이 진입 전 예외로 끊어 캐치올(500)로 가므로,
+        // required=false + orEmpty 로 항상 서비스 검증(invalidImageCount, 400)에 닿게 한다.
+        val itemIds = tournamentItemService.addItemsFromImages(userId, tournamentId, images.orEmpty())
         return ApiResponseBody.ok(AddTournamentItemsFromImagesResponse(itemIds))
     }
 

--- a/src/main/kotlin/com/depromeet/piki/wishlist/controller/WishlistApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/wishlist/controller/WishlistApi.kt
@@ -375,6 +375,6 @@ interface WishlistApi {
     )
     fun registerFromImages(
         @Parameter(hidden = true) userId: UUID,
-        images: List<MultipartFile>,
+        images: List<MultipartFile>?,
     ): ApiResponseBody<List<WishItemResponse>>
 }

--- a/src/main/kotlin/com/depromeet/piki/wishlist/controller/WishlistApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/wishlist/controller/WishlistApi.kt
@@ -319,18 +319,19 @@ interface WishlistApi {
     ): ApiResponseBody<Unit>
 
     @Operation(
-        summary = "위시리스트 이미지 등록",
+        summary = "위시리스트 이미지 등록 (다건)",
         description = """
-            상품 페이지를 캡처한 이미지를 받아 Gemini Vision 으로 상품명/가격을 추출한 뒤 유저의 위시리스트에 등록한다.
+            상품 페이지를 캡처한 이미지 1~5장을 받아, 각 이미지를 PROCESSING 상태의 위시 항목으로 즉시 등록하고 목록을 반환한다.
+            실제 상품 정보 추출(Gemini Vision)은 백그라운드에서 비동기로 진행되어 각 항목을 READY 또는 FAILED 로 전이시킨다.
             URL 등록과 결과 모양(WishItemResponse)이 같다. 이미지 등록 항목은 URL 이 없어 sourceUrl 이 null 이며,
-            추출이 부정확하면 수정 API 로 교정한다.
+            추출 결과는 조회로 폴링하거나 수정 API 로 교정한다.
         """,
     )
     @ApiResponses(
         value = [
             ApiResponse(
                 responseCode = "201",
-                description = "이미지 등록 성공",
+                description = "이미지 등록 접수 — 각 항목이 PROCESSING 상태로 생성되고 비동기 파싱이 시작된다",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,
@@ -340,7 +341,9 @@ interface WishlistApi {
             ),
             ApiResponse(
                 responseCode = "400",
-                description = "잘못된 요청 (빈 이미지 · 이미지 타입 미지정 · 지원하지 않는 이미지 형식(png/jpeg/webp/heic/heif만 허용))",
+                description =
+                    "잘못된 요청 (이미지 개수 1~5 위반 · 빈 이미지 · 이미지 타입 미지정 · " +
+                        "지원하지 않는 이미지 형식(png/jpeg/webp/heic/heif만 허용))",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,
@@ -368,20 +371,10 @@ interface WishlistApi {
                     ),
                 ],
             ),
-            ApiResponse(
-                responseCode = "502",
-                description = "Gemini 호출/응답 처리 실패",
-                content = [
-                    Content(
-                        mediaType = MediaType.APPLICATION_JSON_VALUE,
-                        schema = Schema(implementation = ApiResponseBody::class),
-                    ),
-                ],
-            ),
         ],
     )
     fun registerFromImages(
         @Parameter(hidden = true) userId: UUID,
-        image: MultipartFile,
-    ): ApiResponseBody<WishItemResponse>
+        images: List<MultipartFile>,
+    ): ApiResponseBody<List<WishItemResponse>>
 }

--- a/src/main/kotlin/com/depromeet/piki/wishlist/controller/WishlistApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/wishlist/controller/WishlistApiExamples.kt
@@ -173,8 +173,18 @@ class WishlistApiExamples(
                 operation.examples(openApiObjectMapper.delegate) {
                     add(
                         status = HttpStatus.CREATED,
-                        name = "이미지 등록 성공 (URL 없음)",
-                        payload = ApiResponseBody.created(imageSampleEntry),
+                        name = "이미지 등록 접수 (PROCESSING, 다건)",
+                        payload = ApiResponseBody.created(imageProcessingEntries),
+                    )
+                    add(
+                        status = HttpStatus.BAD_REQUEST,
+                        name = "이미지 개수 위반 (1~5개 아님)",
+                        payload =
+                            ApiResponseBody.fail<Unit>(
+                                category = ErrorCategory.INVALID_INPUT,
+                                status = HttpStatus.BAD_REQUEST,
+                                detail = "이미지는 최소 1개, 최대 5개까지 전송할 수 있습니다.",
+                            ),
                     )
                     add(
                         status = HttpStatus.BAD_REQUEST,
@@ -184,16 +194,6 @@ class WishlistApiExamples(
                                 category = ErrorCategory.INVALID_INPUT,
                                 status = HttpStatus.BAD_REQUEST,
                                 detail = ProductImage.unsupportedMimeTypeMessage("image/gif"),
-                            ),
-                    )
-                    add(
-                        status = HttpStatus.BAD_GATEWAY,
-                        name = "Gemini 호출 실패",
-                        payload =
-                            ApiResponseBody.fail<Unit>(
-                                category = ErrorCategory.RETRYABLE,
-                                status = HttpStatus.BAD_GATEWAY,
-                                detail = "Gemini 호출 실패",
                             ),
                     )
                 }
@@ -241,23 +241,42 @@ class WishlistApiExamples(
                 ),
         )
 
-    // 이미지 등록 항목 — URL·이미지·통화가 없어 해당 필드가 null 이다. 동기 완성이라 READY.
-    private val imageSampleEntry =
-        WishItemResponse(
-            wish =
-                WishItemResponse.WishView(
-                    id = 1025,
-                    createdAt = LocalDateTime.of(2026, 5, 21, 10, 5, 0),
-                ),
-            item =
-                WishItemResponse.ItemView(
-                    id = 513,
-                    status = ItemStatus.READY,
-                    name = "에어 조던 1 미드",
-                    currentPrice = 119_000,
-                    currency = null,
-                    imageUrl = null,
-                    sourceUrl = null,
-                ),
+    // 이미지 등록 직후 항목들 — link 도 없는 PROCESSING(sourceUrl=null). 비동기 추출이 끝나면 name·가격·이미지가 채워진다.
+    private val imageProcessingEntries =
+        listOf(
+            WishItemResponse(
+                wish =
+                    WishItemResponse.WishView(
+                        id = 1025,
+                        createdAt = LocalDateTime.of(2026, 5, 21, 10, 5, 0),
+                    ),
+                item =
+                    WishItemResponse.ItemView(
+                        id = 513,
+                        status = ItemStatus.PROCESSING,
+                        name = null,
+                        currentPrice = null,
+                        currency = null,
+                        imageUrl = null,
+                        sourceUrl = null,
+                    ),
+            ),
+            WishItemResponse(
+                wish =
+                    WishItemResponse.WishView(
+                        id = 1027,
+                        createdAt = LocalDateTime.of(2026, 5, 21, 10, 5, 0),
+                    ),
+                item =
+                    WishItemResponse.ItemView(
+                        id = 515,
+                        status = ItemStatus.PROCESSING,
+                        name = null,
+                        currentPrice = null,
+                        currency = null,
+                        imageUrl = null,
+                        sourceUrl = null,
+                    ),
+            ),
         )
 }

--- a/src/main/kotlin/com/depromeet/piki/wishlist/controller/WishlistController.kt
+++ b/src/main/kotlin/com/depromeet/piki/wishlist/controller/WishlistController.kt
@@ -42,10 +42,10 @@ class WishlistController(
     @ResponseStatus(HttpStatus.CREATED)
     override fun registerFromImages(
         @AuthenticationPrincipal userId: UUID,
-        @RequestParam("image") image: MultipartFile,
-    ): ApiResponseBody<WishItemResponse> {
-        val result = wishlistService.registerFromImages(image = image, userId = userId)
-        return ApiResponseBody.created(WishItemResponse.from(result.wish, result.item))
+        @RequestParam("images") images: List<MultipartFile>,
+    ): ApiResponseBody<List<WishItemResponse>> {
+        val results = wishlistService.registerFromImages(images = images, userId = userId)
+        return ApiResponseBody.created(results.map { WishItemResponse.from(it.wish, it.item) })
     }
 
     @GetMapping

--- a/src/main/kotlin/com/depromeet/piki/wishlist/controller/WishlistController.kt
+++ b/src/main/kotlin/com/depromeet/piki/wishlist/controller/WishlistController.kt
@@ -42,9 +42,11 @@ class WishlistController(
     @ResponseStatus(HttpStatus.CREATED)
     override fun registerFromImages(
         @AuthenticationPrincipal userId: UUID,
-        @RequestParam("images") images: List<MultipartFile>,
+        @RequestParam("images", required = false) images: List<MultipartFile>?,
     ): ApiResponseBody<List<WishItemResponse>> {
-        val results = wishlistService.registerFromImages(images = images, userId = userId)
+        // images 파트를 아예 안 보내면(0장) Spring 이 컨트롤러 진입 전 MissingServletRequestPartException 으로
+        // 끊어 캐치올(500)로 떨어진다. required=false + orEmpty 로 항상 서비스 검증(invalidImageCount, 400)에 닿게 한다.
+        val results = wishlistService.registerFromImages(images = images.orEmpty(), userId = userId)
         return ApiResponseBody.created(results.map { WishItemResponse.from(it.wish, it.item) })
     }
 

--- a/src/main/kotlin/com/depromeet/piki/wishlist/domain/WishException.kt
+++ b/src/main/kotlin/com/depromeet/piki/wishlist/domain/WishException.kt
@@ -35,5 +35,12 @@ class WishException private constructor(
                 ErrorCategory.NOT_FOUND,
                 HttpStatus.NOT_FOUND,
             )
+
+        fun invalidImageCount(): WishException =
+            WishException(
+                "이미지는 최소 1개, 최대 5개까지 전송할 수 있습니다.",
+                ErrorCategory.INVALID_INPUT,
+                HttpStatus.BAD_REQUEST,
+            )
     }
 }

--- a/src/main/kotlin/com/depromeet/piki/wishlist/service/WishPersistenceService.kt
+++ b/src/main/kotlin/com/depromeet/piki/wishlist/service/WishPersistenceService.kt
@@ -1,6 +1,7 @@
 package com.depromeet.piki.wishlist.service
 
 import com.depromeet.piki.item.domain.Item
+import com.depromeet.piki.item.domain.ItemStatus
 import com.depromeet.piki.item.repository.ItemRepository
 import com.depromeet.piki.wishlist.domain.Wish
 import com.depromeet.piki.wishlist.repository.WishRepository
@@ -27,5 +28,19 @@ class WishPersistenceService(
         val saved = itemRepository.save(item)
         val wish = wishRepository.save(Wish(userId = userId, itemId = saved.getId()))
         return WishWithItem(wish = wish, item = saved)
+    }
+
+    // 이미지 다건 등록용 — link 없는 PROCESSING item 을 count 만큼 배치 저장하고, 각각에 wish 를 건다.
+    // 추출은 호출부가 비동기 워커에 위임하므로 여기선 PROCESSING 상태만 영속화한다.
+    @Transactional
+    fun persistProcessingImages(
+        userId: UUID,
+        count: Int,
+    ): List<WishWithItem> {
+        val items = itemRepository.saveAll(List(count) { Item(status = ItemStatus.PROCESSING) })
+        return items.map { item ->
+            val wish = wishRepository.save(Wish(userId = userId, itemId = item.getId()))
+            WishWithItem(wish = wish, item = item)
+        }
     }
 }

--- a/src/main/kotlin/com/depromeet/piki/wishlist/service/WishlistService.kt
+++ b/src/main/kotlin/com/depromeet/piki/wishlist/service/WishlistService.kt
@@ -1,11 +1,9 @@
 package com.depromeet.piki.wishlist.service
 
-import com.depromeet.piki.common.storage.ImageStorage
 import com.depromeet.piki.image.domain.ProductImage
-import com.depromeet.piki.image.service.ImageCropper
-import com.depromeet.piki.image.service.ProductImageExtractor
 import com.depromeet.piki.item.domain.Item
 import com.depromeet.piki.item.repository.ItemRepository
+import com.depromeet.piki.item.service.ImageParsingWorker
 import com.depromeet.piki.item.service.ItemParsingService
 import com.depromeet.piki.item.service.ItemParsingWorker
 import com.depromeet.piki.product.domain.ProductLink
@@ -16,6 +14,7 @@ import com.depromeet.piki.wishlist.repository.WishRepository
 import com.depromeet.piki.wishlist.service.dto.WishWithItem
 import com.depromeet.piki.wishlist.service.dto.WishlistPage
 import org.slf4j.LoggerFactory
+import org.springframework.core.task.TaskRejectedException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
@@ -23,10 +22,8 @@ import java.util.UUID
 
 @Service
 class WishlistService(
-    private val productImageExtractor: ProductImageExtractor,
-    private val imageCropper: ImageCropper,
-    private val imageStorage: ImageStorage,
     private val itemParsingWorker: ItemParsingWorker,
+    private val imageParsingWorker: ImageParsingWorker,
     private val itemParsingService: ItemParsingService,
     private val wishPersistenceService: WishPersistenceService,
     private val wishRepository: WishRepository,
@@ -53,30 +50,30 @@ class WishlistService(
         return result
     }
 
-    // 이미지 등록도 link 와 같은 흐름 — 입력이 이미지일 뿐. 외부 추출·크롭·S3 업로드는 트랜잭션 바깥, 영속화만 위임.
-    // 추출 결과는 link 추출과 동일한 ProductSnapshot 이라 Item.from 을 공유한다 (link 만 null).
-    // bbox 가 있으면 상품 영역을 크롭해 S3 에 올리고 그 URL 을 imageUrl 로 채운다.
-    // bbox 가 없거나(못 잡음) 크롭이 불가한 포맷(HEIC 등)이면 imageUrl 은 null 로 둔다.
+    // 이미지 등록은 register(link)와 같은 비동기 흐름 — 입력이 이미지(다건)일 뿐이다.
+    // 개수·형식을 동기로 검증(400)한 뒤 PROCESSING item·wish 를 배치 저장해 즉시 반환하고,
+    // 실제 추출(Gemini·크롭·S3)은 imageParsingWorker 가 백그라운드에서 각 이미지를 병렬 파싱해
+    // READY/FAILED 로 전이시킨다. 토너먼트 아이템 이미지 등록과 동일한 패턴이다.
     fun registerFromImages(
-        image: MultipartFile,
+        images: List<MultipartFile>,
         userId: UUID,
-    ): WishWithItem {
-        val productImage = ProductImage.of(image.bytes, image.contentType)
-        val extraction = productImageExtractor.extract(productImage)
-        // 크롭 이미지는 부가 정보다. S3 일시 장애·타임아웃이 이미지 등록 전체를 5xx 로 깨뜨리지 않도록,
-        // 업로드 실패는 imageUrl=null 로 degrade 한다 (imageUrl 없이도 등록 가능한 계약).
-        val imageUrl =
-            extraction.boundingBox
-                ?.let { imageCropper.crop(productImage.bytes, it) }
-                ?.let { cropped ->
-                    runCatching {
-                        imageStorage.upload(cropped, "items/${UUID.randomUUID()}.png", "image/png")
-                    }.getOrElse { e ->
-                        log.warn("크롭 이미지 S3 업로드 실패, imageUrl 없이 등록 진행: {}", e.message)
-                        null
-                    }
-                }
-        return wishPersistenceService.persist(userId, Item.from(extraction.snapshot.copy(imageUrl = imageUrl)))
+    ): List<WishWithItem> {
+        if (images.size !in MIN_IMAGE_COUNT..MAX_IMAGE_COUNT) throw WishException.invalidImageCount()
+        // 형식 검증(빈 바이트·미지원 MIME) — 실패 시 즉시 400. 유효한 이미지만 PROCESSING 으로 등록한다.
+        val productImages = images.map { ProductImage.of(it.bytes, it.contentType) }
+        val results = wishPersistenceService.persistProcessingImages(userId, productImages.size)
+        results.zip(productImages).forEach { (result, productImage) ->
+            val itemId = result.item.getId()
+            // 워커 디스패치가 큐 포화 등으로 거부되면 PROCESSING 으로 방치하지 않고 즉시 FAILED 로 떨어뜨린다.
+            try {
+                imageParsingWorker.parse(itemId, productImage)
+            } catch (e: TaskRejectedException) {
+                log.warn("파싱 워커 디스패치 거부, item {} 를 FAILED 처리: {}", itemId, e.message)
+                runCatching { itemParsingService.markFailed(itemId) }
+                    .onFailure { ex -> log.error("item {} FAILED 전이 실패, PROCESSING 방치 위험", itemId, ex) }
+            }
+        }
+        return results
     }
 
     @Transactional(readOnly = true)
@@ -149,5 +146,10 @@ class WishlistService(
         val wish = wishRepository.findById(wishId) ?: throw WishException.notFound()
         wish.verifyOwnedBy(userId)
         wish.delete()
+    }
+
+    companion object {
+        private const val MIN_IMAGE_COUNT = 1
+        private const val MAX_IMAGE_COUNT = 5
     }
 }

--- a/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
@@ -695,6 +695,20 @@ class TournamentControllerTest : IntegrationTestSupport() {
     }
 
     @Test
+    fun `POST tournaments-id-items-images 에서 이미지 파트를 보내지 않으면 400 을 반환한다`() {
+        val mockMvc = buildMockMvc()
+        val tournamentId = createTournament(mockMvc)
+
+        // .file(...) 없이 images 파트를 아예 생략 — required=false + orEmpty 로 서비스 검증(개수 0)에 닿아 400.
+        mockMvc
+            .perform(
+                multipart("/api/v1/tournaments/$tournamentId/items/images")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(userId)),
+            ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.status").value(400))
+    }
+
+    @Test
     fun `POST tournaments-id-items 에서 위시리스트에 없는 아이템이면 403 을 반환한다`() {
         val mockMvc = buildMockMvc()
         val tournamentId = createTournament(mockMvc)

--- a/src/test/kotlin/com/depromeet/piki/wishlist/controller/WishlistControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/wishlist/controller/WishlistControllerIntegrationTest.kt
@@ -518,6 +518,22 @@ class WishlistControllerIntegrationTest : IntegrationTestSupport() {
     }
 
     @Test
+    fun `이미지 파트를 보내지 않으면 400 BAD_REQUEST 가 반환된다`() {
+        val mockMvc = buildMockMvc()
+        val userId = UUID.randomUUID()
+        insertMember(userId)
+
+        // .file(...) 없이 images 파트를 아예 생략 — required=false + orEmpty 로 서비스 검증(개수 0)에 닿아 400.
+        mockMvc
+            .perform(
+                multipart("/api/v1/wishlists/images")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer ${memberToken(userId)}"),
+            ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value("BAD_REQUEST"))
+    }
+
+    @Test
     fun `빈 이미지로 등록하면 400 BAD_REQUEST 가 반환된다`() {
         val mockMvc = buildMockMvc()
         val userId = UUID.randomUUID()

--- a/src/test/kotlin/com/depromeet/piki/wishlist/controller/WishlistControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/wishlist/controller/WishlistControllerIntegrationTest.kt
@@ -1,20 +1,14 @@
 package com.depromeet.piki.wishlist.controller
 
 import com.depromeet.piki.auth.infrastructure.jwt.JwtProvider
-import com.depromeet.piki.image.domain.BoundingBox
-import com.depromeet.piki.image.service.ImageExtraction
 import com.depromeet.piki.item.domain.Item
 import com.depromeet.piki.product.domain.ProductLink
 import com.depromeet.piki.product.service.ProductSnapshot
-import com.depromeet.piki.product.service.gemini.GeminiApiException
 import com.depromeet.piki.support.IntegrationTestSupport
-import com.depromeet.piki.support.StubImageStorage
-import com.depromeet.piki.support.StubProductImageExtractor
 import com.depromeet.piki.support.uuidToBytes
 import com.depromeet.piki.user.domain.IdentityType
 import com.depromeet.piki.wishlist.service.WishPersistenceService
 import org.hamcrest.Matchers.nullValue
-import org.hamcrest.Matchers.startsWith
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpHeaders
@@ -35,10 +29,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.context.WebApplicationContext
 import tools.jackson.databind.ObjectMapper
-import java.awt.image.BufferedImage
-import java.io.ByteArrayOutputStream
 import java.util.UUID
-import javax.imageio.ImageIO
 
 // 조회·수정·삭제 contract 검증. 이 시나리오들의 본질은 "완성된 위시가 있을 때의 동작"이라
 // 등록(비동기) 경로를 거치지 않고 seedReadyWish 로 READY 상태를 시딩한다.
@@ -50,9 +41,6 @@ class WishlistControllerIntegrationTest : IntegrationTestSupport() {
 
     @Autowired
     private lateinit var objectMapper: ObjectMapper
-
-    @Autowired
-    private lateinit var stubProductImageExtractor: StubProductImageExtractor
 
     @Autowired
     private lateinit var wishPersistenceService: WishPersistenceService
@@ -485,97 +473,56 @@ class WishlistControllerIntegrationTest : IntegrationTestSupport() {
     }
 
     @Test
-    fun `이미지로 등록하면 201 과 함께 item·wish 가 저장되고 sourceUrl 은 null 이다`() {
+    fun `다건 이미지로 등록하면 201 과 함께 PROCESSING 항목이 개수만큼 반환된다`() {
         val mockMvc = buildMockMvc()
         val userId = UUID.randomUUID()
         insertMember(userId)
-        stubProductImageExtractor.build = {
-            ImageExtraction(
-                snapshot = ProductSnapshot(link = null, name = "나이키 에어포스", currentPrice = 99_000, currency = "KRW"),
-                boundingBox = null,
-            )
-        }
-        val image = MockMultipartFile("image", "product.png", "image/png", byteArrayOf(1, 2, 3))
+        val image1 = MockMultipartFile("images", "p1.png", "image/png", byteArrayOf(1, 2, 3))
+        val image2 = MockMultipartFile("images", "p2.png", "image/png", byteArrayOf(4, 5, 6))
 
         mockMvc
             .perform(
                 multipart("/api/v1/wishlists/images")
-                    .file(image)
+                    .file(image1)
+                    .file(image2)
                     .header(HttpHeaders.AUTHORIZATION, "Bearer ${memberToken(userId)}"),
             ).andExpect(status().isCreated)
             .andExpect(jsonPath("$.status").value(201))
-            .andExpect(jsonPath("$.data.wish.id").isNumber)
-            .andExpect(jsonPath("$.data.item.name").value("나이키 에어포스"))
-            .andExpect(jsonPath("$.data.item.currentPrice").value(99_000))
-            .andExpect(jsonPath("$.data.item.currency").value("KRW"))
-            // 이미지 추출은 동기 완성이라 status 는 READY.
-            .andExpect(jsonPath("$.data.item.status").value("READY"))
-            // bbox 가 없으면 크롭을 건너뛰어 imageUrl 은 null. sourceUrl 도 이미지 등록이라 null.
-            .andExpect(jsonPath("$.data.item.sourceUrl").value(nullValue()))
-            .andExpect(jsonPath("$.data.item.imageUrl").value(nullValue()))
-    }
-
-    @Test
-    fun `이미지에 bbox 가 있으면 크롭 이미지를 업로드해 imageUrl 이 채워진다`() {
-        val mockMvc = buildMockMvc()
-        val userId = UUID.randomUUID()
-        insertMember(userId)
-        stubProductImageExtractor.build = {
-            ImageExtraction(
-                snapshot = ProductSnapshot(link = null, name = "나이키 에어포스", currentPrice = 99_000, currency = "KRW"),
-                boundingBox = BoundingBox(yMin = 100, xMin = 100, yMax = 500, xMax = 500),
-            )
-        }
-        // 크롭이 동작하려면 실제 디코딩 가능한 PNG 여야 한다 (ImageCropper 는 실제 빈, 업로드만 stub).
-        val pngBytes =
-            ByteArrayOutputStream().use { out ->
-                ImageIO.write(BufferedImage(800, 800, BufferedImage.TYPE_INT_RGB), "png", out)
-                out.toByteArray()
-            }
-        val image = MockMultipartFile("image", "product.png", "image/png", pngBytes)
-
-        mockMvc
-            .perform(
-                multipart("/api/v1/wishlists/images")
-                    .file(image)
-                    .header(HttpHeaders.AUTHORIZATION, "Bearer ${memberToken(userId)}"),
-            ).andExpect(status().isCreated)
-            .andExpect(jsonPath("$.data.item.imageUrl").value(startsWith(StubImageStorage.BASE_URL)))
-    }
-
-    @Test
-    fun `이미지 등록 후 조회하면 해당 항목이 sourceUrl null 로 함께 반환된다`() {
-        val mockMvc = buildMockMvc()
-        val userId = UUID.randomUUID()
-        insertMember(userId)
-        val authHeader = "Bearer ${memberToken(userId)}"
-        stubProductImageExtractor.build = {
-            ImageExtraction(
-                snapshot = ProductSnapshot(link = null, name = "에어 조던", currentPrice = 119_000),
-                boundingBox = null,
-            )
-        }
-        val image = MockMultipartFile("image", "product.png", "image/png", byteArrayOf(1, 2, 3))
-
-        mockMvc
-            .perform(
-                multipart("/api/v1/wishlists/images").file(image).header(HttpHeaders.AUTHORIZATION, authHeader),
-            ).andExpect(status().isCreated)
-
-        mockMvc
-            .perform(get("/api/v1/wishlists").header(HttpHeaders.AUTHORIZATION, authHeader))
-            .andExpect(status().isOk)
-            .andExpect(jsonPath("$.data.length()").value(1))
-            .andExpect(jsonPath("$.data[0].item.name").value("에어 조던"))
+            .andExpect(jsonPath("$.code").value("CREATED"))
+            .andExpect(jsonPath("$.data.length()").value(2))
+            // 등록 직후라 두 항목 모두 PROCESSING — 추출 결과는 비어 있고 sourceUrl 도 null(이미지 등록).
+            // 실제 파싱 완료(READY/FAILED)·크롭 imageUrl 은 WishlistRegisterAsyncIntegrationTest 가 검증한다.
+            .andExpect(jsonPath("$.data[0].item.status").value("PROCESSING"))
+            .andExpect(jsonPath("$.data[0].item.name").value(nullValue()))
             .andExpect(jsonPath("$.data[0].item.sourceUrl").value(nullValue()))
+            .andExpect(jsonPath("$.data[0].wish.id").isNumber)
+            .andExpect(jsonPath("$.data[1].item.status").value("PROCESSING"))
     }
 
     @Test
-    fun `빈 이미지로 이미지 등록하면 400 BAD_REQUEST 가 반환된다`() {
+    fun `이미지를 6개 등록하면 400 BAD_REQUEST 가 반환된다`() {
         val mockMvc = buildMockMvc()
         val userId = UUID.randomUUID()
         insertMember(userId)
-        val emptyImage = MockMultipartFile("image", "empty.png", "image/png", ByteArray(0))
+        val request = multipart("/api/v1/wishlists/images")
+        (1..6).forEach { i ->
+            request.file(MockMultipartFile("images", "p$i.png", "image/png", byteArrayOf(1, 2, 3)))
+        }
+        request.header(HttpHeaders.AUTHORIZATION, "Bearer ${memberToken(userId)}")
+
+        mockMvc
+            .perform(request)
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value("BAD_REQUEST"))
+    }
+
+    @Test
+    fun `빈 이미지로 등록하면 400 BAD_REQUEST 가 반환된다`() {
+        val mockMvc = buildMockMvc()
+        val userId = UUID.randomUUID()
+        insertMember(userId)
+        val emptyImage = MockMultipartFile("images", "empty.png", "image/png", ByteArray(0))
 
         mockMvc
             .perform(
@@ -588,11 +535,11 @@ class WishlistControllerIntegrationTest : IntegrationTestSupport() {
     }
 
     @Test
-    fun `지원하지 않는 이미지 형식으로 이미지 등록하면 400 BAD_REQUEST 가 반환된다`() {
+    fun `지원하지 않는 이미지 형식으로 등록하면 400 BAD_REQUEST 가 반환된다`() {
         val mockMvc = buildMockMvc()
         val userId = UUID.randomUUID()
         insertMember(userId)
-        val gif = MockMultipartFile("image", "product.gif", "image/gif", byteArrayOf(1, 2, 3))
+        val gif = MockMultipartFile("images", "product.gif", "image/gif", byteArrayOf(1, 2, 3))
 
         mockMvc
             .perform(
@@ -602,24 +549,5 @@ class WishlistControllerIntegrationTest : IntegrationTestSupport() {
             ).andExpect(status().isBadRequest)
             .andExpect(jsonPath("$.status").value(400))
             .andExpect(jsonPath("$.code").value("BAD_REQUEST"))
-    }
-
-    @Test
-    fun `이미지 등록 중 Gemini 호출이 실패하면 502 BAD_GATEWAY 가 반환된다`() {
-        val mockMvc = buildMockMvc()
-        val userId = UUID.randomUUID()
-        insertMember(userId)
-        stubProductImageExtractor.build =
-            { throw GeminiApiException.upstreamError(RuntimeException("connection timeout")) }
-        val image = MockMultipartFile("image", "product.png", "image/png", byteArrayOf(1, 2, 3))
-
-        mockMvc
-            .perform(
-                multipart("/api/v1/wishlists/images")
-                    .file(image)
-                    .header(HttpHeaders.AUTHORIZATION, "Bearer ${memberToken(userId)}"),
-            ).andExpect(status().isBadGateway)
-            .andExpect(jsonPath("$.status").value(502))
-            .andExpect(jsonPath("$.code").value("BAD_GATEWAY"))
     }
 }

--- a/src/test/kotlin/com/depromeet/piki/wishlist/controller/WishlistRegisterAsyncIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/wishlist/controller/WishlistRegisterAsyncIntegrationTest.kt
@@ -280,6 +280,9 @@ class WishlistRegisterAsyncIntegrationTest : IntegrationTestSupport() {
                     .perform(request)
                     .andExpect(status().isCreated)
                     .andExpect(jsonPath("$.data.length()").value(5))
+                    // 등록 직후 응답은 모두 PROCESSING 이어야 한다 — 서버가 즉시 READY 를 내리는 회귀를 잡는다.
+                    .andExpect(jsonPath("$.data[0].item.status").value("PROCESSING"))
+                    .andExpect(jsonPath("$.data[4].item.status").value("PROCESSING"))
                     .andReturn()
                     .response
                     .getContentAsString(Charsets.UTF_8)

--- a/src/test/kotlin/com/depromeet/piki/wishlist/controller/WishlistRegisterAsyncIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/wishlist/controller/WishlistRegisterAsyncIntegrationTest.kt
@@ -1,11 +1,16 @@
 package com.depromeet.piki.wishlist.controller
 
 import com.depromeet.piki.auth.infrastructure.jwt.JwtProvider
+import com.depromeet.piki.image.domain.BoundingBox
+import com.depromeet.piki.image.service.ImageExtraction
 import com.depromeet.piki.item.domain.ItemStatus
 import com.depromeet.piki.item.repository.ItemRepository
 import com.depromeet.piki.product.service.ProductSnapshot
 import com.depromeet.piki.product.service.ProductSnapshotException
+import com.depromeet.piki.product.service.gemini.GeminiApiException
 import com.depromeet.piki.support.IntegrationTestSupport
+import com.depromeet.piki.support.StubImageStorage
+import com.depromeet.piki.support.StubProductImageExtractor
 import com.depromeet.piki.support.StubProductLinkExtractor
 import com.depromeet.piki.support.uuidToBytes
 import com.depromeet.piki.user.domain.IdentityType
@@ -16,8 +21,10 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.mock.web.MockMultipartFile
 import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -25,8 +32,11 @@ import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.web.context.WebApplicationContext
 import tools.jackson.databind.ObjectMapper
+import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
 import java.time.Duration
 import java.util.UUID
+import javax.imageio.ImageIO
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
@@ -42,6 +52,9 @@ class WishlistRegisterAsyncIntegrationTest : IntegrationTestSupport() {
 
     @Autowired
     private lateinit var stubProductLinkExtractor: StubProductLinkExtractor
+
+    @Autowired
+    private lateinit var stubProductImageExtractor: StubProductImageExtractor
 
     @Autowired
     private lateinit var itemRepository: ItemRepository
@@ -162,6 +175,132 @@ class WishlistRegisterAsyncIntegrationTest : IntegrationTestSupport() {
         }
     }
 
+    @Test
+    fun `이미지로 등록하면 PROCESSING 으로 201 즉시 반환 후 파싱 성공 시 READY 로 전이한다`() {
+        val mockMvc = buildMockMvc()
+        val userId = UUID.randomUUID()
+        insertMember(userId)
+        try {
+            stubProductImageExtractor.build = {
+                ImageExtraction(
+                    snapshot = ProductSnapshot(link = null, name = "나이키 에어포스", currentPrice = 99_000, currency = "KRW"),
+                    boundingBox = null,
+                )
+            }
+            val image = MockMultipartFile("images", "p.png", "image/png", byteArrayOf(1, 2, 3))
+            val itemId = registerImageAndGetItemId(mockMvc, userId, image)
+
+            await().atMost(Duration.ofSeconds(5)).until {
+                itemRepository.findById(itemId)?.status == ItemStatus.READY
+            }
+            val item = itemRepository.findById(itemId) ?: error("item $itemId 가 없다")
+            assertEquals("나이키 에어포스", item.name)
+            assertEquals(99_000, item.currentPrice)
+            assertEquals("KRW", item.currency)
+            // 이미지 등록은 link(원본 URL)가 없다.
+            assertNull(item.link)
+        } finally {
+            cleanup(userId)
+        }
+    }
+
+    @Test
+    fun `이미지에 bbox 가 있으면 비동기 파싱이 크롭 이미지를 올려 imageUrl 이 채워진다`() {
+        val mockMvc = buildMockMvc()
+        val userId = UUID.randomUUID()
+        insertMember(userId)
+        try {
+            stubProductImageExtractor.build = {
+                ImageExtraction(
+                    snapshot = ProductSnapshot(link = null, name = "나이키 에어포스", currentPrice = 99_000),
+                    boundingBox = BoundingBox(yMin = 100, xMin = 100, yMax = 500, xMax = 500),
+                )
+            }
+            // 크롭이 동작하려면 실제 디코딩 가능한 PNG 여야 한다 (ImageCropper 는 실제 빈, 업로드만 stub).
+            val pngBytes =
+                ByteArrayOutputStream().use { out ->
+                    ImageIO.write(BufferedImage(800, 800, BufferedImage.TYPE_INT_RGB), "png", out)
+                    out.toByteArray()
+                }
+            val image = MockMultipartFile("images", "p.png", "image/png", pngBytes)
+            val itemId = registerImageAndGetItemId(mockMvc, userId, image)
+
+            await().atMost(Duration.ofSeconds(5)).until {
+                itemRepository.findById(itemId)?.status == ItemStatus.READY
+            }
+            val item = itemRepository.findById(itemId) ?: error("item $itemId 가 없다")
+            assertEquals(true, item.imageUrl?.startsWith(StubImageStorage.BASE_URL))
+        } finally {
+            cleanup(userId)
+        }
+    }
+
+    @Test
+    fun `이미지 파싱이 실패하면 item 이 FAILED 로 전이한다`() {
+        val mockMvc = buildMockMvc()
+        val userId = UUID.randomUUID()
+        insertMember(userId)
+        try {
+            stubProductImageExtractor.build = {
+                throw GeminiApiException.upstreamError(RuntimeException("connection timeout"))
+            }
+            val image = MockMultipartFile("images", "p.png", "image/png", byteArrayOf(1, 2, 3))
+            val itemId = registerImageAndGetItemId(mockMvc, userId, image)
+
+            await().atMost(Duration.ofSeconds(5)).until {
+                itemRepository.findById(itemId)?.status == ItemStatus.FAILED
+            }
+            val item = itemRepository.findById(itemId) ?: error("item $itemId 가 없다")
+            assertEquals(ItemStatus.FAILED, item.status)
+            assertNull(item.name)
+        } finally {
+            cleanup(userId)
+        }
+    }
+
+    @Test
+    fun `이미지 5개를 등록하면 모두 PROCESSING 으로 반환되고 각각 READY 로 전이한다`() {
+        val mockMvc = buildMockMvc()
+        val userId = UUID.randomUUID()
+        insertMember(userId)
+        try {
+            stubProductImageExtractor.build = {
+                ImageExtraction(
+                    snapshot = ProductSnapshot(link = null, name = "상품", currentPrice = 1_000),
+                    boundingBox = null,
+                )
+            }
+            val request = multipart("/api/v1/wishlists/images")
+            (1..5).forEach { i ->
+                request.file(MockMultipartFile("images", "p$i.png", "image/png", byteArrayOf(i.toByte())))
+            }
+            request.header(HttpHeaders.AUTHORIZATION, "Bearer ${memberToken(userId)}")
+            val response =
+                mockMvc
+                    .perform(request)
+                    .andExpect(status().isCreated)
+                    .andExpect(jsonPath("$.data.length()").value(5))
+                    .andReturn()
+                    .response
+                    .getContentAsString(Charsets.UTF_8)
+            val dataNode = objectMapper.readTree(response).path("data")
+            val itemIds =
+                (0 until dataNode.size()).map { i ->
+                    dataNode
+                        .path(i)
+                        .path("item")
+                        .path("id")
+                        .asLong()
+                }
+
+            await().atMost(Duration.ofSeconds(5)).until {
+                itemIds.all { itemRepository.findById(it)?.status == ItemStatus.READY }
+            }
+        } finally {
+            cleanup(userId)
+        }
+    }
+
     private fun registerAndGetItemId(
         mockMvc: MockMvc,
         userId: UUID,
@@ -179,7 +318,36 @@ class WishlistRegisterAsyncIntegrationTest : IntegrationTestSupport() {
                 .andReturn()
                 .response
                 .getContentAsString(Charsets.UTF_8)
-        return objectMapper.readTree(response).path("data").path("item").path("id").asLong()
+        return objectMapper
+            .readTree(response)
+            .path("data")
+            .path("item")
+            .path("id")
+            .asLong()
+    }
+
+    private fun registerImageAndGetItemId(
+        mockMvc: MockMvc,
+        userId: UUID,
+        image: MockMultipartFile,
+    ): Long {
+        val response =
+            mockMvc
+                .perform(
+                    multipart("/api/v1/wishlists/images")
+                        .file(image)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer ${memberToken(userId)}"),
+                ).andExpect(status().isCreated)
+                .andReturn()
+                .response
+                .getContentAsString(Charsets.UTF_8)
+        return objectMapper
+            .readTree(response)
+            .path("data")
+            .path(0)
+            .path("item")
+            .path("id")
+            .asLong()
     }
 
     private fun buildMockMvc(): MockMvc =


### PR DESCRIPTION
## Situation
- 위시리스트·토너먼트 모두 link·image 두 경로로 상품을 등록하는데, 위시 이미지 등록만 단건+동기로 남아 있었다 — 한 번에 한 장, Gemini 추출(최대 수십 초)이 끝날 때까지 응답 블로킹
- 토너먼트 아이템 이미지 등록은 이미 다건(1–5개)+비동기, 위시 URL 등록(`register`)도 이미 비동기. 위시 이미지만 비대칭이었다
- 직전 OCR→image 리네임(#273) 머지로 두 경로가 `ImageParsingWorker`·`ProductImage`·`AsyncImageParsingWorker`를 공유하게 돼, 토너먼트 패턴을 그대로 적용 가능

## Task
- 위시 이미지 등록을 다건(1–5개)+비동기로 전환해 토너먼트와 대칭으로 맞춘다
- 동기→비동기 전환에 따른 응답 형태(PROCESSING 즉시 반환)와 테스트 분류(동기 contract vs 비동기 전이)를 정한다

## Action
- `POST /api/v1/wishlists/images`: 단일 `image` → `images: List<MultipartFile>`(1–5개), 응답 `List<WishItemResponse>`
- `WishlistService.registerFromImages`: 개수(`WishException.invalidImageCount`)·형식(`ProductImage.of`) 검증 후 `WishPersistenceService.persistProcessingImages`로 PROCESSING item·wish 배치 저장, `imageParsingWorker`에 비동기 디스패치(`TaskRejectedException`→즉시 `markFailed`)하고 즉시 반환
- 비동기 전환으로 동기 추출 의존성(`productImageExtractor`·`imageCropper`·`imageStorage`)을 제거하고 `imageParsingWorker` 주입으로 교체 — 추출·크롭·S3는 `AsyncImageParsingWorker`(토너먼트와 공유 워커)가 백그라운드 수행
- OpenAPI 문서·example을 다건 PROCESSING으로 갱신 — 동기 502(Gemini 실패)는 비동기 전환으로 사라져 제거, 개수 위반 400 example 추가
- 테스트 분류: `WishlistControllerIntegrationTest`(@Transactional)는 동기 contract(다건 PROCESSING 응답·개수/형식 400)만, 파싱 완료(READY/FAILED)·크롭 imageUrl·5개 병렬은 `WishlistRegisterAsyncIntegrationTest`(실제 커밋+Awaitility)로 분리 — @Transactional 자동 롤백이 비동기 워커의 별도 트랜잭션을 못 보기 때문

## Result
- 위시·토너먼트 이미지 등록이 같은 다건+비동기 패턴·공유 워커로 통일됨
- 클라이언트는 PROCESSING으로 즉시 응답받고 조회로 폴링(URL 등록과 동일 계약)
- 컴파일·단위+통합 테스트 통과, 변경 파일 ktlint 클린
- 새 마이그레이션 없음 — link(source_url) nullable은 기존 적용분(V20260522190923) 활용

---
## 연관 이슈

- close #275


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 이미지 일괄 업로드 기능 추가: 최대 5장까지 한 번에 등록 가능
  * 비동기 이미지 처리: 업로드 후 백그라운드에서 상품 정보 자동 추출

* **Bug Fixes & Improvements**
  * 이미지 개수 유효성 검사 강화 (1~5장 범위 제한)
  * 지원하지 않는 이미지 형식 명확한 오류 메시지 제공

* **Tests**
  * 이미지 다건 등록 및 비동기 처리 흐름 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/PIKI-Server/pull/280?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->