### PR TITLE
Grafana Alloy 수집기로 메트릭·로그를 Grafana Cloud 로 수집

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,13 @@ KAKAO_REDIRECT_URI=
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 GOOGLE_REDIRECT_URI=
+
+# Grafana Cloud — EC2 의 Grafana Alloy 수집기가 메트릭·로그를 remote-write 할 때만 쓴다.
+# 로컬 개발엔 불필요(빈 값이면 배포 시 Alloy 기동 자체를 skip). 운영은 GitHub Actions secret 으로 주입.
+# token 1개를 metrics·logs 가 공유하고, URL·USER 는 Prometheus / Loki 가 각각 다르다.
+# (GC 발급 구조가 token 을 분리한다면 token 을 2종으로 늘리면 됨 — config.alloy 의 password 만 분리.)
+GRAFANA_METRICS_URL=
+GRAFANA_METRICS_USER=
+GRAFANA_LOGS_URL=
+GRAFANA_LOGS_USER=
+GRAFANA_CLOUD_TOKEN=

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -115,12 +115,33 @@ jobs:
           target: "/tmp/team3-provision"
           strip_components: 2
 
-      - name: Provision runtime (swap·redis·nginx default)
-        uses: appleboy/ssh-action@v1
+      - name: Upload Alloy config
+        uses: appleboy/scp-action@v1
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
+          source: "infra/alloy/config.alloy"
+          target: "/tmp/team3-alloy"
+          strip_components: 2
+
+      - name: Provision runtime (swap·redis·nginx·alloy)
+        uses: appleboy/ssh-action@v1
+        env:
+          # Alloy 가 Grafana Cloud 로 remote-write 할 자격증명. 미등록(빈 값)이면 provision-runtime.sh 가
+          # Alloy 기동을 skip 한다. token 1개를 metrics·logs 가 공유, URL·USER 는 Prometheus/Loki 각각.
+          GRAFANA_METRICS_URL: ${{ secrets.GRAFANA_METRICS_URL }}
+          GRAFANA_METRICS_USER: ${{ secrets.GRAFANA_METRICS_USER }}
+          GRAFANA_LOGS_URL: ${{ secrets.GRAFANA_LOGS_URL }}
+          GRAFANA_LOGS_USER: ${{ secrets.GRAFANA_LOGS_USER }}
+          GRAFANA_CLOUD_TOKEN: ${{ secrets.GRAFANA_CLOUD_TOKEN }}
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          # appleboy/ssh-action 이 envs 목록을 SSH 세션에 export 하므로, script 가 실행하는
+          # provision-runtime.sh 자식 프로세스도 이 값들을 상속한다.
+          envs: GRAFANA_METRICS_URL,GRAFANA_METRICS_USER,GRAFANA_LOGS_URL,GRAFANA_LOGS_USER,GRAFANA_CLOUD_TOKEN
           script: |
             chmod +x /tmp/team3-provision/provision-runtime.sh
             /tmp/team3-provision/provision-runtime.sh

