### PR TITLE
actuator/prometheus 메트릭 엔드포인트 노출

### DIFF
--- a/.github/workflows/deploy-manual.yml
+++ b/.github/workflows/deploy-manual.yml
@@ -110,9 +110,11 @@ jobs:
             docker pull "$IMAGE"
             docker stop team3-server || true
             docker rm team3-server || true
+            # -p 를 127.0.0.1 에 바인딩해 호스트 공인 IP(EIP)로의 직접 접근을 막는다 (deploy.yml 과 동일 정책 —
+            # nginx·health check 는 localhost 접근이라 무영향, actuator/prometheus 외부 직접 scrape 우회만 차단).
             docker run -d \
               --name team3-server \
-              -p 8080:8080 \
+              -p 127.0.0.1:8080:8080 \
               -e GEMINI_API_KEY="$GEMINI_API_KEY" \
               -e DB_HOST="$DB_HOST" \
               -e DB_PORT="$DB_PORT" \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -185,10 +185,15 @@ jobs:
             docker stop "team3-$INACTIVE" || true
             docker rm "team3-$INACTIVE" || true
 
-            # 새 버전 비활성 포트에 기동
+            # 새 버전 비활성 포트에 기동.
+            # -p 를 127.0.0.1 에 바인딩해 호스트 공인 IP(EIP)로의 직접 접근을 막는다. nginx(호스트 프로세스)와
+            # health check 는 localhost 로 접근하므로 영향 없고, actuator/prometheus 가 SG ingress 설정과 무관하게
+            # 외부에서 직접 scrape 되는 우회 경로를 구조적으로 차단한다 (nginx /actuator 차단의 보강).
+            # 주의: 별도 PR 의 Grafana Alloy 는 같은 호스트의 컨테이너이므로 --network host 로 띄워 localhost 를 scrape 해야 한다
+            #       (redis 가 쓰는 172.17.0.1 bridge 바인딩 방식으로는 127.0.0.1 바인딩 포트에 닿지 못한다).
             docker run -d \
               --name "team3-$INACTIVE" \
-              -p "$INACTIVE_PORT:8080" \
+              -p "127.0.0.1:$INACTIVE_PORT:8080" \
               -e JAVA_TOOL_OPTIONS="-Xmx256m -Xms64m" \
               -e GEMINI_API_KEY="$GEMINI_API_KEY" \
               -e DB_HOST="$DB_HOST" \

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,6 +54,12 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
 
+    // 옵저버빌리티: Actuator 로 health/metrics 노출 + Micrometer Prometheus 레지스트리로
+    // /actuator/prometheus 텍스트 포맷 export. 수집은 EC2 의 Grafana Alloy → Grafana Cloud (별도 PR).
+    // 버전은 Spring Boot BOM 이 관리한다.
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("io.micrometer:micrometer-registry-prometheus")
+
     // 크롭한 상품 이미지를 S3 에 업로드 (#144). 버전은 BOM 이 관리.
     implementation("software.amazon.awssdk:s3")
 

