### PR TITLE
Kakao·Google 소셜 로그인 플로우 구축

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,10 +22,9 @@ build/
 # IntelliJ 컴파일 출력
 out/
 
-# Environment
-.env
-.env.test
-.env-local
+# Environment — .env* 전부 무시하되 템플릿(.env.example)은 커밋 유지
+.env*
+!.env.example
 
 # Kotlin
 .kotlin/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,5 +23,17 @@ services:
       timeout: 3s
       retries: 10
 
+  redis:
+    image: redis:7.4-alpine
+    container_name: piki-redis
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
 volumes:
   piki-mysql-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,8 @@ services:
       MYSQL_USER: ${DB_USERNAME:-piki}
       MYSQL_PASSWORD: ${DB_PASSWORD:-piki}
     ports:
-      - "3306:3306"
+      # loopback 바인딩 — 공유망·원격 Docker host 에서 무인증 외부 접근을 막는다. 로컬 앱은 localhost 로 접속.
+      - "127.0.0.1:3306:3306"
     volumes:
       - piki-mysql-data:/var/lib/mysql
     command:
@@ -28,7 +29,8 @@ services:
     container_name: piki-redis
     restart: unless-stopped
     ports:
-      - "6379:6379"
+      # loopback 바인딩 — Redis 무인증 외부 접근(데이터 변조·삭제) 차단. 로컬 앱은 localhost 로 접속.
+      - "127.0.0.1:6379:6379"
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 5s

--- a/src/main/kotlin/com/depromeet/piki/auth/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/config/SecurityConfig.kt
@@ -45,6 +45,9 @@ class SecurityConfig(
                     .permitAll()
                     .requestMatchers(HttpMethod.POST, "/api/v1/auth/guest")
                     .permitAll()
+                    // 소셜 로그인 진입점 — 미인증으로 호출(게스트 토큰은 선택). 게스트 토큰을 보내면 필터가 principal 을 채워 게스트-연결로 동작.
+                    .requestMatchers(HttpMethod.POST, "/api/v1/auth/login/*")
+                    .permitAll()
                     .requestMatchers(HttpMethod.POST, "/api/v1/auth/token/refresh")
                     .permitAll()
                     .requestMatchers(HttpMethod.POST, "/api/v1/auth/logout")

--- a/src/main/kotlin/com/depromeet/piki/auth/controller/OAuthApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/controller/OAuthApi.kt
@@ -1,0 +1,63 @@
+package com.depromeet.piki.auth.controller
+
+import com.depromeet.piki.auth.controller.dto.OAuthLoginRequest
+import com.depromeet.piki.auth.controller.dto.OAuthLoginResponse
+import com.depromeet.piki.auth.web.ClientType
+import com.depromeet.piki.common.response.ApiResponseBody
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.enums.ParameterIn
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.security.SecurityRequirements
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.MediaType
+import java.util.UUID
+
+@Tag(name = "Auth", description = "인증 API")
+interface OAuthApi {
+    @Operation(
+        summary = "소셜 로그인",
+        description =
+            "kakao/google 소셜 로그인. v1(웹)은 body 에 code+redirectUri, v2(SDK)는 body 에 accessToken 을 보낸다. " +
+                "처음 보는 소셜이면 MEMBER 로 가입(닉네임 자동 fill, 이후 수정 가능)하고, 기존이면 로그인한다. " +
+                "게스트 토큰을 함께 보내면 그 게스트 계정에 소셜을 연결+승격해 위시·토너먼트 데이터를 이어준다. " +
+                "응답 토큰은 기본 HttpOnly 쿠키로 내려가며, X-Client-Type: app 일 때만 body 로 내린다.",
+    )
+    // 만료/미인증 클라이언트도 호출하므로 인증 없이 진입 (SecurityConfig 의 permitAll).
+    @SecurityRequirements
+    @Parameter(
+        name = ClientType.HEADER,
+        `in` = ParameterIn.HEADER,
+        required = false,
+        description = "클라이언트 종류. app 이면 body 로 토큰을 받는다. 그 외·미설정은 HttpOnly 쿠키(기본).",
+        schema = Schema(allowableValues = ["web", "app"]),
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "로그인/가입 성공 (기본: Set-Cookie + body 토큰 null / app: body 토큰)",
+                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청 (code+redirectUri 도 accessToken 도 없음 · 지원하지 않는 provider)",
+                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+            ),
+            ApiResponse(
+                responseCode = "502",
+                description = "소셜 제공자(Kakao/Google) 호출 실패 (네트워크·토큰 교환 실패·user_info 조회 실패 등)",
+                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+            ),
+        ],
+    )
+    fun login(
+        @Parameter(description = "소셜 제공자", example = "kakao", schema = Schema(allowableValues = ["kakao", "google"]))
+        provider: String,
+        request: OAuthLoginRequest,
+        @Parameter(hidden = true) currentUserId: UUID?,
+    ): ApiResponseBody<OAuthLoginResponse>
+}

--- a/src/main/kotlin/com/depromeet/piki/auth/controller/OAuthApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/controller/OAuthApi.kt
@@ -44,7 +44,7 @@ interface OAuthApi {
             ),
             ApiResponse(
                 responseCode = "400",
-                description = "잘못된 요청 (code+redirectUri 도 accessToken 도 없음 · 지원하지 않는 provider)",
+                description = "잘못된 요청 (code+redirectUri 도 accessToken 도 없음 · accessToken 과 code 를 동시 전달 · 지원하지 않는 provider)",
                 content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
             ),
             ApiResponse(

--- a/src/main/kotlin/com/depromeet/piki/auth/controller/OAuthApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/controller/OAuthApi.kt
@@ -40,17 +40,32 @@ interface OAuthApi {
             ApiResponse(
                 responseCode = "200",
                 description = "로그인/가입 성공 (기본: Set-Cookie + body 토큰 null / app: body 토큰)",
-                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
             ),
             ApiResponse(
                 responseCode = "400",
                 description = "잘못된 요청 (code+redirectUri 도 accessToken 도 없음 · accessToken 과 code 를 동시 전달 · 지원하지 않는 provider)",
-                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
             ),
             ApiResponse(
                 responseCode = "502",
                 description = "소셜 제공자(Kakao/Google) 호출 실패 (네트워크·토큰 교환 실패·user_info 조회 실패 등)",
-                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
             ),
         ],
     )

--- a/src/main/kotlin/com/depromeet/piki/auth/controller/OAuthApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/controller/OAuthApiExamples.kt
@@ -1,0 +1,72 @@
+package com.depromeet.piki.auth.controller
+
+import com.depromeet.piki.auth.controller.dto.OAuthLoginResponse
+import com.depromeet.piki.auth.service.dto.TokenPair
+import com.depromeet.piki.common.exception.ErrorCategory
+import com.depromeet.piki.common.openapi.OpenApiObjectMapper
+import com.depromeet.piki.common.openapi.binds
+import com.depromeet.piki.common.openapi.examples
+import com.depromeet.piki.common.response.ApiResponseBody
+import com.depromeet.piki.user.controller.dto.UserResponse
+import com.depromeet.piki.user.domain.IdentityType
+import org.springdoc.core.customizers.OperationCustomizer
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpStatus
+import java.util.UUID
+
+@Configuration
+class OAuthApiExamples(
+    private val openApiObjectMapper: OpenApiObjectMapper,
+) {
+    @Bean
+    fun oAuthOpenApiExamples(): OperationCustomizer =
+        OperationCustomizer { operation, handlerMethod ->
+            if (handlerMethod.binds(OAuthController::login)) {
+                operation.examples(openApiObjectMapper.delegate) {
+                    add(
+                        status = HttpStatus.OK,
+                        name = "로그인/가입 성공 (app — body 토큰)",
+                        payload =
+                            ApiResponseBody.ok(
+                                OAuthLoginResponse(
+                                    user =
+                                        UserResponse(
+                                            id = UUID.fromString("8f1a3c2b-9d44-4e2a-9b12-1a2b3c4d5e6f"),
+                                            nickname = "뛰어다니는 강아지",
+                                            profileImage = "https://lh3.googleusercontent.com/profile.jpg",
+                                            identityType = IdentityType.MEMBER,
+                                        ),
+                                    tokenPair =
+                                        TokenPair(
+                                            accessToken = "eyJhbGciOiJIUzI1NiJ9.access",
+                                            refreshToken = "eyJhbGciOiJIUzI1NiJ9.refresh",
+                                        ),
+                                ),
+                            ),
+                    )
+                    add(
+                        status = HttpStatus.BAD_REQUEST,
+                        name = "잘못된 요청 (자격증명 누락 또는 미지원 provider)",
+                        payload =
+                            ApiResponseBody.fail<Unit>(
+                                category = ErrorCategory.INVALID_INPUT,
+                                status = HttpStatus.BAD_REQUEST,
+                                detail = "소셜 로그인 요청이 올바르지 않습니다 (code+redirectUri 또는 accessToken 이 필요합니다).",
+                            ),
+                    )
+                    add(
+                        status = HttpStatus.BAD_GATEWAY,
+                        name = "소셜 제공자 호출 실패",
+                        payload =
+                            ApiResponseBody.fail<Unit>(
+                                category = ErrorCategory.RETRYABLE,
+                                status = HttpStatus.BAD_GATEWAY,
+                                detail = "소셜 로그인 제공자 호출에 실패했습니다.",
+                            ),
+                    )
+                }
+            }
+            operation
+        }
+}

--- a/src/main/kotlin/com/depromeet/piki/auth/controller/OAuthController.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/controller/OAuthController.kt
@@ -5,6 +5,7 @@ import com.depromeet.piki.auth.controller.dto.OAuthLoginResponse
 import com.depromeet.piki.auth.infrastructure.oauth.OAuthProvider
 import com.depromeet.piki.auth.service.OAuthLoginService
 import com.depromeet.piki.common.response.ApiResponseBody
