### PR TITLE
토너먼트 아이템 단건 조회 및 추가 응답 필드명 통일

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
@@ -150,9 +150,9 @@ interface TournamentApi {
         summary = "URL 링크로 토너먼트 아이템 추가",
         description = """
             PENDING 상태의 토너먼트에 URL 링크를 통해 아이템을 추가한다.
-            아이템이 PROCESSING 상태로 즉시 생성되어 itemId 가 반환된다.
+            아이템이 PROCESSING 상태로 즉시 생성되어 tournamentItemId 가 반환된다.
             파싱은 비동기로 진행되며 완료 시 READY 또는 FAILED 상태로 전환된다.
-            클라이언트는 itemId 로 상태를 폴링한다. 토너먼트 참여자만 추가할 수 있다.
+            클라이언트는 tournamentItemId 로 GET /tournaments/{id}/items/{tournamentItemId} 를 폴링한다. 토너먼트 참여자만 추가할 수 있다.
         """,
     )
     @ApiResponses(
@@ -229,9 +229,9 @@ interface TournamentApi {
         summary = "이미지로 토너먼트 아이템 추가",
         description = """
             PENDING 상태의 토너먼트에 이미지 추출을 통해 아이템을 추가한다.
-            이미지 1~5장을 전달하면 아이템이 PROCESSING 상태로 즉시 생성되어 itemIds 가 반환된다.
+            이미지 1~5장을 전달하면 아이템이 PROCESSING 상태로 즉시 생성되어 tournamentItemIds 가 반환된다.
             이미지 파싱은 비동기로 진행되며 완료 시 READY 또는 FAILED 상태로 전환된다.
-            클라이언트는 itemId 로 상태를 폴링한다. 토너먼트 참여자만 추가할 수 있다.
+            클라이언트는 tournamentItemId 로 GET /tournaments/{id}/items/{tournamentItemId} 를 폴링한다. 토너먼트 참여자만 추가할 수 있다.
         """,
     )
     @ApiResponses(

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
@@ -4,6 +4,7 @@ import com.depromeet.piki.common.response.ApiResponseBody
 import com.depromeet.piki.tournament.controller.dto.AddTournamentItemFromLinkRequest
 import com.depromeet.piki.tournament.controller.dto.AddTournamentItemFromLinkResponse
 import com.depromeet.piki.tournament.controller.dto.AddTournamentItemsFromImagesResponse
+import com.depromeet.piki.tournament.controller.dto.AddTournamentItemsFromWishResponse
 import com.depromeet.piki.tournament.controller.dto.AddTournamentItemsRequest
 import com.depromeet.piki.tournament.controller.dto.CreateTournamentRequest
 import com.depromeet.piki.tournament.controller.dto.CreateTournamentResponse
@@ -74,13 +75,14 @@ interface TournamentApi {
         description = """
             PENDING 상태의 토너먼트에 위시리스트에 있는 아이템을 추가한다. 토너먼트 참여자만 추가할 수 있다.
             itemIds 중 하나라도 조건에 맞지 않으면 요청 전체가 실패한다(부분 성공 없음).
+            응답의 tournamentItemIds 는 요청 itemIds 와 동일한 순서로 대응된다.
         """,
     )
     @ApiResponses(
         value = [
             ApiResponse(
                 responseCode = "200",
-                description = "아이템 추가 성공",
+                description = "아이템 추가 성공 (tournamentItemIds: 요청 itemIds 순서와 동일하게 대응)",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,
@@ -144,7 +146,7 @@ interface TournamentApi {
         @Parameter(hidden = true) userId: UUID,
         @Parameter(description = "토너먼트 ID", example = "1") tournamentId: Long,
         request: AddTournamentItemsRequest,
-    ): ApiResponseBody<Unit>
+    ): ApiResponseBody<AddTournamentItemsFromWishResponse>
 
     @Operation(
         summary = "URL 링크로 토너먼트 아이템 추가",

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
@@ -132,7 +132,7 @@ interface TournamentApi {
             ),
             ApiResponse(
                 responseCode = "409",
-                description = "상태 충돌 (PENDING이 아닌 토너먼트 · 이미 등록된 아이템 · PROCESSING/FAILED 상품 포함)",
+                description = "상태 충돌 (PENDING이 아닌 토너먼트 · 이미 등록된 아이템 · 요청 내 중복 아이템 · PROCESSING/FAILED 상품 포함)",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,
@@ -408,7 +408,7 @@ interface TournamentApi {
             ),
             ApiResponse(
                 responseCode = "403",
-                description = "권한 없음 (토너먼트 소유자가 아님)",
+                description = "권한 없음 (토너먼트 참여자가 아님 · 토너먼트 소유자가 아님)",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
@@ -9,6 +9,7 @@ import com.depromeet.piki.tournament.controller.dto.CreateTournamentRequest
 import com.depromeet.piki.tournament.controller.dto.CreateTournamentResponse
 import com.depromeet.piki.tournament.controller.dto.RecordMatchRequest
 import com.depromeet.piki.tournament.controller.dto.TournamentDetailResponse
+import com.depromeet.piki.tournament.controller.dto.TournamentItemDetailResponse
 import com.depromeet.piki.tournament.controller.dto.TournamentStartResponse
 import com.depromeet.piki.tournament.controller.dto.TournamentSummaryResponse
 import com.depromeet.piki.tournament.domain.TournamentStatus
@@ -618,4 +619,66 @@ interface TournamentApi {
         @Parameter(hidden = true) userId: UUID,
         @Parameter(description = "토너먼트 ID", example = "1") tournamentId: Long,
     ): ApiResponseBody<TournamentDetailResponse>
+
+    @Operation(
+        summary = "토너먼트 아이템 단건 조회",
+        description = """
+            토너먼트 아이템의 상세 정보와 파싱 상태를 조회한다.
+            링크·이미지로 아이템을 추가하면 비동기 파싱이 진행되므로,
+            클라이언트가 status 필드를 폴링해 PROCESSING → READY/FAILED 전환을 감지할 수 있다.
+            - PROCESSING: 파싱 진행 중 (name·price·imageUrl 은 null)
+            - READY: 파싱 완료 (모든 필드 채워짐)
+            - FAILED: 파싱 실패 (상품 페이지 아님 또는 추출 불가)
+            토너먼트 참여자만 조회할 수 있다.
+        """,
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "아이템 조회 성공",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "미인증 (JWT 토큰 없음 또는 유효하지 않음)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "403",
+                description = "권한 없음 (토너먼트 참여자가 아님)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "토너먼트를 찾을 수 없음 · 토너먼트 아이템을 찾을 수 없음 · 아이템이 해당 토너먼트에 속하지 않음",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun getTournamentItem(
+        @Parameter(hidden = true) userId: UUID,
+        @Parameter(description = "토너먼트 ID", example = "1") tournamentId: Long,
+        @Parameter(description = "토너먼트 아이템 ID", example = "10") tournamentItemId: Long,
+    ): ApiResponseBody<TournamentItemDetailResponse>
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApiExamples.kt
@@ -84,7 +84,7 @@ class TournamentApiExamples(
                         add(
                             status = HttpStatus.OK,
                             name = "링크 아이템 추가 성공",
-                            payload = ApiResponseBody.ok(AddTournamentItemFromLinkResponse(itemId = 1L)),
+                            payload = ApiResponseBody.ok(AddTournamentItemFromLinkResponse(tournamentItemId = 1L)),
                         )
                     }
 
@@ -95,7 +95,7 @@ class TournamentApiExamples(
                             name = "이미지 아이템 추가 성공",
                             payload = ApiResponseBody.ok(
                                 AddTournamentItemsFromImagesResponse(
-                                    itemIds = listOf(1L, 2L, 3L),
+                                    tournamentItemIds = listOf(1L, 2L, 3L),
                                 ),
                             ),
                         )

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApiExamples.kt
@@ -7,6 +7,7 @@ import com.depromeet.piki.common.response.ApiResponseBody
 import com.depromeet.piki.item.domain.ItemStatus
 import com.depromeet.piki.tournament.controller.dto.AddTournamentItemFromLinkResponse
 import com.depromeet.piki.tournament.controller.dto.AddTournamentItemsFromImagesResponse
+import com.depromeet.piki.tournament.controller.dto.AddTournamentItemsFromWishResponse
 import com.depromeet.piki.tournament.controller.dto.CreateTournamentResponse
 import com.depromeet.piki.tournament.controller.dto.TournamentDetailResponse
 import com.depromeet.piki.tournament.controller.dto.TournamentItemDetailResponse
@@ -75,7 +76,9 @@ class TournamentApiExamples(
                         add(
                             status = HttpStatus.OK,
                             name = "위시 아이템 추가 성공",
-                            payload = ApiResponseBody.ok<Unit>(),
+                            payload = ApiResponseBody.ok(
+                                AddTournamentItemsFromWishResponse(tournamentItemIds = listOf(10L, 11L)),
+                            ),
                         )
                     }
 

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApiExamples.kt
@@ -4,10 +4,12 @@ import com.depromeet.piki.common.openapi.OpenApiObjectMapper
 import com.depromeet.piki.common.openapi.binds
 import com.depromeet.piki.common.openapi.examples
 import com.depromeet.piki.common.response.ApiResponseBody
+import com.depromeet.piki.item.domain.ItemStatus
 import com.depromeet.piki.tournament.controller.dto.AddTournamentItemFromLinkResponse
 import com.depromeet.piki.tournament.controller.dto.AddTournamentItemsFromImagesResponse
 import com.depromeet.piki.tournament.controller.dto.CreateTournamentResponse
 import com.depromeet.piki.tournament.controller.dto.TournamentDetailResponse
+import com.depromeet.piki.tournament.controller.dto.TournamentItemDetailResponse
 import com.depromeet.piki.tournament.controller.dto.TournamentStartResponse
 import com.depromeet.piki.tournament.controller.dto.TournamentSummaryResponse
 import com.depromeet.piki.tournament.domain.TournamentStatus
@@ -295,6 +297,54 @@ class TournamentApiExamples(
                                             ),
                                     ),
                                 ),
+                        )
+                    }
+                handlerMethod.binds(TournamentController::getTournamentItem) ->
+                    operation.examples(openApiObjectMapper.delegate) {
+                        add(
+                            status = HttpStatus.OK,
+                            name = "READY - 파싱 완료",
+                            payload = ApiResponseBody.ok(
+                                TournamentItemDetailResponse(
+                                    tournamentItemId = 10,
+                                    itemId = 100,
+                                    name = "나이키 에어맥스",
+                                    imageUrl = "https://cdn.example.com/items/1.jpg",
+                                    price = 129_000,
+                                    currency = "KRW",
+                                    status = ItemStatus.READY,
+                                ),
+                            ),
+                        )
+                        add(
+                            status = HttpStatus.OK,
+                            name = "PROCESSING - 파싱 진행 중",
+                            payload = ApiResponseBody.ok(
+                                TournamentItemDetailResponse(
+                                    tournamentItemId = 10,
+                                    itemId = 100,
+                                    name = null,
+                                    imageUrl = null,
+                                    price = null,
+                                    currency = null,
+                                    status = ItemStatus.PROCESSING,
+                                ),
+                            ),
+                        )
+                        add(
+                            status = HttpStatus.OK,
+                            name = "FAILED - 파싱 실패",
+                            payload = ApiResponseBody.ok(
+                                TournamentItemDetailResponse(
+                                    tournamentItemId = 10,
+                                    itemId = 100,
+                                    name = null,
+                                    imageUrl = null,
+                                    price = null,
+                                    currency = null,
+                                    status = ItemStatus.FAILED,
+                                ),
+                            ),
                         )
                     }
             }

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentController.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentController.kt
@@ -63,8 +63,8 @@ class TournamentController(
         @PathVariable tournamentId: Long,
         @Valid @RequestBody request: AddTournamentItemFromLinkRequest,
     ): ApiResponseBody<AddTournamentItemFromLinkResponse> {
-        val itemId = tournamentItemService.addItemFromLink(userId, tournamentId, request.url)
-        return ApiResponseBody.ok(AddTournamentItemFromLinkResponse(itemId))
+        val tournamentItemId = tournamentItemService.addItemFromLink(userId, tournamentId, request.url)
+        return ApiResponseBody.ok(AddTournamentItemFromLinkResponse(tournamentItemId))
     }
 
     @PostMapping("/{tournamentId}/items/images", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
@@ -75,8 +75,8 @@ class TournamentController(
     ): ApiResponseBody<AddTournamentItemsFromImagesResponse> {
         // images 파트 미첨부(0장)는 Spring 이 진입 전 예외로 끊어 캐치올(500)로 가므로,
         // required=false + orEmpty 로 항상 서비스 검증(invalidImageCount, 400)에 닿게 한다.
-        val itemIds = tournamentItemService.addItemsFromImages(userId, tournamentId, images.orEmpty())
-        return ApiResponseBody.ok(AddTournamentItemsFromImagesResponse(itemIds))
+        val tournamentItemIds = tournamentItemService.addItemsFromImages(userId, tournamentId, images.orEmpty())
+        return ApiResponseBody.ok(AddTournamentItemsFromImagesResponse(tournamentItemIds))
     }
 
     @DeleteMapping("/{tournamentId}/items/{tournamentItemId}")

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentController.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentController.kt
@@ -4,6 +4,7 @@ import com.depromeet.piki.common.response.ApiResponseBody
 import com.depromeet.piki.tournament.controller.dto.AddTournamentItemFromLinkRequest
 import com.depromeet.piki.tournament.controller.dto.AddTournamentItemFromLinkResponse
 import com.depromeet.piki.tournament.controller.dto.AddTournamentItemsFromImagesResponse
+import com.depromeet.piki.tournament.controller.dto.AddTournamentItemsFromWishResponse
 import com.depromeet.piki.tournament.controller.dto.AddTournamentItemsRequest
 import com.depromeet.piki.tournament.controller.dto.CreateTournamentRequest
 import com.depromeet.piki.tournament.controller.dto.CreateTournamentResponse
@@ -52,9 +53,9 @@ class TournamentController(
         @AuthenticationPrincipal userId: UUID,
         @PathVariable tournamentId: Long,
         @Valid @RequestBody request: AddTournamentItemsRequest,
-    ): ApiResponseBody<Unit> {
-        tournamentService.addItemsFromWish(userId, request.toAddTournamentItemsFromWish(tournamentId))
-        return ApiResponseBody.ok()
+    ): ApiResponseBody<AddTournamentItemsFromWishResponse> {
+        val tournamentItemIds = tournamentService.addItemsFromWish(userId, request.toAddTournamentItemsFromWish(tournamentId))
+        return ApiResponseBody.ok(AddTournamentItemsFromWishResponse(tournamentItemIds))
     }
 
     @PostMapping("/{tournamentId}/items/link")

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentController.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentController.kt
@@ -9,6 +9,7 @@ import com.depromeet.piki.tournament.controller.dto.CreateTournamentRequest
 import com.depromeet.piki.tournament.controller.dto.CreateTournamentResponse
 import com.depromeet.piki.tournament.controller.dto.RecordMatchRequest
 import com.depromeet.piki.tournament.controller.dto.TournamentDetailResponse
+import com.depromeet.piki.tournament.controller.dto.TournamentItemDetailResponse
 import com.depromeet.piki.tournament.controller.dto.TournamentStartResponse
 import com.depromeet.piki.tournament.controller.dto.TournamentSummaryResponse
 import com.depromeet.piki.tournament.domain.TournamentStatus
@@ -123,5 +124,15 @@ class TournamentController(
     ): ApiResponseBody<TournamentDetailResponse> {
         val detail = tournamentService.getTournamentById(tournamentId, userId)
         return ApiResponseBody.ok(TournamentDetailResponse.from(detail))
+    }
+
+    @GetMapping("/{tournamentId}/items/{tournamentItemId}")
+    override fun getTournamentItem(
+        @AuthenticationPrincipal userId: UUID,
+        @PathVariable tournamentId: Long,
+        @PathVariable tournamentItemId: Long,
+    ): ApiResponseBody<TournamentItemDetailResponse> {
+        val detail = tournamentService.getTournamentItem(userId, tournamentId, tournamentItemId)
+        return ApiResponseBody.ok(TournamentItemDetailResponse.from(detail))
     }
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/dto/AddTournamentItemFromLinkResponse.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/dto/AddTournamentItemFromLinkResponse.kt
@@ -1,5 +1,5 @@
 package com.depromeet.piki.tournament.controller.dto
 
 data class AddTournamentItemFromLinkResponse(
-    val itemId: Long,
+    val tournamentItemId: Long,
 )

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/dto/AddTournamentItemsFromImagesResponse.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/dto/AddTournamentItemsFromImagesResponse.kt
@@ -1,5 +1,5 @@
 package com.depromeet.piki.tournament.controller.dto
 
 data class AddTournamentItemsFromImagesResponse(
-    val itemIds: List<Long>,
+    val tournamentItemIds: List<Long>,
 )

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/dto/AddTournamentItemsFromWishResponse.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/dto/AddTournamentItemsFromWishResponse.kt
@@ -1,0 +1,5 @@
+package com.depromeet.piki.tournament.controller.dto
+
+data class AddTournamentItemsFromWishResponse(
+    val tournamentItemIds: List<Long>,
+)

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/dto/TournamentItemDetailResponse.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/dto/TournamentItemDetailResponse.kt
@@ -1,0 +1,29 @@
+package com.depromeet.piki.tournament.controller.dto
+
+import com.depromeet.piki.item.domain.ItemStatus
+import com.depromeet.piki.tournament.service.dto.TournamentItemDetail
+import com.fasterxml.jackson.annotation.JsonInclude
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class TournamentItemDetailResponse(
+    val tournamentItemId: Long,
+    val itemId: Long,
+    val name: String?,
+    val imageUrl: String?,
+    val price: Int?,
+    val currency: String?,
+    val status: ItemStatus,
+) {
+    companion object {
+        fun from(detail: TournamentItemDetail): TournamentItemDetailResponse =
+            TournamentItemDetailResponse(
+                tournamentItemId = detail.tournamentItemId,
+                itemId = detail.itemId,
+                name = detail.name,
+                imageUrl = detail.imageUrl,
+                price = detail.price,
+                currency = detail.currency,
+                status = detail.status,
+            )
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentItemPersistenceService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentItemPersistenceService.kt
@@ -30,10 +30,10 @@ class TournamentItemPersistenceService(
     ): Long {
         validateAndCheckCapacity(userId, tournamentId, 1)
         val item = itemRepository.save(Item.processing(link))
-        tournamentItemRepository.saveAll(
+        val tournamentItem = tournamentItemRepository.saveAll(
             listOf(TournamentItem(tournamentId = tournamentId, itemId = item.getId(), userId = userId)),
-        )
-        return item.getId()
+        ).first()
+        return tournamentItem.getId()
     }
 
     @Transactional
@@ -44,10 +44,9 @@ class TournamentItemPersistenceService(
     ): List<Long> {
         validateAndCheckCapacity(userId, tournamentId, count)
         val items = itemRepository.saveAll(List(count) { Item(status = ItemStatus.PROCESSING) })
-        tournamentItemRepository.saveAll(
+        return tournamentItemRepository.saveAll(
             items.map { TournamentItem(tournamentId = tournamentId, itemId = it.getId(), userId = userId) },
-        )
-        return items.map { it.getId() }
+        ).map { it.getId() }
     }
 
     private fun validateAndCheckCapacity(

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
@@ -14,6 +14,7 @@ import com.depromeet.piki.tournament.service.dto.AddTournamentItemsFromWish
 import com.depromeet.piki.tournament.service.dto.CreateTournament
 import com.depromeet.piki.tournament.service.dto.RecordMatch
 import com.depromeet.piki.tournament.service.dto.TournamentDetail
+import com.depromeet.piki.tournament.service.dto.TournamentItemDetail
 import com.depromeet.piki.tournament.service.dto.TournamentStartResult
 import com.depromeet.piki.tournament.service.dto.TournamentSummary
 import com.depromeet.piki.user.repository.UserRepository
@@ -236,6 +237,32 @@ class TournamentService(
                 )
             }
         }
+    }
+
+    @Transactional(readOnly = true)
+    fun getTournamentItem(
+        userId: UUID,
+        tournamentId: Long,
+        tournamentItemId: Long,
+    ): TournamentItemDetail {
+        tournamentRepository.findTournamentById(tournamentId)
+            ?: throw TournamentException.notFoundTournament()
+        tournamentUserRepository.findByTournamentIdAndUserId(tournamentId, userId)
+            ?: throw TournamentException.forbiddenTournament()
+        val tournamentItem = tournamentItemRepository.findById(tournamentItemId)
+            ?: throw TournamentException.notFoundTournamentItem()
+        if (tournamentItem.tournamentId != tournamentId) throw TournamentException.notFoundTournamentItem()
+        val item = itemRepository.findById(tournamentItem.itemId)
+            ?: error("item 이 존재하지 않음 — tournamentItemId=$tournamentItemId, itemId=${tournamentItem.itemId}")
+        return TournamentItemDetail(
+            tournamentItemId = tournamentItem.getId(),
+            itemId = item.getId(),
+            name = item.name,
+            imageUrl = item.imageUrl,
+            price = item.currentPrice,
+            currency = item.currency,
+            status = item.status,
+        )
     }
 
     @Transactional(readOnly = true)

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
@@ -53,7 +53,7 @@ class TournamentService(
     fun addItemsFromWish(
         userId: UUID,
         command: AddTournamentItemsFromWish,
-    ) {
+    ): List<Long> {
         val tournament =
             tournamentRepository.findTournamentById(command.tournamentId)
                 ?: throw TournamentException.notFoundTournament()
@@ -80,11 +80,11 @@ class TournamentService(
         if (command.itemIds.any { it !in foundItemIds }) throw TournamentException.notFoundItems()
         // 비동기 파싱 중(PROCESSING)이거나 실패(FAILED)한 상품은 이름·가격이 비어 출전에 부적합하다. READY 만 허용.
         if (foundItems.any { !it.isReady() }) throw TournamentException.itemNotReady()
-        tournamentItemRepository.saveAll(
+        return tournamentItemRepository.saveAll(
             command.itemIds.map { itemId ->
                 TournamentItem(tournamentId = command.tournamentId, itemId = itemId, userId = userId)
             },
-        )
+        ).map { it.getId() }
     }
 
     @Transactional

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
@@ -253,7 +253,7 @@ class TournamentService(
             ?: throw TournamentException.notFoundTournamentItem()
         if (tournamentItem.tournamentId != tournamentId) throw TournamentException.notFoundTournamentItem()
         val item = itemRepository.findById(tournamentItem.itemId)
-            ?: error("item 이 존재하지 않음 — tournamentItemId=$tournamentItemId, itemId=${tournamentItem.itemId}")
+            ?: throw TournamentException.notFoundTournamentItem()
         return TournamentItemDetail(
             tournamentItemId = tournamentItem.getId(),
             itemId = item.getId(),

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/dto/TournamentItemDetail.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/dto/TournamentItemDetail.kt
@@ -1,0 +1,13 @@
+package com.depromeet.piki.tournament.service.dto
+
+import com.depromeet.piki.item.domain.ItemStatus
+
+data class TournamentItemDetail(
+    val tournamentItemId: Long,
+    val itemId: Long,
+    val name: String?,
+    val imageUrl: String?,
+    val price: Int?,
+    val currency: String?,
+    val status: ItemStatus,
+)

--- a/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
@@ -87,7 +87,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
     }
 
     @Test
-    fun `POST tournaments-id-items 는 참여자이면 200 을 반환한다`() {
+    fun `POST tournaments-id-items 는 참여자이면 200 과 함께 tournamentItemIds 를 반환한다`() {
         val mockMvc = buildMockMvc()
         val tournamentId = createTournament(mockMvc)
         val item1Id = saveWishItem()
@@ -101,6 +101,8 @@ class TournamentControllerTest : IntegrationTestSupport() {
                     .content("""{"itemIds":[$item1Id,$item2Id]}"""),
             ).andExpect(status().isOk)
             .andExpect(jsonPath("$.status").value(200))
+            .andExpect(jsonPath("$.data.tournamentItemIds").isArray)
+            .andExpect(jsonPath("$.data.tournamentItemIds.length()").value(2))
     }
 
     @Test
@@ -1018,7 +1020,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
         wishPersistenceService.persist(owner, Item(name = name, currentPrice = price, currency = "KRW")).item.getId()
 
     @Test
-    fun `GET tournaments-id-items-itemId 는 READY 아이템의 이름·가격·이미지·status 를 반환한다`() {
+    fun `GET tournaments-id-items-tournamentItemId 는 READY 아이템의 이름·가격·이미지·status 를 반환한다`() {
         val mockMvc = buildMockMvc()
         val tournamentId = createTournament(mockMvc)
         val itemId = saveWishItem(name = "나이키 에어맥스", price = 129_000)
@@ -1040,7 +1042,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
     }
 
     @Test
-    fun `GET tournaments-id-items-itemId 는 PROCESSING 아이템이면 name·price·imageUrl 이 응답에 없고 status 가 PROCESSING 이다`() {
+    fun `GET tournaments-id-items-tournamentItemId 는 PROCESSING 아이템이면 name·price·imageUrl 이 응답에 없고 status 가 PROCESSING 이다`() {
         val mockMvc = buildMockMvc()
         val tournamentId = createTournament(mockMvc)
         val processingItemId = itemJpaRepository.save(Item(status = ItemStatus.PROCESSING)).getId()
@@ -1059,7 +1061,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
     }
 
     @Test
-    fun `GET tournaments-id-items-itemId 에서 토너먼트 참여자가 아니면 403 을 반환한다`() {
+    fun `GET tournaments-id-items-tournamentItemId 에서 토너먼트 참여자가 아니면 403 을 반환한다`() {
         val mockMvc = buildMockMvc()
         val tournamentId = createTournament(mockMvc)
         addItemsToTournament(mockMvc, tournamentId, userId, saveWishItem())
@@ -1074,7 +1076,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
     }
 
     @Test
-    fun `GET tournaments-id-items-itemId 에서 존재하지 않는 tournamentId 이면 404 를 반환한다`() {
+    fun `GET tournaments-id-items-tournamentItemId 에서 존재하지 않는 tournamentId 이면 404 를 반환한다`() {
         val mockMvc = buildMockMvc()
 
         mockMvc
@@ -1086,7 +1088,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
     }
 
     @Test
-    fun `GET tournaments-id-items-itemId 에서 존재하지 않는 tournamentItemId 이면 404 를 반환한다`() {
+    fun `GET tournaments-id-items-tournamentItemId 에서 존재하지 않는 tournamentItemId 이면 404 를 반환한다`() {
         val mockMvc = buildMockMvc()
         val tournamentId = createTournament(mockMvc)
 
@@ -1099,7 +1101,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
     }
 
     @Test
-    fun `GET tournaments-id-items-itemId 에서 다른 토너먼트 소속 아이템이면 404 를 반환한다`() {
+    fun `GET tournaments-id-items-tournamentItemId 에서 다른 토너먼트 소속 아이템이면 404 를 반환한다`() {
         val mockMvc = buildMockMvc()
         val tournamentId1 = createTournament(mockMvc, "토너먼트1")
         val tournamentId2 = createTournament(mockMvc, "토너먼트2")

--- a/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
@@ -1014,6 +1014,103 @@ class TournamentControllerTest : IntegrationTestSupport() {
     private fun saveWishItem(owner: UUID = userId, name: String = "테스트 아이템", price: Int = 10_000): Long =
         wishPersistenceService.persist(owner, Item(name = name, currentPrice = price, currency = "KRW")).item.getId()
 
+    @Test
+    fun `GET tournaments-id-items-itemId 는 READY 아이템의 이름·가격·이미지·status 를 반환한다`() {
+        val mockMvc = buildMockMvc()
+        val tournamentId = createTournament(mockMvc)
+        val itemId = saveWishItem(name = "나이키 에어맥스", price = 129_000)
+        addItemsToTournament(mockMvc, tournamentId, userId, itemId)
+        val tournamentItemId = tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId).first().getId()
+
+        mockMvc
+            .perform(
+                get("/api/v1/tournaments/$tournamentId/items/$tournamentItemId")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(userId)),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.status").value(200))
+            .andExpect(jsonPath("$.data.tournamentItemId").value(tournamentItemId))
+            .andExpect(jsonPath("$.data.itemId").value(itemId))
+            .andExpect(jsonPath("$.data.name").value("나이키 에어맥스"))
+            .andExpect(jsonPath("$.data.price").value(129_000))
+            .andExpect(jsonPath("$.data.currency").value("KRW"))
+            .andExpect(jsonPath("$.data.status").value("READY"))
+    }
+
+    @Test
+    fun `GET tournaments-id-items-itemId 는 PROCESSING 아이템이면 name·price·imageUrl 이 응답에 없고 status 가 PROCESSING 이다`() {
+        val mockMvc = buildMockMvc()
+        val tournamentId = createTournament(mockMvc)
+        val processingItemId = itemJpaRepository.save(Item(status = ItemStatus.PROCESSING)).getId()
+        tournamentItemJpaRepository.save(TournamentItem(tournamentId = tournamentId, itemId = processingItemId, userId = userId))
+        val tournamentItemId = tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId).first().getId()
+
+        mockMvc
+            .perform(
+                get("/api/v1/tournaments/$tournamentId/items/$tournamentItemId")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(userId)),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.status").value("PROCESSING"))
+            .andExpect(jsonPath("$.data.name").doesNotExist())
+            .andExpect(jsonPath("$.data.price").doesNotExist())
+            .andExpect(jsonPath("$.data.imageUrl").doesNotExist())
+    }
+
+    @Test
+    fun `GET tournaments-id-items-itemId 에서 토너먼트 참여자가 아니면 403 을 반환한다`() {
+        val mockMvc = buildMockMvc()
+        val tournamentId = createTournament(mockMvc)
+        addItemsToTournament(mockMvc, tournamentId, userId, saveWishItem())
+        val tournamentItemId = tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId).first().getId()
+
+        mockMvc
+            .perform(
+                get("/api/v1/tournaments/$tournamentId/items/$tournamentItemId")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(otherUserId)),
+            ).andExpect(status().isForbidden)
+            .andExpect(jsonPath("$.status").value(403))
+    }
+
+    @Test
+    fun `GET tournaments-id-items-itemId 에서 존재하지 않는 tournamentId 이면 404 를 반환한다`() {
+        val mockMvc = buildMockMvc()
+
+        mockMvc
+            .perform(
+                get("/api/v1/tournaments/999999/items/1")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(userId)),
+            ).andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.status").value(404))
+    }
+
+    @Test
+    fun `GET tournaments-id-items-itemId 에서 존재하지 않는 tournamentItemId 이면 404 를 반환한다`() {
+        val mockMvc = buildMockMvc()
+        val tournamentId = createTournament(mockMvc)
+
+        mockMvc
+            .perform(
+                get("/api/v1/tournaments/$tournamentId/items/999999")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(userId)),
+            ).andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.status").value(404))
+    }
+
+    @Test
+    fun `GET tournaments-id-items-itemId 에서 다른 토너먼트 소속 아이템이면 404 를 반환한다`() {
+        val mockMvc = buildMockMvc()
+        val tournamentId1 = createTournament(mockMvc, "토너먼트1")
+        val tournamentId2 = createTournament(mockMvc, "토너먼트2")
+        addItemsToTournament(mockMvc, tournamentId2, userId, saveWishItem())
+        val itemOfTournament2 = tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId2).first().getId()
+
+        mockMvc
+            .perform(
+                get("/api/v1/tournaments/$tournamentId1/items/$itemOfTournament2")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(userId)),
+            ).andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.status").value(404))
+    }
+
     private fun startTournamentWith2Items(mockMvc: MockMvc): TournamentStart {
         val tournamentId = createTournament(mockMvc)
         addItemsToTournament(mockMvc, tournamentId, userId, saveWishItem(name = "아이템1"), saveWishItem(name = "아이템2"))

--- a/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
@@ -765,7 +765,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
     }
 
     @Test
-    fun `POST tournaments-id-items-link 는 참여자이면 PROCESSING 아이템을 생성하고 itemId 를 반환한다`() {
+    fun `POST tournaments-id-items-link 는 참여자이면 PROCESSING 아이템을 생성하고 tournamentItemId 를 반환한다`() {
         stubItemParsingWorker.enabled = false
         try {
             val mockMvc = buildMockMvc()
@@ -780,12 +780,15 @@ class TournamentControllerTest : IntegrationTestSupport() {
                             .content("""{"url":"https://example.com/product"}"""),
                     ).andExpect(status().isOk)
                     .andExpect(jsonPath("$.status").value(200))
-                    .andExpect(jsonPath("$.data.itemId").isNumber)
+                    .andExpect(jsonPath("$.data.tournamentItemId").isNumber)
                     .andReturn()
 
-            val itemId = objectMapper.readTree(result.response.contentAsString)["data"]["itemId"].asLong()
-            assertEquals(1, tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId).size)
-            assertEquals(ItemStatus.PROCESSING, itemJpaRepository.findById(itemId).orElseThrow().status)
+            val tournamentItemId = objectMapper.readTree(result.response.contentAsString)["data"]["tournamentItemId"].asLong()
+            val tournamentItem = tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId).also {
+                assertEquals(1, it.size)
+            }.first()
+            assertEquals(tournamentItemId, tournamentItem.getId())
+            assertEquals(ItemStatus.PROCESSING, itemJpaRepository.findById(tournamentItem.itemId).orElseThrow().status)
         } finally {
             stubItemParsingWorker.enabled = true
         }
@@ -836,7 +839,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
     }
 
     @Test
-    fun `POST tournaments-id-items-images 는 참여자이면 PROCESSING 아이템을 생성하고 itemIds 를 반환한다`() {
+    fun `POST tournaments-id-items-images 는 참여자이면 PROCESSING 아이템을 생성하고 tournamentItemIds 를 반환한다`() {
         stubImageParsingWorker.enabled = false
         try {
             val mockMvc = buildMockMvc()
@@ -852,8 +855,8 @@ class TournamentControllerTest : IntegrationTestSupport() {
                         .header(HttpHeaders.AUTHORIZATION, authHeader(userId)),
                 ).andExpect(status().isOk)
                 .andExpect(jsonPath("$.status").value(200))
-                .andExpect(jsonPath("$.data.itemIds").isArray)
-                .andExpect(jsonPath("$.data.itemIds.length()").value(2))
+                .andExpect(jsonPath("$.data.tournamentItemIds").isArray)
+                .andExpect(jsonPath("$.data.tournamentItemIds.length()").value(2))
 
             assertEquals(2, tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId).size)
         } finally {


### PR DESCRIPTION
## Situation
- 링크·이미지로 토너먼트 아이템을 추가하면 비동기 파싱이 시작되어 PROCESSING → READY/FAILED 전환이 발생한다. 클라이언트가 이 상태 변화를 감지하려면 단건 조회 API가 필요하다.
- 기존 아이템 추가 3종(링크/이미지/위시) 응답 필드명이 제각각이었다 — 링크는 `itemId`, 이미지는 `itemIds`를 반환해 item ID인지 tournamentItem ID인지 모호했고, 위시 추가는 ID를 전혀 반환하지 않아 클라이언트가 단건 조회로 이어갈 방법이 없었다.

## Task
- `GET /tournaments/{tournamentId}/items/{tournamentItemId}` 단건 조회 엔드포인트 추가
- 3종 아이템 추가 응답 필드명을 `tournamentItemId(s)`로 통일해 클라이언트가 단건 조회로 바로 이어갈 수 있도록 한다

## Action

### 단건 조회 API
- `TournamentItemDetail` 서비스 DTO · `TournamentItemDetailResponse` 응답 DTO 신규 추가
- `TournamentService.getTournamentItem`: 토너먼트 존재 확인 → 참여자 권한 확인 → 아이템 소속 확인 순으로 검증. `tournamentItem.tournamentId != tournamentId` 체크로 다른 토너먼트 소속 아이템에 404 반환
- PROCESSING 상태에서 name·price·imageUrl 은 null이므로 `@JsonInclude(NON_NULL)` 적용해 응답에서 제외
- OpenAPI 문서에 READY/PROCESSING/FAILED 세 가지 example 추가, status별 필드 상태 description에 명세

### 추가 응답 일관성 수정
- 링크 추가: `itemId → tournamentItemId`, 이미지 추가: `itemIds → tournamentItemIds` — 반환값이 item ID가 아닌 tournamentItem ID임을 명확히
- 위시 추가: `Unit` → `AddTournamentItemsFromWishResponse(tournamentItemIds)` — 클라이언트가 응답의 tournamentItemId로 바로 단건 조회에 이어갈 수 있도록
- 서비스·퍼시스턴스 레이어도 `item.getId()` → `tournamentItem.getId()` 반환으로 수정

## Result
- 클라이언트가 아이템 추가 직후 받은 `tournamentItemId`로 폴링해 비동기 파싱 완료를 감지할 수 있다
- 3종 추가 응답이 모두 `tournamentItemId(s)` 필드로 통일되어 클라이언트 파싱 코드가 단순해진다

---
## 연관 이슈

- close #284


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 토너먼트 아이템 상세 조회 API 추가 (상태: 준비 완료/처리 중/실패)

* **개선 사항**
  * 위시 기반 아이템 추가 시 생성된 아이템 ID 목록 반환
  * 링크 및 이미지 기반 아이템 추가 API 응답 필드명 정규화
  * API 응답 구조 개선으로 사용성 향상

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/PIKI-Server/pull/286?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->