### PR TITLE
Alloy 로그 수집을 앱 컨테이너로 좁히고 컨테이너 추적 에러 완화

### DIFF
--- a/infra/alloy/config.alloy
+++ b/infra/alloy/config.alloy
@@ -1,5 +1,5 @@
 // Grafana Alloy — PIKI 운영 박스(EC2) 단일 수집기.
-// 앱의 prometheus 메트릭 scrape + team3-* 컨테이너 로그를 Grafana Cloud 로 remote-write 한다.
+// 앱의 prometheus 메트릭 scrape + team3-blue/green 앱 컨테이너 로그를 Grafana Cloud 로 remote-write 한다.
 // 자격증명은 환경변수로 주입한다(provision-runtime.sh 의 docker run -e). secret 미등록 시
 // provision-runtime.sh 가 Alloy 기동 자체를 skip 하므로, 빈 endpoint 로 부팅해 crash loop 하는 일은 없다.
 
@@ -27,18 +27,22 @@ prometheus.remote_write "grafana_cloud" {
   }
 }
 
-// ── 로그: team3-* docker 컨테이너 stdout → Grafana Cloud (Loki) ──
+// ── 로그: team3-blue/green 앱 컨테이너 stdout → Grafana Cloud (Loki) ──
 discovery.docker "containers" {
   host = "unix:///var/run/docker.sock"
+  // blue-green 배포로 컨테이너가 자주 교체된다. 짧은 refresh 로 사라진 컨테이너를 타겟에서
+  // 빨리 제거해 loki.source.docker 의 "No such container" 추적 에러를 줄인다.
+  refresh_interval = "15s"
 }
 
 discovery.relabel "team3" {
   targets = discovery.docker.containers.targets
 
-  // team3-* 컨테이너만 수집한다 (mysql / redis / alloy 자신 등은 제외).
+  // 앱 컨테이너(team3-blue / team3-green)만 수집한다. team3-redis·team3-alloy(자기) 등은 제외 —
+  // redis 의 과거 로그가 GC 의 too-old 거부(400)를 유발했고, 우리가 원하는 건 앱 로그뿐이기 때문.
   rule {
     source_labels = ["__meta_docker_container_name"]
-    regex         = "/team3-.*"
+    regex         = "/team3-(blue|green)"
     action        = "keep"
   }
 


### PR DESCRIPTION
## Situation
- PR2(#292)로 Grafana Alloy 가 EC2 에 떠서 메트릭·로그를 GC 로 보내기 시작했다. 배포 직후 Alloy 로그에서 두 이슈가 관찰됐다.
  - `team3-redis` 의 8일 전 과거 로그가 처음 전송되며 GC Loki 의 too-old 거부(HTTP 400)를 유발 — 애초에 redis 로그는 수집 대상이 아니었어야 한다.
  - blue-green 배포로 구 컨테이너가 제거되자 `loki.source.docker` 가 사라진 컨테이너를 계속 inspect 해 "No such container" 에러를 반복.

## Action
- `discovery.relabel` keep 을 `/team3-.*` → `/team3-(blue|green)` 으로 좁힘 — `team3-redis`·`team3-alloy`(자기) 등을 제외하고 앱 컨테이너 로그만 수집.
- `discovery.docker` 에 `refresh_interval = "15s"` 추가 — 제거된 컨테이너를 타겟에서 빨리 빼 추적 에러를 완화.

## Result
- `grafana/alloy:v1.16.1 validate` EXIT=0.
- 머지·배포 후 redis too-old 400 과 No-such-container 반복 에러가 해소될 것으로 예상. (blue-green 전환 순간의 짧은 추적 에러는 컨테이너 교체 특성상 완전히 0 은 아닐 수 있으나 크게 준다.)

---
## 연관 이슈

- 
