### PR TITLE
직접 수정한 FAILED 위시 항목을 READY 로 복구

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/item/domain/Item.kt
+++ b/src/main/kotlin/com/depromeet/piki/item/domain/Item.kt
@@ -45,7 +45,8 @@ class Item(
     var currency: String? = currency
         protected set
 
-    // 파싱 생애주기. 전이는 markReady/markFailed 로만 일어난다 (setter 비노출).
+    // 파싱 생애주기. PROCESSING→READY/FAILED 전이는 markReady/markFailed 로,
+    // FAILED→READY 복구는 사용자 직접 수정(update)으로 일어난다 (setter 비노출).
     // 기본값 READY 는 동기 완성 경로(Item.from)·DB 로딩 행과의 호환을 위한 것이고,
     // 비동기 등록은 Item.processing 으로 PROCESSING 을 명시한다.
     @Enumerated(EnumType.STRING)
@@ -90,6 +91,13 @@ class Item(
         this.currentPrice = newCurrentPrice
         this.imageUrl = newImageUrl
         this.currency = newCurrency
+        // 사용자가 직접 정보를 보정하면 추출 실패(FAILED) item 도 정상 항목이 된 것이므로 READY 로 복구한다.
+        // PROCESSING(파싱 중)은 백그라운드 워커의 markReady/markFailed 가 책임지므로 여기서 건드리지 않는다.
+        // (markReady 가 호출하는 update 도 이 시점 status 가 PROCESSING 이라 이 분기에 걸리지 않는다.)
+        if (status == ItemStatus.FAILED) {
+            status = ItemStatus.READY
+            log.info("item {} 사용자 직접 수정으로 FAILED → READY 복구", getIdOrNull())
+        }
     }
 
     // PROCESSING → READY. 백그라운드 파싱이 성공해 추출 결과(snapshot)를 채우며 전이한다.

--- a/src/main/kotlin/com/depromeet/piki/wishlist/controller/WishlistApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/wishlist/controller/WishlistApi.kt
@@ -200,6 +200,7 @@ interface WishlistApi {
         description = """
             위시 항목에 연결된 상품(item)의 이름·현재가·이미지·통화를 수정한다. 들어온 필드만 갱신한다.
             본인 위시만 수정 가능하며, item 을 직접 노출하지 않고 위시 소유 단위로 권한을 검증한다.
+            추출 실패(FAILED) 항목을 직접 보정하면 status 가 READY 로 복구된다.
         """,
     )
     @ApiResponses(

--- a/src/test/kotlin/com/depromeet/piki/item/domain/ItemTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/item/domain/ItemTest.kt
@@ -236,4 +236,36 @@ class ItemTest {
         assertFalse(Item.processing(link).isReady())
         assertFalse(Item.processing(link).apply { markFailed() }.isReady())
     }
+
+    @Test
+    fun `FAILED item 을 update 로 직접 보정하면 READY 로 복구되며 보정값이 반영된다`() {
+        val item = Item.processing(link).apply { markFailed() }
+
+        item.update(name = "직접 입력한 이름", currentPrice = 50_000)
+
+        assertEquals(ItemStatus.READY, item.status)
+        assertEquals("직접 입력한 이름", item.name)
+        assertEquals(50_000, item.currentPrice)
+    }
+
+    @Test
+    fun `READY item 을 update 해도 READY 를 유지한다`() {
+        val item = Item.from(ProductSnapshot(link = link, name = "나이키"))
+
+        item.update(name = "수정된 이름")
+
+        assertEquals(ItemStatus.READY, item.status)
+    }
+
+    @Test
+    fun `PROCESSING item 을 update 해도 PROCESSING 을 유지한다`() {
+        // 파싱 중 항목의 status 전이는 백그라운드 워커(markReady/markFailed)가 책임지므로,
+        // 사용자 update 는 정보만 바꾸고 PROCESSING 은 건드리지 않는다.
+        val item = Item.processing(link)
+
+        item.update(name = "끼어든 수정")
+
+        assertEquals(ItemStatus.PROCESSING, item.status)
+        assertEquals("끼어든 수정", item.name)
+    }
 }

--- a/src/test/kotlin/com/depromeet/piki/wishlist/controller/WishlistControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/wishlist/controller/WishlistControllerIntegrationTest.kt
@@ -93,6 +93,19 @@ class WishlistControllerIntegrationTest : IntegrationTestSupport() {
             ).wish
             .getId()
 
+    // FAILED 상태 item+wish 시딩 — 추출 실패 항목을 사용자가 직접 보정하는 시나리오용.
+    // 등록 API(비동기 파싱)를 거치지 않고 markFailed 로 FAILED 상태를 바로 만들어 영속화한다.
+    private fun seedFailedWish(
+        userId: UUID,
+        url: String,
+    ): Long =
+        wishPersistenceService
+            .persist(
+                userId,
+                Item.processing(ProductLink.parse(url)).apply { markFailed() },
+            ).wish
+            .getId()
+
     @Test
     fun `url 이 빈 문자열이면 400 BAD_REQUEST 가 반환된다`() {
         val mockMvc = buildMockMvc()
@@ -353,6 +366,35 @@ class WishlistControllerIntegrationTest : IntegrationTestSupport() {
             .andExpect(jsonPath("$.data.item.currentPrice").value(50_000))
             .andExpect(jsonPath("$.data.item.currency").value("KRW"))
             .andExpect(jsonPath("$.data.item.imageUrl").value("https://cdn.example.com/orig.jpg"))
+    }
+
+    @Test
+    fun `FAILED 상태인 위시 item 을 직접 수정하면 200 과 함께 status 가 READY 로 복구된다`() {
+        val mockMvc = buildMockMvc()
+        val userId = UUID.randomUUID()
+        insertMember(userId)
+        val authHeader = "Bearer ${memberToken(userId)}"
+        val wishId = seedFailedWish(userId, "https://shop.example.com/products/1")
+        val body =
+            objectMapper.writeValueAsString(
+                mapOf(
+                    "name" to "직접 입력한 이름",
+                    "currentPrice" to 50_000,
+                ),
+            )
+
+        mockMvc
+            .perform(
+                patch("/api/v1/wishlists/$wishId")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header(HttpHeaders.AUTHORIZATION, authHeader)
+                    .content(body),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.status").value(200))
+            .andExpect(jsonPath("$.data.item.name").value("직접 입력한 이름"))
+            .andExpect(jsonPath("$.data.item.currentPrice").value(50_000))
+            // 추출 실패(FAILED) 항목을 직접 보정하면 정상 항목이 된 것이므로 READY 로 복구된다.
+            .andExpect(jsonPath("$.data.item.status").value("READY"))
     }
 
     @Test


### PR DESCRIPTION
## Situation
- PATCH `/api/v1/wishlists/{wishId}` 로 `name`·`currentPrice` 등을 직접 입력해 수정해도 `item.status` 가 `FAILED` 에 머무는 버그가 보고됐다.
- 추출 실패(`FAILED`)한 항목을 사용자가 손수 보정하면 정상 항목이 되어야 하는데, status 가 `FAILED` 로 남아 토너먼트 출전 등 "완성된 상품만" 요구하는 곳에서 계속 배제됐다.

## Task
- 사용자가 직접 보정한 `FAILED` 항목을 `READY` 로 복구하는 경로를 만든다.
- 단, 파싱 생애주기 전이 규칙(`PROCESSING → READY/FAILED` 는 백그라운드 워커가 책임)을 깨지 않아야 한다.

## Action

### 원인과 수정
- 원인: `Item.update()` 가 `name`·`currentPrice`·`imageUrl`·`currency` 만 갱신하고 `status` 는 건드리지 않았다. `FAILED → READY` 로 되돌리는 경로가 코드에 아예 없었다 (`markReady`/`markFailed` 는 `PROCESSING` 에서만 호출 가능).
- `update()` 끝에 `FAILED → READY` 복구를 추가했다. 도메인이 자기방어하도록 `update()` 안에 두어, wish·tournament 어느 통로로 수정하든 일관되게 복구된다.

### 전이 정책 결정
- "`FAILED` 일 때만 `READY` 로" 를 택했다. `PROCESSING` 을 `READY` 로 바꾸면 이후 워커의 `markReady`/`markFailed` 가 `check(PROCESSING)` 에서 500 으로 터지기 때문. `PROCESSING` 은 백그라운드 워커에 맡기고 `update` 는 건드리지 않는다.
- `markReady` 가 내부적으로 호출하는 `update` 도 그 시점 status 가 `PROCESSING` 이라 이 분기에 걸리지 않아, 기존 전이 흐름이 깨지지 않음을 확인했다.
- `WishlistApi` 의 `updateWish` 문서에 복구 동작을 한 줄 명시했다 (응답 코드는 200/400/401/403/404 그대로라 `@ApiResponses`·example 은 불변).

### 테스트
- `ItemTest`: `FAILED→READY` 복구, `READY` 유지, `PROCESSING` 유지 3건의 상태 전이 분기를 단위 테스트로 망라.
- `WishlistControllerIntegrationTest`: `seedFailedWish` 헬퍼로 `FAILED` 항목을 시딩하고, PATCH 응답의 `item.status` 가 `READY` 로 내려가는 contract 를 검증.
- 단위 + 통합 전체 BUILD SUCCESSFUL.

## Result
- `FAILED` 항목을 직접 보정하면 status 가 `READY` 로 복구되어 보고된 버그가 해소된다.
- `isReady()` 가 true 가 되므로 복구된 항목이 토너먼트 출전 등에도 정상 포함된다.
- 주의: `PROCESSING` 중인 항목을 PATCH 로 수정하면 정보는 바뀌지만 status 는 `PROCESSING` 을 유지한다 — 이후 백그라운드 파싱이 snapshot 으로 덮어쓸 수 있다 (이번 스코프 밖, 의도된 동작).

---
## 연관 이슈

- 
