### PR TITLE
토너먼트 아이템 파싱이 tournament_item PK 를 item 으로 오인해 항상 실패하던 버그 수정

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentItemPersistenceService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentItemPersistenceService.kt
@@ -8,6 +8,7 @@ import com.depromeet.piki.tournament.domain.TournamentItem
 import com.depromeet.piki.tournament.repository.TournamentItemRepository
 import com.depromeet.piki.tournament.repository.TournamentRepository
 import com.depromeet.piki.tournament.repository.TournamentUserRepository
+import com.depromeet.piki.tournament.service.dto.PersistedTournamentItem
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
@@ -27,13 +28,13 @@ class TournamentItemPersistenceService(
         userId: UUID,
         tournamentId: Long,
         link: ProductLink,
-    ): Long {
+    ): PersistedTournamentItem {
         validateAndCheckCapacity(userId, tournamentId, 1)
         val item = itemRepository.save(Item.processing(link))
         val tournamentItem = tournamentItemRepository.saveAll(
             listOf(TournamentItem(tournamentId = tournamentId, itemId = item.getId(), userId = userId)),
         ).first()
-        return tournamentItem.getId()
+        return PersistedTournamentItem(itemId = item.getId(), tournamentItemId = tournamentItem.getId())
     }
 
     @Transactional
