### PR TITLE
admin 로그인 비밀번호 보기 토글

### DIFF
--- a/src/main/resources/static/admin-assets/backoffice.css
+++ b/src/main/resources/static/admin-assets/backoffice.css
@@ -68,6 +68,26 @@ body {
   background: #1d4ed8;
 }
 
+/* 비밀번호 보기 토글 — .login-container input 의 공통 스타일이 체크박스에 적용되지 않게 reset */
+.login-show-pw {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: #6b7280;
+  cursor: pointer;
+  text-align: left;
+}
+
+.login-show-pw input[type="checkbox"] {
+  width: auto;
+  padding: 0;
+  margin: 0;
+  border: none;
+  border-radius: 0;
+  cursor: pointer;
+}
+
 /* 백오피스 셸 (사이드바 + 본문) */
 .bo-shell {
   display: flex;

--- a/src/main/resources/templates/admin/login.html
+++ b/src/main/resources/templates/admin/login.html
@@ -14,7 +14,12 @@
     <p class="login-info" th:if="${param.logout}">로그아웃되었습니다.</p>
     <form th:action="@{/admin/login}" method="post">
         <input type="text" name="username" placeholder="아이디" required autofocus>
-        <input type="password" name="password" placeholder="비밀번호" required>
+        <input type="password" id="password" name="password" placeholder="비밀번호" required>
+        <label class="login-show-pw">
+            <input type="checkbox"
+                   onchange="document.getElementById('password').type = this.checked ? 'text' : 'password'">
+            비밀번호 보기
+        </label>
         <button type="submit">로그인</button>
     </form>
 </div>


### PR DESCRIPTION
## Situation
- admin 백오피스 로그인 페이지에서 비밀번호 입력값을 눈으로 확인할 수단이 없었다. dev 전용 백오피스에 로그인할 때 오타를 바로 잡기 어려웠다.

## Task
- 로그인 폼에 "비밀번호 보기" 토글을 추가해 입력값을 평문으로 확인할 수 있게 한다.

## Action
- password input 옆에 체크박스를 두고, 체크 시 input `type` 을 `password`↔`text` 로 전환.
- `AdminSecurityConfig` 에 CSP 헤더가 없고 `items.html` 이 이미 인라인 `onsubmit` 을 쓰므로, 같은 결로 인라인 `onchange` 핸들러로 구현 — 별도 JS 파일을 새로 두지 않았다.
- `.login-container input` 공통 스타일(padding·border)이 체크박스에도 적용돼 모양이 깨지던 것을 `.login-show-pw input[type=checkbox]` reset 으로 정정.

## Result
- 로그인 시 비밀번호를 토글로 확인 가능. 클라이언트 JS 만 추가돼 서버 로직·테스트에 영향 없음(통합 테스트 통과 확인).

---
## 연관 이슈

- 
