### PR TITLE
호스트 메트릭(node_exporter) 수집 + 대시보드 재설계

### DIFF
--- a/infra/alloy/config.alloy
+++ b/infra/alloy/config.alloy
@@ -1,5 +1,6 @@
 // Grafana Alloy — PIKI 운영 박스(EC2) 단일 수집기.
-// 앱의 prometheus 메트릭 scrape + team3-blue/green 앱 컨테이너 로그를 Grafana Cloud 로 remote-write 한다.
+// 앱 prometheus 메트릭 scrape + team3-blue/green 컨테이너 로그 + 호스트 메트릭(node_exporter)을
+// Grafana Cloud 로 remote-write 한다.
 // 자격증명은 환경변수로 주입한다(provision-runtime.sh 의 docker run -e). secret 미등록 시
 // provision-runtime.sh 가 Alloy 기동 자체를 skip 하므로, 빈 endpoint 로 부팅해 crash loop 하는 일은 없다.
 
@@ -68,4 +69,30 @@ loki.write "grafana_cloud" {
       password = sys.env("GRAFANA_CLOUD_TOKEN")
     }
   }
+}
+
+// ── 호스트 메트릭: node_exporter (메모리·swap·디스크·CPU) ──
+// 906Mi 박스 + heap 256m + 컨테이너 메모리 무제한이라, OOM·swap 폭증은 JVM heap 메트릭만으론 안 보인다.
+// 1순위 리스크(메모리)를 제대로 잡으려면 OS 레벨 메모리/swap/디스크를 봐야 한다.
+// 컨테이너에서 호스트를 보려면 provision-runtime.sh 가 /proc·/sys·/ 를 /host/* 로 마운트하고,
+// 아래 *_path 가 그 마운트를 가리킨다. node_exporter 메트릭엔 application 라벨이 없다(앱 메트릭과 구분).
+prometheus.exporter.unix "host" {
+  procfs_path = "/host/proc"
+  sysfs_path  = "/host/sys"
+  rootfs_path = "/host/root"
+
+  // 작은 박스라 불필요한 collector 는 끈다.
+  disable_collectors = ["ipvs", "btrfs", "infiniband", "xfs", "zfs"]
+
+  filesystem {
+    mount_points_exclude = "^/(dev|proc|sys|run/credentials/.+|var/lib/docker/.+|host/.+)($|/)"
+    fs_types_exclude     = "^(autofs|binfmt_misc|cgroup2?|configfs|debugfs|devpts|devtmpfs|tmpfs|fusectl|hugetlbfs|mqueue|nsfs|overlay|proc|procfs|pstore|securityfs|sysfs|tracefs)$"
+    mount_timeout        = "5s"
+  }
+}
+
+prometheus.scrape "host" {
+  targets         = prometheus.exporter.unix.host.targets
+  forward_to      = [prometheus.remote_write.grafana_cloud.receiver]
+  scrape_interval = "30s"
 }

--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -14,11 +14,23 @@ Grafana Cloud 가 호스팅하는 Grafana 이므로 셀프호스팅 provisioning
 
 ## 패널
 
-HTTP 요청률·p95 지연, JVM heap 메모리·라이브 스레드·GC pause, HikariCP 커넥션풀,
-executor 스레드풀, process/system CPU, 그리고 `team3-blue`/`team3-green` 앱 로그.
+증상 → 원인 → 로그 순서로 배치한다(위에서 아래로):
 