@@ -41,12 +42,15 @@ class TournamentItemPersistenceService(
         userId: UUID,
         tournamentId: Long,
         count: Int,
-    ): List<Long> {
+    ): List<PersistedTournamentItem> {
         validateAndCheckCapacity(userId, tournamentId, count)
         val items = itemRepository.saveAll(List(count) { Item(status = ItemStatus.PROCESSING) })
-        return tournamentItemRepository.saveAll(
+        val tournamentItems = tournamentItemRepository.saveAll(
             items.map { TournamentItem(tournamentId = tournamentId, itemId = it.getId(), userId = userId) },
-        ).map { it.getId() }
+        )
+        return items.zip(tournamentItems) { item, tournamentItem ->
+            PersistedTournamentItem(itemId = item.getId(), tournamentItemId = tournamentItem.getId())
+        }
     }
 
     private fun validateAndCheckCapacity(

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentItemService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentItemService.kt
@@ -26,7 +26,9 @@ class TournamentItemService(
         url: String,
     ): Long {
         val link = ProductLink.parse(url)
-        val itemId = tournamentItemPersistenceService.persistLinkItem(userId, tournamentId, link)
+        // 파싱·상태 전이는 item PK 를, 클라이언트 응답은 tournament_item PK 를 쓴다 (PersistedTournamentItem).
+        val persisted = tournamentItemPersistenceService.persistLinkItem(userId, tournamentId, link)
+        val itemId = persisted.itemId
         try {
             itemParsingWorker.parse(itemId, link)
         } catch (e: TaskRejectedException) {
@@ -34,7 +36,7 @@ class TournamentItemService(
             runCatching { itemParsingService.markFailed(itemId) }
                 .onFailure { ex -> log.error("item {} FAILED 전이 실패, PROCESSING 방치 위험", itemId, ex) }
         }
-        return itemId
+        return persisted.tournamentItemId
     }
 
     fun addItemsFromImages(
@@ -45,8 +47,10 @@ class TournamentItemService(
         if (images.size !in MIN_IMAGE_COUNT..MAX_IMAGE_COUNT) throw TournamentException.invalidImageCount()
         // 형식 검증(빈 바이트·미지원 MIME) — 실패 시 즉시 400. 유효한 이미지만 PROCESSING 으로 등록한다.
         val productImages = images.map { ProductImage.of(it.bytes, it.contentType) }
-        val itemIds = tournamentItemPersistenceService.persistProcessingItems(userId, tournamentId, productImages.size)
-        itemIds.zip(productImages).forEach { (itemId, productImage) ->
+        // 파싱·상태 전이는 item PK 를, 클라이언트 응답은 tournament_item PK 를 쓴다 (PersistedTournamentItem).
+        val persisted = tournamentItemPersistenceService.persistProcessingItems(userId, tournamentId, productImages.size)
+        persisted.zip(productImages).forEach { (persistedItem, productImage) ->
+            val itemId = persistedItem.itemId
             try {
                 imageParsingWorker.parse(itemId, productImage)
             } catch (e: TaskRejectedException) {
@@ -55,7 +59,7 @@ class TournamentItemService(
                     .onFailure { ex -> log.error("item {} FAILED 전이 실패, PROCESSING 방치 위험", itemId, ex) }
             }
         }
-        return itemIds
+        return persisted.map { it.tournamentItemId }
     }
 
     companion object {

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/dto/PersistedTournamentItem.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/dto/PersistedTournamentItem.kt
@@ -1,0 +1,10 @@
+package com.depromeet.piki.tournament.service.dto
+
+// 토너먼트 아이템 영속화 결과 — item PK 와 tournament_item PK 를 분리해 돌려준다.
+// 비동기 파싱(parse)·상태 전이(markReady/markFailed)는 item PK 를 대상으로 하고,
+// 클라이언트 응답·삭제(DELETE .../items/{tournamentItemId})에는 tournament_item PK 를 쓴다.
+// 둘을 한 Long 으로 뭉뚱그리면 호출부가 혼동해 엉뚱한 item 을 전이시킨다.
+data class PersistedTournamentItem(
+    val itemId: Long,
+    val tournamentItemId: Long,
+)


### PR DESCRIPTION
## Situation
- 운영에서 zigzag 링크로 토너먼트 아이템을 추가하면 항상 FAILED 로 끝났다. EC2 로그상 Gemini 추출(extract)은 매번 성공하는데, 직후 markReady 단계에서 `IllegalStateException: PROCESSING 이 아닌 item(status=READY)은 READY 로 전이할 수 없다` 가 발생
- DB 확인 결과 zigzag item(`170120436`)은 id 109·122–126 전부 FAILED, 24시간 동안 "파싱 완료"(markReady 성공) 로그가 0건이었다

## Task
- 토너먼트 링크/이미지 아이템 파싱이 전부 실패하는 근본 원인을 찾아 핫픽스
- zigzag 특정 문제가 아니라 토너먼트 등록 경로 전반의 문제임을 규명

## Action
- **원인**: `persistLinkItem` / `persistProcessingItems` 가 item PK 가 아니라 tournament_item PK 를 반환하고 있었다. 호출부(`TournamentItemService`)가 그 값을 `itemParsingWorker.parse` 의 itemId 로 넘기면서, 엉뚱한(이미 READY 인 옛 item)을 markReady 하려다 깨지고, 진짜 PROCESSING item 은 아무도 건드리지 않아 방치되다 `StaleProcessingItemSweeper` 가 FAILED 로 정리하고 있었다
- **DB 로 확정**: markReady 실패 로그의 itemId(82–86)가 tournament_items 의 PK 와 정확히 일치했고, 진짜 zigzag item 의 PK(122–126)와는 +40 오프셋이라 항상 다른 item 을 건드리고 있었다 (extract 성공 로그 시각과 markReady 실패 시각도 1:1로 대응)
- **수정**: 반환 타입을 `Long` → `PersistedTournamentItem(itemId, tournamentItemId)` 으로 분리. 비동기 파싱·상태 전이(`parse` / `markReady` / `markFailed`)는 item PK 를, 클라이언트 응답(`AddTournamentItemFromLinkResponse`)·삭제 경로(`DELETE .../items/{tournamentItemId}`)는 tournament_item PK 를 쓰도록 호출부에서 명시적으로 구분
- wishlist 경로는 `result.item.getId()`(진짜 item PK)를 써 이미 정상이라 영향 없음 — 토너먼트 경로만 깨져 있었다

## Result
- 토너먼트 링크/이미지 아이템이 정상적으로 READY 로 전이한다
- 클라이언트가 받는 `tournamentItemId` 응답 계약은 그대로라 API 동작은 불변
- 핫픽스 우선이라 회귀 통합 테스트는 **후속 PR 로 분리**. 기존 토너먼트 통합 테스트(`TournamentControllerTest`)는 통과 확인했으나, 그 link 테스트가 `stubItemParsingWorker.enabled = false` 로 실제 parse 를 끄고 PROCESSING 응답만 검증하고 있어 이 버그를 못 잡았다 — 후속에서 실제 async 전이(진짜 item 이 READY 로 가는지)를 검증하는 테스트를 추가해야 한다

---
## 연관 이슈

- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **코드 개선**
  * 토너먼트 아이템 저장 시 반환되는 데이터 구조가 개선되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/PIKI-Server/pull/302?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->