### PR TITLE
admin 백오피스 dev 배포 노출 (Secrets 로 자격증명 주입)

### DIFF
--- a/.github/workflows/deploy-manual.yml
+++ b/.github/workflows/deploy-manual.yml
@@ -98,13 +98,18 @@ jobs:
           GOOGLE_REDIRECT_URI: ${{ secrets.GOOGLE_REDIRECT_URI }}
           S3_BUCKET: ${{ secrets.S3_BUCKET }}
           S3_PUBLIC_BASE_URL: ${{ secrets.S3_PUBLIC_BASE_URL }}
+          # admin 백오피스(dev 전용). ENABLED 만 평문(민감정보 아님)으로 두어 "dev 에 켰다"는 의도를 드러내고,
+          # 자격증명(ID·PW)은 Secrets 로만 주입해 워크플로 파일·git 히스토리에 평문이 남지 않게 한다.
+          ADMIN_ENABLED: "true"
+          ADMIN_USERNAME: ${{ secrets.ADMIN_USERNAME }}
+          ADMIN_PASSWORD: ${{ secrets.ADMIN_PASSWORD }}
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           IMAGE_TAG: ${{ steps.tag.outputs.value }}
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
-          envs: GEMINI_API_KEY,DB_HOST,DB_PORT,DB_NAME,DB_USERNAME,DB_PASSWORD,JWT_SECRET,REDIS_HOST,REDIS_PORT,KAKAO_CLIENT_ID,KAKAO_CLIENT_SECRET,KAKAO_REDIRECT_URI,GOOGLE_CLIENT_ID,GOOGLE_CLIENT_SECRET,GOOGLE_REDIRECT_URI,S3_BUCKET,S3_PUBLIC_BASE_URL,DOCKERHUB_USERNAME,IMAGE_TAG
+          envs: GEMINI_API_KEY,DB_HOST,DB_PORT,DB_NAME,DB_USERNAME,DB_PASSWORD,JWT_SECRET,REDIS_HOST,REDIS_PORT,KAKAO_CLIENT_ID,KAKAO_CLIENT_SECRET,KAKAO_REDIRECT_URI,GOOGLE_CLIENT_ID,GOOGLE_CLIENT_SECRET,GOOGLE_REDIRECT_URI,S3_BUCKET,S3_PUBLIC_BASE_URL,ADMIN_ENABLED,ADMIN_USERNAME,ADMIN_PASSWORD,DOCKERHUB_USERNAME,IMAGE_TAG
           script: |
             IMAGE="$DOCKERHUB_USERNAME/team3-server:$IMAGE_TAG"
             docker pull "$IMAGE"
@@ -132,6 +137,9 @@ jobs:
               -e GOOGLE_REDIRECT_URI="$GOOGLE_REDIRECT_URI" \
               -e S3_BUCKET="$S3_BUCKET" \
               -e S3_PUBLIC_BASE_URL="$S3_PUBLIC_BASE_URL" \
+              -e ADMIN_ENABLED="$ADMIN_ENABLED" \
+              -e ADMIN_USERNAME="$ADMIN_USERNAME" \
+              -e ADMIN_PASSWORD="$ADMIN_PASSWORD" \
               "$IMAGE"
 
       - name: Health check

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -170,13 +170,18 @@ jobs:
           GOOGLE_REDIRECT_URI: ${{ secrets.GOOGLE_REDIRECT_URI }}
           S3_BUCKET: ${{ secrets.S3_BUCKET }}
           S3_PUBLIC_BASE_URL: ${{ secrets.S3_PUBLIC_BASE_URL }}