-모든 메트릭은 `application="PIKI"` 라벨로 필터한다(Alloy 의 prometheus.scrape 가 붙임).
-blue-green 이라 한 시점에 한 슬롯만 활성이며, `instance` 라벨로 blue/green 을 구분한다.
+1. **한눈 건강(stat, 임계 색상)** — 앱 up · 5xx 에러율 · p99 지연 · JVM heap 사용률 · 호스트 메모리 사용률 · swap 사용량. 위험하면 노랑/빨강.
+2. **트래픽(RED)** — 요청률(status별) · 5xx 요청률(uri별) · 지연 p50/95/99.
+3. **JVM 메모리·GC** — heap used/max · nonheap · GC pause p99·빈도. (heap 256m·906Mi 박스라 1순위 리스크)
+4. **호스트(node_exporter)** — 메모리 used/total · swap · 디스크 여유. OOM-kill·swap 폭증을 OS 레벨로 잡는다.
+5. **의존성** — 502율(Gemini 등 외부 실패) · executor active/queued · HikariCP active/idle/pending.
+6. **리소스** — 앱 process/system CPU · JVM 스레드 · 호스트 CPU.
+7. **로그** — 에러/경고 필터 로그 + 전체 로그(`team3-blue`/`team3-green`).
+
+앱 메트릭은 `application="PIKI"` 라벨로 필터한다(Alloy 의 prometheus.scrape 가 붙임).
+blue-green 이라 한 시점에 한 슬롯만 활성이며 `instance` 라벨로 blue/green 을 구분한다.
+호스트 메트릭(`node_*`)은 application 라벨이 없다 — `prometheus.exporter.unix` 가 별도로 내보낸다.
+
+### 알려진 한계 (계측이 더 필요한 것)
+- **Gemini(LLM) 호출 자체**는 직접 계측이 없어 `502` 서버 응답으로만 간접 관측된다. 호출 latency/실패율을 직접 보려면 `GeminiHttpClient` 의 RestClient 를 자동설정 builder/`@Observed` 로 바꿔야 한다.
+- **S3·Redis** 호출도 자동 계측이 없다(필요 시 `@Timed`/MeterRegistry 추가).
 
 ## 갱신
 

--- a/infra/grafana/dashboard.json
+++ b/infra/grafana/dashboard.json
@@ -18,228 +18,386 @@
     }
   ],
   "__requires": [],
-  "title": "PIKI - 앱 개요",
+  "title": "PIKI - 앱 + 호스트 개요",
   "uid": "piki-app-overview",
   "tags": ["piki"],
   "timezone": "browser",
   "editable": true,
   "schemaVersion": 39,
-  "version": 1,
+  "version": 2,
   "refresh": "30s",
   "time": { "from": "now-1h", "to": "now" },
   "templating": { "list": [] },
   "annotations": { "list": [] },
   "panels": [
     {
+      "id": 100,
+      "type": "row",
+      "title": "한눈 건강 (위험하면 빨강)",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 }
+    },
+    {
       "id": 1,
-      "type": "timeseries",
-      "title": "HTTP 요청률 (req/s, status별)",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "type": "stat",
+      "title": "앱 상태 (up)",
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 1 },
       "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
       "fieldConfig": {
-        "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never" } },
+        "defaults": {
+          "unit": "short",
+          "mappings": [
+            { "type": "value", "options": { "0": { "text": "DOWN", "color": "red" }, "1": { "text": "UP", "color": "green" } } }
+          ],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "red", "value": null }, { "color": "green", "value": 1 } ] }
+        },
         "overrides": []
       },
-      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "options": { "colorMode": "background", "graphMode": "none", "textMode": "auto", "reduceOptions": { "calcs": ["lastNotNull"] } },
       "targets": [
-        {
-          "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
-          "expr": "sum by (status) (rate(http_server_requests_seconds_count{application=\"PIKI\"}[$__rate_interval]))",
-          "legendFormat": "{{status}}"
-        }
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "max(up{job=\"prometheus.scrape.app\"})" }
       ]
     },
     {
       "id": 2,
-      "type": "timeseries",
-      "title": "HTTP p95 지연 (uri별)",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "type": "stat",
+      "title": "5xx 에러율",
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 1 },
       "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
       "fieldConfig": {
-        "defaults": { "unit": "s", "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never" } },
+        "defaults": {
+          "unit": "percent",
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 1 }, { "color": "red", "value": 5 } ] }
+        },
         "overrides": []
       },