--- a/infra/alloy/config.alloy
+++ b/infra/alloy/config.alloy
@@ -1,0 +1,67 @@
+// Grafana Alloy — PIKI 운영 박스(EC2) 단일 수집기.
+// 앱의 prometheus 메트릭 scrape + team3-* 컨테이너 로그를 Grafana Cloud 로 remote-write 한다.
+// 자격증명은 환경변수로 주입한다(provision-runtime.sh 의 docker run -e). secret 미등록 시
+// provision-runtime.sh 가 Alloy 기동 자체를 skip 하므로, 빈 endpoint 로 부팅해 crash loop 하는 일은 없다.
+
+// ── 메트릭: 앱 /actuator/prometheus → Grafana Cloud (Prometheus) ──
+// blue-green 이라 한 시점에 8080·8081 중 한 포트만 떠 있다. 죽은 포트의 scrape 실패는
+// 해당 타겟만 down 으로 잡힐 뿐 무해하다. 앱 포트가 127.0.0.1 바인딩(PR #290)이므로
+// 이 Alloy 는 --network host 로 띄워 localhost 를 scrape 한다.
+prometheus.scrape "app" {
+  targets = [
+    {"__address__" = "localhost:8080", "instance" = "team3-blue"},
+    {"__address__" = "localhost:8081", "instance" = "team3-green"},
+  ]
+  metrics_path    = "/actuator/prometheus"
+  scrape_interval = "30s"
+  forward_to      = [prometheus.remote_write.grafana_cloud.receiver]
+}
+
+prometheus.remote_write "grafana_cloud" {
+  endpoint {
+    url = sys.env("GRAFANA_METRICS_URL")
+    basic_auth {
+      username = sys.env("GRAFANA_METRICS_USER")
+      password = sys.env("GRAFANA_CLOUD_TOKEN")
+    }
+  }
+}
+
+// ── 로그: team3-* docker 컨테이너 stdout → Grafana Cloud (Loki) ──
+discovery.docker "containers" {
+  host = "unix:///var/run/docker.sock"
+}
+
+discovery.relabel "team3" {
+  targets = discovery.docker.containers.targets
+
+  // team3-* 컨테이너만 수집한다 (mysql / redis / alloy 자신 등은 제외).
+  rule {
+    source_labels = ["__meta_docker_container_name"]
+    regex         = "/team3-.*"
+    action        = "keep"
+  }
+
+  // docker 가 붙이는 선행 슬래시를 떼어 container 라벨로 (/team3-blue → team3-blue).
+  rule {
+    source_labels = ["__meta_docker_container_name"]
+    regex         = "/(.*)"
+    target_label  = "container"
+  }
+}
+
+loki.source.docker "containers" {
+  host       = "unix:///var/run/docker.sock"
+  targets    = discovery.relabel.team3.output
+  forward_to = [loki.write.grafana_cloud.receiver]
+}
+
+loki.write "grafana_cloud" {
+  endpoint {
+    url = sys.env("GRAFANA_LOGS_URL")
+    basic_auth {
+      username = sys.env("GRAFANA_LOGS_USER")
+      password = sys.env("GRAFANA_CLOUD_TOKEN")
+    }
+  }
+}

--- a/infra/scripts/provision-runtime.sh
+++ b/infra/scripts/provision-runtime.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # EC2 런타임 프로비저닝 — 멱등(idempotent). 배포 때 실행되어 박스 안 런타임 설정
-# (swap / redis / nginx default 사이트)이 레포 정의 상태가 되도록 보장한다.
-# 이미 있는 자원은 건드리지 않고 skip 한다 — 기존 인스턴스엔 영향 0, 새 인스턴스에서만 생성. (#217)
+# (swap / redis / nginx default / grafana alloy)이 레포 정의 상태가 되도록 보장한다.
+# swap·redis·nginx 는 이미 있으면 skip 하고, alloy 는 config 가 레포에서 오므로 매 배포 갱신·재기동한다. (#217)
 #
 # docker 명령은 sudo 없이(ubuntu 가 docker 그룹), 시스템·nginx 는 sudo 로 — deploy.yml 기존 패턴과 동일.
 set -euo pipefail
@@ -40,6 +40,35 @@ if [ -e /etc/nginx/sites-enabled/default ]; then
   sudo nginx -t && sudo nginx -s reload
 else
   echo "[nginx] default 없음 — skip"
+fi
+
+# 4) grafana-alloy — 앱 메트릭 scrape + team3-* 컨테이너 로그를 Grafana Cloud 로 보내는 단일 수집기.
+#    Alloy 는 stateless 이고 config 가 레포(infra/alloy/config.alloy)에서 오므로, redis 의 "있으면 skip" 과 달리
+#    매 배포마다 config 를 갱신하고 재기동한다 (restart 비용은 작고 scrape 공백도 수초 수준).
+#    자격증명(GRAFANA_*)이 없으면(secret 미등록) 기동을 skip 한다 — 빈 endpoint 로 부팅하면 config 검증 실패로
+#    crash loop 가 나기 때문. secret 등록 후 다음 배포에 자동 기동된다.
+#    --network host: 앱 포트가 127.0.0.1 바인딩(#290)이라 localhost:8080/8081 을 scrape 하려면 필요.
+#    --server.http.listen-addr=127.0.0.1: host 네트워크라 debug UI(12345)를 루프백에만 묶어 외부 노출을 막는다.
+if [ -z "${GRAFANA_METRICS_URL:-}" ]; then
+  echo "[alloy] GRAFANA_* 미설정 — skip (secret 등록 후 다음 배포에 기동)"
+else
+  echo "[alloy] config 갱신 후 (재)기동"
+  sudo mkdir -p /etc/alloy-team3
+  sudo cp /tmp/team3-alloy/config.alloy /etc/alloy-team3/config.alloy
+  docker rm -f team3-alloy 2>/dev/null || true
+  docker run -d \
+    --name team3-alloy \
+    --restart unless-stopped \
+    --network host \
+    -v /etc/alloy-team3/config.alloy:/etc/alloy/config.alloy:ro \
+    -v /var/run/docker.sock:/var/run/docker.sock:ro \
+    -e GRAFANA_METRICS_URL="${GRAFANA_METRICS_URL:-}" \
+    -e GRAFANA_METRICS_USER="${GRAFANA_METRICS_USER:-}" \
+    -e GRAFANA_LOGS_URL="${GRAFANA_LOGS_URL:-}" \
+    -e GRAFANA_LOGS_USER="${GRAFANA_LOGS_USER:-}" \
+    -e GRAFANA_CLOUD_TOKEN="${GRAFANA_CLOUD_TOKEN:-}" \
+    grafana/alloy:v1.16.1 \
+      run --server.http.listen-addr=127.0.0.1:12345 /etc/alloy/config.alloy
 fi
 
 echo "런타임 프로비저닝 완료"


