### PR TITLE
/issue 스킬에서 stale 워크트리 정리 단계 제거

### DIFF
--- a/.claude/commands/issue.md
+++ b/.claude/commands/issue.md
@@ -239,9 +239,7 @@ gh api graphql \
 
 #### 워크트리 선택 시
 
-1. **stale 워크트리 정리** (생성 직전 — CLAUDE.md "worktree 정리는 ... 이벤트에 얹는다"). `git worktree prune` 후 머지·삭제(gone)된 브랜치의 워크트리만 제거. **clean 한 것만, `--force` 금지** — dirty 면 작업 중일 수 있으므로 건드리지 않고 넘어간다.
-
-2. GitHub 브랜치 생성 + 이슈 연결. **`--checkout` 을 주지 않는다** — 현재 디렉토리를 끌고 가면 같은 브랜치를 워크트리에서 다시 체크아웃할 수 없어 충돌한다.
+1. GitHub 브랜치 생성 + 이슈 연결. **`--checkout` 을 주지 않는다** — 현재 디렉토리를 끌고 가면 같은 브랜치를 워크트리에서 다시 체크아웃할 수 없어 충돌한다.
    ```bash
    gh issue develop {이슈번호} \
      --repo depromeet/18th-team3-server \
@@ -249,14 +247,14 @@ gh api graphql \
      --name "{prefix}/{이슈번호}-{slug}"
    ```
 
-3. `gh` 가 만든 원격 브랜치를 가져와 워크트리로 분리한다 (로컬 브랜치는 워크트리에서 생성):
+2. `gh` 가 만든 원격 브랜치를 가져와 워크트리로 분리한다 (로컬 브랜치는 워크트리에서 생성):
    ```bash
    git fetch origin "{prefix}/{이슈번호}-{slug}":"refs/remotes/origin/{prefix}/{이슈번호}-{slug}"
    git worktree add ".claude/worktrees/{slug}" "{prefix}/{이슈번호}-{slug}"
    ```
    `git worktree add <path> <branch>` 는 로컬에 `{branch}` 가 없고 `origin/{branch}` 가 정확히 하나면 DWIM 으로 추적 브랜치를 만들어 붙인다. DWIM 이 안 되면 명시형으로 fallback: `git worktree add --track -b "{prefix}/{이슈번호}-{slug}" ".claude/worktrees/{slug}" "origin/{prefix}/{이슈번호}-{slug}"`.
 
-4. 세션을 워크트리로 진입시킨다 — `EnterWorktree` 도구를 **`path=".claude/worktrees/{slug}"`** 로 호출 (이미 만든 워크트리에 진입). `name=` 으로 새로 만들지 않는다 — 브랜치는 `gh issue develop` 이 base `dev` 로 이미 만들었고, `EnterWorktree(name=...)` 의 baseRef 기본값(`fresh`=origin/default-branch)은 이 레포에선 `main` 을 가리켜 CLAUDE.md(dev 분기) 와 어긋나기 때문. 이후 작업·커밋·`/pr` 은 이 워크트리에서 진행된다.
+3. 세션을 워크트리로 진입시킨다 — `EnterWorktree` 도구를 **`path=".claude/worktrees/{slug}"`** 로 호출 (이미 만든 워크트리에 진입). `name=` 으로 새로 만들지 않는다 — 브랜치는 `gh issue develop` 이 base `dev` 로 이미 만들었고, `EnterWorktree(name=...)` 의 baseRef 기본값(`fresh`=origin/default-branch)은 이 레포에선 `main` 을 가리켜 CLAUDE.md(dev 분기) 와 어긋나기 때문. 이후 작업·커밋·`/pr` 은 이 워크트리에서 진행된다.
 
 #### 현재 브랜치 선택 시 (기존 동작)
 
@@ -294,8 +292,7 @@ gh project item-add 99 --owner depromeet --url {이슈 URL}
 - 분류 자동 결정은 시그널이 명확할 때만. 모호하면 `chore` fallback (보수적).
 - 라벨이 레포에 없어 `gh issue create` 가 실패하면 에러 그대로 보고.
 - `gh issue develop` 은 `--name` (브랜치 이름 옵션) 을 명시 (인터랙티브 회피). `--branch-name` 은 존재하지 않는 옵션이니 주의. `--checkout` 은 **현재 브랜치 작업을 고른 경우에만** 붙인다 — 워크트리 작업이면 현재 디렉토리가 끌려가 충돌하므로 빼고, 체크아웃은 `EnterWorktree` 가 대신한다.