-      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "options": { "colorMode": "background", "graphMode": "area", "textMode": "auto", "reduceOptions": { "calcs": ["lastNotNull"] } },
       "targets": [
-        {
-          "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
-          "expr": "histogram_quantile(0.95, sum by (le, uri) (rate(http_server_requests_seconds_bucket{application=\"PIKI\"}[$__rate_interval])))",
-          "legendFormat": "{{uri}}"
-        }
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "sum(rate(http_server_requests_seconds_count{application=\"PIKI\", status=~\"5..\"}[$__rate_interval])) / clamp_min(sum(rate(http_server_requests_seconds_count{application=\"PIKI\"}[$__rate_interval])), 0.001) * 100" }
       ]
     },
     {
       "id": 3,
-      "type": "timeseries",
-      "title": "JVM Heap 메모리 사용",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "type": "stat",
+      "title": "HTTP p99 지연",
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 1 },
       "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
       "fieldConfig": {
-        "defaults": { "unit": "bytes", "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never" } },
+        "defaults": {
+          "unit": "s",
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 1 }, { "color": "red", "value": 5 } ] }
+        },
         "overrides": []
       },
-      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "options": { "colorMode": "background", "graphMode": "area", "textMode": "auto", "reduceOptions": { "calcs": ["lastNotNull"] } },
       "targets": [
-        {
-          "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
-          "expr": "sum by (instance) (jvm_memory_used_bytes{application=\"PIKI\", area=\"heap\"})",
-          "legendFormat": "used {{instance}}"
-        },
-        {
-          "refId": "B",
-          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
-          "expr": "sum by (instance) (jvm_memory_max_bytes{application=\"PIKI\", area=\"heap\"})",
-          "legendFormat": "max {{instance}}"
-        }
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "histogram_quantile(0.99, sum by (le) (rate(http_server_requests_seconds_bucket{application=\"PIKI\"}[$__rate_interval])))" }
       ]
     },
     {
       "id": 4,
-      "type": "timeseries",
-      "title": "JVM 라이브 스레드",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "type": "stat",
+      "title": "JVM Heap 사용률",
+      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 1 },
       "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
       "fieldConfig": {
-        "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never" } },
+        "defaults": {
+          "unit": "percent",
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 70 }, { "color": "red", "value": 85 } ] }
+        },
         "overrides": []
       },
-      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "options": { "colorMode": "background", "graphMode": "area", "textMode": "auto", "reduceOptions": { "calcs": ["lastNotNull"] } },
       "targets": [
-        {
-          "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
-          "expr": "jvm_threads_live_threads{application=\"PIKI\"}",
-          "legendFormat": "{{instance}}"
-        }
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "sum(jvm_memory_used_bytes{application=\"PIKI\", area=\"heap\"}) / sum(jvm_memory_max_bytes{application=\"PIKI\", area=\"heap\"}) * 100" }
       ]
     },
     {
       "id": 5,
-      "type": "timeseries",
-      "title": "HikariCP 커넥션풀",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "type": "stat",
+      "title": "호스트 메모리 사용률",
+      "gridPos": { "h": 4, "w": 4, "x": 16, "y": 1 },
       "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
       "fieldConfig": {
-        "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never" } },
+        "defaults": {
+          "unit": "percent",
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 80 }, { "color": "red", "value": 90 } ] }
+        },
         "overrides": []
       },
