### PR TITLE
admin favicon 요청이 JWT 체인으로 새 401 나던 문제 차단

### DIFF
--- a/src/main/resources/templates/admin/fragments/layout.html
+++ b/src/main/resources/templates/admin/fragments/layout.html
@@ -10,6 +10,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title th:text="${pageTitle}">PIKI 백오피스</title>
     <link rel="stylesheet" th:href="@{/admin-assets/backoffice.css}">
+    <!-- 빈 favicon. 없으면 브라우저가 /favicon.ico 를 자동 요청하는데, 이 경로는 admin SecurityFilterChain
+         (securityMatcher: /admin/**, /admin-assets/**) 밖이라 JWT 체인(@Order 2)이 잡아 401 JSON 을 낸다.
+         data:, 로 요청 자체를 없애 401 을 차단한다. -->
+    <link rel="icon" href="data:,">
 </head>
 <body>
 <aside th:fragment="sidebar(active)" class="bo-sidebar">

--- a/src/main/resources/templates/admin/login.html
+++ b/src/main/resources/templates/admin/login.html
@@ -5,6 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>PIKI 백오피스 로그인</title>
     <link rel="stylesheet" th:href="@{/admin-assets/backoffice.css}">
+    <!-- 빈 favicon. 없으면 브라우저가 /favicon.ico 를 자동 요청 → admin 체인 밖이라 JWT 체인이 401 을 낸다. data:, 로 차단. -->
+    <link rel="icon" href="data:,">
 </head>
 <body>
 <div class="login-container">


### PR DESCRIPTION
## Situation
- admin 백오피스(dev)에서 **"배포 직후 첫 로그인"** 시 화면에 `{"status":401,"code":"UNAUTHORIZED","detail":"인증 필요 — 로그인 후 재시도"}` JSON 이 노출된다는 제보. 로그인은 성공했는데 가끔 401 이 떴다.

## Task
- admin 은 세션 form login(미인증 시 302 redirect)인데 왜 JWT 체인의 `ApiResponseBody` 401 JSON 이 나오는지 규명하고 차단한다.

## Action
- dev 에서 로그인 후 경로별 응답을 직접 재현: `/admin`·`/admin/items` 는 200 HTML, 사이드바 링크도 전부 admin 체인. 그러나 **`/favicon.ico` 만 401 JSON** 임을 확인 (사용자가 붙인 응답과 정확히 일치).
- 원인: `AdminSecurityConfig` 의 `securityMatcher` 가 `/admin/**`·`/admin-assets/**` 만 관할 → 브라우저가 admin 페이지에서 자동 요청하는 `/favicon.ico` 가 admin 체인 밖 → JWT 체인(@Order 2)이 잡는다. admin 세션(JSESSIONID)은 있지만 JWT 토큰이 없어 `ApiResponseAuthenticationEntryPoint` 가 401 JSON 을 반환.
- "배포 직후 첫 로그인만" 인 이유: 브라우저가 favicon 결과를 캐시하므로 첫 방문 때만 `/favicon.ico` 를 요청 → 그때만 401 이 노출.
- 해결: `layout.html`(items·home)·`login.html` head 에 `<link rel="icon" href="data:,">` 를 박아 `/favicon.ico` 요청 자체를 제거. **JWT 인증 체인(팀원 영역)은 건드리지 않고** admin 템플릿에서만 닫았다.

## Result
- admin 페이지가 더는 `/favicon.ico` 를 요청하지 않아 401 JSON 노출이 사라진다.
- 검증: 배포 후 login/items HTML 에 favicon link 포함 + 브라우저 첫 로그인 재현 예정.
- 부수 발견(이번 스코프 밖): `/admin/`(trailing slash)·미구현 경로(`/admin/home`·`/admin/audit`)는 500 JSON, 게스트 로그인(`/api/v1/auth/guest`)은 현재 500(닉네임 생성 실패) — 각각 별도 정리 대상.

---
## 연관 이슈

- 