--- a/infra/nginx/api.depromeet18team3.cloud.conf
+++ b/infra/nginx/api.depromeet18team3.cloud.conf
@@ -20,6 +20,11 @@ server {
     # actuator 엔드포인트는 외부에 노출하지 않는다. 메트릭(/actuator/prometheus)·health 는
     # EC2 내부의 Grafana Alloy 가 localhost 컨테이너 포트로 직접 scrape 하므로 nginx 를 거치지 않는다.
     # ^~ 접두어 매칭이 아래 정규/일반 `location /` 보다 우선해, /actuator/* 외부 요청은 앱까지 가지 않고 여기서 끊긴다.
+    # `^~ /actuator/` 는 슬래시로 끝나는 prefix 라 슬래시 없는 부모 경로 `/actuator`(actuator 인덱스)는
+    # 안 잡혀 location / 로 새어 나간다. `= /actuator` 정확 매칭을 따로 둬 그 구멍을 막는다.
+    location = /actuator {
+        return 403;
+    }
     location ^~ /actuator/ {
         return 403;
     }

--- a/infra/nginx/api.depromeet18team3.cloud.conf
+++ b/infra/nginx/api.depromeet18team3.cloud.conf
@@ -17,6 +17,13 @@ server {
 
     client_max_body_size 25M;
 
+    # actuator 엔드포인트는 외부에 노출하지 않는다. 메트릭(/actuator/prometheus)·health 는
+    # EC2 내부의 Grafana Alloy 가 localhost 컨테이너 포트로 직접 scrape 하므로 nginx 를 거치지 않는다.
+    # ^~ 접두어 매칭이 아래 정규/일반 `location /` 보다 우선해, /actuator/* 외부 요청은 앱까지 가지 않고 여기서 끊긴다.
+    location ^~ /actuator/ {
+        return 403;
+    }
+
     location / {
         proxy_pass http://team3;
         proxy_set_header Host $host;

--- a/src/main/kotlin/com/depromeet/piki/auth/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/config/SecurityConfig.kt
@@ -37,6 +37,12 @@ class SecurityConfig(
                     // 신규 컨테이너 롤백 → 배포 차단으로 이어진다.
                     .requestMatchers(HttpMethod.GET, "/health")
                     .permitAll()
+                    // actuator health/prometheus 는 EC2 내부의 Grafana Alloy 가 localhost 로
+                    // 직접 scrape 한다 (nginx 미경유). 외부 도달은 nginx 가 /actuator/ 를 403 으로
+                    // 차단(infra/nginx/...conf)하므로, 앱 레벨 permitAll + 네트워크 레벨 차단의 2층 구조다.
+                    // metrics·env 등 나머지 actuator 엔드포인트는 application.yml 에서 애초에 노출하지 않는다.
+                    .requestMatchers(HttpMethod.GET, "/actuator/health", "/actuator/prometheus")
+                    .permitAll()
                     .requestMatchers(HttpMethod.POST, "/api/v1/auth/guest")
                     .permitAll()
                     .requestMatchers(HttpMethod.POST, "/api/v1/auth/token/refresh")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -66,3 +66,17 @@ springdoc:
   api-docs:
     path: /v3/api-docs
   default-produces-media-type: application/json
+
+management:
+  endpoints:
+    web:
+      exposure:
+        # 최소 노출: health(상태), info(빌드 정보), prometheus(메트릭 scrape).
+        # metrics 등 나머지 actuator 엔드포인트는 노출하지 않는다.
+        # 외부(nginx 443) 는 /actuator/ 를 차단하고, EC2 내부의 Grafana Alloy 만
+        # localhost 로 /actuator/prometheus 를 scrape 한다 (별도 PR).
+        include: health, info, prometheus
+  metrics:
+    tags:
+      # Grafana Cloud 에서 서비스 단위로 메트릭을 구분하는 공통 라벨.
+      application: ${spring.application.name}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -71,11 +71,12 @@ management:
   endpoints:
     web:
       exposure:
-        # 최소 노출: health(상태), info(빌드 정보), prometheus(메트릭 scrape).
-        # metrics 등 나머지 actuator 엔드포인트는 노출하지 않는다.
+        # 최소 노출: health(상태), prometheus(메트릭 scrape) 둘뿐.
+        # info·metrics·env 등 나머지 actuator 엔드포인트는 노출하지 않는다 (info 는 contributor 가
+        # 없어 빈 응답이라 노출 표면만 늘릴 뿐이고, Alloy 도 prometheus·health 만 긁는다).
         # 외부(nginx 443) 는 /actuator/ 를 차단하고, EC2 내부의 Grafana Alloy 만
         # localhost 로 /actuator/prometheus 를 scrape 한다 (별도 PR).
-        include: health, info, prometheus
+        include: health, prometheus
   metrics:
     tags:
       # Grafana Cloud 에서 서비스 단위로 메트릭을 구분하는 공통 라벨.

--- a/src/test/kotlin/com/depromeet/piki/common/controller/ActuatorIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/common/controller/ActuatorIntegrationTest.kt
@@ -53,9 +53,13 @@ class ActuatorIntegrationTest : IntegrationTestSupport() {
 
     @Test
     fun `GET actuator metrics - 미노출 경로라 인증 없이 접근 시 401 (노출 정책 회귀 가드)`() {
-        // metrics 엔드포인트는 application.yml exposure.include 에서 제외했고
-        // SecurityConfig 에서도 permitAll 하지 않았다. anyRequest().authenticated() 에 걸려 401.
-        // 향후 실수로 metrics 를 노출+permitAll 하면 이 단언이 깨져 회귀를 잡는다.
+        // metrics 엔드포인트는 application.yml exposure.include 에서 제외했고 SecurityConfig
+        // permitAll 에도 없다. permitAll 이 아니므로 anyRequest().authenticated() 에 걸려 인증 없이는 401.
+        //
+        // 주의 — 이 401 은 "permitAll 아님"만 증명한다. Security 필터가 DispatcherServlet 보다 먼저라
+        // 엔드포인트 등록 여부와 무관하게 401 이 난다. 따라서 누군가 metrics 를 exposure 에 노출하되
+        // permitAll 을 빠뜨리면 여전히 401 이라 이 가드는 못 잡는다. 이 가드가 실제로 막는 회귀는
+        // "노출 + permitAll 까지 돼 외부에 열리는" 경우다 (그 조합이면 200 이 되어 단언이 깨진다).
         val mockMvc =
             MockMvcBuilders
                 .webAppContextSetup(webApplicationContext)

--- a/src/test/kotlin/com/depromeet/piki/common/controller/ActuatorIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/common/controller/ActuatorIntegrationTest.kt
@@ -1,0 +1,69 @@
+package com.depromeet.piki.common.controller
+
+import com.depromeet.piki.support.IntegrationTestSupport
+import org.hamcrest.Matchers.containsString
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.web.context.WebApplicationContext
+
+class ActuatorIntegrationTest : IntegrationTestSupport() {
+    @Autowired
+    private lateinit var webApplicationContext: WebApplicationContext
+
+    @Test
+    fun `GET actuator health - 인증 없이 200, status UP 이 와야 한다 (Alloy scrape 가드)`() {
+        // EC2 내부 Grafana Alloy 가 인증 없이 localhost 로 scrape 해야 한다.
+        // SecurityConfig 의 permitAll 이 누락되면 401 이 되어 수집이 끊긴다.
+        // actuator health 응답은 ApiResponseBody 래퍼가 아닌 actuator 고유 포맷이라
+        // $.status 는 우리 API 의 숫자 코드가 아니라 문자열 "UP" 이다.
+        val mockMvc =
+            MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .apply<DefaultMockMvcBuilder>(springSecurity())
+                .build()
+
+        mockMvc
+            .perform(get("/actuator/health"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.status").value("UP"))
+    }
+
+    @Test
+    fun `GET actuator prometheus - 인증 없이 200, JVM 메트릭 텍스트가 노출돼야 한다`() {
+        // micrometer-registry-prometheus 가 클래스패스에 있고 prometheus 엔드포인트가
+        // exposure.include 에 포함돼야 텍스트 포맷 메트릭이 노출된다.
+        val mockMvc =
+            MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .apply<DefaultMockMvcBuilder>(springSecurity())
+                .build()
+
+        mockMvc
+            .perform(get("/actuator/prometheus"))
+            .andExpect(status().isOk)
+            .andExpect(content().string(containsString("jvm_")))
+    }
+
+    @Test
+    fun `GET actuator metrics - 미노출 경로라 인증 없이 접근 시 401 (노출 정책 회귀 가드)`() {
+        // metrics 엔드포인트는 application.yml exposure.include 에서 제외했고
+        // SecurityConfig 에서도 permitAll 하지 않았다. anyRequest().authenticated() 에 걸려 401.
+        // 향후 실수로 metrics 를 노출+permitAll 하면 이 단언이 깨져 회귀를 잡는다.
+        val mockMvc =
+            MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .apply<DefaultMockMvcBuilder>(springSecurity())
+                .build()
+
+        mockMvc
+            .perform(get("/actuator/metrics"))
+            .andExpect(status().isUnauthorized)
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -26,3 +26,14 @@ s3:
   bucket: test-bucket
   region: ap-northeast-2
   public-base-url: https://test-bucket.s3.ap-northeast-2.amazonaws.com
+
+# actuator 노출은 운영과 동일하게 박는다 — test classpath 의 application.yml 이 main 을 대체하므로
+# 여기 없으면 health(기본 노출)만 떠 /actuator/prometheus 통합 테스트가 깨진다.
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, prometheus
+  metrics:
+    tags:
+      application: ${spring.application.name}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -33,7 +33,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health, info, prometheus
+        include: health, prometheus
   metrics:
     tags:
       application: ${spring.application.name}


### PR DESCRIPTION
## Situation
- PIKI 서버에 옵저버빌리티가 전무했다. `actuator` / `micrometer` 의존성 자체가 없어 JVM·HTTP·DB 커넥션풀 상태를 외부에서 관측할 수 없고, 장애 시 `docker logs` 수동 확인이 유일한 수단이었다.
- 목표는 메트릭 + 로그 + 대시보드를 Grafana Cloud 무료티어로 보내는 것. EC2 가 906Mi(swap 1G 의존) 박스라 Prometheus/Grafana 셀프호스팅은 메모리 부담이 커, 수집기 한 개(Grafana Alloy)만 박스에 띄워 GC 로 remote-write 하는 구조로 합의했다.

## Task
- 옵저버빌리티 도입 1단계: 앱이 Prometheus 포맷 메트릭을 노출하게 만든다.
- 수집기·대시보드는 후속 PR 로 분리한다 — Grafana Cloud 자격증명 발급이 사용자 액션이라, 이 PR 이 거기에 블로킹되지 않도록 2단계로 나눴다. 이 PR 은 자격증명 없이도 안전하게 머지 가능하다.

## Action
### 계측
- `spring-boot-starter-actuator` + `io.micrometer:micrometer-registry-prometheus` 추가 (버전은 Spring Boot 4.0.5 BOM 관리).
- `management.endpoints.web.exposure.include` 를 health·info·prometheus 로 최소화. metrics 등 나머지 엔드포인트는 노출하지 않는다. Grafana Cloud 서비스 구분용 `management.metrics.tags.application` 공통 라벨 추가.

### 2층 보안
- SecurityConfig 에서 `/actuator/health`·`/actuator/prometheus` 만 permitAll — 수집기(Alloy)가 nginx 를 거치지 않고 EC2 내부 localhost 컨테이너 포트로 직접 scrape 하므로 앱 레벨 허용이 필요하다.
- nginx 에 `location ^~ /actuator/ { return 403; }` 추가로 외부(443) 접근을 차단. 앱 레벨 허용 + 네트워크 레벨 차단의 2층 구조다.

### 테스트 + 디버깅
- 통합 테스트 3종: health(200·UP) / prometheus(200·jvm_ 메트릭 포함) / metrics(미노출 → 인증 없이 접근 시 401 회귀 가드).
- Boot 4.0 함정 정정: test classpath 의 `application.yml` 이 main 을 통째로 대체하는 기존 구조 때문에, 운영은 정상인데 통합 테스트에서만 `exposure.include` 가 null 로 바인딩돼 health(기본 노출)만 떴다. 진단으로 원인을 확인하고 test yaml 에도 동일 management 블록을 박아 정정.

## Result
- `/actuator/prometheus` 가 Prometheus 텍스트 포맷 메트릭을 노출. 외부에는 nginx 가 403 으로 차단.
- 전체 383개 테스트 통과 (실패 0).
- 후속 PR2(Grafana Alloy 수집기 IaC): scrape → GC Mimir, docker 로그 → GC Loki. 블로커는 사용자 액션 — Grafana Cloud 스택 생성 후 remote_write/Loki 자격증명 secret 6종 등록.

---
## 연관 이슈

- 

## Updates

### 코드리뷰(/code-review xhigh) 반영 (`807bc7c`)
- **info 엔드포인트 노출 제거** — info contributor(buildInfo 등)가 없어 `/actuator/info` 는 빈 `{}` 만 응답하는 dead config 였다. `exposure.include` 를 `health, prometheus` 로 축소해 노출 표면을 줄였다.
- **nginx `/actuator` 부모경로 차단 보강** — `^~ /actuator/`(슬래시 prefix)는 슬래시 없는 `/actuator`(actuator 인덱스)를 안 잡아 `location /` 로 새던 구멍이 있었다. `= /actuator` 정확 매칭을 추가해 막았다.
- **docker 포트 127.0.0.1 바인딩** — deploy.yml·deploy-manual.yml 의 `-p` 를 `0.0.0.0` → `127.0.0.1:$PORT:8080` 으로 좁혀, SG ingress 가 8080/8081 을 열어도 외부에서 nginx 를 우회해 `/actuator/prometheus` 를 직접 scrape 하던 경로를 구조적으로 차단했다. nginx(호스트 프로세스)·health check 는 localhost 접근이라 무영향. (후속 PR 의 Grafana Alloy 는 `--network host` 로 띄워 localhost 를 scrape 해야 한다.)
- metrics→401 테스트 가드 주석을 실제 커버리지("노출+permitAll 조합만 차단, 노출 단독은 못 잡음")로 정정했다.
- `management.metrics.tags.application` 은 Boot 4.0.5 에서 정상 동작함을 실측(prometheus 출력에 application 라벨 부착)으로 확인 — 리뷰의 deprecated 우려는 기각, 변경 없음.