-      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "options": { "colorMode": "background", "graphMode": "area", "textMode": "auto", "reduceOptions": { "calcs": ["lastNotNull"] } },
       "targets": [
-        {
-          "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
-          "expr": "hikaricp_connections_active{application=\"PIKI\"}",
-          "legendFormat": "active {{pool}}"
-        },
-        {
-          "refId": "B",
-          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
-          "expr": "hikaricp_connections_idle{application=\"PIKI\"}",
-          "legendFormat": "idle {{pool}}"
-        },
-        {
-          "refId": "C",
-          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
-          "expr": "hikaricp_connections_pending{application=\"PIKI\"}",
-          "legendFormat": "pending {{pool}}"
-        }
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "(1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes) * 100" }
       ]
     },
     {
       "id": 6,
-      "type": "timeseries",
-      "title": "Executor 스레드풀 (active / queued)",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "type": "stat",
+      "title": "Swap 사용량",
+      "gridPos": { "h": 4, "w": 4, "x": 20, "y": 1 },
       "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
       "fieldConfig": {
-        "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never" } },
+        "defaults": {
+          "unit": "bytes",
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 1 }, { "color": "red", "value": 268435456 } ] }
+        },
         "overrides": []
       },
-      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "options": { "colorMode": "background", "graphMode": "area", "textMode": "auto", "reduceOptions": { "calcs": ["lastNotNull"] } },
       "targets": [
-        {
-          "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
-          "expr": "executor_active_threads{application=\"PIKI\"}",
-          "legendFormat": "active {{name}}"
-        },
-        {
-          "refId": "B",
-          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
-          "expr": "executor_queued_tasks{application=\"PIKI\"}",
-          "legendFormat": "queued {{name}}"
-        }
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "node_memory_SwapTotal_bytes - node_memory_SwapFree_bytes" }
       ]
     },
     {
-      "id": 7,
+      "id": 101,
+      "type": "row",
+      "title": "트래픽 (RED: 요청률 · 에러 · 지연)",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 }
+    },
+    {
+      "id": 10,
       "type": "timeseries",
-      "title": "CPU 사용률 (process / system)",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
+      "title": "HTTP 요청률 (status별)",
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 6 },
       "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
-      "fieldConfig": {
-        "defaults": { "unit": "percentunit", "min": 0, "max": 1, "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never" } },
-        "overrides": []
-      },
-      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never" } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "targets": [
-        {
-          "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
-          "expr": "process_cpu_usage{application=\"PIKI\"}",
-          "legendFormat": "process {{instance}}"
-        },
-        {
-          "refId": "B",
-          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
-          "expr": "system_cpu_usage{application=\"PIKI\"}",
-          "legendFormat": "system {{instance}}"
-        }
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "sum by (status) (rate(http_server_requests_seconds_count{application=\"PIKI\"}[$__rate_interval]))", "legendFormat": "{{status}}" }
       ]
     },
     {
-      "id": 8,
+      "id": 11,
       "type": "timeseries",
-      "title": "JVM GC pause (p99)",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+      "title": "5xx 요청률 (uri별)",
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 6 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+      "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "fillOpacity": 20, "showPoints": "never" } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "sum by (uri, status) (rate(http_server_requests_seconds_count{application=\"PIKI\", status=~\"5..\"}[$__rate_interval]))", "legendFormat": "{{status}} {{uri}}" }
+      ]
+    },
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "HTTP 지연 (p50 / p95 / p99)",
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 6 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+      "fieldConfig": { "defaults": { "unit": "s", "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never" } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "histogram_quantile(0.50, sum by (le) (rate(http_server_requests_seconds_bucket{application=\"PIKI\"}[$__rate_interval])))", "legendFormat": "p50" },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_requests_seconds_bucket{application=\"PIKI\"}[$__rate_interval])))", "legendFormat": "p95" },
+        { "refId": "C", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "histogram_quantile(0.99, sum by (le) (rate(http_server_requests_seconds_bucket{application=\"PIKI\"}[$__rate_interval])))", "legendFormat": "p99" }
+      ]
+    },
+    {
+      "id": 102,
+      "type": "row",
+      "title": "JVM 메모리 · GC (1순위 리스크)",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 14 }
+    },
+    {
+      "id": 20,
+      "type": "timeseries",
+      "title": "JVM Heap (used / max)",
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 15 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+      "fieldConfig": { "defaults": { "unit": "bytes", "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never" } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "sum by (instance) (jvm_memory_used_bytes{application=\"PIKI\", area=\"heap\"})", "legendFormat": "used {{instance}}" },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "sum by (instance) (jvm_memory_max_bytes{application=\"PIKI\", area=\"heap\"})", "legendFormat": "max {{instance}}" }
+      ]
+    },
+    {
+      "id": 21,
+      "type": "timeseries",
+      "title": "JVM NonHeap (used)",
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 15 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+      "fieldConfig": { "defaults": { "unit": "bytes", "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never" } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "sum by (instance) (jvm_memory_used_bytes{application=\"PIKI\", area=\"nonheap\"})", "legendFormat": "nonheap {{instance}}" }
+      ]
+    },
+    {
+      "id": 22,
+      "type": "timeseries",
+      "title": "GC pause (p99) · GC 빈도",
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 15 },
       "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
       "fieldConfig": {
         "defaults": { "unit": "s", "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never" } },
