### PR TITLE
위시 이미지 보정(recover)에 multipart 이미지 통합

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/common/storage/ImageStorageException.kt
+++ b/src/main/kotlin/com/depromeet/piki/common/storage/ImageStorageException.kt
@@ -1,0 +1,24 @@
+package com.depromeet.piki.common.storage
+
+import com.depromeet.piki.common.exception.BaseException
+import com.depromeet.piki.common.exception.ErrorCategory
+import com.depromeet.piki.common.exception.HttpMappable
+import org.springframework.http.HttpStatus
+
+// 이미지 저장(S3 등 외부 스토리지) 실패를 나타내는 계약 예외.
+// 멀쩡한 클라이언트의 정상 요청이라도 우리 밖 스토리지 장애로 떨어질 수 있어 도달 가능한 계약 응답이며,
+// GeminiApiException(502) 과 같은 결로 502 BAD_GATEWAY 로 매핑한다 — 클라이언트는 재시도로 처리한다.
+// message 는 고정 사용자 대면 문구로 두고, 원인은 cause 체인·로그로 남긴다(내부 정보 비노출).
+class ImageStorageException private constructor(
+    message: String,
+    override val category: ErrorCategory,
+    cause: Throwable? = null,
+) : BaseException(message, cause),
+    HttpMappable {
+    override val httpStatus: HttpStatus = HttpStatus.BAD_GATEWAY
+
+    companion object {
+        fun uploadFailed(cause: Throwable? = null): ImageStorageException =
+            ImageStorageException("이미지 저장에 실패했습니다. 잠시 후 다시 시도해 주세요.", ErrorCategory.RETRYABLE, cause)
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/common/storage/S3ImageStorage.kt
+++ b/src/main/kotlin/com/depromeet/piki/common/storage/S3ImageStorage.kt
@@ -16,19 +16,21 @@ class S3ImageStorage(
         bytes: ByteArray,
         key: String,
         contentType: String,
-    ): String {
-        // S3 object key 는 raw 로 저장하고, 반환 URL 만 경로 인코딩한다.
-        s3Client.putObject(
-            PutObjectRequest
-                .builder()
-                .bucket(s3Properties.bucket)
-                .key(key)
-                .contentType(contentType)
-                .build(),
-            RequestBody.fromBytes(bytes),
-        )
-        return "${s3Properties.publicBaseUrl.trimEnd('/')}/${encodePath(key)}"
-    }
+    ): String =
+        // AWS SDK 예외(네트워크·권한·버킷 장애)를 계약 예외(502)로 변환해 호출부가 일관되게 다루게 한다.
+        runCatching {
+            // S3 object key 는 raw 로 저장하고, 반환 URL 만 경로 인코딩한다.
+            s3Client.putObject(
+                PutObjectRequest
+                    .builder()
+                    .bucket(s3Properties.bucket)
+                    .key(key)
+                    .contentType(contentType)
+                    .build(),
+                RequestBody.fromBytes(bytes),
+            )
+            "${s3Properties.publicBaseUrl.trimEnd('/')}/${encodePath(key)}"
+        }.getOrElse { e -> throw ImageStorageException.uploadFailed(e) }
 
     // key 의 각 경로 세그먼트를 URL 인코딩한다 ('/' 는 구분자로 보존). 공백/한글/예약문자 키도
     // 접근 가능한 URL 이 되도록 한다 (URLEncoder 의 '+' 는 path 에선 '%20' 이어야 한다).

--- a/src/main/kotlin/com/depromeet/piki/image/domain/ProductImage.kt
+++ b/src/main/kotlin/com/depromeet/piki/image/domain/ProductImage.kt
@@ -19,6 +19,19 @@ class ProductImage private constructor(
     val bytes: ByteArray
         get() = rawBytes.copyOf()
 
+    // 스토리지 object key 의 확장자. of() 가 SUPPORTED_MIME_TYPES 로 mimeType 을 보장하므로
+    // else 는 도달 불가한 불변식 위반(코드 버그)이다.
+    val extension: String
+        get() =
+            when (mimeType) {
+                "image/png" -> "png"
+                "image/jpeg" -> "jpg"
+                "image/webp" -> "webp"
+                "image/heic" -> "heic"
+                "image/heif" -> "heif"
+                else -> error("지원하지 않는 MIME 타입의 확장자를 요청했다: $mimeType")
+            }
+
     companion object {
         // 이미지 추출이 받아들이는 이미지 형식. Gemini Vision 지원 목록 기준.
         // https://ai.google.dev/gemini-api/docs/vision

--- a/src/main/kotlin/com/depromeet/piki/item/domain/Item.kt
+++ b/src/main/kotlin/com/depromeet/piki/item/domain/Item.kt
@@ -145,6 +145,10 @@ class Item(
     // PROCESSING(파싱 중)·FAILED(실패)는 false — 이름·가격이 비어 있어 출전에 부적합하다.
     fun isReady(): Boolean = status == ItemStatus.READY
 
+    // 클라이언트 보정(recover) 대상인지 — FAILED 만 보정 가능. 서비스가 S3 업로드 같은 외부 작업 전에
+    // 미리 걸러 헛된 비용(orphan 업로드)을 막는 사전 가드용. 도메인 최후 보루는 recover 가 진다.
+    fun isFailed(): Boolean = status == ItemStatus.FAILED
+
     // READY 불변식 — "쓸 수 있는 상품"은 최소한 이름이 있어야 한다. isReady() 게이트(목록 노출·토너먼트 출전)가
     // 미완성 item 을 정상 상품으로 취급하지 않도록, READY 가 되는 명시 경로(from·markReady)에서 검사한다.
     // 엔티티 최후의 보루이므로 require(불변식)다 — 정상 흐름에선 입력 경계(recover 의 nameRequiredForReady,

--- a/src/main/kotlin/com/depromeet/piki/wishlist/controller/WishlistApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/wishlist/controller/WishlistApi.kt
@@ -198,8 +198,9 @@ interface WishlistApi {
     @Operation(
         summary = "복구 (추출 실패 보정)",
         description = """
-            추출에 실패(item.status=FAILED)한 위시 항목의 상품 정보(이름·현재가·이미지·통화)를 사용자가 직접 채워 복구한다.
-            들어온 필드만 갱신하며, 보정에 성공하면 status 가 READY 로 복구된다.
+            추출에 실패(item.status=FAILED)한 위시 항목의 상품 정보를 사용자가 직접 채워 복구한다(multipart/form-data).
+            텍스트(이름·현재가·통화)는 form 필드로, 이미지는 image 파트로 받는다 — 이미지는 URL 이 아니라 파일로만 받아
+            서버가 그대로 S3 에 올려 대표 이미지로 채운다(추출·크롭 없음). 들어온 값만 갱신하고, 보정에 성공하면 READY 로 복구된다.
             item 데이터는 링크에서 기계 추출한 사실이라, 이미 완성(READY)된 항목은 수정할 수 없고(409 CONFLICT),
             파싱 중(PROCESSING)인 항목은 백그라운드 워커 소관이라 끼어들 수 없다(409 CONFLICT).
             본인 위시만 보정 가능하며, item 을 직접 노출하지 않고 위시 소유 단위로 권한을 검증한다.
@@ -219,7 +220,9 @@ interface WishlistApi {
             ),
             ApiResponse(
                 responseCode = "400",
-                description = "잘못된 요청 (보정 후에도 상품명 없음 · currentPrice 음수 · name/imageUrl/currency 길이 초과)",
+                description =
+                    "잘못된 요청 (보정 후에도 상품명 없음 · currentPrice 음수 · name/currency 길이 초과 · " +
+                        "빈 이미지 · 지원하지 않는 이미지 형식(png/jpeg/webp/heic/heif만 허용))",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,
@@ -267,12 +270,23 @@ interface WishlistApi {
                     ),
                 ],
             ),
+            ApiResponse(
+                responseCode = "502",
+                description = "이미지 저장소(S3) 업로드 실패 — 재시도 가능",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
         ],
     )
     fun recoverWishItem(
         @Parameter(hidden = true) userId: UUID,
         @Parameter(description = "위시 항목 ID", example = "1024") wishId: Long,
         request: WishlistUpdateRequest,
+        image: MultipartFile?,
     ): ApiResponseBody<WishItemResponse>
 
     @Operation(

--- a/src/main/kotlin/com/depromeet/piki/wishlist/controller/WishlistApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/wishlist/controller/WishlistApiExamples.kt
@@ -168,6 +168,16 @@ class WishlistApiExamples(
                                 detail = "아직 처리 중인 상품은 수정할 수 없습니다.",
                             ),
                     )
+                    add(
+                        status = HttpStatus.BAD_GATEWAY,
+                        name = "이미지 저장 실패",
+                        payload =
+                            ApiResponseBody.fail<Unit>(
+                                category = ErrorCategory.RETRYABLE,
+                                status = HttpStatus.BAD_GATEWAY,
+                                detail = "이미지 저장에 실패했습니다. 잠시 후 다시 시도해 주세요.",
+                            ),
+                    )
                 }
             }
             if (handlerMethod.binds(WishlistController::deleteWish)) {

--- a/src/main/kotlin/com/depromeet/piki/wishlist/controller/WishlistController.kt
+++ b/src/main/kotlin/com/depromeet/piki/wishlist/controller/WishlistController.kt
@@ -13,12 +13,14 @@ import org.springframework.http.MediaType
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.ModelAttribute
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RequestPart
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.multipart.MultipartFile
@@ -74,11 +76,12 @@ class WishlistController(
         return ApiResponseBody.ok(WishItemResponse.from(result.wish, result.item))
     }
 
-    @PatchMapping("/{wishId}")
+    @PatchMapping("/{wishId}", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
     override fun recoverWishItem(
         @AuthenticationPrincipal userId: UUID,
         @PathVariable wishId: Long,
-        @Valid @RequestBody request: WishlistUpdateRequest,
+        @Valid @ModelAttribute request: WishlistUpdateRequest,
+        @RequestPart("image", required = false) image: MultipartFile?,
     ): ApiResponseBody<WishItemResponse> {
         val result =
             wishlistService.recoverWishItem(
@@ -86,8 +89,8 @@ class WishlistController(
                 wishId = wishId,
                 name = request.name,
                 currentPrice = request.currentPrice,
-                imageUrl = request.imageUrl,
                 currency = request.currency,
+                image = image,
             )
         return ApiResponseBody.ok(WishItemResponse.from(result.wish, result.item))
     }

--- a/src/main/kotlin/com/depromeet/piki/wishlist/controller/dto/WishlistUpdateRequest.kt
+++ b/src/main/kotlin/com/depromeet/piki/wishlist/controller/dto/WishlistUpdateRequest.kt
@@ -12,9 +12,6 @@ data class WishlistUpdateRequest(
     @field:Schema(description = "수정할 현재 판매가", example = "119000", nullable = true)
     @field:Min(value = 0, message = "가격은 0 이상이어야 합니다.")
     val currentPrice: Int? = null,
-    @field:Schema(description = "수정할 대표 이미지 URL", example = "https://cdn.example.com/p/512.jpg", nullable = true)
-    @field:Size(max = 2048, message = "이미지 URL 은 2048자를 초과할 수 없습니다.")
-    val imageUrl: String? = null,
     @field:Schema(description = "수정할 통화 코드 (ISO 4217)", example = "KRW", nullable = true)
     @field:Size(max = 8, message = "통화 코드는 8자를 초과할 수 없습니다.")
     val currency: String? = null,

--- a/src/main/kotlin/com/depromeet/piki/wishlist/service/WishPersistenceService.kt
+++ b/src/main/kotlin/com/depromeet/piki/wishlist/service/WishPersistenceService.kt
@@ -43,4 +43,20 @@ class WishPersistenceService(
             WishWithItem(wish = wish, item = item)
         }
     }
+
+    // FAILED item 의 수동 보정 영속화 — S3 업로드(외부 호출)는 호출부가 트랜잭션 바깥에서 끝내고,
+    // 여기선 recover(값 변경 + FAILED→READY 전이)만 짧은 트랜잭션으로 묶는다(dirty checking).
+    // recover 가 READY/PROCESSING 을 409, 이름 없음을 400 으로 막는다(도메인 자기방어).
+    @Transactional
+    fun recoverItem(
+        itemId: Long,
+        name: String?,
+        currentPrice: Int?,
+        imageUrl: String?,
+        currency: String?,
+    ): Item {
+        val item = itemRepository.findById(itemId) ?: error("item $itemId 가 없다")
+        item.recover(name = name, currentPrice = currentPrice, imageUrl = imageUrl, currency = currency)
+        return item
+    }
 }

--- a/src/main/kotlin/com/depromeet/piki/wishlist/service/WishlistService.kt
+++ b/src/main/kotlin/com/depromeet/piki/wishlist/service/WishlistService.kt
@@ -1,5 +1,6 @@
 package com.depromeet.piki.wishlist.service
 
+import com.depromeet.piki.common.storage.ImageStorage
 import com.depromeet.piki.image.domain.ProductImage
 import com.depromeet.piki.item.domain.Item
 import com.depromeet.piki.item.repository.ItemRepository
@@ -27,6 +28,7 @@ class WishlistService(
     private val imageParsingWorker: ImageParsingWorker,
     private val itemParsingService: ItemParsingService,
     private val wishPersistenceService: WishPersistenceService,
+    private val imageStorage: ImageStorage,
     private val wishRepository: WishRepository,
     private val itemRepository: ItemRepository,
 ) {
@@ -121,23 +123,33 @@ class WishlistService(
         return WishWithItem(wish = wish, item = item)
     }
 
-    // 추출 실패(FAILED) item 을 사용자가 직접 보정해 READY 로 복구한다. READY·PROCESSING 은 도메인(recover)이
-    // 409 로 막는다. 변경은 @Transactional 커밋 시 dirty checking 으로 반영.
-    @Transactional
+    // 추출 실패(FAILED) item 을 사용자가 직접 보정해 READY 로 복구한다. 이미지를 함께 주면 그대로 S3 에 올려
+    // imageUrl 을 채운다(추출·크롭 없음 — 사용자가 고른 이미지를 그대로 대표 이미지로). READY·PROCESSING 은
+    // recover 가 409 로 막는다. 외부 호출(S3)을 트랜잭션에 넣지 않기 위해 검증·소유권·상태 사전확인·업로드를
+    // 트랜잭션 밖에서 끝내고, 영속화만 wishPersistenceService.recoverItem(@Transactional)에 위임한다.
     fun recoverWishItem(
         userId: UUID,
         wishId: Long,
         name: String?,
         currentPrice: Int?,
-        imageUrl: String?,
         currency: String?,
+        image: MultipartFile?,
     ): WishWithItem {
+        // 이미지 형식 검증(빈 바이트·미지원 MIME) — 외부 호출 전에 동기로 거른다(400).
+        val productImage = image?.let { ProductImage.of(it.bytes, it.contentType) }
         val wish = wishRepository.findById(wishId) ?: throw WishException.notFound()
         wish.verifyOwnedBy(userId)
         // wish 가 가리키는 item 은 반드시 존재한다. 없으면 영속화 경로가 깨진 코드 버그다.
         val item = itemRepository.findById(wish.itemId) ?: error("wish ${wish.getId()} 의 item ${wish.itemId} 가 없다")
-        item.recover(name = name, currentPrice = currentPrice, imageUrl = imageUrl, currency = currency)
-        return WishWithItem(wish = wish, item = item)
+        // FAILED 가 아니면 S3 에 올리기 전에 막는다(orphan 업로드 방지). recover 가 사유별 409 를 던진다.
+        if (!item.isFailed()) item.recover()
+        // 이미지가 있으면 S3 업로드(트랜잭션 밖). 실패 시 ImageStorageException(502).
+        val imageUrl =
+            productImage?.let {
+                imageStorage.upload(it.bytes, "items/${UUID.randomUUID()}.${it.extension}", it.mimeType)
+            }
+        val recovered = wishPersistenceService.recoverItem(wish.itemId, name, currentPrice, imageUrl, currency)
+        return WishWithItem(wish = wish, item = recovered)
     }
 
     // 멱등 삭제: 없거나 이미 삭제됐으면 "이미 목표 상태(없음)"이므로 성공으로 본다(no-op).

--- a/src/test/kotlin/com/depromeet/piki/image/domain/ProductImageTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/image/domain/ProductImageTest.kt
@@ -2,6 +2,7 @@ package com.depromeet.piki.image.domain
 
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.ValueSource
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
@@ -66,5 +67,20 @@ class ProductImageTest {
         assertFailsWith<IllegalArgumentException> {
             ProductImage.of(byteArrayOf(1), mimeType)
         }
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        "image/png, png",
+        "image/jpeg, jpg",
+        "image/webp, webp",
+        "image/heic, heic",
+        "image/heif, heif",
+    )
+    fun `MIME 타입에서 스토리지 object key 확장자를 도출한다`(
+        mimeType: String,
+        expected: String,
+    ) {
+        assertEquals(expected, ProductImage.of(byteArrayOf(1), mimeType).extension)
     }
 }

--- a/src/test/kotlin/com/depromeet/piki/support/StubImageStorage.kt
+++ b/src/test/kotlin/com/depromeet/piki/support/StubImageStorage.kt
@@ -2,19 +2,25 @@ package com.depromeet.piki.support
 
 import com.depromeet.piki.common.storage.ImageStorage
 
-// S3 업로드를 통합 테스트에서 격리하는 stub. upload 는 key 로 URL 을 만드는 순수 변환이라
+// S3 업로드를 통합 테스트에서 격리하는 stub. 기본 동작은 key 로 URL 을 만드는 순수 변환이라
 // 이전 테스트 상태가 누수될 위험이 없어, ProductExtractor stub 과 달리 default 를 고정 URL 로 둔다.
+// S3 실패(502) 시나리오가 필요한 테스트만 본문에서 behavior 를 throw 람다로 교체한다(직접 복원).
 // 호출 검증이 필요하면 uploadedKeys 를 본다.
 class StubImageStorage : ImageStorage {
     val uploadedKeys = mutableListOf<String>()
+
+    // 기본 동작 — key 로 고정 URL 생성. 502 시나리오 테스트가 behavior 를 throw 람다로 교체한 뒤 이 값으로 복원한다.
+    val defaultBehavior: (ByteArray, String, String) -> String = { _, key, _ -> "$BASE_URL/$key" }
+    var behavior: (ByteArray, String, String) -> String = defaultBehavior
 
     override fun upload(
         bytes: ByteArray,
         key: String,
         contentType: String,
     ): String {
+        val url = behavior(bytes, key, contentType)
         uploadedKeys.add(key)
-        return "$BASE_URL/$key"
+        return url
     }
 
     companion object {

--- a/src/test/kotlin/com/depromeet/piki/wishlist/controller/WishlistControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/wishlist/controller/WishlistControllerIntegrationTest.kt
@@ -1,14 +1,17 @@
 package com.depromeet.piki.wishlist.controller
 
 import com.depromeet.piki.auth.infrastructure.jwt.JwtProvider
+import com.depromeet.piki.common.storage.ImageStorageException
 import com.depromeet.piki.item.domain.Item
 import com.depromeet.piki.product.domain.ProductLink
 import com.depromeet.piki.product.service.ProductSnapshot
 import com.depromeet.piki.support.IntegrationTestSupport
+import com.depromeet.piki.support.StubImageStorage
 import com.depromeet.piki.support.uuidToBytes
 import com.depromeet.piki.user.domain.IdentityType
 import com.depromeet.piki.wishlist.service.WishPersistenceService
 import org.hamcrest.Matchers.nullValue
+import org.hamcrest.Matchers.startsWith
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpHeaders
@@ -20,7 +23,6 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -44,6 +46,9 @@ class WishlistControllerIntegrationTest : IntegrationTestSupport() {
 
     @Autowired
     private lateinit var wishPersistenceService: WishPersistenceService
+
+    @Autowired
+    private lateinit var stubImageStorage: StubImageStorage
 
     @Autowired
     private lateinit var jdbcTemplate: JdbcTemplate
@@ -325,14 +330,15 @@ class WishlistControllerIntegrationTest : IntegrationTestSupport() {
         insertMember(userId)
         val authHeader = "Bearer ${memberToken(userId)}"
         val wishId = seedReadyWish(userId, "https://shop.example.com/products/1", "이미 완성된 상품")
-        val body = objectMapper.writeValueAsString(mapOf("name" to "바꾸려는 이름"))
 
         mockMvc
             .perform(
-                patch("/api/v1/wishlists/$wishId")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .header(HttpHeaders.AUTHORIZATION, authHeader)
-                    .content(body),
+                multipart("/api/v1/wishlists/$wishId")
+                    .param("name", "바꾸려는 이름")
+                    .with {
+                        it.method = "PATCH"
+                        it
+                    }.header(HttpHeaders.AUTHORIZATION, authHeader),
             ).andExpect(status().isConflict)
             .andExpect(jsonPath("$.status").value(409))
             .andExpect(jsonPath("$.code").value("CONFLICT"))
@@ -347,14 +353,15 @@ class WishlistControllerIntegrationTest : IntegrationTestSupport() {
         insertMember(userId)
         val authHeader = "Bearer ${memberToken(userId)}"
         val wishId = seedProcessingWish(userId, "https://shop.example.com/products/1")
-        val body = objectMapper.writeValueAsString(mapOf("name" to "끼어든 수정"))
 
         mockMvc
             .perform(
-                patch("/api/v1/wishlists/$wishId")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .header(HttpHeaders.AUTHORIZATION, authHeader)
-                    .content(body),
+                multipart("/api/v1/wishlists/$wishId")
+                    .param("name", "끼어든 수정")
+                    .with {
+                        it.method = "PATCH"
+                        it
+                    }.header(HttpHeaders.AUTHORIZATION, authHeader),
             ).andExpect(status().isConflict)
             .andExpect(jsonPath("$.status").value(409))
             .andExpect(jsonPath("$.code").value("CONFLICT"))
@@ -368,20 +375,16 @@ class WishlistControllerIntegrationTest : IntegrationTestSupport() {
         insertMember(userId)
         val authHeader = "Bearer ${memberToken(userId)}"
         val wishId = seedFailedWish(userId, "https://shop.example.com/products/1")
-        val body =
-            objectMapper.writeValueAsString(
-                mapOf(
-                    "name" to "직접 입력한 이름",
-                    "currentPrice" to 50_000,
-                ),
-            )
 
         mockMvc
             .perform(
-                patch("/api/v1/wishlists/$wishId")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .header(HttpHeaders.AUTHORIZATION, authHeader)
-                    .content(body),
+                multipart("/api/v1/wishlists/$wishId")
+                    .param("name", "직접 입력한 이름")
+                    .param("currentPrice", "50000")
+                    .with {
+                        it.method = "PATCH"
+                        it
+                    }.header(HttpHeaders.AUTHORIZATION, authHeader),
             ).andExpect(status().isOk)
             .andExpect(jsonPath("$.status").value(200))
             .andExpect(jsonPath("$.data.item.name").value("직접 입력한 이름"))
@@ -398,14 +401,15 @@ class WishlistControllerIntegrationTest : IntegrationTestSupport() {
         insertMember(userId)
         val authHeader = "Bearer ${memberToken(userId)}"
         val wishId = seedFailedWish(userId, "https://shop.example.com/products/1")
-        val body = objectMapper.writeValueAsString(mapOf("currentPrice" to 50_000))
 
         mockMvc
             .perform(
-                patch("/api/v1/wishlists/$wishId")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .header(HttpHeaders.AUTHORIZATION, authHeader)
-                    .content(body),
+                multipart("/api/v1/wishlists/$wishId")
+                    .param("currentPrice", "50000")
+                    .with {
+                        it.method = "PATCH"
+                        it
+                    }.header(HttpHeaders.AUTHORIZATION, authHeader),
             ).andExpect(status().isBadRequest)
             .andExpect(jsonPath("$.status").value(400))
             .andExpect(jsonPath("$.code").value("BAD_REQUEST"))
@@ -420,14 +424,15 @@ class WishlistControllerIntegrationTest : IntegrationTestSupport() {
         insertMember(ownerId)
         insertMember(otherId)
         val wishId = seedReadyWish(ownerId, "https://shop.example.com/products/1", "내 상품")
-        val body = objectMapper.writeValueAsString(mapOf("name" to "남이 바꾼 이름"))
 
         mockMvc
             .perform(
-                patch("/api/v1/wishlists/$wishId")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .header(HttpHeaders.AUTHORIZATION, "Bearer ${memberToken(otherId)}")
-                    .content(body),
+                multipart("/api/v1/wishlists/$wishId")
+                    .param("name", "남이 바꾼 이름")
+                    .with {
+                        it.method = "PATCH"
+                        it
+                    }.header(HttpHeaders.AUTHORIZATION, "Bearer ${memberToken(otherId)}"),
             ).andExpect(status().isForbidden)
             .andExpect(jsonPath("$.status").value(403))
             .andExpect(jsonPath("$.code").value("FORBIDDEN"))
@@ -438,14 +443,15 @@ class WishlistControllerIntegrationTest : IntegrationTestSupport() {
         val mockMvc = buildMockMvc()
         val userId = UUID.randomUUID()
         insertMember(userId)
-        val body = objectMapper.writeValueAsString(mapOf("name" to "아무거나"))
 
         mockMvc
             .perform(
-                patch("/api/v1/wishlists/99999999")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .header(HttpHeaders.AUTHORIZATION, "Bearer ${memberToken(userId)}")
-                    .content(body),
+                multipart("/api/v1/wishlists/99999999")
+                    .param("name", "아무거나")
+                    .with {
+                        it.method = "PATCH"
+                        it
+                    }.header(HttpHeaders.AUTHORIZATION, "Bearer ${memberToken(userId)}"),
             ).andExpect(status().isNotFound)
             .andExpect(jsonPath("$.status").value(404))
             .andExpect(jsonPath("$.code").value("NOT_FOUND"))
@@ -458,17 +464,119 @@ class WishlistControllerIntegrationTest : IntegrationTestSupport() {
         insertMember(userId)
         val authHeader = "Bearer ${memberToken(userId)}"
         val wishId = seedReadyWish(userId, "https://shop.example.com/products/1", "상품")
-        val body = objectMapper.writeValueAsString(mapOf("currentPrice" to -1))
 
         mockMvc
             .perform(
-                patch("/api/v1/wishlists/$wishId")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .header(HttpHeaders.AUTHORIZATION, authHeader)
-                    .content(body),
+                multipart("/api/v1/wishlists/$wishId")
+                    .param("currentPrice", "-1")
+                    .with {
+                        it.method = "PATCH"
+                        it
+                    }.header(HttpHeaders.AUTHORIZATION, authHeader),
             ).andExpect(status().isBadRequest)
             .andExpect(jsonPath("$.status").value(400))
             .andExpect(jsonPath("$.code").value("BAD_REQUEST"))
+    }
+
+    @Test
+    fun `FAILED 위시 item 을 이미지와 함께 보정하면 200 과 갱신된 imageUrl 로 복구된다`() {
+        val mockMvc = buildMockMvc()
+        val userId = UUID.randomUUID()
+        insertMember(userId)
+        val authHeader = "Bearer ${memberToken(userId)}"
+        val wishId = seedFailedWish(userId, "https://shop.example.com/products/1")
+        val image = MockMultipartFile("image", "p.png", "image/png", byteArrayOf(1, 2, 3))
+
+        mockMvc
+            .perform(
+                multipart("/api/v1/wishlists/$wishId")
+                    .file(image)
+                    .param("name", "직접 입력한 이름")
+                    .with {
+                        it.method = "PATCH"
+                        it
+                    }.header(HttpHeaders.AUTHORIZATION, authHeader),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.status").value(200))
+            .andExpect(jsonPath("$.data.item.name").value("직접 입력한 이름"))
+            // 올린 이미지가 그대로 S3(stub)에 올라가 imageUrl 로 채워지고, FAILED 가 READY 로 복구된다.
+            .andExpect(jsonPath("$.data.item.imageUrl").value(startsWith("${StubImageStorage.BASE_URL}/items/")))
+            .andExpect(jsonPath("$.data.item.status").value("READY"))
+    }
+
+    @Test
+    fun `이미지 보정 시 지원하지 않는 형식을 보내면 400 BAD_REQUEST 가 반환된다`() {
+        val mockMvc = buildMockMvc()
+        val userId = UUID.randomUUID()
+        insertMember(userId)
+        val authHeader = "Bearer ${memberToken(userId)}"
+        val wishId = seedFailedWish(userId, "https://shop.example.com/products/1")
+        val gif = MockMultipartFile("image", "p.gif", "image/gif", byteArrayOf(1, 2, 3))
+
+        mockMvc
+            .perform(
+                multipart("/api/v1/wishlists/$wishId")
+                    .file(gif)
+                    .param("name", "이름")
+                    .with {
+                        it.method = "PATCH"
+                        it
+                    }.header(HttpHeaders.AUTHORIZATION, authHeader),
+            ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value("BAD_REQUEST"))
+    }
+
+    @Test
+    fun `이미지 보정 시 빈 이미지를 보내면 400 BAD_REQUEST 가 반환된다`() {
+        val mockMvc = buildMockMvc()
+        val userId = UUID.randomUUID()
+        insertMember(userId)
+        val authHeader = "Bearer ${memberToken(userId)}"
+        val wishId = seedFailedWish(userId, "https://shop.example.com/products/1")
+        val emptyImage = MockMultipartFile("image", "empty.png", "image/png", ByteArray(0))
+
+        mockMvc
+            .perform(
+                multipart("/api/v1/wishlists/$wishId")
+                    .file(emptyImage)
+                    .param("name", "이름")
+                    .with {
+                        it.method = "PATCH"
+                        it
+                    }.header(HttpHeaders.AUTHORIZATION, authHeader),
+            ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value("BAD_REQUEST"))
+    }
+
+    @Test
+    fun `이미지 보정 중 S3 업로드가 실패하면 502 BAD_GATEWAY 가 반환된다`() {
+        val mockMvc = buildMockMvc()
+        val userId = UUID.randomUUID()
+        insertMember(userId)
+        val authHeader = "Bearer ${memberToken(userId)}"
+        val wishId = seedFailedWish(userId, "https://shop.example.com/products/1")
+        val image = MockMultipartFile("image", "p.png", "image/png", byteArrayOf(1, 2, 3))
+        // S3 업로드 실패 주입. 공유 stub 이므로 끝에서 직접 기본 동작으로 복원한다.
+        stubImageStorage.behavior = { _, _, _ -> throw ImageStorageException.uploadFailed() }
+
+        try {
+            mockMvc
+                .perform(
+                    multipart("/api/v1/wishlists/$wishId")
+                        .file(image)
+                        .param("name", "이름")
+                        .with {
+                            it.method = "PATCH"
+                            it
+                        }.header(HttpHeaders.AUTHORIZATION, authHeader),
+                ).andExpect(status().isBadGateway)
+                .andExpect(jsonPath("$.status").value(502))
+                .andExpect(jsonPath("$.code").value("BAD_GATEWAY"))
+        } finally {
+            stubImageStorage.behavior = stubImageStorage.defaultBehavior
+        }
     }
 
     @Test


### PR DESCRIPTION
## Situation
- 위시 항목 수정(`recoverWishItem`, `PATCH /wishlists/{wishId}`)이 `imageUrl: String` 을 JSON 으로 받고 있었다. 그러나 `imageUrl` 은 추출 산출물(URL 등록은 Gemini HTML 추출, 이미지 등록은 비전 추출 후 크롭·S3)이라 **클라이언트가 알 수도 입력할 수도 없는 값** — 잘못된 계약이다.
- 처음엔 이를 고치려 독립 이미지 교체 엔드포인트(`PATCH /{id}/image`, READY in-place 교체)로 만들었다. 그러나 작업 중 **#295 가 dev 에 머지**되며 정책이 바뀌었다: `Item.update()` 제거 → `recover()`(FAILED 만 통과, READY·PROCESSING 은 409). "READY item 은 기계 추출 사실이라 클라이언트가 수정 못 한다. 보정은 FAILED 항목 한정."
- 이미지 보정도 "클라이언트 보정"이니 같은 정책(FAILED 한정)을 따라야 한다 → 독립 교체(READY in-place)는 정책 위반이라 폐기.

## Task
- `imageUrl` JSON 계약을 걷어내고, 이미지 보정을 recover(FAILED 전용) 흐름에 통합한다.
- 두 결정 포인트: (1) 독립 엔드포인트 vs recover 통합 → **recover 통합** (사용자 합의: "독립 이미지 교체는 없다, 실패 개선에 들어간다"). (2) 요청 형태 → 텍스트+이미지를 **multipart 한 요청**으로.

## Action
### 정책 정렬 (#295)
- 독립 이미지 교체 엔드포인트 폐기. 이미지 보정은 recover 의 일부 — FAILED 만 통과, READY/PROCESSING 은 409(`recover` 가 도메인 자기방어).

### recover 를 multipart 로
- `PATCH /wishlists/{wishId}` 를 JSON에서 multipart 로 전환. 텍스트(name·currentPrice·currency)는 `@ModelAttribute` form 필드, 이미지는 `@RequestPart image`(optional)로 받는다. `imageUrl: String` JSON 필드 제거.
- 올린 이미지를 Gemini 추출·크롭 없이 그대로 S3 에 올려 `imageUrl` 을 채운다. recover 의 `imageUrl` 출처가 "클라이언트 JSON" → "서버 S3 업로드 결과"로 바뀔 뿐, `Item.recover()` 도메인 시그니처·검증은 그대로.

### 트랜잭션·안전망
- 외부 호출(S3)을 트랜잭션에 넣지 않으려, 검증·소유권·status 사전확인·업로드를 트랜잭션 밖에서 끝내고 영속화만 `WishPersistenceService.recoverItem`(@Transactional)에 위임.
- S3 orphan 업로드 방지: `Item.isFailed()` 사전 가드로 FAILED 가 아니면 올리기 전에 막고, recover 가 최후 보루로 사유별 409 를 재검증(검증을 경계+엔티티 양쪽에).
- S3 업로드 실패를 502 로 드러내는 `ImageStorageException`(S3ImageStorage 가 AWS 예외 래핑), 원본 MIME 기준 S3 key 확장자 `ProductImage.extension`. recover 응답 전수 문서화에 502 보강.

### 클라이언트 영향 (합의됨)
- 이미지를 안 바꿔도 multipart 요청, 숫자가 문자열로 전송, 이미지가 크거나 형식이 틀리면 텍스트 보정까지 함께 실패(원자성) — 프론트와 공유 필요.

### 테스트
- dev 의 recover 통합테스트(JSON)를 multipart 로 전환하고, 이미지 케이스 추가 — FAILED+이미지 → 200·imageUrl 채워짐·READY, 미지원/빈 이미지 → 400, S3 실패 → 502.

## Result
- "클라이언트 보정은 FAILED 한정"(#295)이라는 정책에 이미지 보정도 정렬됐다. `imageUrl` 은 이제 어떤 경로로도 클라이언트가 직접 못 채운다.
- 이전 독립 교체 커밋(`5ac4ed0`)을 force-push 로 폐기하고, 최신 dev(#295·#305) 위 단일 커밋으로 재작성. (이 PR 본문도 그 방향 전환에 맞춰 전면 재작성됨.)
- 전체 테스트(단위+통합) BUILD SUCCESSFUL, 변경 파일 ktlint 위반 0. 스키마 변경 없음(마이그레이션 불필요).

---
## 연관 이슈

- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 위시 아이템 복구 시 이미지 업로드 기능 추가. 실패한 위시 아이템을 수정할 때 새로운 이미지를 함께 업로드할 수 있습니다.

* **Bug Fixes**
  * 이미지 저장소 오류 처리 개선. 이미지 저장 실패 시 재시도 가능한 에러 메시지를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->