### PR DESCRIPTION
## Situation
- PR1(#290)으로 `/actuator/prometheus` 가 노출됐지만, **그 메트릭을 긁어 어디론가 보내는 수집기가 없어 아직 아무 데이터도 흐르지 않는다** — 모니터링 스택의 미완성 절반이다.
- 906Mi EC2 박스라 Prometheus/Grafana/Loki 셀프호스팅 대신, 수집기 한 개(Grafana Alloy)만 띄워 Grafana Cloud 무료티어로 remote-write 하는 구조로 합의했다.

## Task
- EC2 에 Grafana Alloy 를 멱등 기동해 앱 prometheus 메트릭 + 컨테이너 로그를 Grafana Cloud 로 전송한다.
- GC 자격증명 발급이 사용자 액션 블로커라, **secret 없이도 안전하게 머지되도록**(미설정 시 Alloy 기동 skip) 설계한다.

## Action
### 수집기 설정
- `infra/alloy/config.alloy` 신규: `prometheus.scrape`(localhost:8080·8081 `/actuator/prometheus`, blue-green 양 포트 정적 타겟) → `prometheus.remote_write`(GC Prometheus); `discovery.docker` + `discovery.relabel`(team3-* 만 keep) → `loki.source.docker` → `loki.write`(GC Loki). 자격증명은 `sys.env` 로 읽는다.

### 멱등 프로비저닝
- `provision-runtime.sh`: Alloy 멱등 기동 블록 추가. Alloy 는 stateless 이고 config 가 레포에서 오므로 redis 의 "있으면 skip" 과 달리 매 배포 config 갱신·재기동한다.
- `GRAFANA_METRICS_URL` 빈값(secret 미등록)이면 기동 skip — 빈 endpoint 부팅 시 config 검증 실패로 crash loop 나는 걸 막아 secret 없이도 안전하게 머지된다.
- `--network host`: 앱 포트가 127.0.0.1 바인딩(#290)이라 localhost:8080/8081 scrape 에 필요. debug UI 는 `127.0.0.1:12345` 로 제한해 host 네트워크에서도 외부 노출 안 되게.

### 배포 배선
- `deploy.yml`: Alloy config scp 업로드 + Provision step 에 GRAFANA_* 5종(공용 token + metrics/logs 각 url·user) 주입.
- `deploy-manual.yml` 은 provision/scp step 이 없는 staging 임시 배포라 Alloy 미포함 — dev 운영 박스(deploy.yml)만 Alloy 를 띄운다.
- `.env.example`: Grafana Cloud 구획 추가.

## Result
- config 는 `grafana/alloy:v1.16.1 validate` 로 검증(EXIT=0). 앱 코드(`src/`) 변경이 0 이라 회귀 없음.
- **사용자 액션(머지 후 데이터가 흐르려면 필수)**: Grafana Cloud 스택 생성 → Access Policy token + Prometheus/Loki endpoint·username 확인 → GitHub Actions secret 5종(`GRAFANA_METRICS_URL`, `GRAFANA_METRICS_USER`, `GRAFANA_LOGS_URL`, `GRAFANA_LOGS_USER`, `GRAFANA_CLOUD_TOKEN`) 등록 → 다음 dev 배포에 Alloy 기동. (GC 가 token 을 metrics/logs 로 분리 발급한다면 token 만 2종으로 늘리면 됨.)
- 대시보드는 GC 호스팅 Grafana 에 Micrometer Spring Boot/JVM 대시보드 import 또는 레포 JSON 코드화(후속/선택).

---
## 연관 이슈

- 