-        "overrides": []
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "gc/s" }, "properties": [ { "id": "unit", "value": "ops" } ] }
+        ]
       },
       "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
       "targets": [
-        {
-          "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(jvm_gc_pause_seconds_bucket{application=\"PIKI\"}[$__rate_interval])))",
-          "legendFormat": "gc pause p99"
-        }
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "histogram_quantile(0.99, sum by (le) (rate(jvm_gc_pause_seconds_bucket{application=\"PIKI\"}[$__rate_interval])))", "legendFormat": "pause p99" },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "sum(rate(jvm_gc_pause_seconds_count{application=\"PIKI\"}[$__rate_interval]))", "legendFormat": "gc/s" }
       ]
     },
     {
-      "id": 9,
-      "type": "logs",
-      "title": "앱 로그 (team3-blue / team3-green)",
-      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 32 },
-      "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
-      "options": {
-        "showTime": true,
-        "showLabels": false,
-        "wrapLogMessage": true,
-        "enableLogDetails": true,
-        "dedupStrategy": "none",
-        "sortOrder": "Descending"
-      },
+      "id": 103,
+      "type": "row",
+      "title": "호스트 (메모리 · swap · 디스크)",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 23 }
+    },
+    {
+      "id": 30,
+      "type": "timeseries",
+      "title": "호스트 메모리 (used / total)",
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 24 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+      "fieldConfig": { "defaults": { "unit": "bytes", "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never" } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
       "targets": [
-        {
-          "refId": "A",
-          "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
-          "expr": "{container=~\"team3-(blue|green)\"}"
-        }
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes", "legendFormat": "used" },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "node_memory_MemTotal_bytes", "legendFormat": "total" }
+      ]
+    },
+    {
+      "id": 31,
+      "type": "timeseries",
+      "title": "Swap (used / total)",
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 24 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+      "fieldConfig": { "defaults": { "unit": "bytes", "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never" } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "node_memory_SwapTotal_bytes - node_memory_SwapFree_bytes", "legendFormat": "used" },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "node_memory_SwapTotal_bytes", "legendFormat": "total" }
+      ]
+    },
+    {
+      "id": 32,
+      "type": "timeseries",
+      "title": "디스크 여유 (mountpoint별)",
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 24 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+      "fieldConfig": { "defaults": { "unit": "bytes", "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never" } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "node_filesystem_avail_bytes{fstype!~\"tmpfs|overlay|squashfs\"}", "legendFormat": "{{mountpoint}}" }
+      ]
+    },
+    {
+      "id": 104,
+      "type": "row",
+      "title": "의존성 (외부 호출 · 풀 · 비동기)",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 32 }
+    },
+    {
+      "id": 40,
+      "type": "timeseries",
+      "title": "502 (Gemini 등 외부 의존성 실패)",
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 33 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+      "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "fillOpacity": 20, "showPoints": "never" } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "sum by (uri) (rate(http_server_requests_seconds_count{application=\"PIKI\", status=\"502\"}[$__rate_interval]))", "legendFormat": "{{uri}}" }
+      ]
+    },
+    {
+      "id": 41,
+      "type": "timeseries",
+      "title": "Executor 스레드풀 (active / queued)",
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 33 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+      "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never" } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "executor_active_threads{application=\"PIKI\"}", "legendFormat": "active {{name}}" },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "executor_queued_tasks{application=\"PIKI\"}", "legendFormat": "queued {{name}}" }
+      ]
+    },
+    {
+      "id": 42,
+      "type": "timeseries",
+      "title": "HikariCP 커넥션풀 (active / idle / pending)",
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 33 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+      "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never" } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "hikaricp_connections_active{application=\"PIKI\"}", "legendFormat": "active {{pool}}" },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "hikaricp_connections_idle{application=\"PIKI\"}", "legendFormat": "idle {{pool}}" },
+        { "refId": "C", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "hikaricp_connections_pending{application=\"PIKI\"}", "legendFormat": "pending {{pool}}" }
+      ]
+    },
+    {
+      "id": 105,
+      "type": "row",
+      "title": "리소스 (CPU · 스레드)",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 41 }
+    },
+    {
+      "id": 50,
+      "type": "timeseries",
+      "title": "앱 CPU (process / system)",
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 42 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+      "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0, "max": 1, "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never" } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "process_cpu_usage{application=\"PIKI\"}", "legendFormat": "process {{instance}}" },
+        { "refId": "B", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "system_cpu_usage{application=\"PIKI\"}", "legendFormat": "system {{instance}}" }
+      ]
+    },
+    {
+      "id": 51,
+      "type": "timeseries",
+      "title": "JVM 라이브 스레드",
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 42 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+      "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never" } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "jvm_threads_live_threads{application=\"PIKI\"}", "legendFormat": "{{instance}}" }
+      ]
+    },
+    {
+      "id": 52,
+      "type": "timeseries",
+      "title": "호스트 CPU 사용률",
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 42 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+      "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0, "max": 1, "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never" } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "1 - avg(rate(node_cpu_seconds_total{mode=\"idle\"}[$__rate_interval]))", "legendFormat": "busy" }
+      ]
+    },
+    {
+      "id": 106,
+      "type": "row",
+      "title": "로그 (team3-blue / team3-green)",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 50 }
+    },
+    {
+      "id": 60,
+      "type": "logs",
+      "title": "에러/경고 로그",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 51 },
+      "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+      "options": { "showTime": true, "showLabels": false, "wrapLogMessage": true, "enableLogDetails": true, "dedupStrategy": "none", "sortOrder": "Descending" },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "loki", "uid": "${DS_LOKI}" }, "expr": "{container=~\"team3-(blue|green)\"} |~ \"(?i)(error|exception|warn|fail)\"" }
+      ]
+    },
+    {
+      "id": 61,
+      "type": "logs",
+      "title": "전체 로그",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 59 },
+      "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+      "options": { "showTime": true, "showLabels": false, "wrapLogMessage": true, "enableLogDetails": true, "dedupStrategy": "none", "sortOrder": "Descending" },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "loki", "uid": "${DS_LOKI}" }, "expr": "{container=~\"team3-(blue|green)\"}" }
       ]
     }
   ]

