### PR TITLE
PIKI 앱 개요 Grafana 대시보드 추가 (메트릭 + 로그)

### DIFF
--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -1,0 +1,26 @@
+# Grafana 대시보드
+
+`dashboard.json` 은 PIKI 앱 개요 대시보드다 — 주요 메트릭과 앱 로그를 한 화면에 모은다.
+Grafana Cloud 가 호스팅하는 Grafana 이므로 셀프호스팅 provisioning 이 아니라 **수동 import** 한다.
+
+## Import 방법
+
+1. Grafana Cloud(`piki.grafana.net`) → **Dashboards → New → Import**
+2. `dashboard.json` 내용을 붙여넣기(또는 파일 업로드)
+3. 데이터소스 매핑:
+   - **DS_PROM** → `grafanacloud-piki-prom` (Prometheus)
+   - **DS_LOKI** → `grafanacloud-piki-logs` (Loki)
+4. **Import**
+
+## 패널
+
+HTTP 요청률·p95 지연, JVM heap 메모리·라이브 스레드·GC pause, HikariCP 커넥션풀,
+executor 스레드풀, process/system CPU, 그리고 `team3-blue`/`team3-green` 앱 로그.
+
+모든 메트릭은 `application="PIKI"` 라벨로 필터한다(Alloy 의 prometheus.scrape 가 붙임).
+blue-green 이라 한 시점에 한 슬롯만 활성이며, `instance` 라벨로 blue/green 을 구분한다.
+
+## 갱신
+
+GC 콘솔에서 대시보드를 수정한 뒤 **Dashboard settings → JSON Model** 을 복사해 이 파일을 덮어쓰면
+변경이 버전관리된다. (반대로 이 파일을 고쳐 다시 import 해도 된다.)