+          # admin 백오피스(dev 전용). ENABLED 만 평문(민감정보 아님)으로 두어 "dev 에 켰다"는 의도를 드러내고,
+          # 자격증명(ID·PW)은 Secrets 로만 주입해 워크플로 파일·git 히스토리에 평문이 남지 않게 한다.
+          ADMIN_ENABLED: "true"
+          ADMIN_USERNAME: ${{ secrets.ADMIN_USERNAME }}
+          ADMIN_PASSWORD: ${{ secrets.ADMIN_PASSWORD }}
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           IMAGE_TAG: ${{ github.event.workflow_run.head_sha || github.sha }}
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
-          envs: GEMINI_API_KEY,DB_HOST,DB_PORT,DB_NAME,DB_USERNAME,DB_PASSWORD,JWT_SECRET,REDIS_HOST,REDIS_PORT,KAKAO_CLIENT_ID,KAKAO_CLIENT_SECRET,KAKAO_REDIRECT_URI,GOOGLE_CLIENT_ID,GOOGLE_CLIENT_SECRET,GOOGLE_REDIRECT_URI,S3_BUCKET,S3_PUBLIC_BASE_URL,DOCKERHUB_USERNAME,IMAGE_TAG
+          envs: GEMINI_API_KEY,DB_HOST,DB_PORT,DB_NAME,DB_USERNAME,DB_PASSWORD,JWT_SECRET,REDIS_HOST,REDIS_PORT,KAKAO_CLIENT_ID,KAKAO_CLIENT_SECRET,KAKAO_REDIRECT_URI,GOOGLE_CLIENT_ID,GOOGLE_CLIENT_SECRET,GOOGLE_REDIRECT_URI,S3_BUCKET,S3_PUBLIC_BASE_URL,ADMIN_ENABLED,ADMIN_USERNAME,ADMIN_PASSWORD,DOCKERHUB_USERNAME,IMAGE_TAG
           script: |
             IMAGE="$DOCKERHUB_USERNAME/team3-server:$IMAGE_TAG"
             docker pull "$IMAGE"
@@ -233,6 +238,9 @@ jobs:
               -e GOOGLE_REDIRECT_URI="$GOOGLE_REDIRECT_URI" \
               -e S3_BUCKET="$S3_BUCKET" \
               -e S3_PUBLIC_BASE_URL="$S3_PUBLIC_BASE_URL" \
+              -e ADMIN_ENABLED="$ADMIN_ENABLED" \
+              -e ADMIN_USERNAME="$ADMIN_USERNAME" \
+              -e ADMIN_PASSWORD="$ADMIN_PASSWORD" \
               "$IMAGE"
 
       - name: Health check and switch


### PR DESCRIPTION
## Situation
- admin 백오피스 코드는 PR #298 로 dev 에 머지됐으나, "dev 서버에 실제로 켜는 것"은 관리자 페이지 외부 노출·자격증명 정책이 걸려 의도적으로 별도 PR 로 미뤄둔 상태였다.
- 그래서 dev 서버 컨테이너에는 `ADMIN_*` env 가 없었고, 기본 게이팅(`ADMIN_ENABLED=false`)으로 `/admin` 라우트가 안 떠 `https://api.depromeet18team3.cloud/admin/login` 이 401 을 반환했다 (SSH 로 직접 확인 — health 200 으로 앱은 정상, admin 만 비활성).

## Task
- dev 배포에 admin 백오피스를 켜서 실제로 사용 가능하게 한다.
- 단, 관리자 ID·PW 가 워크플로 파일·PR·git 히스토리 어디에도 평문으로 남지 않아야 한다.

## Action
- `deploy.yml`·`deploy-manual.yml` 의 step env → `envs` 전달 목록 → `docker run -e` 3곳에 `ADMIN_ENABLED`·`ADMIN_USERNAME`·`ADMIN_PASSWORD` 를 일관되게 주입.
- 자격증명(ID·PW)은 GitHub Secrets(`ADMIN_USERNAME`·`ADMIN_PASSWORD`)로만 주입 — 워크플로엔 `${{ secrets.* }}` 참조만 들어가 평문이 남지 않는다. `ADMIN_ENABLED` 만 평문 `"true"` 로 두어 "dev 에 켰다"는 의도를 워크플로에서 드러낸다.
- 자동 배포(`deploy.yml`)와 수동 배포(`deploy-manual.yml`) 양쪽에 동일하게 넣어, 어느 경로로 배포해도 admin 이 유지되게 했다.
- 기존 secrets 전달 패턴(step env 경유 후 `envs` 로 SSH 세션 export)을 그대로 따랐다 — `docker run` 문자열에 `${{ secrets.X }}` 를 직접 박으면 값의 특수문자가 쉘 재해석으로 손상될 수 있다는 기존 주석의 이유와 동일.

## Result
- 이 PR 이 dev 에 머지되면 자동 재배포(`workflow_run` on CI/dev)가 돌며 새 blue-green 컨테이너에 admin 이 활성화되고, `/admin/login` 이 로그인 폼(200)을 응답한다.
- **주의: `/admin/**` 이 공개 도메인으로 노출된다.** 세션 form login(`AdminSecurityConfig`)으로 보호되지만 인터넷에서 접근 가능하므로, **dev 전용**이라는 전제 하에 운영한다.
- 후속: 운영 환경 노출은 별도 판단 대상. 필요해지면 IP allowlist·추가 인증 보호를 검토한다.

---
## 연관 이슈

- 