--- a/infra/scripts/provision-runtime.sh
+++ b/infra/scripts/provision-runtime.sh
@@ -49,6 +49,8 @@ fi
 #    crash loop 가 나기 때문. secret 등록 후 다음 배포에 자동 기동된다.
 #    --network host: 앱 포트가 127.0.0.1 바인딩(#290)이라 localhost:8080/8081 을 scrape 하려면 필요.
 #    --server.http.listen-addr=127.0.0.1: host 네트워크라 debug UI(12345)를 루프백에만 묶어 외부 노출을 막는다.
+#    /proc·/sys·/ 마운트: node_exporter(config 의 prometheus.exporter.unix)가 컨테이너 안에서 호스트
+#    메모리·swap·디스크를 읽으려면 필요하다. config 의 *_path 가 /host/* 를 가리킨다. ro,rslave 로 읽기전용.
 if [ -z "${GRAFANA_METRICS_URL:-}" ]; then
   echo "[alloy] GRAFANA_* 미설정 — skip (secret 등록 후 다음 배포에 기동)"
 else
@@ -62,6 +64,9 @@ else
     --network host \
     -v /etc/alloy-team3/config.alloy:/etc/alloy/config.alloy:ro \
     -v /var/run/docker.sock:/var/run/docker.sock:ro \
