### PR TITLE
Cookie + body 양쪽 응답으로 웹·앱 토큰 전달 contract

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,10 @@ JWT_SECRET=local-dev-jwt-secret-must-be-at-least-32-chars!
 REDIS_HOST=localhost
 REDIS_PORT=6379
 
+# 토큰 쿠키 Secure 속성. 로컬은 HTTP 라 false 로 둬야 브라우저가 쿠키를 전송한다.
+# 운영(HTTPS)은 true (application.yml 기본값). 줄 끝 인라인 주석 금지 — 값만 둔다.
+COOKIE_SECURE=false
+
 # OAuth — 실 호출은 epic #122 (https://github.com/depromeet/PIKI-Server/issues/122) 의
 # Task 6 시점부터. 그 전까진 빈 값으로 둬도 부팅 영향 없음.
 KAKAO_CLIENT_ID=

--- a/src/main/kotlin/com/depromeet/piki/auth/controller/AuthApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/controller/AuthApi.kt
@@ -1,11 +1,14 @@
 package com.depromeet.piki.auth.controller
 
 import com.depromeet.piki.auth.controller.dto.GuestCreateResponse
+import com.depromeet.piki.auth.controller.dto.LogoutResponse
 import com.depromeet.piki.auth.controller.dto.TokenRefreshRequest
 import com.depromeet.piki.auth.controller.dto.TokenRefreshResponse
