### PR TITLE
admin 백오피스 (개발 서버 전용)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,6 +41,10 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-webmvc")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-validation")
+    // 개발 서버 전용 admin 챗봇의 SSR 페이지(admin.enabled 로 게이팅). 버전은 Spring Boot 4.0.5 BOM 이 관리.
+    // CSRF hidden field 는 thymeleaf-spring 의 RequestDataValueProcessor 가 자동 주입하므로
+    // thymeleaf-extras-springsecurity 는 첫 단계에선 불필요(sec: dialect 미사용).
+    implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("tools.jackson.module:jackson-module-kotlin")
 

--- a/src/main/kotlin/com/depromeet/piki/admin/audit/AdminAuditLog.kt
+++ b/src/main/kotlin/com/depromeet/piki/admin/audit/AdminAuditLog.kt
@@ -1,0 +1,31 @@
+package com.depromeet.piki.admin.audit
+
+import com.depromeet.piki.common.domain.LongBaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+
+/**
+ * admin 백오피스가 실행한 작업의 감사 로그. append-only.
+ *
+ * admin 계정은 InMemory(users 테이블과 무관)라 admin_username 문자열로 기록하고 FK 를 두지 않는다.
+ * parameters/request_message 는 마스킹을 거친 값만 저장한다(AdminAuditService).
+ */
+@Entity
+@Table(name = "admin_audit_logs")
+class AdminAuditLog(
+    @Column(name = "admin_username", nullable = false, length = 100)
+    val adminUsername: String,
+    @Column(name = "action_type", nullable = false, length = 50)
+    val actionType: String,
+    @Column(name = "tool_name", nullable = false, length = 100)
+    val toolName: String,
+    @Column(name = "result_status", nullable = false, length = 20)
+    val resultStatus: String,
+    @Column(name = "parameters", columnDefinition = "JSON")
+    val parameters: String? = null,
+    @Column(name = "result_summary", length = 1000)
+    val resultSummary: String? = null,
+    @Column(name = "request_message", length = 2000)
+    val requestMessage: String? = null,
+) : LongBaseEntity()

--- a/src/main/kotlin/com/depromeet/piki/admin/audit/AdminAuditLogRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/admin/audit/AdminAuditLogRepository.kt
@@ -1,0 +1,5 @@
+package com.depromeet.piki.admin.audit
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface AdminAuditLogRepository : JpaRepository<AdminAuditLog, Long>

--- a/src/main/kotlin/com/depromeet/piki/admin/audit/AdminAuditLogRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/admin/audit/AdminAuditLogRepository.kt
@@ -1,5 +1,15 @@
 package com.depromeet.piki.admin.audit
 
-import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.repository.Repository
 
-interface AdminAuditLogRepository : JpaRepository<AdminAuditLog, Long>
+/**
+ * append-only 감사 로그 저장소.
+ *
+ * JpaRepository 를 그대로 노출하면 delete*·재저장 같은 변경 API 가 열려 append-only 불변식이 깨진다 —
+ * 호출부 하나만 늘어도 감사 로그가 삭제·변조될 수 있다. save 와 조회만 노출하는 좁은 Repository 로 제한한다.
+ */
+interface AdminAuditLogRepository : Repository<AdminAuditLog, Long> {
+    fun save(entity: AdminAuditLog): AdminAuditLog
+
+    fun findAll(): List<AdminAuditLog>
+}