+import jakarta.validation.Valid
 import org.slf4j.LoggerFactory
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.PathVariable
@@ -25,7 +26,7 @@ class OAuthController(
     @PostMapping("/{provider}")
     override fun login(
         @PathVariable provider: String,
-        @RequestBody request: OAuthLoginRequest,
+        @Valid @RequestBody request: OAuthLoginRequest,
         @AuthenticationPrincipal currentUserId: UUID?,
     ): ApiResponseBody<OAuthLoginResponse> {
         val oAuthProvider = OAuthProvider.from(provider)

--- a/src/main/kotlin/com/depromeet/piki/auth/controller/OAuthController.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/controller/OAuthController.kt
@@ -1,0 +1,36 @@
+package com.depromeet.piki.auth.controller
+
+import com.depromeet.piki.auth.controller.dto.OAuthLoginRequest
+import com.depromeet.piki.auth.controller.dto.OAuthLoginResponse
+import com.depromeet.piki.auth.infrastructure.oauth.OAuthProvider
+import com.depromeet.piki.auth.service.OAuthLoginService
+import com.depromeet.piki.common.response.ApiResponseBody
+import org.slf4j.LoggerFactory
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping("/api/v1/auth/login")
+class OAuthController(
+    private val oAuthLoginService: OAuthLoginService,
+) : OAuthApi {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    // currentUserId 는 게스트 토큰을 함께 보낸 경우에만 채워진다(permitAll 이라 토큰 없어도 진입). 있으면 게스트-연결 흐름.
+    @PostMapping("/{provider}")
+    override fun login(
+        @PathVariable provider: String,
+        @RequestBody request: OAuthLoginRequest,
+        @AuthenticationPrincipal currentUserId: UUID?,
+    ): ApiResponseBody<OAuthLoginResponse> {
+        val oAuthProvider = OAuthProvider.from(provider)
+        log.info("소셜 로그인 요청: provider={}, 게스트연결={}", oAuthProvider, currentUserId?.let { "있음" } ?: "없음")
+        val result = oAuthLoginService.login(oAuthProvider, request.toCommand(), currentUserId)
+        return ApiResponseBody.ok(OAuthLoginResponse.from(result.tokenPair, result.user))
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/auth/controller/dto/OAuthLoginRequest.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/controller/dto/OAuthLoginRequest.kt
@@ -24,5 +24,6 @@ data class OAuthLoginRequest(
             return v1 xor v2
         }
 
-    fun toCommand(): OAuthLoginCommand = OAuthLoginCommand(code = code, redirectUri = redirectUri, accessToken = accessToken)
+    fun toCommand(): OAuthLoginCommand =
+        OAuthLoginCommand(code = code, redirectUri = redirectUri, accessToken = accessToken)
 }

--- a/src/main/kotlin/com/depromeet/piki/auth/controller/dto/OAuthLoginRequest.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/controller/dto/OAuthLoginRequest.kt
@@ -1,0 +1,16 @@
+package com.depromeet.piki.auth.controller.dto
+
+import com.depromeet.piki.auth.service.dto.OAuthLoginCommand
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "소셜 로그인 요청 — v1(웹): code+redirectUri / v2(SDK): accessToken")
+data class OAuthLoginRequest(
+    @field:Schema(description = "v1 웹 흐름 — provider 가 redirect 로 준 인가 코드", nullable = true)
+    val code: String? = null,
+    @field:Schema(description = "v1 웹 흐름 — 코드 발급에 사용한 redirect_uri (provider 에 등록된 값과 일치)", nullable = true)
+    val redirectUri: String? = null,
+    @field:Schema(description = "v2 SDK 흐름 — 모바일 SDK 가 받은 access_token", nullable = true)
+    val accessToken: String? = null,
+) {
+    fun toCommand(): OAuthLoginCommand = OAuthLoginCommand(code = code, redirectUri = redirectUri, accessToken = accessToken)
+}

--- a/src/main/kotlin/com/depromeet/piki/auth/controller/dto/OAuthLoginRequest.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/controller/dto/OAuthLoginRequest.kt
@@ -1,7 +1,9 @@
 package com.depromeet.piki.auth.controller.dto
 
 import com.depromeet.piki.auth.service.dto.OAuthLoginCommand
+import com.fasterxml.jackson.annotation.JsonIgnore
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.AssertTrue
 
 @Schema(description = "소셜 로그인 요청 — v1(웹): code+redirectUri / v2(SDK): accessToken")
 data class OAuthLoginRequest(
@@ -12,5 +14,15 @@ data class OAuthLoginRequest(
     @field:Schema(description = "v2 SDK 흐름 — 모바일 SDK 가 받은 access_token", nullable = true)
     val accessToken: String? = null,
 ) {
+    // v1(code+redirectUri) XOR v2(accessToken) — 정확히 한 흐름만 유효. 둘 다·둘 다 없음·공백은 400(입력 경계 계약).
+    @get:JsonIgnore
+    @get:AssertTrue(message = "code+redirectUri 또는 accessToken 중 한 흐름만 보내야 합니다.")
+    val validFlow: Boolean
+        get() {
+            val v1 = !code.isNullOrBlank() && !redirectUri.isNullOrBlank()
+            val v2 = !accessToken.isNullOrBlank()
+            return v1 xor v2
+        }
+
     fun toCommand(): OAuthLoginCommand = OAuthLoginCommand(code = code, redirectUri = redirectUri, accessToken = accessToken)
 }

--- a/src/main/kotlin/com/depromeet/piki/auth/controller/dto/OAuthLoginResponse.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/controller/dto/OAuthLoginResponse.kt
@@ -1,0 +1,35 @@
+package com.depromeet.piki.auth.controller.dto
+
+import com.depromeet.piki.auth.service.dto.TokenPair
+import com.depromeet.piki.auth.web.TokenCarrying
+import com.depromeet.piki.user.controller.dto.UserResponse
+import com.depromeet.piki.user.domain.User
+import com.fasterxml.jackson.annotation.JsonIgnore
+import io.swagger.v3.oas.annotations.media.Schema
+
+// TokenCarrying — guest 응답과 동일하게 #166 advice 가 (WEB 이면) 쿠키 set 후 body 토큰을 비운다.
+// 토큰은 nullable: APP=값 / WEB=null(쿠키로 전달). user 는 로그인/가입된 회원 정보.
+@Schema(description = "소셜 로그인 응답")
+data class OAuthLoginResponse(
+    @field:Schema(description = "로그인/가입된 유저 정보. 신규 가입이면 자동 fill 된 닉네임이 온다.")
+    val user: UserResponse,
+    @get:JsonIgnore
+    override val tokenPair: TokenPair,
+    @get:JsonIgnore
+    val bodyTokensIncluded: Boolean = true,
+) : TokenCarrying {
+    @get:Schema(description = "액세스 토큰 (APP=값 / WEB=null, 쿠키로 전달)", nullable = true, example = "eyJhbGciOiJIUzI1NiJ9...")
+    val accessToken: String? get() = tokenPair.accessToken.takeIf { bodyTokensIncluded }
+
+    @get:Schema(description = "리프레시 토큰 (APP=값 / WEB=null, 쿠키로 전달)", nullable = true, example = "eyJhbGciOiJIUzI1NiJ9...")
+    val refreshToken: String? get() = tokenPair.refreshToken.takeIf { bodyTokensIncluded }
+
+    override fun withoutBodyTokens(): TokenCarrying = copy(bodyTokensIncluded = false)
+
+    companion object {
+        fun from(
+            tokenPair: TokenPair,
+            user: User,
+        ): OAuthLoginResponse = OAuthLoginResponse(user = UserResponse.from(user), tokenPair = tokenPair)
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/auth/controller/dto/OAuthLoginResponse.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/controller/dto/OAuthLoginResponse.kt
@@ -21,7 +21,11 @@ data class OAuthLoginResponse(
     @get:Schema(description = "액세스 토큰 (APP=값 / WEB=null, 쿠키로 전달)", nullable = true, example = "eyJhbGciOiJIUzI1NiJ9...")
     val accessToken: String? get() = tokenPair.accessToken.takeIf { bodyTokensIncluded }
 
-    @get:Schema(description = "리프레시 토큰 (APP=값 / WEB=null, 쿠키로 전달)", nullable = true, example = "eyJhbGciOiJIUzI1NiJ9...")
+    @get:Schema(
+        description = "리프레시 토큰 (APP=값 / WEB=null, 쿠키로 전달)",
+        nullable = true,
+        example = "eyJhbGciOiJIUzI1NiJ9...",
+    )
     val refreshToken: String? get() = tokenPair.refreshToken.takeIf { bodyTokensIncluded }
 
     override fun withoutBodyTokens(): TokenCarrying = copy(bodyTokensIncluded = false)

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthClientConfig.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthClientConfig.kt
@@ -1,0 +1,22 @@
+package com.depromeet.piki.auth.infrastructure.oauth
+
+import com.depromeet.piki.auth.infrastructure.oauth.google.GoogleOAuthClient
+import com.depromeet.piki.auth.infrastructure.oauth.google.GoogleProperties
+import com.depromeet.piki.auth.infrastructure.oauth.kakao.KakaoOAuthClient
+import com.depromeet.piki.auth.infrastructure.oauth.kakao.KakaoProperties
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+// 운영 OAuthClient 빈 배선. 클라이언트는 Properties(env)만 의존하는 단순 객체라 @Component 대신 명시 @Bean.
+// 통합 테스트는 oauth.client.enabled=false 로 이 설정을 꺼서, IntegrationStubs 의 stub 빈
+// (googleOAuthClient/kakaoOAuthClient)만 컨텍스트에 남게 한다 (외부 호출 격리, 빈 충돌 없음).
+@Configuration
+@ConditionalOnProperty(name = ["oauth.client.enabled"], havingValue = "true", matchIfMissing = true)
+class OAuthClientConfig {
+    @Bean
+    fun googleOAuthClient(googleProperties: GoogleProperties): OAuthClient = GoogleOAuthClient(googleProperties)
+
+    @Bean
+    fun kakaoOAuthClient(kakaoProperties: KakaoProperties): OAuthClient = KakaoOAuthClient(kakaoProperties)
+}

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthClientRegistry.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthClientRegistry.kt
@@ -1,0 +1,14 @@
+package com.depromeet.piki.auth.infrastructure.oauth
+
+import org.springframework.stereotype.Component
+
+// provider → OAuthClient 라우팅. 등록된 모든 OAuthClient 빈을 주입받아 provider 로 색인한다.
+// Apple 처럼 enum 만 있고 구현체가 없는 provider 는 맵에 없어 unsupportedProvider 로 떨어진다.
+@Component
+class OAuthClientRegistry(
+    clients: List<OAuthClient>,
+) {
+    private val byProvider: Map<OAuthProvider, OAuthClient> = clients.associateBy { it.provider }
+
+    fun resolve(provider: OAuthProvider): OAuthClient = byProvider[provider] ?: throw OAuthException.unsupportedProvider()
+}

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthClientRegistry.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthClientRegistry.kt
@@ -18,5 +18,6 @@ class OAuthClientRegistry(
                 require(duplicates.isEmpty()) { "중복 OAuthClient provider 등록: $duplicates" }
             }.mapValues { (_, list) -> list.single() }
 
-    fun resolve(provider: OAuthProvider): OAuthClient = byProvider[provider] ?: throw OAuthException.unsupportedProvider()
+    fun resolve(provider: OAuthProvider): OAuthClient =
+        byProvider[provider] ?: throw OAuthException.unsupportedProvider()
 }

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthClientRegistry.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthClientRegistry.kt
@@ -8,7 +8,15 @@ import org.springframework.stereotype.Component
 class OAuthClientRegistry(
     clients: List<OAuthClient>,
 ) {
-    private val byProvider: Map<OAuthProvider, OAuthClient> = clients.associateBy { it.provider }
+    // 같은 provider 빈이 둘 이상이면 associateBy 가 조용히 마지막으로 덮어써 라우팅이 틀어질 수 있다.
+    // 설정 충돌은 개발자 실수(불변식 위반)이므로 시작 시점에 require 로 fail-fast 한다.
+    private val byProvider: Map<OAuthProvider, OAuthClient> =
+        clients
+            .groupBy { it.provider }
+            .also { grouped ->
+                val duplicates = grouped.filterValues { it.size > 1 }.keys
+                require(duplicates.isEmpty()) { "중복 OAuthClient provider 등록: $duplicates" }
+            }.mapValues { (_, list) -> list.single() }
 
     fun resolve(provider: OAuthProvider): OAuthClient = byProvider[provider] ?: throw OAuthException.unsupportedProvider()
 }

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthException.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthException.kt
@@ -1,0 +1,33 @@
+package com.depromeet.piki.auth.infrastructure.oauth
+
+import com.depromeet.piki.common.exception.BaseException
+import com.depromeet.piki.common.exception.ErrorCategory
+import com.depromeet.piki.common.exception.HttpMappable
+import org.springframework.http.HttpStatus
+
+class OAuthException private constructor(
+    message: String,
+    override val category: ErrorCategory,
+    override val httpStatus: HttpStatus,
+    cause: Throwable? = null,
+) : BaseException(message, cause),
+    HttpMappable {
+    companion object {
+        // 소셜 제공자(Kakao/Google) 호출 실패 — 우리 밖 의존성. 정상 요청이어도 도달 가능한 계약 → 502.
+        // 디버깅용 원인은 cause 로만 남기고 message 는 고정 문구(원문 노출 금지).
+        fun providerError(cause: Throwable): OAuthException =
+            OAuthException("소셜 로그인 제공자 호출에 실패했습니다.", ErrorCategory.RETRYABLE, HttpStatus.BAD_GATEWAY, cause)
+
+        // code(+redirectUri) 도 accessToken 도 없어 어느 흐름도 성립 안 함 → 400.
+        fun invalidRequest(): OAuthException =
+            OAuthException(
+                "소셜 로그인 요청이 올바르지 않습니다 (code+redirectUri 또는 accessToken 이 필요합니다).",
+                ErrorCategory.INVALID_INPUT,
+                HttpStatus.BAD_REQUEST,
+            )
+
+        // 지원하지 않는 provider (미구현 apple · 오타 등) → 400.
+        fun unsupportedProvider(): OAuthException =
+            OAuthException("지원하지 않는 소셜 로그인 제공자입니다.", ErrorCategory.INVALID_INPUT, HttpStatus.BAD_REQUEST)
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthProvider.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthProvider.kt
@@ -12,6 +12,7 @@ enum class OAuthProvider {
     companion object {
         // path 의 provider 문자열을 enum 으로. 미상은 400 (구현체 유무는 registry 가 판단).
         fun from(raw: String): OAuthProvider =
-            entries.firstOrNull { it.name.equals(raw.trim(), ignoreCase = true) } ?: throw OAuthException.unsupportedProvider()
+            entries.firstOrNull { it.name.equals(raw.trim(), ignoreCase = true) }
+                ?: throw OAuthException.unsupportedProvider()
     }
 }

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthProvider.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthProvider.kt
@@ -3,4 +3,15 @@ package com.depromeet.piki.auth.infrastructure.oauth
 // V6 마이그레이션 CHECK 제약과 에픽 #122 Task 3 항목 모두 APPLE 을 포함한다.
 // Apple OAuth 클라이언트 구현은 후속 작업 (Sign in with Apple 의 client_secret JWT 갱신 흐름이
 // Kakao/Google 과 달라 별도 비중) 이라 enum 만 미리 추가해 두고 구현체는 추후 도입한다.
-enum class OAuthProvider { KAKAO, GOOGLE, APPLE }
+enum class OAuthProvider {
+    KAKAO,
+    GOOGLE,
+    APPLE,
+    ;
+
+    companion object {
+        // path 의 provider 문자열을 enum 으로. 미상은 400 (구현체 유무는 registry 가 판단).
+        fun from(raw: String): OAuthProvider =
+            entries.firstOrNull { it.name.equals(raw.trim(), ignoreCase = true) } ?: throw OAuthException.unsupportedProvider()
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthRestClient.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthRestClient.kt
@@ -1,0 +1,24 @@
+package com.depromeet.piki.auth.infrastructure.oauth
+
+import org.springframework.http.client.SimpleClientHttpRequestFactory
+import org.springframework.web.client.RestClient
+import java.time.Duration
+
+// OAuth provider 호출용 RestClient 팩토리. 외부 호출(토큰 교환·userinfo)이 늘어져 요청 스레드를
+// 무한정 잡는 것을 막기 위해 connect/read 타임아웃을 둔다. OAuth 응답은 빠른 게 정상이라 짧게 잡는다.
+// (GeminiHttpClient 와 동일하게 SimpleClientHttpRequestFactory 사용.)
+object OAuthRestClient {
+    private val CONNECT_TIMEOUT = Duration.ofSeconds(5)
+    private val READ_TIMEOUT = Duration.ofSeconds(10)
+
+    fun create(baseUrl: String): RestClient =
+        RestClient
+            .builder()
+            .baseUrl(baseUrl)
+            .requestFactory(
+                SimpleClientHttpRequestFactory().apply {
+                    setConnectTimeout(CONNECT_TIMEOUT)
+                    setReadTimeout(READ_TIMEOUT)
+                },
+            ).build()
+}

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthUserInfo.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthUserInfo.kt
@@ -3,6 +3,7 @@ package com.depromeet.piki.auth.infrastructure.oauth
 data class OAuthUserInfo(
     val provider: OAuthProvider,
     val socialId: String,
-    val email: String,
-    val profileImage: String,
+    // provider 가 프로필 이미지를 안 주거나(사용자 동의 거부 등) 빈 값이면 null.
+    // 소비측(소셜 가입)에서 null 이면 기본 이미지로 대체한다. email 은 받지 않기로 결정(스키마에서도 드롭).
+    val profileImage: String?,
 )

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/google/GoogleOAuthClient.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/google/GoogleOAuthClient.kt
@@ -3,13 +3,13 @@ package com.depromeet.piki.auth.infrastructure.oauth.google
 import com.depromeet.piki.auth.infrastructure.oauth.OAuthClient
 import com.depromeet.piki.auth.infrastructure.oauth.OAuthParams
 import com.depromeet.piki.auth.infrastructure.oauth.OAuthProvider
+import com.depromeet.piki.auth.infrastructure.oauth.OAuthRestClient
 import com.depromeet.piki.auth.infrastructure.oauth.OAuthUserInfo
 import com.depromeet.piki.auth.infrastructure.oauth.google.dto.GoogleTokenResponse
 import com.depromeet.piki.auth.infrastructure.oauth.google.dto.GoogleUserInfoResponse
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.util.LinkedMultiValueMap
-import org.springframework.web.client.RestClient
 import org.springframework.web.client.body
 
 class GoogleOAuthClient(
@@ -17,8 +17,8 @@ class GoogleOAuthClient(
 ) : OAuthClient {
     override val provider = OAuthProvider.GOOGLE
 
-    private val tokenClient = RestClient.builder().baseUrl(TOKEN_BASE_URL).build()
-    private val userInfoClient = RestClient.builder().baseUrl(USER_INFO_BASE_URL).build()
+    private val tokenClient = OAuthRestClient.create(TOKEN_BASE_URL)
+    private val userInfoClient = OAuthRestClient.create(USER_INFO_BASE_URL)
 
     // v1 — 백엔드가 code → access_token 교환 후 v2 메서드를 재사용해 user_info 조회.
     override fun fetchUserInfoByCode(

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/google/GoogleOAuthClient.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/google/GoogleOAuthClient.kt
@@ -38,8 +38,7 @@ class GoogleOAuthClient(
         return OAuthUserInfo(
             provider = OAuthProvider.GOOGLE,
             socialId = userInfo.id,
-            email = userInfo.email,
-            profileImage = userInfo.picture,
+            profileImage = userInfo.picture.ifBlank { null },
         )
     }
 

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/google/GoogleProperties.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/google/GoogleProperties.kt
@@ -1,10 +1,18 @@
 package com.depromeet.piki.auth.infrastructure.oauth.google
 
+import jakarta.validation.constraints.NotBlank
 import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.validation.annotation.Validated
 
+// env(.env / 운영 환경변수)에서만 주입한다. 빈 default 를 두면 env 누락 시 빈 문자열로 조용히 떠
+// 첫 로그인 호출에서야 깨진다. @Validated + @NotBlank 로 부팅 시점에 BindException 으로 fail-fast.
+@Validated
 @ConfigurationProperties("oauth.google")
 data class GoogleProperties(
-    val clientId: String = "",
-    val clientSecret: String = "",
-    val redirectUri: String = "",
+    @field:NotBlank(message = "Google client-id 는 비어 있을 수 없다.")
+    val clientId: String,
+    @field:NotBlank(message = "Google client-secret 는 비어 있을 수 없다.")
+    val clientSecret: String,
+    @field:NotBlank(message = "Google redirect-uri 는 비어 있을 수 없다.")
+    val redirectUri: String,
 )

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/google/dto/GoogleUserInfoResponse.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/google/dto/GoogleUserInfoResponse.kt
@@ -2,6 +2,5 @@ package com.depromeet.piki.auth.infrastructure.oauth.google.dto
 
 data class GoogleUserInfoResponse(
     val id: String,
-    val email: String,
     val picture: String = "",
 )

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/kakao/KakaoOAuthClient.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/kakao/KakaoOAuthClient.kt
@@ -36,7 +36,9 @@ class KakaoOAuthClient(
         return OAuthUserInfo(
             provider = OAuthProvider.KAKAO,
             socialId = userInfo.id.toString(),
-            profileImage = userInfo.kakaoAccount.profile.profileImageUrl.ifBlank { null },
+            profileImage =
+                userInfo.kakaoAccount.profile.profileImageUrl
+                    .ifBlank { null },
         )
     }
 

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/kakao/KakaoOAuthClient.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/kakao/KakaoOAuthClient.kt
@@ -36,8 +36,7 @@ class KakaoOAuthClient(
         return OAuthUserInfo(
             provider = OAuthProvider.KAKAO,
             socialId = userInfo.id.toString(),
-            email = userInfo.kakaoAccount.email,
-            profileImage = userInfo.kakaoAccount.profile.profileImageUrl,
+            profileImage = userInfo.kakaoAccount.profile.profileImageUrl.ifBlank { null },
         )
     }
 

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/kakao/KakaoOAuthClient.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/kakao/KakaoOAuthClient.kt
@@ -3,13 +3,13 @@ package com.depromeet.piki.auth.infrastructure.oauth.kakao
 import com.depromeet.piki.auth.infrastructure.oauth.OAuthClient
 import com.depromeet.piki.auth.infrastructure.oauth.OAuthParams
 import com.depromeet.piki.auth.infrastructure.oauth.OAuthProvider
+import com.depromeet.piki.auth.infrastructure.oauth.OAuthRestClient
 import com.depromeet.piki.auth.infrastructure.oauth.OAuthUserInfo
 import com.depromeet.piki.auth.infrastructure.oauth.kakao.dto.KakaoTokenResponse
 import com.depromeet.piki.auth.infrastructure.oauth.kakao.dto.KakaoUserInfoResponse
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.util.LinkedMultiValueMap
-import org.springframework.web.client.RestClient
 import org.springframework.web.client.body
 
 class KakaoOAuthClient(
@@ -17,8 +17,8 @@ class KakaoOAuthClient(
 ) : OAuthClient {
     override val provider = OAuthProvider.KAKAO
 
-    private val authClient = RestClient.builder().baseUrl(AUTH_BASE_URL).build()
-    private val apiClient = RestClient.builder().baseUrl(API_BASE_URL).build()
+    private val authClient = OAuthRestClient.create(AUTH_BASE_URL)
+    private val apiClient = OAuthRestClient.create(API_BASE_URL)
 
     // v1 — 백엔드가 code → access_token 교환 후 v2 메서드를 재사용해 user_info 조회.
     override fun fetchUserInfoByCode(

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/kakao/KakaoProperties.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/kakao/KakaoProperties.kt
@@ -1,10 +1,18 @@
 package com.depromeet.piki.auth.infrastructure.oauth.kakao
 
+import jakarta.validation.constraints.NotBlank
 import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.validation.annotation.Validated
 
+// env(.env / 운영 환경변수)에서만 주입한다. 빈 default 를 두면 env 누락 시 빈 문자열로 조용히 떠
+// 첫 로그인 호출에서야 깨진다. @Validated + @NotBlank 로 부팅 시점에 BindException 으로 fail-fast.
+@Validated
 @ConfigurationProperties("oauth.kakao")
 data class KakaoProperties(
-    val clientId: String = "",
-    val clientSecret: String = "",
-    val redirectUri: String = "",
+    @field:NotBlank(message = "Kakao client-id 는 비어 있을 수 없다.")
+    val clientId: String,
+    @field:NotBlank(message = "Kakao client-secret 는 비어 있을 수 없다.")
+    val clientSecret: String,
+    @field:NotBlank(message = "Kakao redirect-uri 는 비어 있을 수 없다.")
+    val redirectUri: String,
 )

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/kakao/dto/KakaoUserInfoResponse.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/kakao/dto/KakaoUserInfoResponse.kt
@@ -7,7 +7,6 @@ data class KakaoUserInfoResponse(
     @JsonProperty("kakao_account") val kakaoAccount: KakaoAccount,
 ) {
     data class KakaoAccount(
-        val email: String = "",
         val profile: Profile = Profile(),
     ) {
         data class Profile(

--- a/src/main/kotlin/com/depromeet/piki/auth/service/AuthService.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/service/AuthService.kt
@@ -51,7 +51,11 @@ class AuthService(
     }
 
     // 이미 확정된 user 에게 토큰 발급. 소셜 로그인(OAuthLoginService)이 resolve 한 user 로 재사용한다.
-    fun issueTokensFor(user: User): SignupResult = SignupResult(tokenPair = issueTokenPair(user), user = user)
+    // 탈퇴 유저가 소셜 로그인으로 다시 토큰을 받지 못하도록 막는다 (refresh/issueTokenForExistingUser 와 동일 가드).
+    fun issueTokensFor(user: User): SignupResult {
+        user.deletedAt?.let { throw UserException.deletedUser(user.id) }
+        return SignupResult(tokenPair = issueTokenPair(user), user = user)
+    }
 
     private fun issueTokenPair(user: User): TokenPair {
         val accessToken = jwtProvider.generateAccessToken(user.id, user.identityType)

--- a/src/main/kotlin/com/depromeet/piki/auth/service/AuthService.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/service/AuthService.kt
@@ -50,6 +50,9 @@ class AuthService(
         refreshTokenStore.delete(userId)
     }
 
+    // 이미 확정된 user 에게 토큰 발급. 소셜 로그인(OAuthLoginService)이 resolve 한 user 로 재사용한다.
+    fun issueTokensFor(user: User): SignupResult = SignupResult(tokenPair = issueTokenPair(user), user = user)
+
     private fun issueTokenPair(user: User): TokenPair {
         val accessToken = jwtProvider.generateAccessToken(user.id, user.identityType)
         val refreshToken = jwtProvider.generateRefreshToken(user.id)

--- a/src/main/kotlin/com/depromeet/piki/auth/service/OAuthLoginService.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/service/OAuthLoginService.kt
@@ -34,19 +34,13 @@ class OAuthLoginService(
         client: OAuthClient,
         command: OAuthLoginCommand,
     ): OAuthUserInfo {
-        val accessToken = command.accessToken?.ifBlank { null }
-        val code = command.code?.ifBlank { null }
-        val redirectUri = command.redirectUri?.ifBlank { null }
-
-        // v2(accessToken) 흐름. code/redirectUri 가 함께 오면 어느 흐름인지 모호하므로 400 (silent v2 채택 금지).
-        accessToken?.let { token ->
-            (code ?: redirectUri)?.let { throw OAuthException.invalidRequest() }
-            return runProvider { client.fetchUserInfoByAccessToken(token) }
+        // v1 XOR v2 계약은 입력 경계(OAuthLoginRequest.validFlow)가 강제한다. 여기선 흐름 선택 + null-safety 만.
+        command.accessToken?.ifBlank { null }?.let { accessToken ->
+            return runProvider { client.fetchUserInfoByAccessToken(accessToken) }
         }
-        // v1(code+redirectUri) 흐름. 둘 중 하나라도 없으면 400.
-        val resolvedCode = code ?: throw OAuthException.invalidRequest()
-        val resolvedRedirectUri = redirectUri ?: throw OAuthException.invalidRequest()
-        return runProvider { client.fetchUserInfoByCode(resolvedCode, resolvedRedirectUri) }
+        val code = command.code?.ifBlank { null } ?: throw OAuthException.invalidRequest()
+        val redirectUri = command.redirectUri?.ifBlank { null } ?: throw OAuthException.invalidRequest()
+        return runProvider { client.fetchUserInfoByCode(code, redirectUri) }
     }
 
     // provider 호출 실패(네트워크·4xx/5xx·역직렬화 등)는 외부 의존성 장애로 502 로 매핑한다.

--- a/src/main/kotlin/com/depromeet/piki/auth/service/OAuthLoginService.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/service/OAuthLoginService.kt
@@ -34,12 +34,19 @@ class OAuthLoginService(
         client: OAuthClient,
         command: OAuthLoginCommand,
     ): OAuthUserInfo {
-        command.accessToken?.ifBlank { null }?.let { accessToken ->
-            return runProvider { client.fetchUserInfoByAccessToken(accessToken) }
+        val accessToken = command.accessToken?.ifBlank { null }
+        val code = command.code?.ifBlank { null }
+        val redirectUri = command.redirectUri?.ifBlank { null }
+
+        // v2(accessToken) 흐름. code/redirectUri 가 함께 오면 어느 흐름인지 모호하므로 400 (silent v2 채택 금지).
+        accessToken?.let { token ->
+            (code ?: redirectUri)?.let { throw OAuthException.invalidRequest() }
+            return runProvider { client.fetchUserInfoByAccessToken(token) }
         }
-        val code = command.code?.ifBlank { null } ?: throw OAuthException.invalidRequest()
-        val redirectUri = command.redirectUri?.ifBlank { null } ?: throw OAuthException.invalidRequest()
-        return runProvider { client.fetchUserInfoByCode(code, redirectUri) }
+        // v1(code+redirectUri) 흐름. 둘 중 하나라도 없으면 400.
+        val resolvedCode = code ?: throw OAuthException.invalidRequest()
+        val resolvedRedirectUri = redirectUri ?: throw OAuthException.invalidRequest()
+        return runProvider { client.fetchUserInfoByCode(resolvedCode, resolvedRedirectUri) }
     }
 
     // provider 호출 실패(네트워크·4xx/5xx·역직렬화 등)는 외부 의존성 장애로 502 로 매핑한다.

--- a/src/main/kotlin/com/depromeet/piki/auth/service/OAuthLoginService.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/service/OAuthLoginService.kt
@@ -1,0 +1,54 @@
+package com.depromeet.piki.auth.service
+
+import com.depromeet.piki.auth.infrastructure.oauth.OAuthClient
+import com.depromeet.piki.auth.infrastructure.oauth.OAuthClientRegistry
+import com.depromeet.piki.auth.infrastructure.oauth.OAuthException
+import com.depromeet.piki.auth.infrastructure.oauth.OAuthProvider
+import com.depromeet.piki.auth.infrastructure.oauth.OAuthUserInfo
+import com.depromeet.piki.auth.service.dto.OAuthLoginCommand
+import com.depromeet.piki.auth.service.dto.SignupResult
+import org.springframework.stereotype.Service
+import java.util.UUID
+
+// 소셜 로그인 오케스트레이션. 외부 OAuth 호출(provider user_info 조회)은 트랜잭션 밖에서 끝내고,
+// 영속화(find-or-create/link)는 SocialAccountService 의 짧은 트랜잭션에 위임한다.
+@Service
+class OAuthLoginService(
+    private val oAuthClientRegistry: OAuthClientRegistry,
+    private val socialAccountService: SocialAccountService,
+    private val authService: AuthService,
+) {
+    fun login(
+        provider: OAuthProvider,
+        command: OAuthLoginCommand,
+        currentUserId: UUID?,
+    ): SignupResult {
+        val client = oAuthClientRegistry.resolve(provider)
+        val userInfo = fetchUserInfo(client, command) // 외부 호출, tx 밖
+        val user = socialAccountService.resolveUser(userInfo, currentUserId) // 영속화, 짧은 tx
+        return authService.issueTokensFor(user)
+    }
+
+    // accessToken(v2) 이 있으면 SDK 흐름, 아니면 code+redirectUri(v1) 흐름. 둘 다 없으면 400.
+    private fun fetchUserInfo(
+        client: OAuthClient,
+        command: OAuthLoginCommand,
+    ): OAuthUserInfo {
+        command.accessToken?.ifBlank { null }?.let { accessToken ->
+            return runProvider { client.fetchUserInfoByAccessToken(accessToken) }
+        }
+        val code = command.code?.ifBlank { null } ?: throw OAuthException.invalidRequest()
+        val redirectUri = command.redirectUri?.ifBlank { null } ?: throw OAuthException.invalidRequest()
+        return runProvider { client.fetchUserInfoByCode(code, redirectUri) }
+    }
+
+    // provider 호출 실패(네트워크·4xx/5xx·역직렬화 등)는 외부 의존성 장애로 502 로 매핑한다.
+    private inline fun runProvider(block: () -> OAuthUserInfo): OAuthUserInfo =
+        try {
+            block()
+        } catch (e: OAuthException) {
+            throw e
+        } catch (e: Exception) {
+            throw OAuthException.providerError(e)
+        }
+}

--- a/src/main/kotlin/com/depromeet/piki/auth/service/SocialAccountService.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/service/SocialAccountService.kt
@@ -1,0 +1,59 @@
+package com.depromeet.piki.auth.service
+
+import com.depromeet.piki.auth.infrastructure.oauth.OAuthUserInfo
+import com.depromeet.piki.user.domain.IdentityType
+import com.depromeet.piki.user.domain.User
+import com.depromeet.piki.user.domain.UserDetail
+import com.depromeet.piki.user.repository.UserDetailRepository
+import com.depromeet.piki.user.service.UserService
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+// 소셜 아이디 ↔ user 영속화. 외부 OAuth 호출과 분리된 짧은 트랜잭션 (OAuthLoginService 가 호출).
+@Service
+class SocialAccountService(
+    private val userService: UserService,
+    private val userDetailRepository: UserDetailRepository,
+) {
+    @Transactional
+    fun resolveUser(
+        userInfo: OAuthUserInfo,
+        currentUserId: UUID?,
+    ): User {
+        // 1. 이미 가입된 소셜 → 그 user 로 로그인. (재방문 / 게스트의 소셜이 이미 타계정 → 그 계정 로그인 = 게스트 포기)
+        userDetailRepository
+            .findByProviderAndSocialId(userInfo.provider.name, userInfo.socialId)
+            ?.let { return userService.findById(it.getIdOrNull()) }
+
+        // 2. 신규 소셜 + 현재 게스트면 → 게스트 계정에 연결 + 승격 (위시·토너먼트 데이터 이어줌)
+        currentUserId?.let { guestId ->
+            linkToGuestIfEligible(guestId, userInfo)?.let { return it }
+        }
+
+        // 3. 순수 신규 가입 → MEMBER 생성 + 소셜 연결
+        val user = userService.createSocialUser(userInfo.profileImage)
+        linkSocial(user.id, userInfo)
+        return user
+    }
+
+    private fun linkToGuestIfEligible(
+        guestId: UUID,
+        userInfo: OAuthUserInfo,
+    ): User? {
+        val guest = userService.findById(guestId)
+        guest.deletedAt?.let { return null } // 탈퇴 게스트 → 연결 대상 아님
+        if (guest.identityType != IdentityType.GUEST) return null // 이미 MEMBER → 게스트-연결 케이스 아님
+        linkSocial(guestId, userInfo)
+        return userService.promoteToMember(guestId)
+    }
+
+    private fun linkSocial(
+        userId: UUID,
+        userInfo: OAuthUserInfo,
+    ) {
+        userDetailRepository.save(
+            UserDetail(userId = userId, provider = userInfo.provider.name, socialId = userInfo.socialId),
+        )
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/auth/service/SocialAccountService.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/service/SocialAccountService.kt
@@ -1,59 +1,50 @@
 package com.depromeet.piki.auth.service
 
 import com.depromeet.piki.auth.infrastructure.oauth.OAuthUserInfo
-import com.depromeet.piki.user.domain.IdentityType
 import com.depromeet.piki.user.domain.User
-import com.depromeet.piki.user.domain.UserDetail
 import com.depromeet.piki.user.repository.UserDetailRepository
 import com.depromeet.piki.user.service.UserService
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
 
-// 소셜 아이디 ↔ user 영속화. 외부 OAuth 호출과 분리된 짧은 트랜잭션 (OAuthLoginService 가 호출).
+// 소셜 아이디 ↔ user 해소. 영속화 mutation 은 SocialAccountWriter(REQUIRED 트랜잭션)에 위임하고,
+// 이 클래스는 비트랜잭션 오케스트레이션만 한다 — 동시 첫 로그인 충돌을 catch 후 재조회·합류로 마무리하려면
+// resolveUser 자신이 트랜잭션을 들고 있으면 안 되기 때문이다(상위 tx 가 rollback-only 로 오염되면 재조회가 깨진다).
 @Service
 class SocialAccountService(
     private val userService: UserService,
     private val userDetailRepository: UserDetailRepository,
+    private val socialAccountWriter: SocialAccountWriter,
 ) {
-    @Transactional
     fun resolveUser(
         userInfo: OAuthUserInfo,
         currentUserId: UUID?,
     ): User {
         // 1. 이미 가입된 소셜 → 그 user 로 로그인. (재방문 / 게스트의 소셜이 이미 타계정 → 그 계정 로그인 = 게스트 포기)
-        userDetailRepository
-            .findByProviderAndSocialId(userInfo.provider.name, userInfo.socialId)
-            ?.let { return userService.findById(it.getIdOrNull()) }
+        findExisting(userInfo)?.let { return it }
 
         // 2. 신규 소셜 + 현재 게스트면 → 게스트 계정에 연결 + 승격 (위시·토너먼트 데이터 이어줌)
         currentUserId?.let { guestId ->
-            linkToGuestIfEligible(guestId, userInfo)?.let { return it }
+            try {
+                socialAccountWriter.linkGuestAndPromote(guestId, userInfo)?.let { return it }
+            } catch (e: DataIntegrityViolationException) {
+                // 동시 충돌: 다른 요청이 이 소셜을 먼저 선점 → 그 계정으로 합류 (게스트 포기)
+                return findExisting(userInfo) ?: throw e
+            }
         }
 
         // 3. 순수 신규 가입 → MEMBER 생성 + 소셜 연결
-        val user = userService.createSocialUser(userInfo.profileImage)
-        linkSocial(user.id, userInfo)
-        return user
+        return try {
+            socialAccountWriter.createSocialUserAndLink(userInfo)
+        } catch (e: DataIntegrityViolationException) {
+            // 동시 충돌: 다른 요청이 먼저 같은 소셜로 가입 → 그 user 로 합류 (내가 만든 user 는 REQUIRED tx 롤백으로 폐기)
+            findExisting(userInfo) ?: throw e
+        }
     }
 
-    private fun linkToGuestIfEligible(
-        guestId: UUID,
-        userInfo: OAuthUserInfo,
-    ): User? {
-        val guest = userService.findById(guestId)
-        guest.deletedAt?.let { return null } // 탈퇴 게스트 → 연결 대상 아님
-        if (guest.identityType != IdentityType.GUEST) return null // 이미 MEMBER → 게스트-연결 케이스 아님
-        linkSocial(guestId, userInfo)
-        return userService.promoteToMember(guestId)
-    }
-
-    private fun linkSocial(
-        userId: UUID,
-        userInfo: OAuthUserInfo,
-    ) {
-        userDetailRepository.save(
-            UserDetail(userId = userId, provider = userInfo.provider.name, socialId = userInfo.socialId),
-        )
-    }
+    private fun findExisting(userInfo: OAuthUserInfo): User? =
+        userDetailRepository
+            .findByProviderAndSocialId(userInfo.provider.name, userInfo.socialId)
+            ?.let { userService.findById(it.getIdOrNull()) }
 }

--- a/src/main/kotlin/com/depromeet/piki/auth/service/SocialAccountWriter.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/service/SocialAccountWriter.kt
@@ -1,0 +1,57 @@
+package com.depromeet.piki.auth.service
+
+import com.depromeet.piki.auth.infrastructure.oauth.OAuthUserInfo
+import com.depromeet.piki.user.domain.IdentityType
+import com.depromeet.piki.user.domain.User
+import com.depromeet.piki.user.domain.UserDetail
+import com.depromeet.piki.user.repository.UserDetailRepository
+import com.depromeet.piki.user.service.UserService
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+// 소셜 연결 mutation 을 한 트랜잭션으로 묶는 별도 빈.
+//
+// 왜 별도 빈 + 기본 REQUIRED 인가:
+// - SocialAccountService.resolveUser 는 비트랜잭션이라, 그 안에서 @Transactional 메서드를 self-invocation
+//   하면 proxy 를 안 거쳐 트랜잭션이 안 걸린다. 그래서 별도 빈으로 빼 proxy 경계를 만든다.
+// - 운영(상위 tx 없음): REQUIRED 가 새 tx 를 열어 커밋한다. 동시 첫 로그인 충돌
+//   (uk_user_details_provider_social)이 나면 이 tx 가 롤백되고 호출자(resolveUser, 비트랜잭션)가
+//   DataIntegrityViolationException 으로 받아 재조회·합류한다 — 비트랜잭션이라 catch 후 재조회가 깨지지 않는다.
+// - 통합 테스트(@Transactional 롤백 격리): REQUIRED 는 테스트 트랜잭션에 join 되어 끝에서 함께 롤백된다.
+//   REQUIRES_NEW 였다면 별도 커밋이라 테스트가 행을 남겨 격리가 깨졌을 것이다.
+@Service
+class SocialAccountWriter(
+    private val userService: UserService,
+    private val userDetailRepository: UserDetailRepository,
+) {
+    // 순수 신규 가입: MEMBER 생성 + 소셜 연결을 한 트랜잭션으로 (충돌 시 둘 다 롤백).
+    @Transactional
+    fun createSocialUserAndLink(userInfo: OAuthUserInfo): User {
+        val user = userService.createSocialUser(userInfo.profileImage)
+        link(user.id, userInfo)
+        return user
+    }
+
+    // 게스트 연결: 미탈퇴 GUEST 면 소셜 연결 + 승격을 한 트랜잭션으로, 아니면 null(호출자가 신규 생성으로 진행).
+    @Transactional
+    fun linkGuestAndPromote(
+        guestId: UUID,
+        userInfo: OAuthUserInfo,
+    ): User? {
+        val guest = userService.findById(guestId)
+        guest.deletedAt?.let { return null } // 탈퇴 게스트 → 연결 대상 아님
+        if (guest.identityType != IdentityType.GUEST) return null // 이미 MEMBER → 게스트-연결 케이스 아님
+        link(guestId, userInfo)
+        return userService.promoteToMember(guestId)
+    }
+
+    private fun link(
+        userId: UUID,
+        userInfo: OAuthUserInfo,
+    ) {
+        userDetailRepository.save(
+            UserDetail(userId = userId, provider = userInfo.provider.name, socialId = userInfo.socialId),
+        )
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/auth/service/dto/OAuthLoginCommand.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/service/dto/OAuthLoginCommand.kt
@@ -1,0 +1,9 @@
+package com.depromeet.piki.auth.service.dto
+
+// 소셜 로그인 자격 증명. v1(web): code+redirectUri / v2(SDK): accessToken.
+// 둘 중 하나만 채워져 오며, 서비스가 accessToken 우선으로 흐름을 고른다.
+data class OAuthLoginCommand(
+    val code: String?,
+    val redirectUri: String?,
+    val accessToken: String?,
+)

--- a/src/main/kotlin/com/depromeet/piki/user/service/UserService.kt
+++ b/src/main/kotlin/com/depromeet/piki/user/service/UserService.kt
@@ -81,6 +81,26 @@ class UserService(
         }
     }
 
+    // 소셜 신규 가입용 MEMBER 생성. 닉네임은 게스트와 동일하게 자동 생성(fill)하고 사용자가 나중에 수정한다.
+    // 프로필 이미지는 provider 가 준 게 있으면 쓰고, 없으면(동의 거부 등) dicebear 기본 아바타.
+    @Transactional
+    fun createSocialUser(profileImage: String?): User {
+        val id = UUID.randomUUID()
+        val nickname = generateUniqueGuestNickname()
+        return try {
+            userRepository.save(
+                User(
+                    id = id,
+                    nickname = nickname,
+                    profileImage = profileImage ?: dicebearUrl(id),
+                    identityType = IdentityType.MEMBER,
+                ),
+            )
+        } catch (e: DataIntegrityViolationException) {
+            throw UserException.duplicateNickname()
+        }
+    }
+
     @Transactional(readOnly = true)
     fun findById(userId: UUID): User = userRepository.findById(userId) ?: throw UserException.notFound(userId)
 

--- a/src/main/kotlin/com/depromeet/piki/user/service/UserService.kt
+++ b/src/main/kotlin/com/depromeet/piki/user/service/UserService.kt
@@ -17,6 +17,8 @@ class UserService(
         private const val MAX_NICKNAME_ATTEMPTS = 10
         private const val DICEBEAR_BASE_URL = "https://api.dicebear.com/9.x/bottts/svg?seed="
 
+        // 형용사 32 × 동물 32 = 1024 조합. 모든 조합이 닉네임 10자 제한 이하가 되도록
+        // 형용사는 5자 이하, 동물은 3자 이하로 유지한다(최대 5+1+3=9자). 풀 고갈 근본 대응은 #312.
         private val NICKNAME_PREFIXES =
             listOf(
                 "날뛰는",
@@ -35,6 +37,22 @@ class UserService(
                 "구르는",
                 "노래하는",
                 "울부짖는",
+                "용감한",
+                "귀여운",
+                "똑똑한",
+                "엉뚱한",
+                "수줍은",
+                "행복한",
+                "게으른",
+                "화난",
+                "신비한",
+                "우아한",
+                "까칠한",
+                "명랑한",
+                "차분한",
+                "도도한",
+                "엉큼한",
+                "발랄한",
             )
         private val NICKNAME_ANIMALS =
             listOf(
@@ -54,6 +72,22 @@ class UserService(
                 "돌고래",
                 "부엉이",
                 "다람쥐",
+                "너구리",
+                "수달",
+                "거북이",
+                "두더지",
+                "햄스터",
+                "코알라",
+                "캥거루",
+                "미어캣",
+                "알파카",
+                "치타",
+                "표범",
+                "오리",
+                "거위",
+                "두루미",
+                "청설모",
+                "살쾡이",
             )
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,10 @@ spring:
   application:
     name: PIKI
   config:
-    import: optional:file:.env[.properties]
+    # .env 다음에 .env.local 을 읽어 로컬 개인 override 를 덮어쓴다(뒤가 우선). 둘 다 optional·gitignore.
+    import:
+      - optional:file:.env[.properties]
+      - optional:file:.env.local[.properties]
   servlet:
     multipart:
       max-file-size: 5MB

--- a/src/test/kotlin/com/depromeet/piki/auth/controller/OAuthLoginIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/controller/OAuthLoginIntegrationTest.kt
@@ -188,7 +188,8 @@ class OAuthLoginIntegrationTest : IntegrationTestSupport() {
                             .header("X-Client-Type", "app")
                             .header(HttpHeaders.AUTHORIZATION, "Bearer ${guest.accessToken}")
                             .content(body),
-                    ).andReturn()
+                    ).andExpect(status().isOk)
+                    .andReturn()
                     .response.contentAsString,
             )
 
@@ -272,5 +273,6 @@ class OAuthLoginIntegrationTest : IntegrationTestSupport() {
             .andExpect(cookie().exists("access_token"))
             .andExpect(cookie().exists("refresh_token"))
             .andExpect(jsonPath("$.data.accessToken").value(nullValue()))
+            .andExpect(jsonPath("$.data.refreshToken").value(nullValue()))
     }
 }

--- a/src/test/kotlin/com/depromeet/piki/auth/controller/OAuthLoginIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/controller/OAuthLoginIntegrationTest.kt
@@ -4,6 +4,8 @@ import com.depromeet.piki.auth.infrastructure.oauth.OAuthProvider
 import com.depromeet.piki.auth.infrastructure.oauth.OAuthUserInfo
 import com.depromeet.piki.support.IntegrationTestSupport
 import com.depromeet.piki.support.StubOAuthClient
+import com.depromeet.piki.wishlist.domain.Wish
+import com.depromeet.piki.wishlist.repository.WishRepository
 import org.hamcrest.Matchers.nullValue
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -21,6 +23,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.context.WebApplicationContext
 import tools.jackson.databind.ObjectMapper
+import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 
@@ -40,6 +43,9 @@ class OAuthLoginIntegrationTest : IntegrationTestSupport() {
     @Qualifier("googleOAuthClient")
     private lateinit var googleOAuthClient: StubOAuthClient
 
+    @Autowired
+    private lateinit var wishRepository: WishRepository
+
     private fun mockMvc(): MockMvc =
         MockMvcBuilders
             .webAppContextSetup(webApplicationContext)
@@ -50,7 +56,10 @@ class OAuthLoginIntegrationTest : IntegrationTestSupport() {
 
     private fun userIdOf(json: String): String = objectMapper.readTree(json).at("/data/user/id").asString()
 
-    private data class Guest(val accessToken: String, val userId: String)
+    private data class Guest(
+        val accessToken: String,
+        val userId: String,
+    )
 
     private fun createGuest(): Guest {
         val json =
@@ -65,7 +74,8 @@ class OAuthLoginIntegrationTest : IntegrationTestSupport() {
 
     @Test
     fun `신규 소셜 - app 으로 v2 로그인하면 MEMBER 로 가입되고 body 토큰이 온다`() {
-        googleOAuthClient.fetchByAccessTokenStub = { OAuthUserInfo(OAuthProvider.GOOGLE, "google_fresh", "https://img/p.jpg") }
+        googleOAuthClient.fetchByAccessTokenStub =
+            { OAuthUserInfo(OAuthProvider.GOOGLE, "google_fresh", "https://img/p.jpg") }
 
         mockMvc()
             .perform(
@@ -87,12 +97,20 @@ class OAuthLoginIntegrationTest : IntegrationTestSupport() {
 
         val first =
             mockMvc()
-                .perform(post("/api/v1/auth/login/kakao").contentType(MediaType.APPLICATION_JSON).header("X-Client-Type", "app").content(body))
-                .andReturn().response.contentAsString
+                .perform(
+                    post(
+                        "/api/v1/auth/login/kakao",
+                    ).contentType(MediaType.APPLICATION_JSON).header("X-Client-Type", "app").content(body),
+                ).andReturn()
+                .response.contentAsString
         val second =
             mockMvc()
-                .perform(post("/api/v1/auth/login/kakao").contentType(MediaType.APPLICATION_JSON).header("X-Client-Type", "app").content(body))
-                .andReturn().response.contentAsString
+                .perform(
+                    post(
+                        "/api/v1/auth/login/kakao",
+                    ).contentType(MediaType.APPLICATION_JSON).header("X-Client-Type", "app").content(body),
+                ).andReturn()
+                .response.contentAsString
 
         assertEquals(userIdOf(first), userIdOf(second))
     }
@@ -115,6 +133,36 @@ class OAuthLoginIntegrationTest : IntegrationTestSupport() {
     }
 
     @Test
+    fun `게스트 연결 - 승격 후에도 게스트가 만든 위시(데이터)가 그대로 승계된다`() {
+        val guest = createGuest()
+        val guestId = UUID.fromString(guest.userId)
+        // 게스트 상태에서 위시 1건 생성 (user_id = 게스트 id). 승격은 id 를 유지하므로 이 행이 그대로 따라와야 한다.
+        wishRepository.save(Wish(userId = guestId, itemId = 1L))
+        kakaoOAuthClient.fetchByAccessTokenStub = { OAuthUserInfo(OAuthProvider.KAKAO, "kakao_inherit", null) }
+
+        val resultId =
+            userIdOf(
+                mockMvc()
+                    .perform(
+                        post("/api/v1/auth/login/kakao")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .header("X-Client-Type", "app")
+                            .header(HttpHeaders.AUTHORIZATION, "Bearer ${guest.accessToken}")
+                            .content(loginBody("accessToken" to "t")),
+                    ).andExpect(status().isOk)
+                    .andExpect(jsonPath("$.data.user.identityType").value("MEMBER"))
+                    .andReturn()
+                    .response.contentAsString,
+            )
+
+        // 승격된 멤버는 게스트와 같은 id 라, 그 id 로 만든 위시가 그대로 승계된다
+        assertEquals(guest.userId, resultId)
+        val wishes = wishRepository.findPage(guestId, null, 10)
+        assertEquals(1, wishes.size)
+        assertEquals(guestId, wishes.first().userId)
+    }
+
+    @Test
     fun `소셜 중복 - 게스트가 이미 타계정에 연결된 소셜로 로그인하면 그 기존 계정으로 로그인된다(게스트 포기)`() {
         kakaoOAuthClient.fetchByAccessTokenStub = { OAuthUserInfo(OAuthProvider.KAKAO, "kakao_dup", null) }
         val body = loginBody("accessToken" to "t")
@@ -122,8 +170,12 @@ class OAuthLoginIntegrationTest : IntegrationTestSupport() {
         val userAId =
             userIdOf(
                 mockMvc()
-                    .perform(post("/api/v1/auth/login/kakao").contentType(MediaType.APPLICATION_JSON).header("X-Client-Type", "app").content(body))
-                    .andReturn().response.contentAsString,
+                    .perform(
+                        post(
+                            "/api/v1/auth/login/kakao",
+                        ).contentType(MediaType.APPLICATION_JSON).header("X-Client-Type", "app").content(body),
+                    ).andReturn()
+                    .response.contentAsString,
             )
 
         val guest = createGuest()
@@ -136,7 +188,8 @@ class OAuthLoginIntegrationTest : IntegrationTestSupport() {
                             .header("X-Client-Type", "app")
                             .header(HttpHeaders.AUTHORIZATION, "Bearer ${guest.accessToken}")
                             .content(body),
-                    ).andReturn().response.contentAsString,
+                    ).andReturn()
+                    .response.contentAsString,
             )
 
         assertEquals(userAId, resultId)
@@ -181,7 +234,11 @@ class OAuthLoginIntegrationTest : IntegrationTestSupport() {
     fun `미지원 provider - apple 은 400`() {
         mockMvc()
             .perform(
-                post("/api/v1/auth/login/apple").contentType(MediaType.APPLICATION_JSON).content(loginBody("accessToken" to "t")),
+                post("/api/v1/auth/login/apple").contentType(MediaType.APPLICATION_JSON).content(
+                    loginBody(
+                        "accessToken" to "t",
+                    ),
+                ),
             ).andExpect(status().isBadRequest)
     }
 
@@ -191,7 +248,11 @@ class OAuthLoginIntegrationTest : IntegrationTestSupport() {
 
         mockMvc()
             .perform(
-                post("/api/v1/auth/login/google").contentType(MediaType.APPLICATION_JSON).content(loginBody("accessToken" to "t")),
+                post("/api/v1/auth/login/google").contentType(MediaType.APPLICATION_JSON).content(
+                    loginBody(
+                        "accessToken" to "t",
+                    ),
+                ),
             ).andExpect(status().isBadGateway)
             .andExpect(jsonPath("$.status").value(502))
     }
@@ -202,7 +263,11 @@ class OAuthLoginIntegrationTest : IntegrationTestSupport() {
 
         mockMvc()
             .perform(
-                post("/api/v1/auth/login/google").contentType(MediaType.APPLICATION_JSON).content(loginBody("accessToken" to "t")),
+                post("/api/v1/auth/login/google").contentType(MediaType.APPLICATION_JSON).content(
+                    loginBody(
+                        "accessToken" to "t",
+                    ),
+                ),
             ).andExpect(status().isOk)
             .andExpect(cookie().exists("access_token"))
             .andExpect(cookie().exists("refresh_token"))

--- a/src/test/kotlin/com/depromeet/piki/auth/controller/OAuthLoginIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/controller/OAuthLoginIntegrationTest.kt
@@ -167,6 +167,17 @@ class OAuthLoginIntegrationTest : IntegrationTestSupport() {
     }
 
     @Test
+    fun `잘못된 요청 - accessToken 과 code 를 동시에 보내면 400`() {
+        mockMvc()
+            .perform(
+                post("/api/v1/auth/login/google")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(loginBody("accessToken" to "t", "code" to "c", "redirectUri" to "https://app/callback")),
+            ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.code").value("BAD_REQUEST"))
+    }
+
+    @Test
     fun `미지원 provider - apple 은 400`() {
         mockMvc()
             .perform(

--- a/src/test/kotlin/com/depromeet/piki/auth/controller/OAuthLoginIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/controller/OAuthLoginIntegrationTest.kt
@@ -1,0 +1,200 @@
+package com.depromeet.piki.auth.controller
+
+import com.depromeet.piki.auth.infrastructure.oauth.OAuthProvider
+import com.depromeet.piki.auth.infrastructure.oauth.OAuthUserInfo
+import com.depromeet.piki.support.IntegrationTestSupport
+import com.depromeet.piki.support.StubOAuthClient
+import org.hamcrest.Matchers.nullValue
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.context.WebApplicationContext
+import tools.jackson.databind.ObjectMapper
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+@Transactional
+class OAuthLoginIntegrationTest : IntegrationTestSupport() {
+    @Autowired
+    private lateinit var webApplicationContext: WebApplicationContext
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @Autowired
+    @Qualifier("kakaoOAuthClient")
+    private lateinit var kakaoOAuthClient: StubOAuthClient
+
+    @Autowired
+    @Qualifier("googleOAuthClient")
+    private lateinit var googleOAuthClient: StubOAuthClient
+
+    private fun mockMvc(): MockMvc =
+        MockMvcBuilders
+            .webAppContextSetup(webApplicationContext)
+            .apply<DefaultMockMvcBuilder>(springSecurity())
+            .build()
+
+    private fun loginBody(vararg pairs: Pair<String, String>): String = objectMapper.writeValueAsString(mapOf(*pairs))
+
+    private fun userIdOf(json: String): String = objectMapper.readTree(json).at("/data/user/id").asString()
+
+    private data class Guest(val accessToken: String, val userId: String)
+
+    private fun createGuest(): Guest {
+        val json =
+            mockMvc()
+                .perform(
+                    post("/api/v1/auth/guest").contentType(MediaType.APPLICATION_JSON).header("X-Client-Type", "app"),
+                ).andReturn()
+                .response.contentAsString
+        val node = objectMapper.readTree(json)
+        return Guest(node.at("/data/accessToken").asString(), node.at("/data/user/id").asString())
+    }
+
+    @Test
+    fun `신규 소셜 - app 으로 v2 로그인하면 MEMBER 로 가입되고 body 토큰이 온다`() {
+        googleOAuthClient.fetchByAccessTokenStub = { OAuthUserInfo(OAuthProvider.GOOGLE, "google_fresh", "https://img/p.jpg") }
+
+        mockMvc()
+            .perform(
+                post("/api/v1/auth/login/google")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header("X-Client-Type", "app")
+                    .content(loginBody("accessToken" to "sdk-token")),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.user.identityType").value("MEMBER"))
+            .andExpect(jsonPath("$.data.user.profileImage").value("https://img/p.jpg"))
+            .andExpect(jsonPath("$.data.accessToken").isString)
+            .andExpect(jsonPath("$.data.refreshToken").isString)
+    }
+
+    @Test
+    fun `재방문 - 같은 소셜로 다시 로그인하면 동일 user 가 반환된다`() {
+        kakaoOAuthClient.fetchByAccessTokenStub = { OAuthUserInfo(OAuthProvider.KAKAO, "kakao_return", null) }
+        val body = loginBody("accessToken" to "t")
+
+        val first =
+            mockMvc()
+                .perform(post("/api/v1/auth/login/kakao").contentType(MediaType.APPLICATION_JSON).header("X-Client-Type", "app").content(body))
+                .andReturn().response.contentAsString
+        val second =
+            mockMvc()
+                .perform(post("/api/v1/auth/login/kakao").contentType(MediaType.APPLICATION_JSON).header("X-Client-Type", "app").content(body))
+                .andReturn().response.contentAsString
+
+        assertEquals(userIdOf(first), userIdOf(second))
+    }
+
+    @Test
+    fun `게스트 연결 - 게스트 토큰 + 신규 소셜이면 그 게스트가 MEMBER 로 승격되고 데이터를 이어받는다`() {
+        val guest = createGuest()
+        kakaoOAuthClient.fetchByAccessTokenStub = { OAuthUserInfo(OAuthProvider.KAKAO, "kakao_link", null) }
+
+        mockMvc()
+            .perform(
+                post("/api/v1/auth/login/kakao")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header("X-Client-Type", "app")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer ${guest.accessToken}")
+                    .content(loginBody("accessToken" to "t")),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.user.id").value(guest.userId))
+            .andExpect(jsonPath("$.data.user.identityType").value("MEMBER"))
+    }
+
+    @Test
+    fun `소셜 중복 - 게스트가 이미 타계정에 연결된 소셜로 로그인하면 그 기존 계정으로 로그인된다(게스트 포기)`() {
+        kakaoOAuthClient.fetchByAccessTokenStub = { OAuthUserInfo(OAuthProvider.KAKAO, "kakao_dup", null) }
+        val body = loginBody("accessToken" to "t")
+
+        val userAId =
+            userIdOf(
+                mockMvc()
+                    .perform(post("/api/v1/auth/login/kakao").contentType(MediaType.APPLICATION_JSON).header("X-Client-Type", "app").content(body))
+                    .andReturn().response.contentAsString,
+            )
+
+        val guest = createGuest()
+        val resultId =
+            userIdOf(
+                mockMvc()
+                    .perform(
+                        post("/api/v1/auth/login/kakao")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .header("X-Client-Type", "app")
+                            .header(HttpHeaders.AUTHORIZATION, "Bearer ${guest.accessToken}")
+                            .content(body),
+                    ).andReturn().response.contentAsString,
+            )
+
+        assertEquals(userAId, resultId)
+        assertNotEquals(guest.userId, resultId)
+    }
+
+    @Test
+    fun `v1 - code+redirectUri 로 로그인된다`() {
+        googleOAuthClient.fetchByCodeStub = { _, _ -> OAuthUserInfo(OAuthProvider.GOOGLE, "google_v1", null) }
+
+        mockMvc()
+            .perform(
+                post("/api/v1/auth/login/google")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header("X-Client-Type", "app")
+                    .content(loginBody("code" to "auth-code", "redirectUri" to "https://app/callback")),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.accessToken").isString)
+    }
+
+    @Test
+    fun `잘못된 요청 - code 도 accessToken 도 없으면 400`() {
+        mockMvc()
+            .perform(
+                post("/api/v1/auth/login/google").contentType(MediaType.APPLICATION_JSON).content("{}"),
+            ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.code").value("BAD_REQUEST"))
+    }
+
+    @Test
+    fun `미지원 provider - apple 은 400`() {
+        mockMvc()
+            .perform(
+                post("/api/v1/auth/login/apple").contentType(MediaType.APPLICATION_JSON).content(loginBody("accessToken" to "t")),
+            ).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `provider 호출 실패 - 502 Bad Gateway 로 매핑된다`() {
+        googleOAuthClient.fetchByAccessTokenStub = { error("google down") }
+
+        mockMvc()
+            .perform(
+                post("/api/v1/auth/login/google").contentType(MediaType.APPLICATION_JSON).content(loginBody("accessToken" to "t")),
+            ).andExpect(status().isBadGateway)
+            .andExpect(jsonPath("$.status").value(502))
+    }
+
+    @Test
+    fun `기본(헤더 없음) - 토큰을 쿠키로 내리고 body 토큰은 null 이다`() {
+        googleOAuthClient.fetchByAccessTokenStub = { OAuthUserInfo(OAuthProvider.GOOGLE, "google_web", null) }
+
+        mockMvc()
+            .perform(
+                post("/api/v1/auth/login/google").contentType(MediaType.APPLICATION_JSON).content(loginBody("accessToken" to "t")),
+            ).andExpect(status().isOk)
+            .andExpect(cookie().exists("access_token"))
+            .andExpect(cookie().exists("refresh_token"))
+            .andExpect(jsonPath("$.data.accessToken").value(nullValue()))
+    }
+}

--- a/src/test/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthClientIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthClientIntegrationTest.kt
@@ -24,7 +24,6 @@ class OAuthClientIntegrationTest : IntegrationTestSupport() {
             OAuthUserInfo(
                 provider = OAuthProvider.KAKAO,
                 socialId = "kakao_123",
-                email = "user@kakao.com",
                 profileImage = "https://img.kakao.com/profile.jpg",
             )
         }
@@ -33,7 +32,7 @@ class OAuthClientIntegrationTest : IntegrationTestSupport() {
 
         assertEquals(OAuthProvider.KAKAO, result.provider)
         assertEquals("kakao_123", result.socialId)
-        assertEquals("user@kakao.com", result.email)
+        assertEquals("https://img.kakao.com/profile.jpg", result.profileImage)
     }
 
     @Test
@@ -42,7 +41,6 @@ class OAuthClientIntegrationTest : IntegrationTestSupport() {
             OAuthUserInfo(
                 provider = OAuthProvider.KAKAO,
                 socialId = "kakao_sdk_123",
-                email = "user@kakao.com",
                 profileImage = "https://img.kakao.com/profile.jpg",
             )
         }
@@ -59,7 +57,6 @@ class OAuthClientIntegrationTest : IntegrationTestSupport() {
             OAuthUserInfo(
                 provider = OAuthProvider.GOOGLE,
                 socialId = "google_456",
-                email = "user@gmail.com",
                 profileImage = "https://lh3.googleusercontent.com/profile.jpg",
             )
         }
@@ -68,7 +65,6 @@ class OAuthClientIntegrationTest : IntegrationTestSupport() {
 
         assertEquals(OAuthProvider.GOOGLE, result.provider)
         assertEquals("google_456", result.socialId)
-        assertEquals("user@gmail.com", result.email)
     }
 
     @Test
@@ -77,8 +73,7 @@ class OAuthClientIntegrationTest : IntegrationTestSupport() {
             OAuthUserInfo(
                 provider = OAuthProvider.GOOGLE,
                 socialId = "google_sdk_456",
-                email = "user@gmail.com",
-                profileImage = "https://lh3.googleusercontent.com/profile.jpg",
+                profileImage = null,
             )
         }
 
@@ -86,6 +81,8 @@ class OAuthClientIntegrationTest : IntegrationTestSupport() {
 
         assertEquals(OAuthProvider.GOOGLE, result.provider)
         assertEquals("google_sdk_456", result.socialId)
+        // provider 가 이미지를 안 주면 null (소비측에서 기본 이미지로 대체)
+        assertEquals(null, result.profileImage)
     }
 
     @Test

--- a/src/test/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthClientRegistryTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthClientRegistryTest.kt
@@ -1,0 +1,26 @@
+package com.depromeet.piki.auth.infrastructure.oauth
+
+import com.depromeet.piki.support.StubOAuthClient
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class OAuthClientRegistryTest {
+    @Test
+    fun `등록된 provider 는 해당 client 로 resolve 된다`() {
+        val registry =
+            OAuthClientRegistry(
+                listOf(StubOAuthClient(OAuthProvider.KAKAO), StubOAuthClient(OAuthProvider.GOOGLE)),
+            )
+
+        assertEquals(OAuthProvider.KAKAO, registry.resolve(OAuthProvider.KAKAO).provider)
+        assertEquals(OAuthProvider.GOOGLE, registry.resolve(OAuthProvider.GOOGLE).provider)
+    }
+
+    @Test
+    fun `구현체가 없는 provider(apple)는 unsupportedProvider 로 거절된다`() {
+        val registry = OAuthClientRegistry(listOf(StubOAuthClient(OAuthProvider.KAKAO)))
+
+        assertFailsWith<OAuthException> { registry.resolve(OAuthProvider.APPLE) }
+    }
+}

--- a/src/test/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthClientRegistryTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthClientRegistryTest.kt
@@ -23,4 +23,13 @@ class OAuthClientRegistryTest {
 
         assertFailsWith<OAuthException> { registry.resolve(OAuthProvider.APPLE) }
     }
+
+    @Test
+    fun `동일 provider 를 두 번 등록하면 require 로 fail-fast 한다`() {
+        assertFailsWith<IllegalArgumentException> {
+            OAuthClientRegistry(
+                listOf(StubOAuthClient(OAuthProvider.KAKAO), StubOAuthClient(OAuthProvider.KAKAO)),
+            )
+        }
+    }
 }

--- a/src/test/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthProviderTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthProviderTest.kt
@@ -1,0 +1,25 @@
+package com.depromeet.piki.auth.infrastructure.oauth
+
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.ValueSource
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class OAuthProviderTest {
+    @ParameterizedTest
+    @CsvSource("kakao, KAKAO", "GOOGLE, GOOGLE", "Apple, APPLE", "' kakao ', KAKAO")
+    fun `from 은 대소문자·공백 무시하고 enum 으로 매핑한다`(
+        raw: String,
+        expected: OAuthProvider,
+    ) {
+        assertEquals(expected, OAuthProvider.from(raw))
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["naver", "foo", ""])
+    fun `정의되지 않은 provider 는 OAuthException 으로 거절된다`(raw: String) {
+        assertFailsWith<OAuthException> { OAuthProvider.from(raw) }
+    }
+}

--- a/src/test/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthProviderTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthProviderTest.kt
@@ -3,7 +3,6 @@ package com.depromeet.piki.auth.infrastructure.oauth
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.ValueSource
-import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 

--- a/src/test/kotlin/com/depromeet/piki/auth/service/SocialAccountConcurrencyIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/service/SocialAccountConcurrencyIntegrationTest.kt
@@ -1,0 +1,71 @@
+package com.depromeet.piki.auth.service
+
+import com.depromeet.piki.auth.infrastructure.oauth.OAuthProvider
+import com.depromeet.piki.auth.infrastructure.oauth.OAuthUserInfo
+import com.depromeet.piki.support.IntegrationTestSupport
+import com.depromeet.piki.user.repository.UserDetailRepository
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.jdbc.core.JdbcTemplate
+import java.util.Collections
+import java.util.UUID
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+// 동시 첫 로그인 race 검증. @Transactional 자동 롤백을 쓰지 않는다 — 별도 트랜잭션 동시 진행이
+// 시뮬레이션의 본질이라(REQUIRED mutation 이 각자 커밋돼야 충돌이 재현된다), 격리된 socialId 를 쓰고
+// 끝에서 만든 행을 직접 정리한다. (CLAUDE.md "동시성·시간 의존 통합 테스트" 분류)
+class SocialAccountConcurrencyIntegrationTest : IntegrationTestSupport() {
+    @Autowired
+    private lateinit var socialAccountService: SocialAccountService
+
+    @Autowired
+    private lateinit var userDetailRepository: UserDetailRepository
+
+    @Autowired
+    private lateinit var jdbcTemplate: JdbcTemplate
+
+    @Test
+    fun `같은 소셜로 동시 첫 로그인해도 한 user 로 합류하고 500 이 터지지 않는다`() {
+        val socialId = "concurrent-${UUID.randomUUID()}"
+        val userInfo = OAuthUserInfo(OAuthProvider.GOOGLE, socialId, null)
+        val threadCount = 4
+        val pool = Executors.newFixedThreadPool(threadCount)
+        val ready = CountDownLatch(threadCount)
+        val start = CountDownLatch(1)
+        val resolvedIds = Collections.synchronizedList(mutableListOf<UUID>())
+        val errors = Collections.synchronizedList(mutableListOf<Throwable>())
+
+        try {
+            repeat(threadCount) {
+                pool.submit {
+                    ready.countDown()
+                    start.await()
+                    runCatching { socialAccountService.resolveUser(userInfo, null).id }
+                        .onSuccess { resolvedIds.add(it) }
+                        .onFailure { errors.add(it) }
+                }
+            }
+            ready.await(5, TimeUnit.SECONDS)
+            start.countDown() // 동시 출발
+            pool.shutdown()
+            assertTrue(pool.awaitTermination(15, TimeUnit.SECONDS), "동시 작업이 시간 내 끝나야 한다")
+
+            assertEquals(emptyList(), errors.map { it.message }, "동시 첫 로그인에서 예외(500)가 나면 안 된다")
+            assertEquals(threadCount, resolvedIds.size, "모든 요청이 user 를 받아야 한다")
+            assertEquals(1, resolvedIds.toSet().size, "모든 동시 요청이 같은 user 로 합류해야 한다")
+
+            val linked = userDetailRepository.findByProviderAndSocialId(OAuthProvider.GOOGLE.name, socialId)
+            assertNotNull(linked, "소셜 연결이 정확히 하나 남아야 한다")
+            assertEquals(resolvedIds.first(), linked.getIdOrNull(), "합류된 user 가 연결의 주인과 같아야 한다")
+        } finally {
+            // @Transactional 자동 롤백이 없으므로 만든 행을 직접 정리 (social_id 문자열로 삭제 → UUID 바이너리 바인딩 회피)
+            jdbcTemplate.update("DELETE FROM users WHERE id IN (SELECT user_id FROM user_details WHERE social_id = ?)", socialId)
+            jdbcTemplate.update("DELETE FROM user_details WHERE social_id = ?", socialId)
+        }
+    }
+}

--- a/src/test/kotlin/com/depromeet/piki/auth/service/SocialAccountConcurrencyIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/service/SocialAccountConcurrencyIntegrationTest.kt
@@ -66,7 +66,10 @@ class SocialAccountConcurrencyIntegrationTest : IntegrationTestSupport() {
             assertEquals(resolvedIds.first(), linked.getIdOrNull(), "합류된 user 가 연결의 주인과 같아야 한다")
         } finally {
             // @Transactional 자동 롤백이 없으므로 만든 행을 직접 정리 (social_id 문자열로 삭제 → UUID 바이너리 바인딩 회피)
-            jdbcTemplate.update("DELETE FROM users WHERE id IN (SELECT user_id FROM user_details WHERE social_id = ?)", socialId)
+            jdbcTemplate.update(
+                "DELETE FROM users WHERE id IN (SELECT user_id FROM user_details WHERE social_id = ?)",
+                socialId,
+            )
             jdbcTemplate.update("DELETE FROM user_details WHERE social_id = ?", socialId)
         }
     }

--- a/src/test/kotlin/com/depromeet/piki/auth/service/SocialAccountConcurrencyIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/service/SocialAccountConcurrencyIntegrationTest.kt
@@ -50,7 +50,9 @@ class SocialAccountConcurrencyIntegrationTest : IntegrationTestSupport() {
                         .onFailure { errors.add(it) }
                 }
             }
-            ready.await(5, TimeUnit.SECONDS)
+            // 모든 스레드가 시작 게이트에 도달했는지 강제 검증 — 안 하면 느린 CI 에서 일부가 준비 전에
+            // start 가 풀려 동시성이 약해지고 race 가 거짓양성으로 통과할 수 있다.
+            assertTrue(ready.await(5, TimeUnit.SECONDS), "모든 스레드가 시작 게이트에 준비돼야 한다")
             start.countDown() // 동시 출발
             pool.shutdown()
             assertTrue(pool.awaitTermination(15, TimeUnit.SECONDS), "동시 작업이 시간 내 끝나야 한다")

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -6,9 +6,20 @@ spring:
 
 # 운영 OAuthClientConfig 의 실제 클라이언트 빈을 테스트 컨텍스트에서는 끈다.
 # 그러면 IntegrationStubs 의 stub(googleOAuthClient/kakaoOAuthClient)만 남아 외부 호출 없이 격리된다.
+# google/kakao 더미 값: GoogleProperties·KakaoProperties 는 @ConfigurationPropertiesScan 으로
+# 빈이 생성되고 @Validated(@NotBlank) 라, 값이 없으면 컨텍스트 로딩이 깨진다. 실제 호출은 stub 이
+# 대체하므로 값은 쓰이지 않는다 (test classpath 의 application.yml 이 main 을 대체하므로 여기 박는다).
 oauth:
   client:
     enabled: false
+  google:
+    client-id: test-google-client-id
+    client-secret: test-google-client-secret
+    redirect-uri: http://localhost/auth/callback/google
+  kakao:
+    client-id: test-kakao-client-id
+    client-secret: test-kakao-client-secret
+    redirect-uri: http://localhost/auth/callback/kakao
 
 # 컨텍스트 로딩만 통과시키기 위한 더미 fallback. 실제 Gemini 호출 테스트는 @Disabled 또는
 # @EnabledIfEnvironmentVariable 로 별도 격리되어 있으므로 CI 에서 GEMINI_API_KEY 가 없어도

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -4,6 +4,12 @@ spring:
   config:
     import: optional:file:.env.test[.properties]
 
+# 운영 OAuthClientConfig 의 실제 클라이언트 빈을 테스트 컨텍스트에서는 끈다.
+# 그러면 IntegrationStubs 의 stub(googleOAuthClient/kakaoOAuthClient)만 남아 외부 호출 없이 격리된다.
+oauth:
+  client:
+    enabled: false
+
 # 컨텍스트 로딩만 통과시키기 위한 더미 fallback. 실제 Gemini 호출 테스트는 @Disabled 또는
 # @EnabledIfEnvironmentVariable 로 별도 격리되어 있으므로 CI 에서 GEMINI_API_KEY 가 없어도
 # 컨텍스트 로딩 자체는 깨지지 않는다.


### PR DESCRIPTION
## Situation
- epic #122(소셜 로그인) 의 마지막 조각. 기존엔 OAuthClient 인프라(provider 별 token/userinfo 호출)만 있고, 그걸 엮어 "로그인 → 유저 생성/연결 → JWT 발급"으로 잇는 플로우가 없었다.
- 직전 #166 에서 게스트 로그인의 cookie(web)/body(app) 토큰 전달 contract 를 secure-by-default 로 정리해둔 상태라, 소셜 로그인도 같은 contract 를 그대로 타도록 얹는 게 자연스러웠다.

## Task
- 단일 엔드포인트로 Kakao·Google 을, v1(웹 code) / v2(앱 SDK accessToken) 두 흐름을 모두 받는 소셜 로그인 구축.
- 게스트가 소셜 로그인하면 그 게스트 계정을 그대로 MEMBER 로 승격(데이터 승계)할지, 새 계정을 만들지 — 계정 연결 정책 결정.
- 외부 OAuth HTTP 호출이 DB 트랜잭션을 잡아 커넥션 풀을 마르게 하지 않도록 경계 분리.

## Action

### 로그인 플로우
- `POST /api/v1/auth/login/{provider}` 단일 엔드포인트. provider 는 `OAuthProvider.from` 으로 파싱, 미지원(apple 등)은 `OAuthException.unsupportedProvider()` → 400.
- provider 별 client 를 `OAuthClientRegistry` 로 묶고 `OAuthClientConfig` 가 빈 등록. `registry.resolve(provider)` 로 분기.
- v1(code+redirectUri): 백엔드가 provider 에 code→token 교환 후 userinfo 조회. v2(accessToken): 앱 SDK 가 받은 토큰으로 userinfo 만 조회. 둘 다 없으면 400.
- 발급된 토큰은 #166 의 cookie/body contract 를 그대로 탐 — web=Set-Cookie, app(`X-Client-Type: app`)=body.

### 계정 연결 정책 (SocialAccountService.resolveUser)
- 기존 소셜 → 그 유저로 로그인(재방문).
- 게스트 토큰 + 신규 소셜 → 그 게스트를 MEMBER 로 승격, id·데이터 그대로 승계.
- 게스트가 이미 타계정에 연결된 소셜로 로그인 → 그 기존 계정으로 로그인(게스트는 포기).
- 그 외 → 신규 MEMBER 생성.

### 경계·정책 결정
- 외부 OAuth 호출은 트랜잭션 밖(`OAuthLoginService`, 비트랜잭션)에서 끝내고, 영속화만 `SocialAccountService`(`@Transactional`)에 위임.
- email 은 받지 않기로 한 결정(#262)에 맞춰 `OAuthUserInfo`·각 provider userinfo DTO 에서 제거. 프로필 이미지는 있으면 가져오고, 없으면(사용자 거부 등) dicebear 기본 이미지.
- provider 호출 실패 → `OAuthException.providerError()` → 502.

### 테스트
- 운영 `OAuthClientConfig` 빈을 test 컨텍스트에서 `oauth.client.enabled=false` 로 끄고 `IntegrationStubs` 의 stub 만 남겨 외부 호출 격리. bean override 대신 `@ConditionalOnProperty` 를 택해 컨텍스트 캐시 보존.
- 통합 9 시나리오(신규/재방문/게스트승격/소셜중복/v1/400 2종/502/web쿠키) + 단위(OAuthProvider·Registry).

### 로컬 실검증 인프라 (chore)
- docker-compose 에 redis(7.4-alpine) 추가 — 토큰 저장에 Redis 가 필요한데 기존 compose 엔 mysql 만 있었음.
- `application.yml` config.import 를 `.env` → `.env.local` 순으로 읽도록 리스트화(뒤가 우선), `.gitignore` 를 `.env*` 글롭 + `.env.example` 화이트리스트로 단순화.

## Result
- 실제 Google 계정으로 로컬에서 end-to-end 검증 완료: 신규 가입(MEMBER·프로필이미지 승계)·재방문(동일 id)·게스트 승격(id 유지)·web쿠키/app body 분기·JWT 인증·토큰 리프레시 전부 통과.
- 발견·분리: 본문 없는 요청이 표준 예외(`HttpMessageNotReadableException`)로 500 나는 전역 핸들링 갭은 이 PR 범위 밖 — #300 으로 분리해둠.
- 후속(epic #122): Google id_token(JWKS 검증) 흐름은 Task 6 으로 별도, Apple 로그인은 client 추가 시 registry 에 자동 편입.

---
## 연관 이슈

- close #162


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Google/Kakao 소셜 로그인(v1/v2) 추가, 게스트 계정의 소셜 연결 시 자동 회원 전환 및 토큰 발급(바디/쿠키 토큰 동작 제어 포함), 프로필 이미지 처리 개선
* **Chores**
  * 로컬 Docker 구성(로컬 바인딩된 MySQL/Redis) 업데이트 및 .env* 무시 규칙(.env.example 예외) 적용, 설정 파일 import 우선순위 조정
* **Tests**
  * 소셜 로그인 흐름·레지스트리·유효성·동시성 통합 및 단위 테스트 대폭 추가/확장
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
## Updates

### CodeRabbit 리뷰 대응 (+ 동시성·검증 보강)

- **탈퇴 유저 토큰 재발급 차단** — `issueTokensFor` 에 `deletedAt` 가드 누락(refresh·issueTokenForExistingUser 는 이미 막음). 소셜 로그인 경로만 빠져 탈퇴 계정이 토큰을 재발급받던 갭을 동일 가드로 차단 (`d0bcebe`)
- **자격증명 동시 전달 차단 → DTO 입력 경계로** — accessToken+code 동시 전달 시 조용히 v2 채택하던 걸 400 으로. 처음엔 서비스에 뒀다가 CLAUDE.md "검증은 입력 경계(DTO)" 규약에 맞춰 `OAuthLoginRequest.@AssertTrue` 로 이동, 서비스는 흐름 선택만 남김 (`89cb50d`, `f589724`)
- **OAuthClientRegistry 중복 provider fail-fast** — `associateBy` 가 같은 provider 를 조용히 덮어쓰던 걸 `require` 로 시작 시점 차단 (불변식 → require) (`1bfa7f5`)
- **docker-compose 포트 loopback** — redis·mysql `127.0.0.1` 바인딩으로 무인증 외부 접근 차단 (`43e5359`)
- **동시 첫 로그인 race condition 처리** — 같은 (provider, social_id) 동시 첫 로그인 시 커밋 시점 유니크 충돌로 500 나던 걸, mutation 을 `SocialAccountWriter`(REQUIRED) 별도 빈으로 분리 + `resolveUser` 비트랜잭션 catch·재조회 합류로 해결. REQUIRES_NEW 대신 REQUIRED 라 `@Transactional` 통합테스트 롤백 격리도 보존. 별도 `SocialAccountConcurrencyIntegrationTest`(catch 제거 시 FAIL 확인)로 검증. close #311 (`260504d`)
- **자동 닉네임 풀 16×16 → 32×32 확장** — 로컬 검증 중 256 조합이 거의 소진돼 1024 조합으로 임시 확장(닉네임 10자 제한 유지). 가변 suffix+재시도 근본 해결은 #312 (`4753b65`)

Review 처리 요약: accept 5 / `@Transactional` 제거는 reject(컨벤션 유지, commit 경계는 위 동시성 테스트가 커버) / nitpick 1 답변. defer 2건은 #311(이 PR 로 해결)·#312 로 분리.


### 리뷰 추가 대응 — OAuthClient 견고화

- **provider 호출 타임아웃 추가** — `GoogleOAuthClient`·`KakaoOAuthClient` 의 RestClient 가 timeout 없이 빌드돼 provider 지연 시 요청 스레드가 무한 점유될 수 있던 것을, `OAuthRestClient` 공유 팩토리(connect 5s / read 10s, `SimpleClientHttpRequestFactory`)로 4개 RestClient 전부 통일 (`5fccc74`)
- **OAuth Properties fail-fast** — `GoogleProperties`·`KakaoProperties` 의 빈 문자열 default 를 제거하고 `@Validated` + `@field:NotBlank` 적용. env 누락 시 첫 로그인이 아니라 **부팅 시점 BindException** 으로 깨지게 함(JwtProperties 패턴). `@ConfigurationPropertiesScan` 으로 테스트 컨텍스트도 생성되므로 test `application.yml` 에 oauth 더미 값 추가(실 호출은 stub 대체라 미사용) (`30c59b9`)