+    -v /proc:/host/proc:ro,rslave \
+    -v /sys:/host/sys:ro,rslave \
+    -v /:/host/root:ro,rslave \
     -e GRAFANA_METRICS_URL="${GRAFANA_METRICS_URL:-}" \
     -e GRAFANA_METRICS_USER="${GRAFANA_METRICS_USER:-}" \
     -e GRAFANA_LOGS_URL="${GRAFANA_LOGS_URL:-}" \


### PR DESCRIPTION
## Situation
- 906Mi EC2 + JVM heap 256m + 컨테이너 메모리 무제한 구성이라 **OOM·swap 폭증이 초기 1순위 리스크**다. 특히 blue-green 전환 순간 구·신 컨테이너가 잠깐 공존해 메모리가 2배로 압박된다.
- 그런데 기존 대시보드(PR #299)는 JVM heap 메트릭만 봐서 **OS 레벨 메모리/swap/디스크가 사각**이었고, 패널 순서도 우선순위 없이 평면적이었다.

## Action
- **호스트 메트릭 수집**: Alloy 에 `prometheus.exporter.unix`(node_exporter) 추가. `provision-runtime.sh` 가 Alloy 컨테이너에 `/proc`·`/sys`·`/` 를 `/host/*` 로 `ro,rslave` 마운트하고 config 의 `*_path` 가 이를 가리켜, 컨테이너 안에서 호스트 메모리·swap·디스크·CPU 를 읽는다.
- **대시보드 재설계** (9 → 23패널): 증상 → 원인 → 로그 순서로 재배치.
  - 상단 **요약 stat 6종**(앱 up · 5xx율 · p99 지연 · JVM heap% · 호스트 메모리% · swap)에 **임계 색상**(heap 85%·호스트메모리 90% 등에서 빨강) — 한눈에 위험 감지.
  - RED(요청률·5xx·지연 p50/95/99) → JVM 메모리·GC → **호스트 메모리/swap/디스크** → 의존성(502율·executor·HikariCP) → 리소스(CPU·스레드) → 로그(에러 필터 + 전체).
- **README**: 패널 구성·순서와 **계측 한계**(Gemini 호출은 직접 계측 없어 502 로 간접 관측 — 후속 `@Observed` 필요, S3·Redis 도 자동 계측 없음) 명시.

## Result
- `grafana/alloy:v1.16.1 validate` EXIT=0, dashboard.json JSON 검증 통과. 앱 코드(`src/`) 변경 0.
- 머지·배포 시 Alloy 가 재기동되며 호스트 메트릭이 흐르기 시작한다. 그 후 GC 콘솔에서 dashboard.json 을 **재 import**(같은 uid 라 덮어쓰기)하면 호스트 패널까지 채워진다.
- 후속 후보: Gemini 호출 직접 계측(`@Observed`), HikariCP 명시 튜닝.

---
## 연관 이슈

- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 호스트 메트릭(메모리, CPU, 디스크, Swap 등) 수집 기능 추가
  * 대시보드에 7개 섹션(한눈 건강, 트래픽, JVM, 호스트, 의존성, 리소스, 로그)으로 재구성된 상세 메트릭 시각화 추가

* **Documentation**
  * 대시보드 패널 배치와 계측 한계에 대한 설명 업데이트

* **Chores**
  * 호스트 리소스 접근을 위한 런타임 설정 업데이트

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/PIKI-Server/pull/303?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->