+import com.depromeet.piki.auth.web.ClientType
 import com.depromeet.piki.common.response.ApiResponseBody
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.enums.ParameterIn
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
@@ -19,7 +22,10 @@ import java.util.UUID
 interface AuthApi {
     @Operation(
         summary = "게스트 생성",
-        description = "새 GUEST User 를 생성하고 JWT 토큰 쌍을 발급한다.",
+        description =
+            "새 GUEST User 를 생성하고 JWT 토큰 쌍을 발급한다. " +
+                "X-Client-Type: web 이면 토큰을 HttpOnly 쿠키(Set-Cookie)로 내리고 body 토큰은 null, " +
+                "그 외(APP·미설정)는 body 로 토큰을 내린다.",
     )
     // 인증 없이 호출하는 진입점 (SecurityConfig 의 permitAll). 글로벌 Bearer 요구를 해제한다.
     @SecurityRequirements
@@ -27,7 +33,7 @@ interface AuthApi {
         value = [
             ApiResponse(
                 responseCode = "201",
-                description = "게스트 생성 성공",
+                description = "게스트 생성 성공 (WEB: Set-Cookie 2개 + body 토큰 null / APP: body 토큰)",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,
@@ -37,11 +43,21 @@ interface AuthApi {
             ),
         ],
     )
+    @Parameter(
+        name = ClientType.HEADER,
+        `in` = ParameterIn.HEADER,
+        required = false,
+        description = "클라이언트 종류. web 이면 토큰을 HttpOnly 쿠키로 받고 body 토큰은 null. 그 외·미설정은 body 로 받음(기본).",
+        schema = Schema(allowableValues = ["web", "app"]),
+    )
     fun createGuest(): ApiResponseBody<GuestCreateResponse>
 
     @Operation(
         summary = "토큰 갱신",
-        description = "리프레시 토큰을 검증하고 새 액세스·리프레시 토큰 쌍을 발급한다.",
+        description =
+            "리프레시 토큰을 검증하고 새 액세스·리프레시 토큰 쌍을 발급한다. " +
+                "리프레시 토큰은 refresh_token 쿠키(WEB) 또는 요청 body(APP) 어느 쪽으로든 받는다. " +
+                "X-Client-Type: web 이면 새 토큰을 Set-Cookie 로 회전하고 body 토큰은 null.",
     )
     // 만료된 액세스 토큰을 가진 클라이언트도 호출해야 하므로 인증 없이 진입 (SecurityConfig 의 permitAll).
     @SecurityRequirements
@@ -49,7 +65,7 @@ interface AuthApi {
         value = [
             ApiResponse(
                 responseCode = "200",
-                description = "토큰 갱신 성공",
+                description = "토큰 갱신 성공 (WEB: Set-Cookie 회전 + body 토큰 null / APP: body 토큰)",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,
@@ -59,7 +75,7 @@ interface AuthApi {
             ),
             ApiResponse(
                 responseCode = "400",
-                description = "refreshToken 미입력",
+                description = "리프레시 토큰 미입력 (쿠키·body 모두 없음) · body 의 refreshToken 이 공백",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,
@@ -79,17 +95,30 @@ interface AuthApi {
             ),
         ],
     )
-    fun refresh(request: TokenRefreshRequest): ApiResponseBody<TokenRefreshResponse>
+    @Parameter(
+        name = ClientType.HEADER,
+        `in` = ParameterIn.HEADER,
+        required = false,
+        description = "클라이언트 종류. web 이면 새 토큰을 Set-Cookie 로 회전하고 body 토큰은 null. 그 외·미설정은 body 로 받음(기본).",
+        schema = Schema(allowableValues = ["web", "app"]),
+    )
+    fun refresh(
+        request: TokenRefreshRequest?,
+        @Parameter(hidden = true) cookieRefreshToken: String?,
+    ): ApiResponseBody<TokenRefreshResponse>
 
     @Operation(
         summary = "로그아웃",
-        description = "리프레시 토큰을 삭제하여 로그아웃 처리한다.",
+        description =
+            "리프레시 토큰을 삭제하여 로그아웃 처리하고, 토큰 쿠키를 만료(Max-Age=0)시킨다. " +
+                "쿠키 만료는 클라이언트 종류와 무관하게 항상 내려간다(웹 쿠키가 확실히 삭제되도록). " +
+                "APP 은 쿠키를 쓰지 않아 영향 없다.",
     )
     @ApiResponses(
         value = [
             ApiResponse(
                 responseCode = "200",
-                description = "로그아웃 성공",
+                description = "로그아웃 성공 (토큰 쿠키 만료)",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,
@@ -111,5 +140,5 @@ interface AuthApi {
     )
     fun logout(
         @Parameter(hidden = true) userId: UUID,
-    ): ApiResponseBody<Unit>
+    ): ApiResponseBody<LogoutResponse>
 }

--- a/src/main/kotlin/com/depromeet/piki/auth/controller/AuthApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/controller/AuthApi.kt
@@ -24,8 +24,8 @@ interface AuthApi {
         summary = "게스트 생성",
         description =
             "새 GUEST User 를 생성하고 JWT 토큰 쌍을 발급한다. " +
-                "X-Client-Type: web 이면 토큰을 HttpOnly 쿠키(Set-Cookie)로 내리고 body 토큰은 null, " +
-                "그 외(APP·미설정)는 body 로 토큰을 내린다.",
+                "기본은 토큰을 HttpOnly 쿠키(Set-Cookie)로 내리고 body 토큰은 null 이며(secure by default), " +
+                "X-Client-Type: app 일 때만 body 로 토큰을 내린다(네이티브 앱).",
     )
     // 인증 없이 호출하는 진입점 (SecurityConfig 의 permitAll). 글로벌 Bearer 요구를 해제한다.
     @SecurityRequirements
@@ -33,7 +33,7 @@ interface AuthApi {
         value = [
             ApiResponse(
                 responseCode = "201",
-                description = "게스트 생성 성공 (WEB: Set-Cookie 2개 + body 토큰 null / APP: body 토큰)",
+                description = "게스트 생성 성공 (기본: Set-Cookie 2개 + body 토큰 null / app: body 토큰)",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,
@@ -47,7 +47,7 @@ interface AuthApi {
         name = ClientType.HEADER,
         `in` = ParameterIn.HEADER,
         required = false,
-        description = "클라이언트 종류. web 이면 토큰을 HttpOnly 쿠키로 받고 body 토큰은 null. 그 외·미설정은 body 로 받음(기본).",
+        description = "클라이언트 종류. app 이면 body 로 토큰을 받는다(네이티브 secure storage). 그 외·미설정은 HttpOnly 쿠키로 받고 body 토큰은 null(기본, secure by default).",
         schema = Schema(allowableValues = ["web", "app"]),
     )
     fun createGuest(): ApiResponseBody<GuestCreateResponse>
@@ -56,8 +56,8 @@ interface AuthApi {
         summary = "토큰 갱신",
         description =
             "리프레시 토큰을 검증하고 새 액세스·리프레시 토큰 쌍을 발급한다. " +
-                "리프레시 토큰은 refresh_token 쿠키(WEB) 또는 요청 body(APP) 어느 쪽으로든 받는다. " +
-                "X-Client-Type: web 이면 새 토큰을 Set-Cookie 로 회전하고 body 토큰은 null.",
+                "리프레시 토큰은 refresh_token 쿠키(기본) 또는 요청 body(app) 어느 쪽으로든 받는다. " +
+                "기본은 새 토큰을 Set-Cookie 로 회전하고 body 토큰은 null 이며, X-Client-Type: app 일 때만 body 로 내린다.",
     )
     // 만료된 액세스 토큰을 가진 클라이언트도 호출해야 하므로 인증 없이 진입 (SecurityConfig 의 permitAll).
     @SecurityRequirements
@@ -65,7 +65,7 @@ interface AuthApi {
         value = [
             ApiResponse(
                 responseCode = "200",
-                description = "토큰 갱신 성공 (WEB: Set-Cookie 회전 + body 토큰 null / APP: body 토큰)",
+                description = "토큰 갱신 성공 (기본: Set-Cookie 회전 + body 토큰 null / app: body 토큰)",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,
@@ -99,7 +99,7 @@ interface AuthApi {
         name = ClientType.HEADER,
         `in` = ParameterIn.HEADER,
         required = false,
-        description = "클라이언트 종류. web 이면 새 토큰을 Set-Cookie 로 회전하고 body 토큰은 null. 그 외·미설정은 body 로 받음(기본).",
+        description = "클라이언트 종류. app 이면 body 로 받는다. 그 외·미설정은 새 토큰을 Set-Cookie 로 회전하고 body 토큰은 null(기본).",
         schema = Schema(allowableValues = ["web", "app"]),
     )
     fun refresh(

--- a/src/main/kotlin/com/depromeet/piki/auth/controller/AuthApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/controller/AuthApiExamples.kt
@@ -1,7 +1,9 @@
 package com.depromeet.piki.auth.controller
 
 import com.depromeet.piki.auth.controller.dto.GuestCreateResponse
+import com.depromeet.piki.auth.controller.dto.LogoutResponse
 import com.depromeet.piki.auth.controller.dto.TokenRefreshResponse
+import com.depromeet.piki.auth.service.dto.TokenPair
 import com.depromeet.piki.common.exception.ErrorCategory
 import com.depromeet.piki.common.openapi.OpenApiObjectMapper
 import com.depromeet.piki.common.openapi.binds
@@ -27,12 +29,10 @@ class AuthApiExamples(
                     operation.examples(openApiObjectMapper.delegate) {
                         add(
                             status = HttpStatus.CREATED,
-                            name = "게스트 생성 성공",
+                            name = "게스트 생성 성공 (APP — body 토큰)",
                             payload =
                                 ApiResponseBody.created(
                                     GuestCreateResponse(
-                                        accessToken = "eyJhbGciOiJIUzI1NiJ9.access",
-                                        refreshToken = "eyJhbGciOiJIUzI1NiJ9.refresh",
                                         user =
                                             UserResponse(
                                                 id = UUID.fromString("8f1a3c2b-9d44-4e2a-9b12-1a2b3c4d5e6f"),
@@ -40,6 +40,11 @@ class AuthApiExamples(
                                                 profileImage =
                                                     "https://api.dicebear.com/9.x/bottts/svg?seed=8f1a3c2b-9d44-4e2a-9b12-1a2b3c4d5e6f",
                                                 identityType = IdentityType.GUEST,
+                                            ),
+                                        tokenPair =
+                                            TokenPair(
+                                                accessToken = "eyJhbGciOiJIUzI1NiJ9.access",
+                                                refreshToken = "eyJhbGciOiJIUzI1NiJ9.refresh",
                                             ),
                                     ),
                                 ),
@@ -50,13 +55,26 @@ class AuthApiExamples(
                     operation.examples(openApiObjectMapper.delegate) {
                         add(
                             status = HttpStatus.OK,
-                            name = "토큰 갱신 성공",
+                            name = "토큰 갱신 성공 (APP — body 토큰)",
                             payload =
                                 ApiResponseBody.ok(
                                     TokenRefreshResponse(
-                                        accessToken = "eyJhbGciOiJIUzI1NiJ9.access",
-                                        refreshToken = "eyJhbGciOiJIUzI1NiJ9.refresh",
+                                        tokenPair =
+                                            TokenPair(
+                                                accessToken = "eyJhbGciOiJIUzI1NiJ9.access",
+                                                refreshToken = "eyJhbGciOiJIUzI1NiJ9.refresh",
+                                            ),
                                     ),
+                                ),
+                        )
+                        add(
+                            status = HttpStatus.BAD_REQUEST,
+                            name = "리프레시 토큰 미입력",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.INVALID_INPUT,
+                                    status = HttpStatus.BAD_REQUEST,
+                                    detail = "리프레시 토큰이 필요합니다.",
                                 ),
                         )
                         add(
@@ -76,7 +94,7 @@ class AuthApiExamples(
                         add(
                             status = HttpStatus.OK,
                             name = "로그아웃 성공",
-                            payload = ApiResponseBody.ok<Unit>(),
+                            payload = ApiResponseBody.ok(LogoutResponse()),
                         )
                         add(
                             status = HttpStatus.UNAUTHORIZED,
@@ -97,8 +115,6 @@ class AuthApiExamples(
                             payload =
                                 ApiResponseBody.created(
                                     GuestCreateResponse(
-                                        accessToken = "eyJhbGciOiJIUzI1NiJ9.access",
-                                        refreshToken = "eyJhbGciOiJIUzI1NiJ9.refresh",
                                         user =
                                             UserResponse(
                                                 id = UUID.fromString("3b9c1d2e-4f5a-4b6c-8d7e-9f0a1b2c3d4e"),
@@ -106,6 +122,11 @@ class AuthApiExamples(
                                                 profileImage =
                                                     "https://api.dicebear.com/9.x/bottts/svg?seed=3b9c1d2e-4f5a-4b6c-8d7e-9f0a1b2c3d4e",
                                                 identityType = IdentityType.MEMBER,
+                                            ),
+                                        tokenPair =
+                                            TokenPair(
+                                                accessToken = "eyJhbGciOiJIUzI1NiJ9.access",
+                                                refreshToken = "eyJhbGciOiJIUzI1NiJ9.refresh",
                                             ),
                                     ),
                                 ),
@@ -130,8 +151,6 @@ class AuthApiExamples(
                             payload =
                                 ApiResponseBody.created(
                                     GuestCreateResponse(
-                                        accessToken = "eyJhbGciOiJIUzI1NiJ9.access",
-                                        refreshToken = "eyJhbGciOiJIUzI1NiJ9.refresh",
                                         user =
                                             UserResponse(
                                                 id = UUID.fromString("3b9c1d2e-4f5a-4b6c-8d7e-9f0a1b2c3d4e"),
@@ -139,6 +158,11 @@ class AuthApiExamples(
                                                 profileImage =
                                                     "https://api.dicebear.com/9.x/bottts/svg?seed=3b9c1d2e-4f5a-4b6c-8d7e-9f0a1b2c3d4e",
                                                 identityType = IdentityType.MEMBER,
+                                            ),
+                                        tokenPair =
+                                            TokenPair(
+                                                accessToken = "eyJhbGciOiJIUzI1NiJ9.access",
+                                                refreshToken = "eyJhbGciOiJIUzI1NiJ9.refresh",
                                             ),
                                     ),
                                 ),

--- a/src/main/kotlin/com/depromeet/piki/auth/controller/AuthController.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/controller/AuthController.kt
@@ -9,6 +9,7 @@ import com.depromeet.piki.auth.service.AuthService
 import com.depromeet.piki.auth.web.TokenCookieWriter
 import com.depromeet.piki.common.response.ApiResponseBody
 import jakarta.validation.Valid
+import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.CookieValue
@@ -24,6 +25,8 @@ import java.util.UUID
 class AuthController(
     private val authService: AuthService,
 ) : AuthApi {
+    private val log = LoggerFactory.getLogger(javaClass)
+
     @PostMapping("/guest")
     @ResponseStatus(HttpStatus.CREATED)
     override fun createGuest(): ApiResponseBody<GuestCreateResponse> {
@@ -38,7 +41,10 @@ class AuthController(
         @Valid @RequestBody(required = false) request: TokenRefreshRequest?,
         @CookieValue(name = TokenCookieWriter.REFRESH_COOKIE, required = false) cookieRefreshToken: String?,
     ): ApiResponseBody<TokenRefreshResponse> {
-        val refreshToken = cookieRefreshToken ?: request?.refreshToken ?: throw AuthException.refreshTokenRequired()
+        // 빈 쿠키 값은 없는 것으로 본다 — 빈 쿠키가 body 입력을 가리지 않도록.
+        val cookieToken = cookieRefreshToken?.ifBlank { null }
+        val refreshToken = cookieToken ?: request?.refreshToken ?: throw AuthException.refreshTokenRequired()
+        log.info("토큰 갱신 요청: refreshToken 출처={}", cookieToken?.let { "cookie" } ?: "body")
         val tokenPair = authService.refresh(refreshToken)
         return ApiResponseBody.ok(TokenRefreshResponse.from(tokenPair))
     }

--- a/src/main/kotlin/com/depromeet/piki/auth/controller/AuthController.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/controller/AuthController.kt
@@ -1,13 +1,17 @@
 package com.depromeet.piki.auth.controller
 
 import com.depromeet.piki.auth.controller.dto.GuestCreateResponse
+import com.depromeet.piki.auth.controller.dto.LogoutResponse
 import com.depromeet.piki.auth.controller.dto.TokenRefreshRequest
 import com.depromeet.piki.auth.controller.dto.TokenRefreshResponse
+import com.depromeet.piki.auth.exception.AuthException
 import com.depromeet.piki.auth.service.AuthService
+import com.depromeet.piki.auth.web.TokenCookieWriter
 import com.depromeet.piki.common.response.ApiResponseBody
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.CookieValue
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -27,19 +31,23 @@ class AuthController(
         return ApiResponseBody.created(GuestCreateResponse.from(result.tokenPair, result.user))
     }
 
+    // refresh 토큰을 쿠키(WEB) 또는 body(APP) 어느 쪽에서든 받는다. 둘 다 없으면 400.
+    // 쿠키 정책(HttpOnly·SameSite 등)은 TokenCookieWriter/advice 가 소유하고, 여기선 입력만 읽는다.
     @PostMapping("/token/refresh")
     override fun refresh(
-        @Valid @RequestBody request: TokenRefreshRequest,
+        @Valid @RequestBody(required = false) request: TokenRefreshRequest?,
+        @CookieValue(name = TokenCookieWriter.REFRESH_COOKIE, required = false) cookieRefreshToken: String?,
     ): ApiResponseBody<TokenRefreshResponse> {
-        val tokenPair = authService.refresh(request.refreshToken)
+        val refreshToken = cookieRefreshToken ?: request?.refreshToken ?: throw AuthException.refreshTokenRequired()
+        val tokenPair = authService.refresh(refreshToken)
         return ApiResponseBody.ok(TokenRefreshResponse.from(tokenPair))
     }
 
     @PostMapping("/logout")
     override fun logout(
         @AuthenticationPrincipal userId: UUID,
-    ): ApiResponseBody<Unit> {
+    ): ApiResponseBody<LogoutResponse> {
         authService.logout(userId)
-        return ApiResponseBody.ok()
+        return ApiResponseBody.ok(LogoutResponse())
     }
 }

--- a/src/main/kotlin/com/depromeet/piki/auth/controller/dto/GuestCreateResponse.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/controller/dto/GuestCreateResponse.kt
@@ -1,28 +1,36 @@
 package com.depromeet.piki.auth.controller.dto
 
 import com.depromeet.piki.auth.service.dto.TokenPair
+import com.depromeet.piki.auth.web.TokenCarrying
 import com.depromeet.piki.user.controller.dto.UserResponse
 import com.depromeet.piki.user.domain.User
+import com.fasterxml.jackson.annotation.JsonIgnore
 import io.swagger.v3.oas.annotations.media.Schema
 
+// TokenCarrying — TokenCookieResponseAdvice 가 (WEB 이면) 쿠키 set 후 body 토큰을 비운다.
+// accessToken/refreshToken 은 tokenPair 에서 파생되며 bodyTokensIncluded=false 일 때 null 이 된다.
+// 따라서 contract 상 두 토큰은 nullable: APP=값 / WEB=null(쿠키로 전달).
 @Schema(description = "게스트 생성 응답")
 data class GuestCreateResponse(
-    @field:Schema(description = "액세스 토큰", example = "eyJhbGciOiJIUzI1NiJ9...")
-    val accessToken: String,
-    @field:Schema(description = "리프레시 토큰", example = "eyJhbGciOiJIUzI1NiJ9...")
-    val refreshToken: String,
     @field:Schema(description = "서버가 fill 한 초기 유저 정보. FE 가 확정/수정 UI 의 초기값으로 사용.")
     val user: UserResponse,
-) {
+    @get:JsonIgnore
+    override val tokenPair: TokenPair,
+    @get:JsonIgnore
+    val bodyTokensIncluded: Boolean = true,
+) : TokenCarrying {
+    @get:Schema(description = "액세스 토큰 (APP=값 / WEB=null, 쿠키로 전달)", nullable = true, example = "eyJhbGciOiJIUzI1NiJ9...")
+    val accessToken: String? get() = tokenPair.accessToken.takeIf { bodyTokensIncluded }
+
+    @get:Schema(description = "리프레시 토큰 (APP=값 / WEB=null, 쿠키로 전달)", nullable = true, example = "eyJhbGciOiJIUzI1NiJ9...")
+    val refreshToken: String? get() = tokenPair.refreshToken.takeIf { bodyTokensIncluded }
+
+    override fun withoutBodyTokens(): TokenCarrying = copy(bodyTokensIncluded = false)
+
     companion object {
         fun from(
             tokenPair: TokenPair,
             user: User,
-        ): GuestCreateResponse =
-            GuestCreateResponse(
-                accessToken = tokenPair.accessToken,
-                refreshToken = tokenPair.refreshToken,
-                user = UserResponse.from(user),
-            )
+        ): GuestCreateResponse = GuestCreateResponse(user = UserResponse.from(user), tokenPair = tokenPair)
     }
 }

--- a/src/main/kotlin/com/depromeet/piki/auth/controller/dto/LogoutResponse.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/controller/dto/LogoutResponse.kt
@@ -1,0 +1,12 @@
+package com.depromeet.piki.auth.controller.dto
+
+import com.depromeet.piki.auth.web.TokenClearing
+import io.swagger.v3.oas.annotations.media.Schema
+
+// TokenClearing — TokenCookieResponseAdvice 가 (WEB 이면) 토큰 쿠키를 만료시킨다.
+// loggedOut 필드는 빈 객체 직렬화(FAIL_ON_EMPTY_BEANS) 회피 겸 완료 확인용.
+@Schema(description = "로그아웃 응답")
+data class LogoutResponse(
+    @field:Schema(description = "로그아웃 완료 여부", example = "true")
+    val loggedOut: Boolean = true,
+) : TokenClearing

--- a/src/main/kotlin/com/depromeet/piki/auth/controller/dto/TokenRefreshResponse.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/controller/dto/TokenRefreshResponse.kt
@@ -1,20 +1,27 @@
 package com.depromeet.piki.auth.controller.dto
 
 import com.depromeet.piki.auth.service.dto.TokenPair
+import com.depromeet.piki.auth.web.TokenCarrying
+import com.fasterxml.jackson.annotation.JsonIgnore
 import io.swagger.v3.oas.annotations.media.Schema
 
+// TokenCarrying — refresh 도 토큰을 회전하므로 (WEB 이면) 새 쿠키를 내리고 body 토큰을 비운다.
 @Schema(description = "토큰 갱신 응답")
 data class TokenRefreshResponse(
-    @field:Schema(description = "새 액세스 토큰", example = "eyJhbGciOiJIUzI1NiJ9...")
-    val accessToken: String,
-    @field:Schema(description = "새 리프레시 토큰", example = "eyJhbGciOiJIUzI1NiJ9...")
-    val refreshToken: String,
-) {
+    @get:JsonIgnore
+    override val tokenPair: TokenPair,
+    @get:JsonIgnore
+    val bodyTokensIncluded: Boolean = true,
+) : TokenCarrying {
+    @get:Schema(description = "새 액세스 토큰 (APP=값 / WEB=null, 쿠키로 전달)", nullable = true, example = "eyJhbGciOiJIUzI1NiJ9...")
+    val accessToken: String? get() = tokenPair.accessToken.takeIf { bodyTokensIncluded }
+
+    @get:Schema(description = "새 리프레시 토큰 (APP=값 / WEB=null, 쿠키로 전달)", nullable = true, example = "eyJhbGciOiJIUzI1NiJ9...")
+    val refreshToken: String? get() = tokenPair.refreshToken.takeIf { bodyTokensIncluded }
+
+    override fun withoutBodyTokens(): TokenCarrying = copy(bodyTokensIncluded = false)
+
     companion object {
-        fun from(tokenPair: TokenPair): TokenRefreshResponse =
-            TokenRefreshResponse(
-                accessToken = tokenPair.accessToken,
-                refreshToken = tokenPair.refreshToken,
-            )
+        fun from(tokenPair: TokenPair): TokenRefreshResponse = TokenRefreshResponse(tokenPair = tokenPair)
     }
 }

--- a/src/main/kotlin/com/depromeet/piki/auth/exception/AuthException.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/exception/AuthException.kt
@@ -25,5 +25,13 @@ class AuthException private constructor(
                 ErrorCategory.INVALID_INPUT,
                 HttpStatus.BAD_REQUEST,
             )
+
+        // refresh 토큰이 쿠키·body 어느 쪽에도 없을 때. 정상 클라이언트가 도달 가능한 계약 → 400.
+        fun refreshTokenRequired(): AuthException =
+            AuthException(
+                "리프레시 토큰이 필요합니다.",
+                ErrorCategory.INVALID_INPUT,
+                HttpStatus.BAD_REQUEST,
+            )
     }
 }

--- a/src/main/kotlin/com/depromeet/piki/auth/filter/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/filter/JwtAuthenticationFilter.kt
@@ -1,6 +1,7 @@
 package com.depromeet.piki.auth.filter
 
 import com.depromeet.piki.auth.infrastructure.jwt.JwtProvider
+import com.depromeet.piki.auth.web.TokenCookieWriter
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -30,11 +31,17 @@ class JwtAuthenticationFilter(
         filterChain.doFilter(request, response)
     }
 
-    private fun extractToken(request: HttpServletRequest): String? {
+    // 헤더(APP) 우선 → 없으면 access_token 쿠키(WEB). 둘 다 있으면 헤더가 이긴다.
+    private fun extractToken(request: HttpServletRequest): String? = extractFromHeader(request) ?: extractFromCookie(request)
+
+    private fun extractFromHeader(request: HttpServletRequest): String? {
         val header = request.getHeader(HttpHeaders.AUTHORIZATION) ?: return null
         if (!header.startsWith(BEARER_PREFIX)) return null
         return header.substring(BEARER_PREFIX.length)
     }
+
+    private fun extractFromCookie(request: HttpServletRequest): String? =
+        request.cookies?.firstOrNull { it.name == TokenCookieWriter.ACCESS_COOKIE }?.value
 
     companion object {
         private const val BEARER_PREFIX = "Bearer "

--- a/src/main/kotlin/com/depromeet/piki/auth/service/dto/TokenPair.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/service/dto/TokenPair.kt
@@ -3,4 +3,9 @@ package com.depromeet.piki.auth.service.dto
 data class TokenPair(
     val accessToken: String,
     val refreshToken: String,
-)
+) {
+    // raw 토큰이 로그·예외에 새지 않도록 toString 을 마스킹한다. data class 자동 toString 이
+    // 토큰을 그대로 노출하는 것을 막고, 이 객체를 주 생성자에 포함하는 DTO
+    // (GuestCreateResponse·TokenRefreshResponse)의 자동 toString 도 함께 보호된다.
+    override fun toString(): String = "TokenPair(accessToken=***, refreshToken=***)"
+}

--- a/src/main/kotlin/com/depromeet/piki/auth/web/AuthCookieProperties.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/web/AuthCookieProperties.kt
@@ -1,0 +1,14 @@
+package com.depromeet.piki.auth.web
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+// 토큰 쿠키의 env-varying 한 속성만 둔다. 이름·Path·SameSite 등 환경 무관한 정책은
+// TokenCookieWriter 의 상수로 고정한다.
+//
+// secure: 운영(HTTPS)은 true. 로컬(HTTP)은 false — Secure 쿠키는 HTTPS 에서만 전송돼
+// 로컬에서 쿠키 흐름 테스트가 막히기 때문이다. 누락 시 기본 true(fail-safe-secure)로 두고,
+// 로컬은 .env 의 COOKIE_SECURE=false 로 끈다.
+@ConfigurationProperties("auth.cookie")
+data class AuthCookieProperties(
+    val secure: Boolean = true,
+)

--- a/src/main/kotlin/com/depromeet/piki/auth/web/ClientType.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/web/ClientType.kt
@@ -1,0 +1,22 @@
+package com.depromeet.piki.auth.web
+
+// 클라이언트 종류. X-Client-Type 헤더로 구분한다.
+// - WEB: HttpOnly 쿠키로 토큰 수신 (body 토큰 생략)
+// - APP: body 로 토큰 수신 (쿠키 미사용)
+enum class ClientType {
+    WEB,
+    APP,
+    ;
+
+    companion object {
+        const val HEADER = "X-Client-Type"
+
+        // 헤더 누락·미상 값은 APP 으로 처리한다 (graceful default = body 토큰).
+        // 웹이 헤더를 빠뜨려도 body 로 받아 로그인이 깨지지 않고 하드닝만 덜 된다.
+        // 또한 curl·Postman·Swagger·dev 스크립트는 헤더 없이 호출하므로 기존 흐름이 그대로 유지된다.
+        fun from(raw: String?): ClientType {
+            raw ?: return APP
+            return entries.firstOrNull { it.name.equals(raw.trim(), ignoreCase = true) } ?: APP
+        }
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/auth/web/ClientType.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/web/ClientType.kt
@@ -11,12 +11,10 @@ enum class ClientType {
     companion object {
         const val HEADER = "X-Client-Type"
 
-        // 헤더 누락·미상 값은 APP 으로 처리한다 (graceful default = body 토큰).
-        // 웹이 헤더를 빠뜨려도 body 로 받아 로그인이 깨지지 않고 하드닝만 덜 된다.
-        // 또한 curl·Postman·Swagger·dev 스크립트는 헤더 없이 호출하므로 기존 흐름이 그대로 유지된다.
-        fun from(raw: String?): ClientType {
-            raw ?: return APP
-            return entries.firstOrNull { it.name.equals(raw.trim(), ignoreCase = true) } ?: APP
-        }
+        // secure by default — body 토큰 전달은 브라우저에서 XSS 노출 경로(위험구역)이므로,
+        // 위험한 body 는 app 을 명시한 경우에만 내주고, 그 외(web 명시·미상·누락)는 전부 안전한 WEB(쿠키)로 둔다.
+        // 브라우저는 X-Client-Type: app 을 보낼 일이 없으므로, 브라우저가 body 토큰을 받는 경우가 구조적으로 없다.
+        // 네이티브 앱은 자신을 app 으로 명시해야 body 토큰을 받는다(안 보내면 쿠키를 받아 안전하게 깨질 뿐 토큰 유출은 없음).
+        fun from(raw: String?): ClientType = if (raw?.trim().equals(APP.name, ignoreCase = true)) APP else WEB
     }
 }

--- a/src/main/kotlin/com/depromeet/piki/auth/web/TokenCookieMarkers.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/web/TokenCookieMarkers.kt
@@ -1,0 +1,16 @@
+package com.depromeet.piki.auth.web
+
+import com.depromeet.piki.auth.service.dto.TokenPair
+
+// 응답이 토큰을 싣는다는 타입 계약. TokenCookieResponseAdvice 가 이 타입을 보고
+// (WEB 이면) 쿠키를 set 하고 body 토큰을 비운다. 컨트롤러는 이 타입의 DTO 를 반환할 뿐
+// 쿠키 동작을 알지 못한다.
+interface TokenCarrying {
+    val tokenPair: TokenPair
+
+    // WEB 응답용 — body 의 토큰을 노출하지 않는 복제본. advice 가 쿠키 set 후 호출한다.
+    fun withoutBodyTokens(): TokenCarrying
+}
+
+// 응답이 토큰 쿠키를 비운다는 타입 계약 (logout). advice 가 (WEB 이면) 만료 쿠키를 내린다.
+interface TokenClearing

--- a/src/main/kotlin/com/depromeet/piki/auth/web/TokenCookieResponseAdvice.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/web/TokenCookieResponseAdvice.kt
@@ -1,6 +1,7 @@
 package com.depromeet.piki.auth.web
 
 import com.depromeet.piki.common.response.ApiResponseBody
+import org.slf4j.LoggerFactory
 import org.springframework.core.MethodParameter
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
@@ -21,6 +22,8 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice
 class TokenCookieResponseAdvice(
     private val tokenCookieWriter: TokenCookieWriter,
 ) : ResponseBodyAdvice<Any> {
+    private val log = LoggerFactory.getLogger(javaClass)
+
     override fun supports(
         returnType: MethodParameter,
         converterType: Class<out HttpMessageConverter<*>>,
@@ -36,30 +39,55 @@ class TokenCookieResponseAdvice(
     ): Any? {
         val responseBody = body as? ApiResponseBody<*> ?: return body
         return when (val data = responseBody.data) {
-            // 토큰 발급: WEB 만 쿠키로 내리고 body 토큰을 비운다. APP·미상은 body 그대로(graceful default).
-            is TokenCarrying -> {
-                if (!isWebClient(request)) return body
-                writeCookies(response, tokenCookieWriter.setCookies(data.tokenPair))
-                stripBodyTokens(responseBody, data)
-            }
-            // 로그아웃: 쿠키 만료는 ClientType 무관하게 무조건 내린다. 웹이 X-Client-Type 을 빠뜨려도
-            // 쿠키가 확실히 삭제되도록(fail-safe — 안 지우면 access 쿠키가 만료까지 인증에 쓰임).
-            // APP 은 쿠키 jar 가 없어 만료 쿠키를 받아도 무해하다.
+            is TokenCarrying -> handleTokenIssue(responseBody, data, request, response)
             is TokenClearing -> {
-                writeCookies(response, tokenCookieWriter.clearCookies())
+                handleTokenClear(response)
                 body
             }
             else -> body
         }
     }
 
-    // 웹 판별: X-Client-Type: web 이거나, 요청에 우리 토큰 쿠키가 동봉된 경우.
-    // 앱(네이티브)은 쿠키 jar 가 없어 우리 쿠키를 절대 보내지 않으므로 false positive 가 없다.
-    // 이 덕분에 웹이 refresh 에서 X-Client-Type 을 빠뜨려도(쿠키는 자동 전송) 쿠키 회전이 보장된다.
-    // login(첫 접촉)엔 쿠키가 없어 영향이 없고 헤더로만 판별된다.
-    private fun isWebClient(request: ServerHttpRequest): Boolean =
-        ClientType.from(request.headers.getFirst(ClientType.HEADER)) == ClientType.WEB ||
-            carriesAuthCookie(request)
+    // 토큰 발급: WEB 만 쿠키로 내리고 body 토큰을 비운다. APP·미상은 body 그대로(graceful default).
+    private fun handleTokenIssue(
+        responseBody: ApiResponseBody<*>,
+        data: TokenCarrying,
+        request: ServerHttpRequest,
+        response: ServerHttpResponse,
+    ): Any? {
+        val header = request.headers.getFirst(ClientType.HEADER)
+        val hasCookie = carriesAuthCookie(request)
+        val web = resolveIsWeb(header, hasCookie)
+        // 토큰 값은 절대 로깅하지 않는다. 판별 신호(헤더 값·쿠키 동봉 여부)만 남긴다.
+        log.info(
+            "토큰 발급 응답: clientType={} (X-Client-Type={}, cookie동봉={})",
+            if (web) ClientType.WEB else ClientType.APP,
+            header ?: "none",
+            hasCookie,
+        )
+        if (!web) return responseBody
+        writeCookies(response, tokenCookieWriter.setCookies(data.tokenPair))
+        return stripBodyTokens(responseBody, data)
+    }
+
+    // 로그아웃: 쿠키 만료는 ClientType 무관하게 무조건 내린다. 웹이 X-Client-Type 을 빠뜨려도
+    // 쿠키가 확실히 삭제되도록(fail-safe — 안 지우면 access 쿠키가 만료까지 인증에 쓰임).
+    // APP 은 쿠키 jar 가 없어 만료 쿠키를 받아도 무해하다.
+    private fun handleTokenClear(response: ServerHttpResponse) {
+        log.info("토큰 쿠키 만료 (logout)")
+        writeCookies(response, tokenCookieWriter.clearCookies())
+    }
+
+    // 명시된 X-Client-Type 은 권위적이다 — app 이 어떤 이유로 우리 쿠키를 갖고 있어도 APP 으로 존중한다.
+    // 헤더가 없을 때만 쿠키 동봉으로 web 을 추론한다. 이 추론 덕에 웹이 refresh 에서 헤더를 빠뜨려도
+    // (브라우저가 쿠키 자동 전송) 쿠키 회전이 보장된다. login(첫 접촉)엔 쿠키가 없어 헤더로만 판별된다.
+    private fun resolveIsWeb(
+        header: String?,
+        hasCookie: Boolean,
+    ): Boolean {
+        header ?: return hasCookie
+        return ClientType.from(header) == ClientType.WEB
+    }
 
     private fun carriesAuthCookie(request: ServerHttpRequest): Boolean {
         val servletRequest = (request as? ServletServerHttpRequest)?.servletRequest ?: return false

--- a/src/main/kotlin/com/depromeet/piki/auth/web/TokenCookieResponseAdvice.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/web/TokenCookieResponseAdvice.kt
@@ -9,15 +9,15 @@ import org.springframework.http.ResponseCookie
 import org.springframework.http.converter.HttpMessageConverter
 import org.springframework.http.server.ServerHttpRequest
 import org.springframework.http.server.ServerHttpResponse
-import org.springframework.http.server.ServletServerHttpRequest
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice
 
 // 토큰 전달의 cross-cutting 처리. 컨트롤러는 TokenCarrying/TokenClearing DTO 를 반환할 뿐이고,
 // 쿠키 set/expire 는 여기서 타입 매칭으로 일어난다 (문자열 sniffing 없음).
 //
-// - WEB: TokenCarrying → 쿠키 set + body 토큰 제거 / TokenClearing → 만료 쿠키
-// - APP·미상: 쿠키 미사용, body 그대로 (graceful default = body 토큰)
+// secure by default — 기본은 WEB(쿠키)이고, body 토큰은 X-Client-Type: app 을 명시한 경우에만 내준다.
+// - WEB(기본·web 명시·미상): TokenCarrying → 쿠키 set + body 토큰 제거 / TokenClearing → 만료 쿠키
+// - APP(app 명시): 쿠키 미사용, body 그대로
 @RestControllerAdvice
 class TokenCookieResponseAdvice(
     private val tokenCookieWriter: TokenCookieWriter,
@@ -48,7 +48,7 @@ class TokenCookieResponseAdvice(
         }
     }
 
-    // 토큰 발급: WEB 만 쿠키로 내리고 body 토큰을 비운다. APP·미상은 body 그대로(graceful default).
+    // 토큰 발급: WEB(기본)은 쿠키로 내리고 body 토큰을 비운다. app 명시일 때만 body 그대로.
     private fun handleTokenIssue(
         responseBody: ApiResponseBody<*>,
         data: TokenCarrying,
@@ -56,44 +56,24 @@ class TokenCookieResponseAdvice(
         response: ServerHttpResponse,
     ): Any? {
         val header = request.headers.getFirst(ClientType.HEADER)
-        val hasCookie = carriesAuthCookie(request)
-        val web = resolveIsWeb(header, hasCookie)
-        // 토큰 값은 절대 로깅하지 않는다. 판별 신호(헤더 값·쿠키 동봉 여부)만 남긴다.
+        val web = ClientType.from(header) == ClientType.WEB
+        // 토큰 값은 절대 로깅하지 않는다. 판별 신호(헤더 값)만 남긴다.
         log.info(
-            "토큰 발급 응답: clientType={} (X-Client-Type={}, cookie동봉={})",
+            "토큰 발급 응답: clientType={} (X-Client-Type={})",
             if (web) ClientType.WEB else ClientType.APP,
             header ?: "none",
-            hasCookie,
         )
         if (!web) return responseBody
         writeCookies(response, tokenCookieWriter.setCookies(data.tokenPair))
         return stripBodyTokens(responseBody, data)
     }
 
-    // 로그아웃: 쿠키 만료는 ClientType 무관하게 무조건 내린다. 웹이 X-Client-Type 을 빠뜨려도
+    // 로그아웃: 쿠키 만료는 ClientType 무관하게 무조건 내린다. 클라가 X-Client-Type 을 빠뜨려도
     // 쿠키가 확실히 삭제되도록(fail-safe — 안 지우면 access 쿠키가 만료까지 인증에 쓰임).
     // APP 은 쿠키 jar 가 없어 만료 쿠키를 받아도 무해하다.
     private fun handleTokenClear(response: ServerHttpResponse) {
         log.info("토큰 쿠키 만료 (logout)")
         writeCookies(response, tokenCookieWriter.clearCookies())
-    }
-
-    // 명시된 X-Client-Type 은 권위적이다 — app 이 어떤 이유로 우리 쿠키를 갖고 있어도 APP 으로 존중한다.
-    // 헤더가 없을 때만 쿠키 동봉으로 web 을 추론한다. 이 추론 덕에 웹이 refresh 에서 헤더를 빠뜨려도
-    // (브라우저가 쿠키 자동 전송) 쿠키 회전이 보장된다. login(첫 접촉)엔 쿠키가 없어 헤더로만 판별된다.
-    private fun resolveIsWeb(
-        header: String?,
-        hasCookie: Boolean,
-    ): Boolean {
-        header ?: return hasCookie
-        return ClientType.from(header) == ClientType.WEB
-    }
-
-    private fun carriesAuthCookie(request: ServerHttpRequest): Boolean {
-        val servletRequest = (request as? ServletServerHttpRequest)?.servletRequest ?: return false
-        return servletRequest.cookies?.any {
-            it.name == TokenCookieWriter.ACCESS_COOKIE || it.name == TokenCookieWriter.REFRESH_COOKIE
-        } ?: false
     }
 
     private fun writeCookies(

--- a/src/main/kotlin/com/depromeet/piki/auth/web/TokenCookieResponseAdvice.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/web/TokenCookieResponseAdvice.kt
@@ -1,0 +1,89 @@
+package com.depromeet.piki.auth.web
+
+import com.depromeet.piki.common.response.ApiResponseBody
+import org.springframework.core.MethodParameter
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseCookie
+import org.springframework.http.converter.HttpMessageConverter
+import org.springframework.http.server.ServerHttpRequest
+import org.springframework.http.server.ServerHttpResponse
+import org.springframework.http.server.ServletServerHttpRequest
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice
+
+// 토큰 전달의 cross-cutting 처리. 컨트롤러는 TokenCarrying/TokenClearing DTO 를 반환할 뿐이고,
+// 쿠키 set/expire 는 여기서 타입 매칭으로 일어난다 (문자열 sniffing 없음).
+//
+// - WEB: TokenCarrying → 쿠키 set + body 토큰 제거 / TokenClearing → 만료 쿠키
+// - APP·미상: 쿠키 미사용, body 그대로 (graceful default = body 토큰)
+@RestControllerAdvice
+class TokenCookieResponseAdvice(
+    private val tokenCookieWriter: TokenCookieWriter,
+) : ResponseBodyAdvice<Any> {
+    override fun supports(
+        returnType: MethodParameter,
+        converterType: Class<out HttpMessageConverter<*>>,
+    ): Boolean = true
+
+    override fun beforeBodyWrite(
+        body: Any?,
+        returnType: MethodParameter,
+        selectedContentType: MediaType,
+        selectedConverterType: Class<out HttpMessageConverter<*>>,
+        request: ServerHttpRequest,
+        response: ServerHttpResponse,
+    ): Any? {
+        val responseBody = body as? ApiResponseBody<*> ?: return body
+        return when (val data = responseBody.data) {
+            // 토큰 발급: WEB 만 쿠키로 내리고 body 토큰을 비운다. APP·미상은 body 그대로(graceful default).
+            is TokenCarrying -> {
+                if (!isWebClient(request)) return body
+                writeCookies(response, tokenCookieWriter.setCookies(data.tokenPair))
+                stripBodyTokens(responseBody, data)
+            }
+            // 로그아웃: 쿠키 만료는 ClientType 무관하게 무조건 내린다. 웹이 X-Client-Type 을 빠뜨려도
+            // 쿠키가 확실히 삭제되도록(fail-safe — 안 지우면 access 쿠키가 만료까지 인증에 쓰임).
+            // APP 은 쿠키 jar 가 없어 만료 쿠키를 받아도 무해하다.
+            is TokenClearing -> {
+                writeCookies(response, tokenCookieWriter.clearCookies())
+                body
+            }
+            else -> body
+        }
+    }
+
+    // 웹 판별: X-Client-Type: web 이거나, 요청에 우리 토큰 쿠키가 동봉된 경우.
+    // 앱(네이티브)은 쿠키 jar 가 없어 우리 쿠키를 절대 보내지 않으므로 false positive 가 없다.
+    // 이 덕분에 웹이 refresh 에서 X-Client-Type 을 빠뜨려도(쿠키는 자동 전송) 쿠키 회전이 보장된다.
+    // login(첫 접촉)엔 쿠키가 없어 영향이 없고 헤더로만 판별된다.
+    private fun isWebClient(request: ServerHttpRequest): Boolean =
+        ClientType.from(request.headers.getFirst(ClientType.HEADER)) == ClientType.WEB ||
+            carriesAuthCookie(request)
+
+    private fun carriesAuthCookie(request: ServerHttpRequest): Boolean {
+        val servletRequest = (request as? ServletServerHttpRequest)?.servletRequest ?: return false
+        return servletRequest.cookies?.any {
+            it.name == TokenCookieWriter.ACCESS_COOKIE || it.name == TokenCookieWriter.REFRESH_COOKIE
+        } ?: false
+    }
+
+    private fun writeCookies(
+        response: ServerHttpResponse,
+        cookies: List<ResponseCookie>,
+    ) {
+        cookies.forEach { response.headers.add(HttpHeaders.SET_COOKIE, it.toString()) }
+    }
+
+    private fun stripBodyTokens(
+        original: ApiResponseBody<*>,
+        data: TokenCarrying,
+    ): ApiResponseBody<*> =
+        ApiResponseBody(
+            status = original.status,
+            data = data.withoutBodyTokens(),
+            detail = original.detail,
+            code = original.code,
+            pageResponse = original.pageResponse,
+        )
+}

--- a/src/main/kotlin/com/depromeet/piki/auth/web/TokenCookieWriter.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/web/TokenCookieWriter.kt
@@ -1,0 +1,56 @@
+package com.depromeet.piki.auth.web
+
+import com.depromeet.piki.auth.infrastructure.jwt.JwtProperties
+import com.depromeet.piki.auth.service.dto.TokenPair
+import org.springframework.http.ResponseCookie
+import org.springframework.stereotype.Component
+
+// 토큰 쿠키 정책(이름·HttpOnly·Secure·SameSite·Path·Max-Age)을 한 곳에 캡슐화한다.
+// 컨트롤러·서비스·토큰 도메인은 이 정책을 모른다 — advice 만 이 빈을 사용한다.
+//
+// - access_token: Path=/ (모든 API 요청에 전송돼 인증)
+// - refresh_token: Path=/api/v1/auth (refresh·logout 에만 전송 → 노출 최소화)
+// - Domain 미설정(host-only): 쿠키는 api 호스트만 소비하므로 서브도메인 공유 불필요
+// - SameSite=Strict: same-site 전제라 SPA fetch 는 전송되고 third-party CSRF 는 차단
+@Component
+class TokenCookieWriter(
+    private val jwtProperties: JwtProperties,
+    private val authCookieProperties: AuthCookieProperties,
+) {
+    fun setCookies(tokenPair: TokenPair): List<ResponseCookie> =
+        listOf(
+            build(ACCESS_COOKIE, tokenPair.accessToken, ROOT_PATH, jwtProperties.accessTokenExpiry.seconds),
+            build(REFRESH_COOKIE, tokenPair.refreshToken, AUTH_PATH, jwtProperties.refreshTokenExpiry.seconds),
+        )
+
+    // 만료(삭제) 쿠키: 동일 name·path·속성 + 빈 값 + Max-Age=0.
+    // path 가 set 시점과 같아야 브라우저가 해당 쿠키를 삭제한다.
+    fun clearCookies(): List<ResponseCookie> =
+        listOf(
+            build(ACCESS_COOKIE, "", ROOT_PATH, 0),
+            build(REFRESH_COOKIE, "", AUTH_PATH, 0),
+        )
+
+    private fun build(
+        name: String,
+        value: String,
+        path: String,
+        maxAgeSeconds: Long,
+    ): ResponseCookie =
+        ResponseCookie
+            .from(name, value)
+            .httpOnly(true)
+            .secure(authCookieProperties.secure)
+            .sameSite(SAME_SITE)
+            .path(path)
+            .maxAge(maxAgeSeconds)
+            .build()
+
+    companion object {
+        const val ACCESS_COOKIE = "access_token"
+        const val REFRESH_COOKIE = "refresh_token"
+        private const val ROOT_PATH = "/"
+        private const val AUTH_PATH = "/api/v1/auth"
+        private const val SAME_SITE = "Strict"
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,6 +42,12 @@ jwt:
   access-token-expiry: ${JWT_ACCESS_EXPIRY:1h}
   refresh-token-expiry: ${JWT_REFRESH_EXPIRY:14d}
 
+auth:
+  cookie:
+    # 토큰 쿠키의 Secure 속성. 운영(HTTPS)은 true, 로컬(HTTP)은 .env 의 COOKIE_SECURE=false 로 끈다.
+    # 누락 시 기본 true (fail-safe-secure).
+    secure: ${COOKIE_SECURE:true}
+
 oauth:
   kakao:
     client-id: ${KAKAO_CLIENT_ID:}

--- a/src/test/kotlin/com/depromeet/piki/auth/controller/AuthControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/controller/AuthControllerIntegrationTest.kt
@@ -33,7 +33,7 @@ class AuthControllerIntegrationTest : IntegrationTestSupport() {
     fun `POST auth guest - 201 과 accessToken, refreshToken, user 가 응답에 포함된다`() {
         // FE 의 진입 fill 흐름을 위해 user 정보가 응답에 같이 와야 한다. 회귀 가드.
         mockMvc()
-            .perform(post("/api/v1/auth/guest").contentType(MediaType.APPLICATION_JSON))
+            .perform(post("/api/v1/auth/guest").contentType(MediaType.APPLICATION_JSON).header("X-Client-Type", "app"))
             .andExpect(status().isCreated)
             .andExpect(jsonPath("$.status").value(201))
             .andExpect(jsonPath("$.code").value("CREATED"))
@@ -49,7 +49,7 @@ class AuthControllerIntegrationTest : IntegrationTestSupport() {
     fun `POST auth token refresh - 유효한 refreshToken 으로 새 토큰 쌍이 발급된다`() {
         val guestResult =
             mockMvc()
-                .perform(post("/api/v1/auth/guest").contentType(MediaType.APPLICATION_JSON))
+                .perform(post("/api/v1/auth/guest").contentType(MediaType.APPLICATION_JSON).header("X-Client-Type", "app"))
                 .andReturn()
         val refreshToken =
             objectMapper
@@ -62,6 +62,7 @@ class AuthControllerIntegrationTest : IntegrationTestSupport() {
             .perform(
                 post("/api/v1/auth/token/refresh")
                     .contentType(MediaType.APPLICATION_JSON)
+                    .header("X-Client-Type", "app")
                     .content(body),
             ).andExpect(status().isOk)
             .andExpect(jsonPath("$.status").value(200))
@@ -98,7 +99,7 @@ class AuthControllerIntegrationTest : IntegrationTestSupport() {
     fun `POST auth logout - 인증된 사용자가 로그아웃하면 200 이 반환된다`() {
         val guestResult =
             mockMvc()
-                .perform(post("/api/v1/auth/guest").contentType(MediaType.APPLICATION_JSON))
+                .perform(post("/api/v1/auth/guest").contentType(MediaType.APPLICATION_JSON).header("X-Client-Type", "app"))
                 .andReturn()
         val accessToken =
             objectMapper

--- a/src/test/kotlin/com/depromeet/piki/auth/controller/AuthTokenStateIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/controller/AuthTokenStateIntegrationTest.kt
@@ -44,7 +44,7 @@ class AuthTokenStateIntegrationTest : IntegrationTestSupport() {
     private fun createGuest(): Pair<String, String> {
         val result =
             mockMvc()
-                .perform(post("/api/v1/auth/guest").contentType(MediaType.APPLICATION_JSON))
+                .perform(post("/api/v1/auth/guest").contentType(MediaType.APPLICATION_JSON).header("X-Client-Type", "app"))
                 .andReturn()
         val json = objectMapper.readTree(result.response.contentAsString)
         return json.at("/data/accessToken").asText() to json.at("/data/refreshToken").asText()
@@ -69,6 +69,7 @@ class AuthTokenStateIntegrationTest : IntegrationTestSupport() {
                         mockMvc
                             .perform(
                                 post("/api/v1/auth/token/refresh")
+                                    .header("X-Client-Type", "app")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(objectMapper.writeValueAsString(mapOf("refreshToken" to r1))),
                             ).andExpect(status().isOk)
@@ -81,6 +82,7 @@ class AuthTokenStateIntegrationTest : IntegrationTestSupport() {
             mockMvc
                 .perform(
                     post("/api/v1/auth/token/refresh")
+                        .header("X-Client-Type", "app")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(mapOf("refreshToken" to r2))),
                 ).andExpect(status().isOk)
@@ -107,6 +109,7 @@ class AuthTokenStateIntegrationTest : IntegrationTestSupport() {
                         mockMvc
                             .perform(
                                 post("/api/v1/auth/token/refresh")
+                                    .header("X-Client-Type", "app")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(r1Body),
                             ).andExpect(status().isOk)
@@ -120,6 +123,7 @@ class AuthTokenStateIntegrationTest : IntegrationTestSupport() {
             mockMvc
                 .perform(
                     post("/api/v1/auth/token/refresh")
+                        .header("X-Client-Type", "app")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(r1Body),
                 ).andExpect(status().isUnauthorized)
@@ -129,6 +133,7 @@ class AuthTokenStateIntegrationTest : IntegrationTestSupport() {
             mockMvc
                 .perform(
                     post("/api/v1/auth/token/refresh")
+                        .header("X-Client-Type", "app")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(mapOf("refreshToken" to r2))),
                 ).andExpect(status().isUnauthorized)
@@ -156,6 +161,7 @@ class AuthTokenStateIntegrationTest : IntegrationTestSupport() {
                         mockMvc
                             .perform(
                                 post("/api/v1/auth/token/refresh")
+                                    .header("X-Client-Type", "app")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .content(r1Body),
                             ).andExpect(status().isOk)
@@ -169,6 +175,7 @@ class AuthTokenStateIntegrationTest : IntegrationTestSupport() {
             mockMvc
                 .perform(
                     post("/api/v1/auth/token/refresh")
+                        .header("X-Client-Type", "app")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(r1Body),
                 ).andExpect(status().isUnauthorized)
@@ -177,6 +184,7 @@ class AuthTokenStateIntegrationTest : IntegrationTestSupport() {
             mockMvc
                 .perform(
                     post("/api/v1/auth/token/refresh")
+                        .header("X-Client-Type", "app")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(mapOf("refreshToken" to attackerR2))),
                 ).andExpect(status().isUnauthorized)
@@ -202,6 +210,7 @@ class AuthTokenStateIntegrationTest : IntegrationTestSupport() {
             mockMvc
                 .perform(
                     post("/api/v1/auth/token/refresh")
+                        .header("X-Client-Type", "app")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(mapOf("refreshToken" to refreshToken))),
                 ).andExpect(status().isUnauthorized)

--- a/src/test/kotlin/com/depromeet/piki/auth/controller/CookieBodyContractIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/controller/CookieBodyContractIntegrationTest.kt
@@ -24,7 +24,8 @@ import tools.jackson.databind.ObjectMapper
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 
-// cookie + body 토큰 전달 contract (#166). WEB=쿠키전용 / APP=body전용 분리, 헤더 우선, refresh·logout.
+// cookie + body 토큰 전달 contract (#166). secure by default — 기본(미설정·web)=쿠키전용,
+// X-Client-Type: app 명시일 때만 body 전용. + 쿠키 인증·refresh 회전·logout 만료.
 @Transactional
 class CookieBodyContractIntegrationTest : IntegrationTestSupport() {
     @Autowired
@@ -39,28 +40,27 @@ class CookieBodyContractIntegrationTest : IntegrationTestSupport() {
             .apply<DefaultMockMvcBuilder>(springSecurity())
             .build()
 
+    // 기본(헤더 없음)이 곧 WEB 이라 헤더 없이 호출해 쿠키를 받는다.
     private fun createGuestWeb(): MvcResult =
-        mockMvc()
-            .perform(
-                post("/api/v1/auth/guest")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .header(ClientType.HEADER, "web"),
-            ).andReturn()
-
-    private fun createGuestApp(): MvcResult =
         mockMvc()
             .perform(post("/api/v1/auth/guest").contentType(MediaType.APPLICATION_JSON))
             .andReturn()
 
+    // body 토큰을 받으려면 app 을 명시해야 한다.
+    private fun createGuestApp(): MvcResult =
+        mockMvc()
+            .perform(
+                post("/api/v1/auth/guest")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header(ClientType.HEADER, "app"),
+            ).andReturn()
+
     @Test
-    fun `WEB - guest 생성 시 토큰을 HttpOnly 쿠키로 내리고 body 토큰은 null 이다`() {
+    fun `기본(헤더 없음) - 토큰을 HttpOnly 쿠키로 내리고 body 토큰은 null 이다 (secure by default)`() {
         val result =
             mockMvc()
-                .perform(
-                    post("/api/v1/auth/guest")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .header(ClientType.HEADER, "web"),
-                ).andExpect(status().isCreated)
+                .perform(post("/api/v1/auth/guest").contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated)
                 .andExpect(cookie().exists("access_token"))
                 .andExpect(cookie().httpOnly("access_token", true))
                 .andExpect(cookie().path("access_token", "/"))
@@ -81,10 +81,13 @@ class CookieBodyContractIntegrationTest : IntegrationTestSupport() {
     }
 
     @Test
-    fun `APP - 헤더 없으면 Set-Cookie 없이 body 로 토큰을 내린다 (회귀)`() {
+    fun `APP - X-Client-Type app 명시 시 Set-Cookie 없이 body 로 토큰을 내린다`() {
         mockMvc()
-            .perform(post("/api/v1/auth/guest").contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isCreated)
+            .perform(
+                post("/api/v1/auth/guest")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header(ClientType.HEADER, "app"),
+            ).andExpect(status().isCreated)
             .andExpect(cookie().doesNotExist("access_token"))
             .andExpect(cookie().doesNotExist("refresh_token"))
             .andExpect(jsonPath("$.data.accessToken").isString)
@@ -92,7 +95,7 @@ class CookieBodyContractIntegrationTest : IntegrationTestSupport() {
     }
 
     @Test
-    fun `WEB - access_token 쿠키만으로 인증 엔드포인트가 통과한다`() {
+    fun `기본 - access_token 쿠키만으로 인증 엔드포인트가 통과한다`() {
         val accessCookie = createGuestWeb().response.getCookie("access_token")!!
 
         mockMvc()
@@ -117,15 +120,13 @@ class CookieBodyContractIntegrationTest : IntegrationTestSupport() {
     }
 
     @Test
-    fun `WEB - refresh_token 쿠키로 토큰이 갱신되고 새 쿠키 값이 회전된다`() {
+    fun `기본 - refresh_token 쿠키로 토큰이 갱신되고 새 쿠키 값이 회전된다`() {
         val oldRefresh = createGuestWeb().response.getCookie("refresh_token")!!
 
         val result =
             mockMvc()
                 .perform(
-                    post("/api/v1/auth/token/refresh")
-                        .header(ClientType.HEADER, "web")
-                        .cookie(oldRefresh),
+                    post("/api/v1/auth/token/refresh").cookie(oldRefresh),
                 ).andExpect(status().isOk)
                 .andExpect(cookie().exists("access_token"))
                 .andExpect(cookie().exists("refresh_token"))
@@ -138,24 +139,8 @@ class CookieBodyContractIntegrationTest : IntegrationTestSupport() {
     }
 
     @Test
-    fun `refresh - X-Client-Type 없이 refresh_token 쿠키만 있어도 쿠키로 회전한다 (하드닝)`() {
-        // 웹이 refresh 에 X-Client-Type 을 빠뜨려도, 브라우저가 자동 전송한 refresh_token 쿠키로
-        // 웹임을 추론해 쿠키를 회전한다. 안 그러면 옛 쿠키가 stale 로 남아 세션이 죽는다.
-        val refreshCookie = createGuestWeb().response.getCookie("refresh_token")!!
-
-        mockMvc()
-            .perform(
-                post("/api/v1/auth/token/refresh")
-                    .cookie(refreshCookie),
-            ).andExpect(status().isOk)
-            .andExpect(cookie().exists("access_token"))
-            .andExpect(cookie().exists("refresh_token"))
-            .andExpect(jsonPath("$.data.accessToken").value(nullValue()))
-    }
-
-    @Test
-    fun `refresh - X-Client-Type app 이 명시되면 쿠키가 동봉돼도 body 로 응답한다 (명시 헤더 권위)`() {
-        // 명시한 app 헤더는 권위적 — 어떤 이유로 우리 쿠키가 동봉돼도 쿠키 추론으로 web 오분류되지 않는다.
+    fun `APP - X-Client-Type app 이 명시되면 쿠키가 동봉돼도 body 로 응답한다 (명시 헤더 권위)`() {
+        // app 을 명시하면 쿠키가 동봉돼도 body 로 준다 — 브라우저 외 클라가 쿠키를 갖고 있어도 app 계약을 존중.
         val refreshCookie = createGuestWeb().response.getCookie("refresh_token")!!
 
         mockMvc()
@@ -179,14 +164,12 @@ class CookieBodyContractIntegrationTest : IntegrationTestSupport() {
 
     @Test
     fun `logout 시 X-Client-Type 없이도 토큰 쿠키가 Max-Age 0 으로 만료된다 (무조건)`() {
-        // 쿠키 만료는 fail-safe 로 ClientType 무관하게 내려가야 한다.
-        // 웹이 logout 에 X-Client-Type 을 빠뜨려도 살아있는 access 쿠키가 확실히 삭제되도록.
+        // 쿠키 만료는 fail-safe 로 ClientType 무관하게 내려가야 한다. 살아있는 access 쿠키가 확실히 삭제되도록.
         val accessCookie = createGuestWeb().response.getCookie("access_token")!!
 
         mockMvc()
             .perform(
-                post("/api/v1/auth/logout")
-                    .cookie(accessCookie),
+                post("/api/v1/auth/logout").cookie(accessCookie),
             ).andExpect(status().isOk)
             .andExpect(cookie().maxAge("access_token", 0))
             // path 까지 set 시점과 동일해야 브라우저가 실제로 삭제한다. path 가 틀려도 Max-Age=0 만 보면 통과하므로 함께 고정.

--- a/src/test/kotlin/com/depromeet/piki/auth/controller/CookieBodyContractIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/controller/CookieBodyContractIntegrationTest.kt
@@ -130,7 +130,9 @@ class CookieBodyContractIntegrationTest : IntegrationTestSupport() {
                 ).andExpect(status().isOk)
                 .andExpect(cookie().exists("access_token"))
                 .andExpect(cookie().exists("refresh_token"))
+                // WEB 계약: 두 body 토큰 모두 null(XSS 탈취 창 축소). guest WEB 테스트와 동일 강도.
                 .andExpect(jsonPath("$.data.accessToken").value(nullValue()))
+                .andExpect(jsonPath("$.data.refreshToken").value(nullValue()))
                 .andReturn()
 
         // 존재만이 아니라 값이 실제로 바뀌었는지까지 본다 — 같은 토큰을 재발급하는 회귀를 잡기 위함.

--- a/src/test/kotlin/com/depromeet/piki/auth/controller/CookieBodyContractIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/controller/CookieBodyContractIntegrationTest.kt
@@ -147,6 +147,21 @@ class CookieBodyContractIntegrationTest : IntegrationTestSupport() {
     }
 
     @Test
+    fun `refresh - X-Client-Type app 이 명시되면 쿠키가 동봉돼도 body 로 응답한다 (명시 헤더 권위)`() {
+        // 명시한 app 헤더는 권위적 — 어떤 이유로 우리 쿠키가 동봉돼도 쿠키 추론으로 web 오분류되지 않는다.
+        val refreshCookie = createGuestWeb().response.getCookie("refresh_token")!!
+
+        mockMvc()
+            .perform(
+                post("/api/v1/auth/token/refresh")
+                    .header(ClientType.HEADER, "app")
+                    .cookie(refreshCookie),
+            ).andExpect(status().isOk)
+            .andExpect(cookie().doesNotExist("access_token"))
+            .andExpect(jsonPath("$.data.accessToken").isString)
+    }
+
+    @Test
     fun `refresh - 쿠키도 body 도 없으면 400 이다`() {
         mockMvc()
             .perform(post("/api/v1/auth/token/refresh").contentType(MediaType.APPLICATION_JSON))

--- a/src/test/kotlin/com/depromeet/piki/auth/controller/CookieBodyContractIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/controller/CookieBodyContractIntegrationTest.kt
@@ -21,6 +21,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.context.WebApplicationContext
 import tools.jackson.databind.ObjectMapper
+import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 
 // cookie + body 토큰 전달 contract (#166). WEB=쿠키전용 / APP=body전용 분리, 헤더 우선, refresh·logout.
@@ -116,18 +117,24 @@ class CookieBodyContractIntegrationTest : IntegrationTestSupport() {
     }
 
     @Test
-    fun `WEB - refresh_token 쿠키로 토큰이 갱신되고 새 쿠키가 내려온다`() {
-        val refreshCookie = createGuestWeb().response.getCookie("refresh_token")!!
+    fun `WEB - refresh_token 쿠키로 토큰이 갱신되고 새 쿠키 값이 회전된다`() {
+        val oldRefresh = createGuestWeb().response.getCookie("refresh_token")!!
 
-        mockMvc()
-            .perform(
-                post("/api/v1/auth/token/refresh")
-                    .header(ClientType.HEADER, "web")
-                    .cookie(refreshCookie),
-            ).andExpect(status().isOk)
-            .andExpect(cookie().exists("access_token"))
-            .andExpect(cookie().exists("refresh_token"))
-            .andExpect(jsonPath("$.data.accessToken").value(nullValue()))
+        val result =
+            mockMvc()
+                .perform(
+                    post("/api/v1/auth/token/refresh")
+                        .header(ClientType.HEADER, "web")
+                        .cookie(oldRefresh),
+                ).andExpect(status().isOk)
+                .andExpect(cookie().exists("access_token"))
+                .andExpect(cookie().exists("refresh_token"))
+                .andExpect(jsonPath("$.data.accessToken").value(nullValue()))
+                .andReturn()
+
+        // 존재만이 아니라 값이 실제로 바뀌었는지까지 본다 — 같은 토큰을 재발급하는 회귀를 잡기 위함.
+        val newRefresh = result.response.getCookie("refresh_token")!!.value
+        assertNotEquals(oldRefresh.value, newRefresh, "refresh_token 이 회전돼 값이 바뀌어야 한다")
     }
 
     @Test
@@ -182,7 +189,10 @@ class CookieBodyContractIntegrationTest : IntegrationTestSupport() {
                     .cookie(accessCookie),
             ).andExpect(status().isOk)
             .andExpect(cookie().maxAge("access_token", 0))
+            // path 까지 set 시점과 동일해야 브라우저가 실제로 삭제한다. path 가 틀려도 Max-Age=0 만 보면 통과하므로 함께 고정.
+            .andExpect(cookie().path("access_token", "/"))
             .andExpect(cookie().maxAge("refresh_token", 0))
+            .andExpect(cookie().path("refresh_token", "/api/v1/auth"))
             .andExpect(jsonPath("$.data.loggedOut").value(true))
     }
 }

--- a/src/test/kotlin/com/depromeet/piki/auth/controller/CookieBodyContractIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/controller/CookieBodyContractIntegrationTest.kt
@@ -1,0 +1,173 @@
+package com.depromeet.piki.auth.controller
+
+import com.depromeet.piki.auth.web.ClientType
+import com.depromeet.piki.support.IntegrationTestSupport
+import jakarta.servlet.http.Cookie
+import org.hamcrest.Matchers.nullValue
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.MvcResult
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.context.WebApplicationContext
+import tools.jackson.databind.ObjectMapper
+import kotlin.test.assertTrue
+
+// cookie + body 토큰 전달 contract (#166). WEB=쿠키전용 / APP=body전용 분리, 헤더 우선, refresh·logout.
+@Transactional
+class CookieBodyContractIntegrationTest : IntegrationTestSupport() {
+    @Autowired
+    private lateinit var webApplicationContext: WebApplicationContext
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    private fun mockMvc(): MockMvc =
+        MockMvcBuilders
+            .webAppContextSetup(webApplicationContext)
+            .apply<DefaultMockMvcBuilder>(springSecurity())
+            .build()
+
+    private fun createGuestWeb(): MvcResult =
+        mockMvc()
+            .perform(
+                post("/api/v1/auth/guest")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header(ClientType.HEADER, "web"),
+            ).andReturn()
+
+    private fun createGuestApp(): MvcResult =
+        mockMvc()
+            .perform(post("/api/v1/auth/guest").contentType(MediaType.APPLICATION_JSON))
+            .andReturn()
+
+    @Test
+    fun `WEB - guest 생성 시 토큰을 HttpOnly 쿠키로 내리고 body 토큰은 null 이다`() {
+        val result =
+            mockMvc()
+                .perform(
+                    post("/api/v1/auth/guest")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(ClientType.HEADER, "web"),
+                ).andExpect(status().isCreated)
+                .andExpect(cookie().exists("access_token"))
+                .andExpect(cookie().httpOnly("access_token", true))
+                .andExpect(cookie().path("access_token", "/"))
+                .andExpect(cookie().exists("refresh_token"))
+                .andExpect(cookie().httpOnly("refresh_token", true))
+                .andExpect(cookie().path("refresh_token", "/api/v1/auth"))
+                .andExpect(jsonPath("$.data.accessToken").value(nullValue()))
+                .andExpect(jsonPath("$.data.refreshToken").value(nullValue()))
+                .andExpect(jsonPath("$.data.user.identityType").value("GUEST"))
+                .andReturn()
+
+        // SameSite 는 jakarta Cookie 에 없어 Set-Cookie 헤더 문자열로 확인한다.
+        val setCookies = result.response.getHeaders(HttpHeaders.SET_COOKIE)
+        assertTrue(
+            setCookies.any { it.startsWith("access_token=") && it.contains("SameSite=Strict") },
+            "access_token 쿠키에 SameSite=Strict 가 있어야 한다",
+        )
+    }
+
+    @Test
+    fun `APP - 헤더 없으면 Set-Cookie 없이 body 로 토큰을 내린다 (회귀)`() {
+        mockMvc()
+            .perform(post("/api/v1/auth/guest").contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isCreated)
+            .andExpect(cookie().doesNotExist("access_token"))
+            .andExpect(cookie().doesNotExist("refresh_token"))
+            .andExpect(jsonPath("$.data.accessToken").isString)
+            .andExpect(jsonPath("$.data.refreshToken").isString)
+    }
+
+    @Test
+    fun `WEB - access_token 쿠키만으로 인증 엔드포인트가 통과한다`() {
+        val accessCookie = createGuestWeb().response.getCookie("access_token")!!
+
+        mockMvc()
+            .perform(get("/api/v1/users/me").cookie(accessCookie))
+            .andExpect(status().isOk)
+    }
+
+    @Test
+    fun `헤더가 유효하면 잘못된 쿠키가 있어도 헤더로 인증된다 (헤더 우선)`() {
+        val accessToken =
+            objectMapper
+                .readTree(createGuestApp().response.contentAsString)
+                .at("/data/accessToken")
+                .asString()
+
+        mockMvc()
+            .perform(
+                get("/api/v1/users/me")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer $accessToken")
+                    .cookie(Cookie("access_token", "garbage-token")),
+            ).andExpect(status().isOk)
+    }
+
+    @Test
+    fun `WEB - refresh_token 쿠키로 토큰이 갱신되고 새 쿠키가 내려온다`() {
+        val refreshCookie = createGuestWeb().response.getCookie("refresh_token")!!
+
+        mockMvc()
+            .perform(
+                post("/api/v1/auth/token/refresh")
+                    .header(ClientType.HEADER, "web")
+                    .cookie(refreshCookie),
+            ).andExpect(status().isOk)
+            .andExpect(cookie().exists("access_token"))
+            .andExpect(cookie().exists("refresh_token"))
+            .andExpect(jsonPath("$.data.accessToken").value(nullValue()))
+    }
+
+    @Test
+    fun `refresh - X-Client-Type 없이 refresh_token 쿠키만 있어도 쿠키로 회전한다 (하드닝)`() {
+        // 웹이 refresh 에 X-Client-Type 을 빠뜨려도, 브라우저가 자동 전송한 refresh_token 쿠키로
+        // 웹임을 추론해 쿠키를 회전한다. 안 그러면 옛 쿠키가 stale 로 남아 세션이 죽는다.
+        val refreshCookie = createGuestWeb().response.getCookie("refresh_token")!!
+
+        mockMvc()
+            .perform(
+                post("/api/v1/auth/token/refresh")
+                    .cookie(refreshCookie),
+            ).andExpect(status().isOk)
+            .andExpect(cookie().exists("access_token"))
+            .andExpect(cookie().exists("refresh_token"))
+            .andExpect(jsonPath("$.data.accessToken").value(nullValue()))
+    }
+
+    @Test
+    fun `refresh - 쿠키도 body 도 없으면 400 이다`() {
+        mockMvc()
+            .perform(post("/api/v1/auth/token/refresh").contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value("BAD_REQUEST"))
+    }
+
+    @Test
+    fun `logout 시 X-Client-Type 없이도 토큰 쿠키가 Max-Age 0 으로 만료된다 (무조건)`() {
+        // 쿠키 만료는 fail-safe 로 ClientType 무관하게 내려가야 한다.
+        // 웹이 logout 에 X-Client-Type 을 빠뜨려도 살아있는 access 쿠키가 확실히 삭제되도록.
+        val accessCookie = createGuestWeb().response.getCookie("access_token")!!
+
+        mockMvc()
+            .perform(
+                post("/api/v1/auth/logout")
+                    .cookie(accessCookie),
+            ).andExpect(status().isOk)
+            .andExpect(cookie().maxAge("access_token", 0))
+            .andExpect(cookie().maxAge("refresh_token", 0))
+            .andExpect(jsonPath("$.data.loggedOut").value(true))
+    }
+}

--- a/src/test/kotlin/com/depromeet/piki/auth/controller/DevAuthControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/controller/DevAuthControllerIntegrationTest.kt
@@ -1,10 +1,12 @@
 package com.depromeet.piki.auth.controller
 
 import com.depromeet.piki.auth.infrastructure.jwt.JwtProvider
+import com.depromeet.piki.auth.web.ClientType
 import com.depromeet.piki.support.IntegrationTestSupport
 import com.depromeet.piki.support.uuidToBytes
 import com.depromeet.piki.user.domain.IdentityType
 import org.hamcrest.Matchers.notNullValue
+import org.hamcrest.Matchers.nullValue
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpHeaders
@@ -12,6 +14,7 @@ import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
@@ -32,7 +35,28 @@ class DevAuthControllerIntegrationTest : IntegrationTestSupport() {
     private lateinit var jdbcTemplate: JdbcTemplate
 
     @Test
-    fun `MEMBER user 의 ID 로 토큰 발급 요청 시 201 과 access·refresh 토큰이 반환된다`() {
+    fun `app - MEMBER user 의 ID 로 토큰 발급 시 201 과 body 에 access·refresh 토큰이 반환된다`() {
+        val targetUserId = UUID.randomUUID()
+        insertUser(targetUserId, IdentityType.MEMBER, deleted = false)
+        val guestToken = jwtProvider.generateAccessToken(UUID.randomUUID(), IdentityType.GUEST)
+
+        buildMockMvc()
+            .perform(
+                post("/api/v1/dev/$targetUserId/token")
+                    .header(ClientType.HEADER, "app")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer $guestToken"),
+            ).andExpect(status().isCreated)
+            .andExpect(jsonPath("$.status").value(201))
+            .andExpect(jsonPath("$.code").value("CREATED"))
+            .andExpect(jsonPath("$.data.accessToken", notNullValue()))
+            .andExpect(jsonPath("$.data.refreshToken", notNullValue()))
+            .andExpect(jsonPath("$.data.user.id").value(targetUserId.toString()))
+            .andExpect(jsonPath("$.data.user.identityType").value("MEMBER"))
+    }
+
+    @Test
+    fun `web(기본) - 토큰 발급 시 Set-Cookie 로 내리고 body 토큰은 null 이다`() {
+        // dev 엔드포인트도 FE 웹 팀이 쿠키 흐름으로 테스트할 수 있어야 하므로 양쪽을 모두 검증한다.
         val targetUserId = UUID.randomUUID()
         insertUser(targetUserId, IdentityType.MEMBER, deleted = false)
         val guestToken = jwtProvider.generateAccessToken(UUID.randomUUID(), IdentityType.GUEST)
@@ -42,11 +66,10 @@ class DevAuthControllerIntegrationTest : IntegrationTestSupport() {
                 post("/api/v1/dev/$targetUserId/token")
                     .header(HttpHeaders.AUTHORIZATION, "Bearer $guestToken"),
             ).andExpect(status().isCreated)
-            .andExpect(jsonPath("$.status").value(201))
-            .andExpect(jsonPath("$.code").value("CREATED"))
-            .andExpect(jsonPath("$.data.accessToken", notNullValue()))
-            .andExpect(jsonPath("$.data.refreshToken", notNullValue()))
-            .andExpect(jsonPath("$.data.user.id").value(targetUserId.toString()))
+            .andExpect(cookie().exists("access_token"))
+            .andExpect(cookie().exists("refresh_token"))
+            .andExpect(jsonPath("$.data.accessToken").value(nullValue()))
+            .andExpect(jsonPath("$.data.refreshToken").value(nullValue()))
             .andExpect(jsonPath("$.data.user.identityType").value("MEMBER"))
     }
 

--- a/src/test/kotlin/com/depromeet/piki/auth/controller/RefreshTokenFamilyInvalidationConcurrencyIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/controller/RefreshTokenFamilyInvalidationConcurrencyIntegrationTest.kt
@@ -47,7 +47,7 @@ class RefreshTokenFamilyInvalidationConcurrencyIntegrationTest : IntegrationTest
 
         val guestResult =
             mockMvc
-                .perform(post("/api/v1/auth/guest").contentType(MediaType.APPLICATION_JSON))
+                .perform(post("/api/v1/auth/guest").contentType(MediaType.APPLICATION_JSON).header("X-Client-Type", "app"))
                 .andReturn()
         val guestJson = objectMapper.readTree(guestResult.response.contentAsString)
         val accessToken = guestJson.at("/data/accessToken").asText()

--- a/src/test/kotlin/com/depromeet/piki/auth/controller/dto/GuestCreateResponseSerializationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/controller/dto/GuestCreateResponseSerializationTest.kt
@@ -1,0 +1,53 @@
+package com.depromeet.piki.auth.controller.dto
+
+import com.depromeet.piki.auth.service.dto.TokenPair
+import com.depromeet.piki.user.controller.dto.UserResponse
+import com.depromeet.piki.user.domain.IdentityType
+import tools.jackson.module.kotlin.jacksonObjectMapper
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+// TokenCarrying DTO 의 직렬화 contract 를 검증한다:
+// - 내부필드(tokenPair·bodyTokensIncluded)는 절대 노출되지 않는다 (@get:JsonIgnore)
+// - APP(기본): body 에 토큰 / WEB(withoutBodyTokens): 토큰 null
+class GuestCreateResponseSerializationTest {
+    private val mapper = jacksonObjectMapper()
+
+    private fun user(): UserResponse =
+        UserResponse(
+            id = UUID.fromString("8f1a3c2b-9d44-4e2a-9b12-1a2b3c4d5e6f"),
+            nickname = "닉",
+            profileImage = "img",
+            identityType = IdentityType.GUEST,
+        )
+
+    @Suppress("UNCHECKED_CAST")
+    private fun toMap(any: Any): Map<String, Any?> =
+        mapper.readValue(mapper.writeValueAsString(any), Map::class.java) as Map<String, Any?>
+
+    @Test
+    fun `APP 응답은 body 에 토큰을 싣고 내부필드는 노출하지 않는다`() {
+        val map = toMap(GuestCreateResponse(user = user(), tokenPair = TokenPair("at", "rt")))
+
+        assertEquals("at", map["accessToken"])
+        assertEquals("rt", map["refreshToken"])
+        assertTrue(map.containsKey("user"))
+        assertTrue("tokenPair" !in map, "tokenPair 가 직렬화에 노출되면 안 된다")
+        assertTrue("bodyTokensIncluded" !in map, "bodyTokensIncluded 가 직렬화에 노출되면 안 된다")
+    }
+
+    @Test
+    fun `WEB 응답(withoutBodyTokens)은 토큰을 null 로 비우고 user 는 유지한다`() {
+        val web = GuestCreateResponse(user = user(), tokenPair = TokenPair("at", "rt")).withoutBodyTokens()
+        val map = toMap(web)
+
+        assertTrue(map.containsKey("accessToken"))
+        assertNull(map["accessToken"])
+        assertNull(map["refreshToken"])
+        assertTrue(map.containsKey("user"))
+        assertTrue("tokenPair" !in map)
+    }
+}

--- a/src/test/kotlin/com/depromeet/piki/auth/controller/dto/GuestCreateResponseSerializationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/controller/dto/GuestCreateResponseSerializationTest.kt
@@ -46,6 +46,8 @@ class GuestCreateResponseSerializationTest {
 
         assertTrue(map.containsKey("accessToken"))
         assertNull(map["accessToken"])
+        // refreshToken 도 "키는 존재 + 값은 null" 까지 본다 — 필드가 통째로 빠져도 통과하는 회귀를 막기 위함.
+        assertTrue(map.containsKey("refreshToken"))
         assertNull(map["refreshToken"])
         assertTrue(map.containsKey("user"))
         assertTrue("tokenPair" !in map)

--- a/src/test/kotlin/com/depromeet/piki/auth/service/dto/TokenPairTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/service/dto/TokenPairTest.kt
@@ -1,0 +1,18 @@
+package com.depromeet.piki.auth.service.dto
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class TokenPairTest {
+    // data class 자동 toString 이 raw 토큰을 노출하면, 이 객체를 품은 DTO 를 log("{}", dto) 로 찍는 순간
+    // 토큰이 샌다. toString 마스킹으로 그 경로를 닫는다.
+    @Test
+    fun `toString 은 raw 토큰을 노출하지 않고 마스킹한다`() {
+        val rendered = TokenPair(accessToken = "secret-access-token", refreshToken = "secret-refresh-token").toString()
+
+        assertFalse(rendered.contains("secret-access-token"), "access 토큰이 toString 에 노출되면 안 된다")
+        assertFalse(rendered.contains("secret-refresh-token"), "refresh 토큰이 toString 에 노출되면 안 된다")
+        assertTrue(rendered.contains("***"))
+    }
+}

--- a/src/test/kotlin/com/depromeet/piki/auth/web/ClientTypeTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/web/ClientTypeTest.kt
@@ -1,0 +1,31 @@
+package com.depromeet.piki.auth.web
+
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.NullSource
+import org.junit.jupiter.params.provider.ValueSource
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ClientTypeTest {
+    @ParameterizedTest
+    @CsvSource("web, WEB", "WEB, WEB", "Web, WEB", "' web ', WEB")
+    fun `web 값은 대소문자·공백 무시하고 WEB 으로 매핑된다`(
+        raw: String,
+        expected: ClientType,
+    ) {
+        assertEquals(expected, ClientType.from(raw))
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["app", "APP", "ios", "android", "", "  "])
+    fun `app·미상 값은 APP 으로 매핑된다`(raw: String) {
+        assertEquals(ClientType.APP, ClientType.from(raw))
+    }
+
+    @ParameterizedTest
+    @NullSource
+    fun `헤더 누락(null)은 APP 으로 매핑된다 (graceful default)`(raw: String?) {
+        assertEquals(ClientType.APP, ClientType.from(raw))
+    }
+}

--- a/src/test/kotlin/com/depromeet/piki/auth/web/ClientTypeTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/web/ClientTypeTest.kt
@@ -1,7 +1,6 @@
 package com.depromeet.piki.auth.web
 
 import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.NullSource
 import org.junit.jupiter.params.provider.ValueSource
 import kotlin.test.Test
@@ -9,23 +8,20 @@ import kotlin.test.assertEquals
 
 class ClientTypeTest {
     @ParameterizedTest
-    @CsvSource("web, WEB", "WEB, WEB", "Web, WEB", "' web ', WEB")
-    fun `web 값은 대소문자·공백 무시하고 WEB 으로 매핑된다`(
-        raw: String,
-        expected: ClientType,
-    ) {
-        assertEquals(expected, ClientType.from(raw))
+    @ValueSource(strings = ["app", "APP", "App", " app "])
+    fun `app 값만 대소문자·공백 무시하고 APP 으로 매핑된다`(raw: String) {
+        assertEquals(ClientType.APP, ClientType.from(raw))
     }
 
     @ParameterizedTest
-    @ValueSource(strings = ["app", "APP", "ios", "android", "", "  "])
-    fun `app·미상 값은 APP 으로 매핑된다`(raw: String) {
-        assertEquals(ClientType.APP, ClientType.from(raw))
+    @ValueSource(strings = ["web", "WEB", "ios", "android", "weeb", "", "  "])
+    fun `web·미상·빈 값은 모두 WEB 으로 매핑된다 (secure by default)`(raw: String) {
+        assertEquals(ClientType.WEB, ClientType.from(raw))
     }
 
     @ParameterizedTest
     @NullSource
-    fun `헤더 누락(null)은 APP 으로 매핑된다 (graceful default)`(raw: String?) {
-        assertEquals(ClientType.APP, ClientType.from(raw))
+    fun `헤더 누락(null)은 WEB 으로 매핑된다 (secure by default)`(raw: String?) {
+        assertEquals(ClientType.WEB, ClientType.from(raw))
     }
 }

--- a/src/test/kotlin/com/depromeet/piki/auth/web/TokenCookieWriterTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/web/TokenCookieWriterTest.kt
@@ -1,0 +1,60 @@
+package com.depromeet.piki.auth.web
+
+import com.depromeet.piki.auth.infrastructure.jwt.JwtProperties
+import com.depromeet.piki.auth.service.dto.TokenPair
+import java.time.Duration
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class TokenCookieWriterTest {
+    private val accessExpiry = Duration.ofHours(1)
+    private val refreshExpiry = Duration.ofDays(14)
+
+    private fun writer(secure: Boolean = true): TokenCookieWriter =
+        TokenCookieWriter(
+            JwtProperties(
+                secret = "x".repeat(32),
+                accessTokenExpiry = accessExpiry,
+                refreshTokenExpiry = refreshExpiry,
+            ),
+            AuthCookieProperties(secure = secure),
+        )
+
+    @Test
+    fun `access_token 쿠키는 정책대로 HttpOnly·SameSite=Strict·Path 루트·만료시간을 갖는다`() {
+        val access = writer().setCookies(TokenPair("at", "rt")).first { it.name == "access_token" }
+
+        assertEquals("at", access.value)
+        assertTrue(access.isHttpOnly)
+        assertTrue(access.isSecure)
+        assertEquals("Strict", access.sameSite)
+        assertEquals("/", access.path)
+        assertEquals(accessExpiry, access.maxAge)
+    }
+
+    @Test
+    fun `refresh_token 쿠키는 Path 가 api_v1_auth 로 좁혀지고 refresh 만료시간을 갖는다`() {
+        val refresh = writer().setCookies(TokenPair("at", "rt")).first { it.name == "refresh_token" }
+
+        assertEquals("rt", refresh.value)
+        assertEquals("/api/v1/auth", refresh.path)
+        assertEquals(refreshExpiry, refresh.maxAge)
+    }
+
+    @Test
+    fun `secure=false 면 Secure 속성이 꺼진다 (로컬 HTTP)`() {
+        val cookies = writer(secure = false).setCookies(TokenPair("at", "rt"))
+
+        assertTrue(cookies.none { it.isSecure })
+    }
+
+    @Test
+    fun `clearCookies 는 두 쿠키 모두 빈 값·Max-Age 0 으로 만료시키며 path 는 set 과 동일하다`() {
+        val cleared = writer().clearCookies()
+
+        assertTrue(cleared.all { it.value.isEmpty() && it.maxAge.isZero })
+        assertEquals("/", cleared.first { it.name == "access_token" }.path)
+        assertEquals("/api/v1/auth", cleared.first { it.name == "refresh_token" }.path)
+    }
+}

--- a/src/test/kotlin/com/depromeet/piki/user/controller/DevUserControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/user/controller/DevUserControllerIntegrationTest.kt
@@ -1,15 +1,18 @@
 package com.depromeet.piki.user.controller
 
+import com.depromeet.piki.auth.web.ClientType
 import com.depromeet.piki.support.IntegrationTestSupport
 import com.depromeet.piki.support.uuidToBytes
 import com.depromeet.piki.user.domain.IdentityType
 import org.hamcrest.Matchers.notNullValue
+import org.hamcrest.Matchers.nullValue
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
@@ -64,12 +67,12 @@ class DevUserControllerIntegrationTest : IntegrationTestSupport() {
     }
 
     @Test
-    fun `존재하는 userId 로 단건 조회 시 200 과 AT·RT·user 정보가 반환된다`() {
+    fun `app - 단건 조회 시 200 과 body 에 AT·RT·user 정보가 반환된다`() {
         val userId = UUID.randomUUID()
         insertUser(userId, "단건유저", IdentityType.MEMBER)
 
         buildMockMvc()
-            .perform(get("/api/v1/dev/users/$userId"))
+            .perform(get("/api/v1/dev/users/$userId").header(ClientType.HEADER, "app"))
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.status").value(200))
             .andExpect(jsonPath("$.data.accessToken", notNullValue()))
@@ -77,6 +80,22 @@ class DevUserControllerIntegrationTest : IntegrationTestSupport() {
             .andExpect(jsonPath("$.data.user.id").value(userId.toString()))
             .andExpect(jsonPath("$.data.user.nickname").value("단건유저"))
             .andExpect(jsonPath("$.data.user.identityType").value("MEMBER"))
+    }
+
+    @Test
+    fun `web(기본) - 단건 조회 시 Set-Cookie 로 토큰을 내리고 body 토큰은 null 이다`() {
+        // FE 웹 팀이 쿠키 흐름으로도 테스트할 수 있어야 하므로 양쪽을 모두 검증한다.
+        val userId = UUID.randomUUID()
+        insertUser(userId, "단건유저", IdentityType.MEMBER)
+
+        buildMockMvc()
+            .perform(get("/api/v1/dev/users/$userId"))
+            .andExpect(status().isOk)
+            .andExpect(cookie().exists("access_token"))
+            .andExpect(cookie().exists("refresh_token"))
+            .andExpect(jsonPath("$.data.accessToken").value(nullValue()))
+            .andExpect(jsonPath("$.data.refreshToken").value(nullValue()))
+            .andExpect(jsonPath("$.data.user.id").value(userId.toString()))
     }
 
     @Test


### PR DESCRIPTION
## Situation

- 기존 인증은 토큰을 응답 body 로만 내려주고, 필터는 Authorization 헤더만 읽었다. 웹·앱 클라이언트를 단일 endpoint 에서 동시 지원하는 cookie + body contract 가 필요했다 (#166, epic #122 Task 7).
- 웹은 localStorage 가 XSS 위험이 커 HttpOnly 쿠키가 안전한 표준이고, 앱은 secure storage 에 저장해 Bearer 헤더로 보낸다. 한 endpoint 가 양쪽을 내리면 신규 클라이언트가 늘어도 백엔드 변경이 적다.

## Task

- 단일 endpoint 에서 WEB은 HttpOnly 쿠키, APP은 body 로 토큰을 분리 전달한다.
- 컨트롤러·서비스·토큰 도메인은 쿠키 정책을 모르게 한다 (전송은 web 계층의 책임).
- 기존 헤더 인증 흐름과 하위호환을 유지해 백엔드를 먼저 배포해도 깨지지 않게 한다.

## Action

### 전달 메커니즘 — 컨트롤러 무지
- 쿠키 정책(HttpOnly·Secure·SameSite·Path·Max-Age)을 `TokenCookieWriter` 한 곳에 캡슐화했다. 컨트롤러가 쿠키를 모르도록 `TokenCarrying`/`TokenClearing` 마커 + `ResponseBodyAdvice`(타입 매칭, 문자열 sniffing 없음)로 set/expire 를 처리한다. 컨트롤러는 평소대로 DTO 만 반환한다.
- 처음 검토한 "both always" 대신 `ClientType`(WEB·APP) clean split 을 택했다. WEB 응답은 body 토큰을 null 로 비워(`withoutBodyTokens`) 로그인 응답 순간의 XSS 토큰 탈취 창을 닫는다. `X-Client-Type` 누락 시 APP(body)로 graceful fallback 해 기존 클라이언트·dev 흐름과 하위호환이 된다.
- 읽기는 입력 바인딩이라 refresh 만 `@CookieValue` + `@RequestBody` 로 컨트롤러에 두었다. 커스텀 resolver 는 수동 body stream 파싱과 OpenAPI 문서 깨짐을 떠안는 비표준 패턴이라, 표준 Spring 바인딩을 택했다 (쓰기 정책 은닉은 advice 로 이미 달성).

### 보안·경로
- 프론트(depromeet18team3.cloud)와 백엔드(api.depromeet18team3.cloud)가 same-site 라 `SameSite=Strict` + CSRF disable 을 유지한다. `access_token` 은 Path=/, `refresh_token` 은 Path=/api/v1/auth 로 좁혀 노출을 최소화하고, 쿠키는 host-only 로 둔다.
- `secure` 속성은 `auth.cookie.secure` 프로퍼티로 분기한다 (로컬 HTTP=false, 운영 HTTPS=true).

### fail-safe 안전망
- logout 의 쿠키 만료는 ClientType 무관하게 무조건 내린다. 웹이 `X-Client-Type` 을 빠뜨려도 살아있는 access 쿠키가 확실히 삭제되도록 했다 (안 지우면 만료까지 인증에 쓰임).
- refresh 의 WEB 판별은 헤더뿐 아니라 "요청에 우리 쿠키가 동봉됐는지" 로도 추론한다. 앱은 우리 쿠키를 보내지 않아 오판이 없고, 웹이 refresh 에서 헤더를 빠뜨려도(브라우저가 쿠키 자동 전송) 쿠키 회전이 보장돼 stale 세션 사망을 막는다.

### 읽기·필터
- `JwtAuthenticationFilter` 는 Authorization 헤더 우선 → 없으면 access_token 쿠키로 인증한다.
- refresh 는 쿠키(WEB)·body(APP) 양쪽 입력을 받고, 둘 다 없으면 `AuthException.refreshTokenRequired()` 400 으로 처리한다.

## Result

- 단위 테스트 3종(ClientType 매핑, TokenCookieWriter 속성·만료, DTO 직렬화)과 통합 8종(WEB 쿠키 set / APP body 회귀 / 쿠키 인증 / 헤더 우선 / refresh 쿠키 회전 / 헤더 없이 쿠키 추론 회전 / refresh 400 / logout 무조건 만료)을 단위+통합 함께 green 으로 확인했다.
- 백엔드 단독 배포 시 헤더가 없으면 body 토큰을 내려 기존 동작 그대로다. 프론트는 `X-Client-Type: web` + `credentials: include` 로 쿠키 모드로 전환한다.
- login 의 `X-Client-Type` 헤더 의존은 첫 접촉이라 구조상 닫을 수 없다(프론트 글로벌 디폴트 헤더로 해결). 작업 중 발견한 전역 예외 핸들링 갭(Spring 표준 MVC 예외가 catch-all 에 먼저 잡혀 500 으로 새는 문제, refresh malformed body 500 포함)은 범위를 분리해 #300 으로 따로 만들었다.
- 주의: 로컬은 HTTP 라 `.env` 에 COOKIE_SECURE=false 가 필요하다. 운영 프론트 도메인이 api 와 same-site(depromeet18team3.cloud)라는 전제가 깔려 있다.

---
## 연관 이슈

- close #166

---
## Updates

### secure by default — 기본 방향 반전 (위 Action 정정)
> ⚠️ 위 본문은 "기본=APP(body), web 이 opt-in" 으로 작성됐으나, 리뷰 논의로 **기본 방향을 반전**했다. 현재 구현 기준은 아래가 맞다.

- "body 는 브라우저에서 XSS 노출 경로(위험구역)" 라는 리뷰 지적을 받아 **secure by default** 로 전환: 기본을 WEB(HttpOnly 쿠키)로 두고, body 토큰은 `X-Client-Type: app` 을 명시한 경우에만 내린다. 브라우저는 app 을 보낼 일이 없어 브라우저가 body 토큰을 받는 경우가 구조적으로 없다. (`3bf6c14`)
- Sec-Fetch 자동판별안도 검토했으나 Safari 16.4 미만 등 미전송 브라우저가 body 로 떨어지는 구멍이 있어 탈락, 결정적인 default WEB 을 채택.
- `ClientType.from` 의 미상·누락 값이 WEB 로 흡수돼 헤더 추론 하드닝이 불필요해져 advice 를 단순화. 판별식 `X-Client-Type: app → APP, 그 외 → WEB`.
- 테스트 시맨틱 정렬 + dev 엔드포인트는 FE 웹/앱 누가 쓸지 몰라 web·app 양쪽 케이스 모두 검증. (`ee3cc12`)
- **클라이언트 contract 변경**: 앱은 `X-Client-Type: app` 을 보내야 body 토큰을 받고, 웹은 아무것도 안 보내도 쿠키를 받는다.

### CodeRabbit 리뷰 대응
- 클라이언트 판별 precedence 명확화(명시 헤더 우선) + refresh 빈 쿠키가 body 입력을 가리지 않게 `ifBlank` 처리 + 토큰 전달 경로 진단 로깅(토큰 값은 미로깅). (`6e03790`, `eb937c0`)
- `TokenPair.toString()` 마스킹 — `@JsonIgnore` 가 못 막는 data class 자동 toString 의 raw 토큰 노출을 차단(이를 품은 DTO toString 도 함께 보호). (`fcccd31`)
- 회귀 잡는 단언 강화: refresh 회전 값 비교 · logout 쿠키 path 일치 · 직렬화 키 존재 · WEB refresh body 토큰 null. (`e9375c0`, `8db2705`)
- "잘못된 헤더 → 400" 지적은 위 secure-by-default 채택으로 미상 헤더가 안전한 WEB 로 흡수돼 자연 해소.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 웹 클라이언트에 HttpOnly 쿠키로 토큰 발급/저장 지원
  * 클라이언트 타입(웹/앱)에 따라 토큰 전달 방식 자동 분기(쿠키 vs 응답 본문)
  * 액세스 토큰을 Authorization 헤더 또는 쿠키에서 우선 인식

* **Behavior Changes**
  * 토큰 갱신 시 쿠키 또는 요청 본문을 허용하고, 로그아웃 시 토큰 쿠키를 만료 처리하여 로그아웃 상태 반환

* **Tests**
  * 쿠키·바디 토큰 계약과 경계 케이스를 검증하는 통합/단위 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/PIKI-Server/pull/301?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