--- a/infra/grafana/dashboard.json
+++ b/infra/grafana/dashboard.json
@@ -1,0 +1,246 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROM",
+      "label": "Prometheus",
+      "description": "PIKI 메트릭 (grafanacloud-piki-prom)",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    },
+    {
+      "name": "DS_LOKI",
+      "label": "Loki",
+      "description": "PIKI 로그 (grafanacloud-piki-logs)",
+      "type": "datasource",
+      "pluginId": "loki",
+      "pluginName": "Loki"
+    }
+  ],
+  "__requires": [],
+  "title": "PIKI - 앱 개요",
+  "uid": "piki-app-overview",
+  "tags": ["piki"],
+  "timezone": "browser",
+  "editable": true,
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-1h", "to": "now" },
+  "templating": { "list": [] },
+  "annotations": { "list": [] },
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "HTTP 요청률 (req/s, status별)",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never" } },
+        "overrides": []
+      },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "expr": "sum by (status) (rate(http_server_requests_seconds_count{application=\"PIKI\"}[$__rate_interval]))",
+          "legendFormat": "{{status}}"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "HTTP p95 지연 (uri별)",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+      "fieldConfig": {
+        "defaults": { "unit": "s", "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never" } },
+        "overrides": []
+      },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "expr": "histogram_quantile(0.95, sum by (le, uri) (rate(http_server_requests_seconds_bucket{application=\"PIKI\"}[$__rate_interval])))",
+          "legendFormat": "{{uri}}"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "JVM Heap 메모리 사용",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+      "fieldConfig": {
+        "defaults": { "unit": "bytes", "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never" } },
+        "overrides": []
+      },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "expr": "sum by (instance) (jvm_memory_used_bytes{application=\"PIKI\", area=\"heap\"})",
+          "legendFormat": "used {{instance}}"
+        },
+        {
+          "refId": "B",
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "expr": "sum by (instance) (jvm_memory_max_bytes{application=\"PIKI\", area=\"heap\"})",
+          "legendFormat": "max {{instance}}"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "JVM 라이브 스레드",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+      "fieldConfig": {
+        "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never" } },
+        "overrides": []
+      },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "expr": "jvm_threads_live_threads{application=\"PIKI\"}",
+          "legendFormat": "{{instance}}"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "HikariCP 커넥션풀",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+      "fieldConfig": {
+        "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never" } },
+        "overrides": []
+      },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "expr": "hikaricp_connections_active{application=\"PIKI\"}",
+          "legendFormat": "active {{pool}}"
+        },
+        {
+          "refId": "B",
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "expr": "hikaricp_connections_idle{application=\"PIKI\"}",
+          "legendFormat": "idle {{pool}}"
+        },
+        {
+          "refId": "C",
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "expr": "hikaricp_connections_pending{application=\"PIKI\"}",
+          "legendFormat": "pending {{pool}}"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Executor 스레드풀 (active / queued)",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+      "fieldConfig": {
+        "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never" } },
+        "overrides": []
+      },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "expr": "executor_active_threads{application=\"PIKI\"}",
+          "legendFormat": "active {{name}}"
+        },
+        {
+          "refId": "B",
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "expr": "executor_queued_tasks{application=\"PIKI\"}",
+          "legendFormat": "queued {{name}}"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "CPU 사용률 (process / system)",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+      "fieldConfig": {
+        "defaults": { "unit": "percentunit", "min": 0, "max": 1, "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never" } },
+        "overrides": []
+      },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "expr": "process_cpu_usage{application=\"PIKI\"}",
+          "legendFormat": "process {{instance}}"
+        },
+        {
+          "refId": "B",
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "expr": "system_cpu_usage{application=\"PIKI\"}",
+          "legendFormat": "system {{instance}}"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "JVM GC pause (p99)",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+      "fieldConfig": {
+        "defaults": { "unit": "s", "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never" } },
+        "overrides": []
+      },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(jvm_gc_pause_seconds_bucket{application=\"PIKI\"}[$__rate_interval])))",
+          "legendFormat": "gc pause p99"
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "type": "logs",
+      "title": "앱 로그 (team3-blue / team3-green)",
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 32 },
+      "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+      "options": {
+        "showTime": true,
+        "showLabels": false,
+        "wrapLogMessage": true,
+        "enableLogDetails": true,
+        "dedupStrategy": "none",
+        "sortOrder": "Descending"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+          "expr": "{container=~\"team3-(blue|green)\"}"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Situation
- PR #290·#292·#296 으로 메트릭·로그가 Grafana Cloud 로 들어오기 시작했지만, 보려면 Explore 에서 매번 쿼리해야 했다. 주요 지표와 앱 로그를 한 화면에 모아 계속 보는 대시보드가 없었다.

## Action
- `infra/grafana/dashboard.json` 으로 PIKI 앱 개요 대시보드를 코드화. 9개 패널을 한 화면에:
  - HTTP 요청률·p95 지연, JVM heap 메모리·라이브 스레드·GC pause p99, HikariCP 커넥션풀, executor 스레드풀, process/system CPU
  - `team3-blue`/`team3-green` 앱 로그 패널(Loki)
- 메트릭은 `application="PIKI"` 필터, blue-green 은 `instance` 라벨로 구분. datasource 는 GC 마다 uid 가 다르므로 `__inputs` 변수(DS_PROM/DS_LOKI)로 두어 import 시 선택한다.
- `infra/grafana/README.md` 에 import 절차·datasource 매핑·갱신(JSON Model export) 방법 명시.

## Result
- GC 콘솔에서 Dashboards → Import → JSON 붙여넣기 → datasource 매핑만 하면 메트릭+로그가 한 화면에 뜬다. 대시보드가 레포에 버전관리된다.
- 모니터링 스택(계측 → 수집 → 시각화)의 시각화 단계 마무리.
- 참고: GC 가 호스팅하는 Grafana 라 자동 provisioning 이 아니라 수동 import 다. import 후 빈 패널이 있으면 해당 메트릭 이름만 보정하면 된다.

---
## 연관 이슈

- 