-- **워크트리 진입은 `EnterWorktree(path=...)` 로만.** `git worktree add` 로 먼저 만든 뒤 `path` 로 진입한다. `EnterWorktree(name=...)` 는 새 브랜치를 자체 생성하며 baseRef 기본값이 이 레포의 git default branch(`main`)를 가리켜 `dev` 분기 정책과 어긋난다. `path` 로 진입한 워크트리는 `ExitWorktree` 가 제거하지 않으므로, 정리는 `/session-close` 나 다음 `/issue` 의 stale prune 에 맡긴다.
-- **워크트리 stale prune 안전 가드.** 생성 직전 정리는 clean(커밋 안 된 변경 없음) + 머지·삭제(gone)된 브랜치의 워크트리만 제거한다. `--force` 절대 금지, dirty 면 그냥 둔다.
+- **워크트리 진입은 `EnterWorktree(path=...)` 로만.** `git worktree add` 로 먼저 만든 뒤 `path` 로 진입한다. `EnterWorktree(name=...)` 는 새 브랜치를 자체 생성하며 baseRef 기본값이 이 레포의 git default branch(`main`)를 가리켜 `dev` 분기 정책과 어긋난다. `path` 로 진입한 워크트리는 `ExitWorktree` 가 제거하지 않으므로, 정리는 `/session-close` 에 맡긴다.
 - `gh project item-add` 권한 부족 시 사용자에게 `gh auth refresh -h github.com -s project` 안내 (인터랙티브 디바이스 인증, 일회성).
 - 본문에 `#{epic 번호}` 가 들어가면 GitHub 가 자동 cross-reference 링크 — 별도 sub-issue API 불필요.
 - 중복 이슈 검사 false positive 가능성 인지. 사용자가 "다른 이슈" 라 답하면 그대로 진행.


### PR DESCRIPTION
## Situation
- `/issue` 스킬에는 새 워크트리를 만들기 직전, 머지·gone 브랜치의 stale 워크트리를 prune 하는 단계가 박혀 있었다.
- 워크트리 정리 책임이 `/issue`(생성 직전)와 `/session-close`(작업 종료·PR 머지 직후) 두 곳에 분산돼 있어, "정리가 왜 이슈 생성 스킬에 있나"는 의문이 자연스럽게 나왔다.

## Task
- `/issue` 에서 워크트리 정리 맥락을 완전히 제거하고, 정리 책임을 `/session-close` 한 곳으로 단일화한다.

## Action
- B-6 "워크트리 선택 시" 흐름에서 stale 워크트리 정리 단계(`git worktree prune` + 머지·gone 워크트리 제거)를 삭제하고, 남은 단계를 1–2–3 으로 재정렬.
- 주의사항의 "워크트리 stale prune 안전 가드" bullet 을 통째 삭제.
- 주의사항 중 "정리는 `/session-close` 나 다음 `/issue` 의 stale prune 에 맡긴다" 를 "정리는 `/session-close` 에 맡긴다" 로 수정.

## Result
- `/issue` 는 새 워크트리를 만들 때 다른 워크트리를 더 이상 건드리지 않는다. 정리 책임이 `/session-close`(종료·머지 직후) 한 곳으로 단일화됐다.
- 트레이드오프: 작업이 중단돼 어느 정리 이벤트에도 안 걸린 워크트리는 더 오래 남을 수 있다. 이는 세션을 닫지 않은 쪽의 책임으로 두고, 사용자가 직접 삭제한다.
- 후속: `CLAUDE.md` 의 "worktree 정리는 ... 새 worktree 생성 직전" 정책 문구는 이번 PR 범위 밖이라 그대로 남겨 뒀다. 이 문구까지 정리할지는 별도 판단이 필요하다.

---
## 연관 이슈

- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 워크트리 작업 위치 선택 절차를 간결하게 정리했습니다.
  * 워크트리 진입 시 올바른 방식과 이후 작업 진행 방식에 대한 안내를 명확히 했습니다.
  * 워크트리 정리 절차 안내를 업데이트했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/PIKI-Server/pull/297?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->