--- a/src/main/kotlin/com/depromeet/piki/admin/audit/AdminAuditService.kt
+++ b/src/main/kotlin/com/depromeet/piki/admin/audit/AdminAuditService.kt
@@ -28,7 +28,15 @@ class AdminAuditService(
         resultSummary: String?,
         requestMessage: String?,
     ) {
-        val maskedJson = objectMapper.writeValueAsString(mask(parameters))
+        // 감사 기록은 best-effort 다 — 직렬화 실패(순환 참조·직렬화 불가 타입)가 비즈니스 트랜잭션(아이템
+        // 저장 등)까지 롤백시키면 안 되므로, 실패 시 placeholder 로 대체하고 비즈니스는 그대로 진행시킨다.
+        val maskedJson =
+            try {
+                objectMapper.writeValueAsString(mask(parameters))
+            } catch (e: Exception) {
+                log.warn("admin 감사 파라미터 직렬화 실패: action={} tool={}", actionType, toolName, e)
+                AUDIT_SERIALIZATION_FAILED
+            }
         repository.save(
             AdminAuditLog(
                 adminUsername = adminUsername,
@@ -61,6 +69,7 @@ class AdminAuditService(
     companion object {
         private val log = LoggerFactory.getLogger(AdminAuditService::class.java)
         private const val MASK = "*secret*"
+        private const val AUDIT_SERIALIZATION_FAILED = """{"error":"AUDIT_SERIALIZATION_FAILED"}"""
         private val SENSITIVE_KEYS = listOf("password", "token", "secret", "credential", "authorization")
         private const val RESULT_SUMMARY_MAX = 1000
         private const val REQUEST_MESSAGE_MAX = 2000

--- a/src/main/kotlin/com/depromeet/piki/admin/audit/AdminAuditService.kt
+++ b/src/main/kotlin/com/depromeet/piki/admin/audit/AdminAuditService.kt
@@ -1,0 +1,68 @@
+package com.depromeet.piki.admin.audit
+
+import com.depromeet.piki.admin.config.ConditionalOnAdminEnabled
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import tools.jackson.databind.ObjectMapper
+
+/**
+ * admin 작업 감사 로그를 짧은 트랜잭션으로 영속화한다.
+ *
+ * 외부 호출(LLM)은 이미 AdminChatService 에서 트랜잭션 밖으로 끝났고, 여기선 기록만 한다.
+ * parameters 는 민감 키를 마스킹한 뒤 JSON 으로 저장한다.
+ */
+@Service
+@ConditionalOnAdminEnabled
+class AdminAuditService(
+    private val repository: AdminAuditLogRepository,
+    private val objectMapper: ObjectMapper,
+) {
+    @Transactional
+    fun record(
+        adminUsername: String,
+        actionType: String,
+        toolName: String,
+        parameters: Map<String, Any?>,
+        resultStatus: String,
+        resultSummary: String?,
+        requestMessage: String?,
+    ) {
+        val maskedJson = objectMapper.writeValueAsString(mask(parameters))
+        repository.save(
+            AdminAuditLog(
+                adminUsername = adminUsername,
+                actionType = actionType,
+                toolName = toolName,
+                resultStatus = resultStatus,
+                parameters = maskedJson,
+                resultSummary = resultSummary?.take(RESULT_SUMMARY_MAX),
+                requestMessage = requestMessage?.take(REQUEST_MESSAGE_MAX),
+            ),
+        )
+        log.info("admin audit: user={} action={} tool={} status={}", adminUsername, actionType, toolName, resultStatus)
+    }
+
+    // 키 이름에 민감 토큰이 섞이면 값을 가린다. 현재 tool 파라미터엔 민감정보가 없지만, 향후 tool 이 늘어
+    // 토큰·URL 등이 섞여도 로그·DB 로 새지 않게 방어한다. 중첩 map/list 안의 값까지 재귀로 마스킹한다 —
+    // 최상위 키만 보면 {config:{token:...}} 같은 중첩 비밀이 평문으로 새기 때문.
+    private fun mask(value: Any?): Any? =
+        when (value) {
+            is Map<*, *> -> value.entries.associate { (key, nested) -> key to (if (isSensitive(key)) MASK else mask(nested)) }
+            is List<*> -> value.map { mask(it) }
+            else -> value
+        }
+
+    private fun isSensitive(key: Any?): Boolean {
+        val name = key as? String ?: return false
+        return SENSITIVE_KEYS.any { name.contains(it, ignoreCase = true) }
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(AdminAuditService::class.java)
+        private const val MASK = "*secret*"
+        private val SENSITIVE_KEYS = listOf("password", "token", "secret", "credential", "authorization")
+        private const val RESULT_SUMMARY_MAX = 1000
+        private const val REQUEST_MESSAGE_MAX = 2000
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/admin/config/AdminProperties.kt
+++ b/src/main/kotlin/com/depromeet/piki/admin/config/AdminProperties.kt
@@ -1,0 +1,29 @@
+package com.depromeet.piki.admin.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+/**
+ * 개발 서버 전용 admin 백오피스 설정.
+ *
+ * `@ConfigurationPropertiesScan`(PikiApplication)으로 자동 등록된다. enabled=false 여도 이 빈 자체는
+ * 무해하게 바인딩되며, 실제 admin 빈(SecurityFilterChain·컨트롤러·서비스 등)은 [ConditionalOnAdminEnabled]
+ * 로 게이팅된다.
+ */
+@ConfigurationProperties(prefix = "admin")
+data class AdminProperties(
+    val enabled: Boolean = false,
+    val username: String = "",
+    val password: String = "",
+) {
+    init {
+        // enabled=true 인데 자격증명이 비어 있으면 "켰는데 로그인 불가" 상태로 부팅된다.
+        // 부팅 시점에 막아 운영자가 즉시 알아채게 한다 (GeminiProperties.init 선례와 같은 결).
+        if (enabled) {
+            require(username.isNotBlank()) { "admin.enabled=true 인데 ADMIN_USERNAME 이 비어 있습니다." }
+            require(password.isNotBlank()) { "admin.enabled=true 인데 ADMIN_PASSWORD 가 비어 있습니다." }
+        }
+    }
+
+    // data class 기본 toString 은 password 를 그대로 노출하므로 로그 유출 방지를 위해 마스킹한다.
+    override fun toString(): String = "AdminProperties(enabled=$enabled, username=$username, password=*secret*)"
+}

--- a/src/main/kotlin/com/depromeet/piki/admin/config/AdminSecurityConfig.kt
+++ b/src/main/kotlin/com/depromeet/piki/admin/config/AdminSecurityConfig.kt
@@ -1,0 +1,81 @@
+package com.depromeet.piki.admin.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.annotation.Order
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.core.userdetails.User
+import org.springframework.security.core.userdetails.UserDetailsService
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.security.provisioning.InMemoryUserDetailsManager
+import org.springframework.security.web.SecurityFilterChain
+
+/**
+ * admin 백오피스 전용 SecurityFilterChain.
+ *
+ * 기존 앱 JWT(stateless) 체인과 완전히 분리된다 — securityMatcher 로 admin 경로만 관할하고
+ * `@Order(1)` 로 기존 체인(@Order(2))보다 먼저 매칭된다. 인증은 세션 기반 form login + 환경변수로 주입한
+ * 단일 admin 계정(InMemory). [ConditionalOnAdminEnabled] 로 게이팅되어 admin.enabled=true 일 때만 등록된다.
+ *
+ * UserDetailsService/Provider 를 체인-로컬(`authenticationProvider`)로 묶어, 전역 AuthenticationManager 에
+ * admin 계정이 새어 기존 JWT 경로에 의도치 않은 인증 수단이 생기는 것을 막는다.
+ */
+@Configuration
+@ConditionalOnAdminEnabled
+class AdminSecurityConfig(
+    private val adminProperties: AdminProperties,
+) {
+    @Bean
+    @Order(1)
+    fun adminSecurityFilterChain(http: HttpSecurity): SecurityFilterChain {
+        val passwordEncoder: PasswordEncoder = BCryptPasswordEncoder()
+        // env 로 평문 주입된 비밀번호를 부팅 시 1회 해싱해 InMemory 에 적재한다 (평문이 메모리에 남지 않게).
+        val userDetailsService: UserDetailsService =
+            InMemoryUserDetailsManager(
+                User
+                    .withUsername(adminProperties.username)
+                    .password(passwordEncoder.encode(adminProperties.password))
+                    .roles(ADMIN_ROLE)
+                    .build(),
+            )
+        val authProvider = DaoAuthenticationProvider(userDetailsService)
+        authProvider.setPasswordEncoder(passwordEncoder)
+
+        return http
+            // /admin/** 와 정적 리소스만 이 체인이 관할. 그 외 요청은 통과시켜 기존 JWT 체인(@Order(2))이 잡는다.
+            .securityMatcher("/admin/**", "/admin-assets/**")
+            .authenticationProvider(authProvider)
+            .authorizeHttpRequests { auth ->
+                auth
+                    .requestMatchers("/admin/login", "/admin-assets/**")
+                    .permitAll()
+                    .anyRequest()
+                    .authenticated()
+            }.formLogin {
+                it
+                    .loginPage("/admin/login")
+                    .loginProcessingUrl("/admin/login")
+                    .defaultSuccessUrl("/admin", true)
+                    .failureUrl("/admin/login?error")
+                    .permitAll()
+            }.logout {
+                it
+                    .logoutUrl("/admin/logout")
+                    .logoutSuccessUrl("/admin/login?logout")
+                    .invalidateHttpSession(true)
+                    .deleteCookies("JSESSIONID")
+            }
+            // form login + Thymeleaf SSR 이므로 CSRF 는 기본(활성) 유지 — 로그인·채팅·확인 POST 가 CSRF 토큰을 동반한다.
+            // 세션 기반 인증이라 로그인 시 세션을 만든다.
+            .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED) }
+            .build()
+    }
+
+    companion object {
+        // Spring Security 의 roles(..) 는 내부적으로 ROLE_ 접두사를 붙인다.
+        private const val ADMIN_ROLE = "ADMIN"
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/admin/config/ConditionalOnAdminEnabled.kt
+++ b/src/main/kotlin/com/depromeet/piki/admin/config/ConditionalOnAdminEnabled.kt
@@ -1,0 +1,15 @@
+package com.depromeet.piki.admin.config
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+
+/**
+ * admin 백오피스 관련 빈(SecurityFilterChain·컨트롤러·서비스 등)을 한 어노테이션으로 게이팅한다.
+ *
+ * `admin.enabled=true` 인 환경에서만 부착 대상 빈이 등록된다. 기본(false)에선 컨트롤러 핸들러 매핑조차
+ * 생성되지 않아 admin 경로가 404 가 되고, 운영 노출이 코드 레벨에서 차단된다. 메타 어노테이션으로 묶어
+ * 빈마다 `@ConditionalOnProperty` 를 반복하다 한 곳을 빠뜨려 일부만 노출되는 사고를 막는다.
+ */
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@ConditionalOnProperty(prefix = "admin", name = ["enabled"], havingValue = "true")
+annotation class ConditionalOnAdminEnabled

--- a/src/main/kotlin/com/depromeet/piki/admin/item/AdminItemController.kt
+++ b/src/main/kotlin/com/depromeet/piki/admin/item/AdminItemController.kt
@@ -1,0 +1,54 @@
+package com.depromeet.piki.admin.item
+
+import com.depromeet.piki.admin.config.ConditionalOnAdminEnabled
+import io.swagger.v3.oas.annotations.Hidden
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.servlet.mvc.support.RedirectAttributes
+import java.security.Principal
+
+/**
+ * 백오피스 실험 데이터 폼 페이지.
+ *
+ * 최근 item 목록을 보여주고, 샘플 상품을 폼으로 추가한다. 추가는 PRG(POST-Redirect-Get) 패턴 — 성공/실패를
+ * flash 로 전달해 새로고침 중복 제출을 막는다. 확인은 폼의 JS confirm 으로 처리한다.
+ * `@Hidden` 으로 OpenAPI 문서에서 제외한다.
+ */
+@Controller
+@Hidden
+@ConditionalOnAdminEnabled
+class AdminItemController(
+    private val adminItemService: AdminItemService,
+) {
+    @GetMapping("/admin/items")
+    fun items(model: Model): String {
+        model.addAttribute("items", adminItemService.recentItems())
+        return "admin/items"
+    }
+
+    @PostMapping("/admin/items/samples")
+    fun addSamples(
+        @RequestParam count: Int,
+        @RequestParam(required = false) namePrefix: String?,
+        principal: Principal,
+        redirectAttributes: RedirectAttributes,
+    ): String {
+        try {
+            val inserted = adminItemService.insertSamples(count, namePrefix, principal.name)
+            redirectAttributes.addFlashAttribute("message", "샘플 상품 ${inserted}개를 추가했습니다.")
+        } catch (e: IllegalArgumentException) {
+            // 폼 입력 검증 실패 — 사용자에게 사유를 보여주고 폼으로 돌려보낸다.
+            log.info("admin 샘플 추가 입력 오류: {}", e.message)
+            redirectAttributes.addFlashAttribute("error", e.message)
+        }
+        return "redirect:/admin/items"
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(AdminItemController::class.java)
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/admin/item/AdminItemService.kt
+++ b/src/main/kotlin/com/depromeet/piki/admin/item/AdminItemService.kt
@@ -1,0 +1,66 @@
+package com.depromeet.piki.admin.item
+
+import com.depromeet.piki.admin.audit.AdminAuditService
+import com.depromeet.piki.admin.config.ConditionalOnAdminEnabled
+import com.depromeet.piki.item.domain.Item
+import com.depromeet.piki.item.domain.ItemStatus
+import com.depromeet.piki.item.repository.ItemRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * 개발 서버 백오피스의 item 실험 데이터 작업.
+ *
+ * LLM 없이 폼에서 직접 호출된다. 조회는 readOnly, 추가는 영속화 + 감사 기록을 한 트랜잭션으로 묶는다.
+ * 범위·접두사 검증은 입력 경계(컨트롤러 폼)와 여기(require) 양쪽에 둔다 — 폼을 우회한 호출에도 불변식이 선다.
+ */
+@Service
+@ConditionalOnAdminEnabled
+class AdminItemService(
+    private val itemRepository: ItemRepository,
+    private val auditService: AdminAuditService,
+) {
+    @Transactional(readOnly = true)
+    fun recentItems(limit: Int = DEFAULT_LIMIT): List<Item> = itemRepository.findRecent(limit.coerceIn(1, MAX_LIMIT))
+
+    @Transactional
+    fun insertSamples(
+        count: Int,
+        namePrefix: String?,
+        adminUsername: String,
+    ): Int {
+        require(count in 1..MAX_COUNT) { "추가 개수는 1 이상 $MAX_COUNT 이하여야 합니다." }
+        val prefix = (namePrefix?.trim()?.ifBlank { null } ?: DEFAULT_PREFIX).take(PREFIX_MAX_LENGTH)
+        val items =
+            (1..count).map {
+                Item(
+                    name = "$prefix $it",
+                    currentPrice = SAMPLE_PRICE,
+                    currency = SAMPLE_CURRENCY,
+                    status = ItemStatus.READY,
+                )
+            }
+        val saved = itemRepository.saveAll(items)
+        auditService.record(
+            adminUsername = adminUsername,
+            actionType = ACTION_INSERT_SAMPLES,
+            toolName = "items",
+            parameters = mapOf("count" to count, "namePrefix" to prefix),
+            resultStatus = "SUCCESS",
+            resultSummary = "inserted=${saved.size}, ids=${saved.map { it.getId() }}",
+            requestMessage = null,
+        )
+        return saved.size
+    }
+
+    companion object {
+        const val DEFAULT_LIMIT = 10
+        private const val MAX_LIMIT = 50
+        private const val MAX_COUNT = 50
+        private const val DEFAULT_PREFIX = "샘플 상품"
+        private const val PREFIX_MAX_LENGTH = 100
+        private const val SAMPLE_PRICE = 10_000
+        private const val SAMPLE_CURRENCY = "KRW"
+        private const val ACTION_INSERT_SAMPLES = "INSERT_SAMPLE_ITEMS"
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/admin/web/BackofficeViewController.kt
+++ b/src/main/kotlin/com/depromeet/piki/admin/web/BackofficeViewController.kt
@@ -1,0 +1,25 @@
+package com.depromeet.piki.admin.web
+
+import com.depromeet.piki.admin.config.ConditionalOnAdminEnabled
+import io.swagger.v3.oas.annotations.Hidden
+import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.GetMapping
+
+/**
+ * PIKI 백오피스 셸의 SSR 뷰(Thymeleaf). 로그인·홈(대시보드)을 반환한다.
+ *
+ * 각 기능 페이지는 자기 컨트롤러가 담당한다(예: 실험 데이터는 AdminItemController). 기능이 늘면 사이드바 네비
+ * 메뉴(layout fragment)와 해당 기능 컨트롤러를 더한다. `@Hidden` 으로 OpenAPI 문서에서 제외한다.
+ */
+@Controller
+@Hidden
+@ConditionalOnAdminEnabled
+class BackofficeViewController {
+    // 미인증 접근 가능(permitAll). 로그인 성공 시 form login 이 홈(/admin)으로 보낸다.
+    @GetMapping("/admin/login")
+    fun login(): String = "admin/login"
+
+    // 백오피스 홈(대시보드) — 제공 기능을 카드로 보여주는 진입점.
+    @GetMapping("/admin")
+    fun home(): String = "admin/home"
+}

--- a/src/main/kotlin/com/depromeet/piki/auth/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/config/SecurityConfig.kt
@@ -4,6 +4,7 @@ import com.depromeet.piki.auth.filter.JwtAuthenticationFilter
 import com.depromeet.piki.user.domain.IdentityType
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.core.annotation.Order
 import org.springframework.http.HttpMethod
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
@@ -17,7 +18,11 @@ class SecurityConfig(
     private val authenticationEntryPoint: ApiResponseAuthenticationEntryPoint,
     private val accessDeniedHandler: ApiResponseAccessDeniedHandler,
 ) {
+    // @Order(2): admin 백오피스 체인(AdminSecurityConfig, @Order(1))이 /admin/** 를 먼저 잡고,
+    // 나머지 모든 요청은 이 기존 JWT(stateless) 체인이 처리한다. admin.enabled=false 면 admin 체인이
+    // 아예 없어 이 체인만 단독으로 동작한다.
     @Bean
+    @Order(2)
     fun securityFilterChain(
         http: HttpSecurity,
         jwtAuthenticationFilter: JwtAuthenticationFilter,

--- a/src/main/kotlin/com/depromeet/piki/item/repository/ItemJpaRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/item/repository/ItemJpaRepository.kt
@@ -16,6 +16,7 @@ interface ItemJpaRepository : JpaRepository<Item, Long> {
     ): List<Long>
 
     // admin 조회 도구용. 삭제되지 않은 item 을 createdAt 내림차순으로, limit 은 Pageable 로 동적 주입.
-    @Query("select i from Item i where i.deletedAt is null order by i.createdAt desc")
+    // 동률(같은 createdAt)에서 LIMIT 결과가 요청마다 달라지지 않도록 id 를 보조 정렬 키로 둔다.
+    @Query("select i from Item i where i.deletedAt is null order by i.createdAt desc, i.id desc")
     fun findRecent(pageable: Pageable): List<Item>
 }

--- a/src/main/kotlin/com/depromeet/piki/item/repository/ItemJpaRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/item/repository/ItemJpaRepository.kt
@@ -2,6 +2,7 @@ package com.depromeet.piki.item.repository
 
 import com.depromeet.piki.item.domain.Item
 import com.depromeet.piki.item.domain.ItemStatus
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
@@ -13,4 +14,8 @@ interface ItemJpaRepository : JpaRepository<Item, Long> {
         @Param("status") status: ItemStatus,
         @Param("cutoff") cutoff: LocalDateTime,
     ): List<Long>
+
+    // admin 조회 도구용. 삭제되지 않은 item 을 createdAt 내림차순으로, limit 은 Pageable 로 동적 주입.
+    @Query("select i from Item i where i.deletedAt is null order by i.createdAt desc")
+    fun findRecent(pageable: Pageable): List<Item>
 }

--- a/src/main/kotlin/com/depromeet/piki/item/repository/ItemRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/item/repository/ItemRepository.kt
@@ -12,6 +12,9 @@ interface ItemRepository {
 
     fun findById(id: Long): Item?
 
+    // admin 운영 도구의 조회용 — 삭제되지 않은 item 을 createdAt 내림차순으로 limit 개.
+    fun findRecent(limit: Int): List<Item>
+
     // cutoff 이전에 생성됐는데 아직 PROCESSING 인 item — 워커가 죽어 방치된 stale 후보의 id.
     fun findStaleProcessingIds(cutoff: LocalDateTime): List<Long>
 }

--- a/src/main/kotlin/com/depromeet/piki/item/repository/ItemRepositoryImpl.kt
+++ b/src/main/kotlin/com/depromeet/piki/item/repository/ItemRepositoryImpl.kt
@@ -18,7 +18,12 @@ class ItemRepositoryImpl(
 
     override fun findById(id: Long): Item? = itemJpaRepository.findById(id).orElse(null)
 
-    override fun findRecent(limit: Int): List<Item> = itemJpaRepository.findRecent(PageRequest.of(0, limit))
+    override fun findRecent(limit: Int): List<Item> {
+        // PageRequest.of 는 size > 0 을 요구한다. 호출부(AdminItemService)가 coerce 하지만, 리포지토리를
+        // 직접 재사용하는 경로에서도 IllegalArgumentException 으로 깨지지 않게 여기서도 막는다.
+        require(limit > 0) { "limit 은 1 이상이어야 한다: $limit" }
+        return itemJpaRepository.findRecent(PageRequest.of(0, limit))
+    }
 
     override fun findStaleProcessingIds(cutoff: LocalDateTime): List<Long> =
         itemJpaRepository.findIdsByStatusAndCreatedAtBefore(ItemStatus.PROCESSING, cutoff)

--- a/src/main/kotlin/com/depromeet/piki/item/repository/ItemRepositoryImpl.kt
+++ b/src/main/kotlin/com/depromeet/piki/item/repository/ItemRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.depromeet.piki.item.repository
 
 import com.depromeet.piki.item.domain.Item
 import com.depromeet.piki.item.domain.ItemStatus
+import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Repository
 import java.time.LocalDateTime
 
@@ -16,6 +17,8 @@ class ItemRepositoryImpl(
     override fun findByIds(ids: List<Long>): List<Item> = itemJpaRepository.findAllById(ids)
 
     override fun findById(id: Long): Item? = itemJpaRepository.findById(id).orElse(null)
+
+    override fun findRecent(limit: Int): List<Item> = itemJpaRepository.findRecent(PageRequest.of(0, limit))
 
     override fun findStaleProcessingIds(cutoff: LocalDateTime): List<Long> =
         itemJpaRepository.findIdsByStatusAndCreatedAtBefore(ItemStatus.PROCESSING, cutoff)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -68,6 +68,14 @@ gemini:
     max-attempts: ${GEMINI_RETRY_MAX_ATTEMPTS:2}
     initial-delay-ms: ${GEMINI_RETRY_INITIAL_DELAY_MS:1000}
 
+admin:
+  # 개발 서버 전용 관리자 백오피스. 기본 비활성(fail-safe) — ADMIN_ENABLED=true 를 명시한 환경에서만 빈/라우트가 뜬다.
+  # 이 프로젝트엔 런타임 dev 프로파일이 없어(@Profile 미사용) 프로퍼티 게이팅으로 운영 노출을 차단한다.
+  enabled: ${ADMIN_ENABLED:false}
+  # enabled=true 인데 아래가 비어 있으면 AdminProperties.init 에서 부팅 실패시킨다 ("켰는데 로그인 불가" 방지).
+  username: ${ADMIN_USERNAME:}
+  password: ${ADMIN_PASSWORD:}
+
 s3:
   # 크롭한 상품 이미지 저장 버킷. 자격증명은 EC2 instance role / 로컬 환경변수(DefaultCredentialsProvider).
   bucket: ${S3_BUCKET:}

--- a/src/main/resources/db/migration/V20260529191939__create_admin_audit_logs.sql
+++ b/src/main/resources/db/migration/V20260529191939__create_admin_audit_logs.sql
@@ -1,0 +1,19 @@
+-- admin 백오피스가 실행한 작업의 감사 로그. append-only.
+-- 정책: FK 없음(admin 계정은 InMemory 라 users 와 무관) / 테이블명 복수형 / utf8mb4.
+-- created_at/updated_at/deleted_at 은 LongBaseEntity 컬럼 규약을 따른다(ddl-auto=validate 통과용).
+CREATE TABLE admin_audit_logs (
+    id              BIGINT        NOT NULL AUTO_INCREMENT,
+    admin_username  VARCHAR(100)  NOT NULL COMMENT '실행 admin (InMemory 계정명)',
+    action_type     VARCHAR(50)   NOT NULL COMMENT 'WRITE_COMMIT 등 작업 분류',
+    tool_name       VARCHAR(100)  NOT NULL COMMENT '엔진이 호출한 tool 이름',
+    result_status   VARCHAR(20)   NOT NULL COMMENT 'SUCCESS / FAILED',
+    parameters      JSON          NULL COMMENT '마스킹된 파라미터(민감정보 제거 후)',
+    result_summary  VARCHAR(1000) NULL COMMENT '결과 요약(원문 전체 저장 안 함)',
+    request_message VARCHAR(2000) NULL COMMENT '사용자 자연어 요청(마스킹)',
+    created_at      DATETIME(6)   NOT NULL,
+    updated_at      DATETIME(6)   NOT NULL,
+    deleted_at      DATETIME(6)   NULL,
+    PRIMARY KEY (id),
+    KEY idx_admin_audit_logs_admin_username (admin_username),
+    KEY idx_admin_audit_logs_created_at (created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/src/main/resources/db/migration/V20260529220201__add_index_on_items_created_at.sql
+++ b/src/main/resources/db/migration/V20260529220201__add_index_on_items_created_at.sql
@@ -1,0 +1,4 @@
+-- admin 조회 도구(list_recent_items)의 'where deleted_at is null order by created_at desc LIMIT n' 이
+-- full table scan + filesort 를 타지 않도록 복합 인덱스를 추가한다. deleted_at(등치) + created_at(정렬)
+-- 순서라 필터와 정렬을 한 인덱스로 처리해 LIMIT 가 정렬을 short-circuit 한다. FK 아님(조회 인덱스).
+ALTER TABLE items ADD KEY idx_items_deleted_created (deleted_at, created_at);

--- a/src/main/resources/static/admin-assets/backoffice.css
+++ b/src/main/resources/static/admin-assets/backoffice.css
@@ -1,0 +1,290 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
+  background: #f4f5f7;
+  color: #1f2329;
+}
+
+/* 로그인 */
+.login-container {
+  max-width: 360px;
+  margin: 120px auto;
+  padding: 32px;
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+  text-align: center;
+}
+
+.login-container h1 {
+  margin: 0 0 4px;
+  font-size: 24px;
+}
+
+.login-desc {
+  margin: 0 0 24px;
+  color: #6b7280;
+  font-size: 14px;
+}
+
+.login-error {
+  color: #d92d20;
+  font-size: 14px;
+}
+
+.login-info {
+  color: #2563eb;
+  font-size: 14px;
+}
+
+.login-container form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.login-container input {
+  padding: 12px;
+  border: 1px solid #d0d5dd;
+  border-radius: 8px;
+  font-size: 15px;
+}
+
+.login-container button {
+  padding: 12px;
+  border: none;
+  border-radius: 8px;
+  background: #2563eb;
+  color: #fff;
+  font-size: 15px;
+  cursor: pointer;
+}
+
+.login-container button:hover {
+  background: #1d4ed8;
+}
+
+/* 백오피스 셸 (사이드바 + 본문) */
+.bo-shell {
+  display: flex;
+  min-height: 100vh;
+}
+
+.bo-sidebar {
+  width: 220px;
+  flex-shrink: 0;
+  background: #1f2329;
+  color: #e5e7eb;
+  display: flex;
+  flex-direction: column;
+  padding: 20px 0;
+}
+
+.bo-brand {
+  padding: 0 20px 20px;
+  font-size: 18px;
+  font-weight: 600;
+  border-bottom: 1px solid #343a40;
+}
+
+.bo-nav {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 12px 0;
+}
+
+.bo-nav a {
+  padding: 12px 20px;
+  color: #c0c4cc;
+  text-decoration: none;
+  font-size: 15px;
+}
+
+.bo-nav a:hover {
+  background: #2b3036;
+  color: #fff;
+}
+
+.bo-nav a.active {
+  background: #2563eb;
+  color: #fff;
+}
+
+.bo-logout {
+  padding: 12px 20px 0;
+}
+
+.bo-logout button {
+  width: 100%;
+  padding: 10px;
+  border: 1px solid #4b5563;
+  border-radius: 8px;
+  background: transparent;
+  color: #c0c4cc;
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.bo-logout button:hover {
+  background: #2b3036;
+  color: #fff;
+}
+
+.bo-main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  background: #fff;
+}
+
+.bo-header {
+  padding: 16px 24px;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.bo-header h1 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.bo-content {
+  padding: 24px;
+  overflow-y: auto;
+}
+
+.bo-desc {
+  margin: 0 0 20px;
+  color: #6b7280;
+}
+
+/* 홈(대시보드) 카드 */
+.bo-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 16px;
+}
+
+.bo-card {
+  display: block;
+  padding: 20px;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  text-decoration: none;
+  color: inherit;
+  background: #fff;
+  transition: box-shadow 0.15s;
+}
+
+.bo-card:hover {
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.bo-card h2 {
+  margin: 0 0 8px;
+  font-size: 16px;
+}
+
+.bo-card p {
+  margin: 0;
+  color: #6b7280;
+  font-size: 14px;
+}
+
+.bo-card-disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+
+.bo-card-disabled:hover {
+  box-shadow: none;
+}
+
+/* 플래시 메시지 */
+.bo-message {
+  padding: 12px 16px;
+  border-radius: 8px;
+  background: #e7f5ec;
+  color: #137333;
+  margin: 0 0 16px;
+}
+
+.bo-error {
+  padding: 12px 16px;
+  border-radius: 8px;
+  background: #fee4e2;
+  color: #d92d20;
+  margin: 0 0 16px;
+}
+
+/* 패널 (폼 / 테이블 묶음) */
+.bo-panel {
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 20px;
+  margin-bottom: 20px;
+}
+
+.bo-panel h2 {
+  margin: 0 0 16px;
+  font-size: 16px;
+}
+
+/* 폼 */
+.bo-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 12px;
+  max-width: 320px;
+}
+
+.bo-field label {
+  font-size: 13px;
+  color: #6b7280;
+}
+
+.bo-field input {
+  padding: 10px 12px;
+  border: 1px solid #d0d5dd;
+  border-radius: 8px;
+  font-size: 15px;
+}
+
+.bo-panel form button {
+  padding: 10px 20px;
+  border: none;
+  border-radius: 8px;
+  background: #2563eb;
+  color: #fff;
+  font-size: 15px;
+  cursor: pointer;
+}
+
+.bo-panel form button:hover {
+  background: #1d4ed8;
+}
+
+/* 테이블 */
+.bo-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+.bo-table th,
+.bo-table td {
+  padding: 10px 12px;
+  border-bottom: 1px solid #e5e7eb;
+  text-align: left;
+}
+
+.bo-table th {
+  color: #6b7280;
+  font-weight: 600;
+}

--- a/src/main/resources/templates/admin/fragments/layout.html
+++ b/src/main/resources/templates/admin/fragments/layout.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<!--
+  PIKI 백오피스 공통 레이아웃 fragment.
+  head(pageTitle): 메타·CSS.
+  sidebar(active): 좌측 네비. active 인자로 현재 메뉴를 강조한다. 기능이 늘면 nav 에 항목을 추가한다.
+-->
+<head th:fragment="head(pageTitle)">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title th:text="${pageTitle}">PIKI 백오피스</title>
+    <link rel="stylesheet" th:href="@{/admin-assets/backoffice.css}">
+</head>
+<body>
+<aside th:fragment="sidebar(active)" class="bo-sidebar">
+    <div class="bo-brand">PIKI 백오피스</div>
+    <nav class="bo-nav">
+        <a th:href="@{/admin}" th:classappend="${active == 'home'} ? ' active' : ''">대시보드</a>
+        <a th:href="@{/admin/items}" th:classappend="${active == 'items'} ? ' active' : ''">실험 데이터</a>
+    </nav>
+    <form th:action="@{/admin/logout}" method="post" class="bo-logout">
+        <button type="submit">로그아웃</button>
+    </form>
+</aside>
+</body>
+</html>

--- a/src/main/resources/templates/admin/home.html
+++ b/src/main/resources/templates/admin/home.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{admin/fragments/layout :: head('PIKI 백오피스')}"></head>
+<body>
+<div class="bo-shell">
+    <div th:replace="~{admin/fragments/layout :: sidebar('home')}"></div>
+    <main class="bo-main">
+        <header class="bo-header">
+            <h1>대시보드</h1>
+        </header>
+        <section class="bo-content">
+            <p class="bo-desc">PIKI 개발 서버 운영 도구입니다. 아래 기능을 사용할 수 있습니다.</p>
+            <div class="bo-cards">
+                <a th:href="@{/admin/items}" class="bo-card">
+                    <h2>실험 데이터</h2>
+                    <p>샘플 상품을 추가하고 최근 등록된 item 을 조회합니다.</p>
+                </a>
+                <div class="bo-card bo-card-disabled">
+                    <h2>추가 기능</h2>
+                    <p>백오피스 기능이 순차적으로 추가될 예정입니다.</p>
+                </div>
+            </div>
+        </section>
+    </main>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/admin/items.html
+++ b/src/main/resources/templates/admin/items.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{admin/fragments/layout :: head('실험 데이터 - PIKI 백오피스')}"></head>
+<body>
+<div class="bo-shell">
+    <div th:replace="~{admin/fragments/layout :: sidebar('items')}"></div>
+    <main class="bo-main">
+        <header class="bo-header">
+            <h1>실험 데이터</h1>
+        </header>
+        <section class="bo-content">
+            <p class="bo-message" th:if="${message}" th:text="${message}"></p>
+            <p class="bo-error" th:if="${error}" th:text="${error}"></p>
+
+            <div class="bo-panel">
+                <h2>샘플 상품 추가</h2>
+                <form th:action="@{/admin/items/samples}" method="post"
+                      onsubmit="return confirm('입력한 개수만큼 샘플 상품을 추가하시겠습니까?');">
+                    <div class="bo-field">
+                        <label for="count">개수 (1-50)</label>
+                        <input type="number" id="count" name="count" min="1" max="50" value="3" required>
+                    </div>
+                    <div class="bo-field">
+                        <label for="namePrefix">이름 접두사 (선택)</label>
+                        <input type="text" id="namePrefix" name="namePrefix" placeholder="샘플 상품" maxlength="100">
+                    </div>
+                    <button type="submit">추가</button>
+                </form>
+            </div>
+
+            <div class="bo-panel">
+                <h2>최근 item</h2>
+                <table class="bo-table">
+                    <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>이름</th>
+                        <th>가격</th>
+                        <th>통화</th>
+                        <th>상태</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr th:each="item : ${items}">
+                        <td th:text="${item.idOrNull}">-</td>
+                        <td th:text="${item.name}">-</td>
+                        <td th:text="${item.currentPrice}">-</td>
+                        <td th:text="${item.currency}">-</td>
+                        <td th:text="${item.status}">-</td>
+                    </tr>
+                    <tr th:if="${#lists.isEmpty(items)}">
+                        <td colspan="5">등록된 item 이 없습니다.</td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+    </main>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/admin/login.html
+++ b/src/main/resources/templates/admin/login.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PIKI 백오피스 로그인</title>
+    <link rel="stylesheet" th:href="@{/admin-assets/backoffice.css}">
+</head>
+<body>
+<div class="login-container">
+    <h1>PIKI 백오피스</h1>
+    <p class="login-desc">개발 서버 운영 도구</p>
+    <p class="login-error" th:if="${param.error}">아이디 또는 비밀번호가 올바르지 않습니다.</p>
+    <p class="login-info" th:if="${param.logout}">로그아웃되었습니다.</p>
+    <form th:action="@{/admin/login}" method="post">
+        <input type="text" name="username" placeholder="아이디" required autofocus>
+        <input type="password" name="password" placeholder="비밀번호" required>
+        <button type="submit">로그인</button>
+    </form>
+</div>
+</body>
+</html>

--- a/src/test/kotlin/com/depromeet/piki/admin/item/AdminItemControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/admin/item/AdminItemControllerIntegrationTest.kt
@@ -5,6 +5,8 @@ import com.depromeet.piki.item.repository.ItemRepository
 import com.depromeet.piki.support.IntegrationTestSupport
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.mock.web.MockHttpSession
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestBuilders.formLogin
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user
 import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
@@ -52,6 +54,21 @@ class AdminItemControllerIntegrationTest : IntegrationTestSupport() {
     }
 
     @Test
+    fun `실제 form login 으로 로그인하면 세션으로 실험 데이터 페이지에 접근된다`() {
+        // user() 주입이 아니라 실제 /admin/login POST 로 인증해, AdminSecurityConfig 의 form login·
+        // provider·비번 검증·세션 생성·성공 리다이렉트 경로까지 한 번 검증한다(CodeRabbit 지적 반영).
+        val login =
+            mockMvc()
+                .perform(formLogin("/admin/login").user("admin").password("admin-test-pw"))
+                .andExpect(status().is3xxRedirection)
+                .andReturn()
+        val session = login.request.session as MockHttpSession
+        mockMvc()
+            .perform(get("/admin/items").session(session))
+            .andExpect(status().isOk)
+    }
+
+    @Test
     fun `CSRF 토큰 없이 샘플 추가를 요청하면 403 이 반환된다`() {
         mockMvc()
             .perform(
@@ -76,11 +93,13 @@ class AdminItemControllerIntegrationTest : IntegrationTestSupport() {
 
         assertEquals(3, itemRepository.findRecent(10).size)
 
-        val logs = adminAuditLogRepository.findAll()
-        assertEquals(1, logs.size)
-        assertEquals("SUCCESS", logs.first().resultStatus)
-        assertEquals("items", logs.first().toolName)
-        assertEquals("INSERT_SAMPLE_ITEMS", logs.first().actionType)
+        // findAll 은 순서를 보장하지 않으므로 방금 요청의 로그를 action/tool 로 특정해 단언한다.
+        val log =
+            adminAuditLogRepository.findAll().single {
+                it.toolName == "items" && it.actionType == "INSERT_SAMPLE_ITEMS"
+            }
+        assertEquals("SUCCESS", log.resultStatus)
+        assertEquals("admin", log.adminUsername)
     }
 
     @Test

--- a/src/test/kotlin/com/depromeet/piki/admin/item/AdminItemControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/admin/item/AdminItemControllerIntegrationTest.kt
@@ -1,0 +1,100 @@
+package com.depromeet.piki.admin.item
+
+import com.depromeet.piki.admin.audit.AdminAuditLogRepository
+import com.depromeet.piki.item.repository.ItemRepository
+import com.depromeet.piki.support.IntegrationTestSupport
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.flash
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.context.WebApplicationContext
+import kotlin.test.assertEquals
+
+@Transactional
+class AdminItemControllerIntegrationTest : IntegrationTestSupport() {
+    @Autowired
+    private lateinit var webApplicationContext: WebApplicationContext
+
+    @Autowired
+    private lateinit var itemRepository: ItemRepository
+
+    @Autowired
+    private lateinit var adminAuditLogRepository: AdminAuditLogRepository
+
+    private fun mockMvc(): MockMvc =
+        MockMvcBuilders
+            .webAppContextSetup(webApplicationContext)
+            .apply<DefaultMockMvcBuilder>(springSecurity())
+            .build()
+
+    @Test
+    fun `미인증으로 실험 데이터 페이지에 접근하면 로그인 페이지로 리다이렉트된다`() {
+        mockMvc()
+            .perform(get("/admin/items"))
+            .andExpect(status().is3xxRedirection)
+    }
+
+    @Test
+    fun `로그인하면 실험 데이터 페이지가 200 으로 렌더된다`() {
+        mockMvc()
+            .perform(get("/admin/items").with(user("admin").roles("ADMIN")))
+            .andExpect(status().isOk)
+    }
+
+    @Test
+    fun `CSRF 토큰 없이 샘플 추가를 요청하면 403 이 반환된다`() {
+        mockMvc()
+            .perform(
+                post("/admin/items/samples")
+                    .with(user("admin").roles("ADMIN"))
+                    .param("count", "3"),
+            ).andExpect(status().isForbidden)
+    }
+
+    @Test
+    fun `샘플 추가는 DB 에 반영되고 감사 로그에 SUCCESS 로 기록된 뒤 목록으로 리다이렉트된다`() {
+        mockMvc()
+            .perform(
+                post("/admin/items/samples")
+                    .with(user("admin").roles("ADMIN"))
+                    .with(csrf())
+                    .param("count", "3")
+                    .param("namePrefix", "테스트상품"),
+            ).andExpect(status().is3xxRedirection)
+            .andExpect(redirectedUrl("/admin/items"))
+            .andExpect(flash().attributeExists("message"))
+
+        assertEquals(3, itemRepository.findRecent(10).size)
+
+        val logs = adminAuditLogRepository.findAll()
+        assertEquals(1, logs.size)
+        assertEquals("SUCCESS", logs.first().resultStatus)
+        assertEquals("items", logs.first().toolName)
+        assertEquals("INSERT_SAMPLE_ITEMS", logs.first().actionType)
+    }
+
+    @Test
+    fun `허용 범위를 벗어난 개수는 추가되지 않고 오류 메시지와 함께 리다이렉트된다`() {
+        mockMvc()
+            .perform(
+                post("/admin/items/samples")
+                    .with(user("admin").roles("ADMIN"))
+                    .with(csrf())
+                    .param("count", "0"),
+            ).andExpect(status().is3xxRedirection)
+            .andExpect(redirectedUrl("/admin/items"))
+            .andExpect(flash().attributeExists("error"))
+
+        assertEquals(0, itemRepository.findRecent(10).size)
+    }
+}

--- a/src/test/kotlin/com/depromeet/piki/tournament/service/TournamentServiceTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/service/TournamentServiceTest.kt
@@ -95,6 +95,8 @@ class TournamentServiceTest {
 
         override fun findStaleProcessingIds(cutoff: java.time.LocalDateTime): List<Long> = emptyList()
 
+        override fun findRecent(limit: Int): List<Item> = emptyList()
+
         companion object {
             const val DEFAULT_PRICE = 10_000
         }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -37,3 +37,10 @@ management:
   metrics:
     tags:
       application: ${spring.application.name}
+
+# admin 백오피스를 모든 통합 테스트가 공유하는 단일 컨텍스트에서 항상 켠다(전역 1회 — @ActiveProfiles 분기 금지).
+# 폼 기반이라 외부 LLM 호출이 없고, 자격증명은 부팅 통과용 더미.
+admin:
+  enabled: true
+  username: admin
+  password: admin-test-pw


### PR DESCRIPTION
> 챗봇 접근(#294)을 폼 기반으로 재설계해 대체하는 PR입니다. DB 조작을 안전하게 하려고 화이트리스트 tool 로 제한하면 LLM 자연어 유연성이 거의 쓰이지 않고, "정해진 작업 + 단순 파라미터"는 폼이 정확·즉시·무비용·프롬프트인젝션 무풍이며, 챗봇 멀티턴 복잡도가 버그(dangling functionCall·세션 동시성·budget)의 원천이었습니다. **#294 는 닫습니다.**

## Situation
- 개발 서버에서 실험용 데이터 추가·상태 확인 같은 운영 작업을 매번 DB 콘솔로 처리하는 번거로움이 있었다
- 백엔드뿐 아니라 프론트·디자이너도 테스트 데이터를 직접 다룰 수 있는 내부 도구가 필요했다

## Task
- 개발 서버 전용 admin 백오피스에서 폼으로 item 실험 데이터를 추가/조회
- 운영 환경에는 절대 노출되지 않도록 게이팅

## Action
### 백오피스 셸·보안·게이팅
- `/admin` 전용 SecurityFilterChain(`@Order(1)`, 세션 form login, 환경변수 단일 계정, BCrypt)을 기존 JWT stateless 체인(`@Order(2)`)과 분리. provider 를 체인-로컬로 묶어 전역에 admin 계정이 새지 않게 함
- `@ConditionalOnAdminEnabled` 메타 어노테이션으로 모든 admin 빈을 `admin.enabled`(기본 false, fail-safe)로 게이팅 — 운영에선 라우트조차 안 뜬다. 이 레포엔 런타임 dev 프로파일이 없어 `@Profile` 대신 프로퍼티 게이팅을 택함
- Thymeleaf 공통 레이아웃(헤더 + 사이드바)으로 향후 기능이 메뉴로 확장되는 구조

### 폼 기반 실험 데이터
- 최근 item 조회(테이블) + 샘플 상품 추가 폼. PRG(POST-Redirect-Get) 패턴 + flash 메시지, 확인은 폼 JS confirm
- AdminItemService 가 검증·영속화·감사를 한 트랜잭션으로 묶고, 검증은 입력 경계(폼)와 service(require) 양쪽에 둠

### 감사·성능
- admin 작업 감사 로그(`admin_audit_logs`, FK 없음). 마스킹은 중첩 map/list 까지 재귀 적용
- `findRecent` 의 `order by created_at desc LIMIT` 가 full scan + filesort 를 타지 않도록 `(deleted_at, created_at)` 인덱스 추가

## Result
- 1차 기능: 최근 item 조회 + 샘플 추가. 단위/통합 테스트 통과(보안경계·DB 반영·감사 SUCCESS·검증 실패 미반영·CSRF 403)
- 배포: `ADMIN_ENABLED` 기본 false 라 머지해도 운영 노출 없음. dev 서버 노출은 팀 합의 후 별도 PR(`deploy.yml` + GitHub Secrets)
- 후속: 위시 테스트 계정 생성·토너먼트 상태별 생성·데이터 현황 조회·정리도 같은 폼 패턴으로 사이드바 메뉴를 늘려 추가

## 연관 이슈
- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **New Features**
  * 관리자 백오피스 시스템 추가: 보안 로그인 및 대시보드 제공
  * 아이템 관리 페이지: 최근 항목 목록 조회 기능
  * 테스트용 샘플 데이터 자동 생성 도구 추가
  * 모든 관리자 작업의 감사 로그 기록 기능

* **Infrastructure**
  * 관리자 감사 로그 저장을 위한 데이터베이스 테이블 추가
  * 템플릿 렌더링 라이브러리 통합

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/PIKI-Server/pull/298?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->