### PR TITLE
Wishlist API summary·등록 메서드 네이밍 정리

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/wishlist/controller/WishlistApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/wishlist/controller/WishlistApi.kt
@@ -70,7 +70,7 @@ interface WishlistApi {
             ),
         ],
     )
-    fun register(
+    fun registerFromUrl(
         @Parameter(hidden = true) userId: UUID,
         request: WishlistRegisterRequest,
     ): ApiResponseBody<WishItemResponse>

--- a/src/main/kotlin/com/depromeet/piki/wishlist/controller/WishlistApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/wishlist/controller/WishlistApi.kt
@@ -18,7 +18,7 @@ import java.util.UUID
 @Tag(name = "Wishlist", description = "위시리스트 등록/조회/복구/삭제 API")
 interface WishlistApi {
     @Operation(
-        summary = "위시리스트 등록",
+        summary = "등록 (URL)",
         description = """
             상품 페이지 URL 을 받아 위시리스트에 등록한다. 메타데이터(이름/가격/이미지) 추출은 외부 LLM 호출이라
             오래 걸리므로 동기로 기다리지 않는다. 등록 즉시 item.status=PROCESSING 인 항목을 201 로 반환하고,
@@ -76,7 +76,7 @@ interface WishlistApi {
     ): ApiResponseBody<WishItemResponse>
 
     @Operation(
-        summary = "위시리스트 조회",
+        summary = "조회 (다건)",
         description = """
             로그인한 유저 본인의 위시리스트를 최신 등록순(id desc)으로 조회한다.
             cursor 페이지네이션: 직전 응답의 pageResponse.nextCursor 를 다음 요청 cursor 로 그대로 전달한다.
@@ -139,7 +139,7 @@ interface WishlistApi {
     ): ApiResponseBody<List<WishItemResponse>>
 
     @Operation(
-        summary = "위시리스트 단건 조회",
+        summary = "조회 (단건)",
         description = """
             wishId 로 위시 항목 하나를 조회한다. 응답 모양은 목록 조회 항목과 같은 WishItemResponse(wish + item).
             본인 위시만 조회 가능하며, item 을 직접 노출하지 않고 위시 소유 단위로 권한을 검증한다.
@@ -196,7 +196,7 @@ interface WishlistApi {
     ): ApiResponseBody<WishItemResponse>
 
     @Operation(
-        summary = "위시 항목 복구 (추출 실패 보정)",
+        summary = "복구 (추출 실패 보정)",
         description = """
             추출에 실패(item.status=FAILED)한 위시 항목의 상품 정보(이름·현재가·이미지·통화)를 사용자가 직접 채워 복구한다.
             들어온 필드만 갱신하며, 보정에 성공하면 status 가 READY 로 복구된다.
@@ -276,7 +276,7 @@ interface WishlistApi {
     ): ApiResponseBody<WishItemResponse>
 
     @Operation(
-        summary = "위시리스트 삭제",
+        summary = "삭제 (단건)",
         description = """
             위시 항목을 삭제한다(soft delete). 멱등 — 이미 없거나 삭제된 항목이면 아무 일도 하지 않고 성공한다.
             존재하는 항목은 본인 위시만 삭제 가능하다. 삭제된 항목은 조회 결과에서 제외된다.
@@ -322,7 +322,7 @@ interface WishlistApi {
     ): ApiResponseBody<Unit>
 
     @Operation(
-        summary = "위시리스트 다중 삭제",
+        summary = "삭제 (다건)",
         description = """
             위시 항목 여러 개를 한 번에 멱등 삭제한다(soft delete). 요청 목록 중 없거나 이미 삭제된 id 는
             무시하고(목표 상태 달성) 성공으로 처리한다. 단 존재하는 항목 중 본인 소유가 아닌 위시가 하나라도
@@ -383,7 +383,7 @@ interface WishlistApi {
     ): ApiResponseBody<Unit>
 
     @Operation(
-        summary = "위시리스트 이미지 등록 (다건)",
+        summary = "등록 (이미지)",
         description = """
             상품 페이지를 캡처한 이미지 1~5장을 받아, 각 이미지를 PROCESSING 상태의 위시 항목으로 즉시 등록하고 목록을 반환한다.
             실제 상품 정보 추출(Gemini Vision)은 백그라운드에서 비동기로 진행되어 각 항목을 READY 또는 FAILED 로 전이시킨다.

--- a/src/main/kotlin/com/depromeet/piki/wishlist/controller/WishlistApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/wishlist/controller/WishlistApiExamples.kt
@@ -22,7 +22,7 @@ class WishlistApiExamples(
     @Bean
     fun wishlistOpenApiExamples(): OperationCustomizer =
         OperationCustomizer { operation, handlerMethod ->
-            if (handlerMethod.binds(WishlistController::register)) {
+            if (handlerMethod.binds(WishlistController::registerFromUrl)) {
                 operation.examples(openApiObjectMapper.delegate) {
                     add(
                         status = HttpStatus.CREATED,

--- a/src/main/kotlin/com/depromeet/piki/wishlist/controller/WishlistController.kt
+++ b/src/main/kotlin/com/depromeet/piki/wishlist/controller/WishlistController.kt
@@ -31,11 +31,11 @@ class WishlistController(
 ) : WishlistApi {
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    override fun register(
+    override fun registerFromUrl(
         @AuthenticationPrincipal userId: UUID,
         @Valid @RequestBody request: WishlistRegisterRequest,
     ): ApiResponseBody<WishItemResponse> {
-        val result = wishlistService.register(rawUrl = request.url, userId = userId)
+        val result = wishlistService.registerFromUrl(rawUrl = request.url, userId = userId)
         return ApiResponseBody.created(WishItemResponse.from(result.wish, result.item))
     }
 

--- a/src/main/kotlin/com/depromeet/piki/wishlist/service/WishPersistenceService.kt
+++ b/src/main/kotlin/com/depromeet/piki/wishlist/service/WishPersistenceService.kt
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
 
-// WishlistService 의 register 가 외부 LLM 호출을 트랜잭션 바깥에 두도록
+// WishlistService 의 registerFromUrl 가 외부 LLM 호출을 트랜잭션 바깥에 두도록
 // 영속화만 별도 빈으로 분리. 같은 빈에서 호출하면 Spring AOP proxy 를
 // 거치지 않아 @Transactional 가 무력화되기 때문이다.
 @Service

--- a/src/main/kotlin/com/depromeet/piki/wishlist/service/WishlistService.kt
+++ b/src/main/kotlin/com/depromeet/piki/wishlist/service/WishlistService.kt
@@ -32,11 +32,11 @@ class WishlistService(
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
-    // register 는 외부 LLM 호출(read-timeout 60s)을 동기로 기다리지 않는다.
+    // registerFromUrl 는 외부 LLM 호출(read-timeout 60s)을 동기로 기다리지 않는다.
     // link 만 가진 PROCESSING item 을 즉시 저장해 응답을 돌려주고(클라이언트는 "담는 중" 표시),
     // 실제 파싱은 itemParsingWorker 가 백그라운드에서 수행해 READY/FAILED 로 전이시킨다.
     // URL 형식 같은 계약 위반은 ProductLink.parse 가 동기로 거른다(400). 파싱 결과 실패만 FAILED 로 간다.
-    fun register(
+    fun registerFromUrl(
         rawUrl: String,
         userId: UUID,
     ): WishWithItem {
@@ -51,7 +51,7 @@ class WishlistService(
         return result
     }
 
-    // 이미지 등록은 register(link)와 같은 비동기 흐름 — 입력이 이미지(다건)일 뿐이다.
+    // 이미지 등록은 registerFromUrl(link)와 같은 비동기 흐름 — 입력이 이미지(다건)일 뿐이다.
     // 개수·형식을 동기로 검증(400)한 뒤 PROCESSING item·wish 를 배치 저장해 즉시 반환하고,
     // 실제 추출(Gemini·크롭·S3)은 imageParsingWorker 가 백그라운드에서 각 이미지를 병렬 파싱해
     // READY/FAILED 로 전이시킨다. 토너먼트 아이템 이미지 등록과 동일한 패턴이다.


### PR DESCRIPTION
## Situation
- Swagger UI 의 `Wishlist` 탭에서 모든 엔드포인트 summary 가 "위시리스트 ..." 로 시작했다. 태그명이 이미 그룹을 나타내는데 각 항목마다 같은 접두어가 반복돼 노이즈였다.
- 그 반복 접두어에 가려, 정작 구분이 필요한 축(단건/다건, URL/이미지)이 summary 앞쪽에 묻혀 한눈에 들어오지 않았다.

## Task
- summary 7개를 태그 접두어 없이, **행위(등록/조회/삭제/복구)를 앞세우고 한정어를 괄호로** 붙여 같은 행위끼리 묶이게 통일한다. 표기만 손대고 동작은 건드리지 않는다.

## Action
- "위시리스트" 접두어를 전부 제거.
- 등록은 단/다건이 아니라 **입력 소스**로 갈리므로 `(URL)` / `(이미지)` 로 한정. 조회·삭제는 `(단건)` / `(다건)` 으로 한정. 복구는 단건뿐이라 한정어 없이 사유만 남겨 `복구 (추출 실패 보정)`.

  | 메서드 | before | after |
  |---|---|---|
  | `register` | 위시리스트 등록 | 등록 (URL) |
  | `registerFromImages` | 위시리스트 이미지 등록 (다건) | 등록 (이미지) |
  | `getWishlist` | 위시리스트 조회 | 조회 (다건) |
  | `getWish` | 위시리스트 단건 조회 | 조회 (단건) |
  | `deleteWish` | 위시리스트 삭제 | 삭제 (단건) |
  | `deleteWishes` | 위시리스트 다중 삭제 | 삭제 (다건) |
  | `recoverWishItem` | 위시 항목 복구 (추출 실패 보정) | 복구 (추출 실패 보정) |

- `@Operation` 의 `summary` 문자열만 변경. description · example payload · `@ApiResponses` · HTTP contract 는 그대로라 **API 동작·응답 형태 변화는 없다**. 다른 파일·테스트도 옛 summary 문구를 단언/참조하지 않음을 grep 으로 확인.
- 작업 중 Tournament 인터페이스도 동일한 접두어 반복 문제("토너먼트" 반복 + 토너먼트/아이템 행위 혼재)가 있음을 발견. 다만 담당 도메인 분리를 위해 이 PR 엔 포함하지 않고 **별도 PR 로 다룬다**. Auth · User 는 이미 접두어 반복이 없어 손대지 않음.

## Result
- `Wishlist` 탭이 행위별(등록/조회/삭제)로 자연스럽게 정렬돼 어떤 엔드포인트가 무엇을 단/다건·URL/이미지로 다루는지 한눈에 들어온다.
- 코드 변경은 summary 문자열 7개뿐. 로직·테스트·응답 contract 회귀 없음.

---
## 연관 이슈

- 


## Updates

### register → registerFromUrl 메서드 rename (2026-05-31)

summary 를 `등록 (URL)` / `등록 (이미지)` 로 대칭화하고 보니, 정작 메서드 이름이 `register` vs `registerFromImages` 로 비대칭이라 URL 등록이 "기본", 이미지 등록이 "곁다리"처럼 읽히는 문제가 남아 있었다. 개념을 코드 전반에서 같은 높이로 다루기 위해 rename.

- `register` → `registerFromUrl` 로 바꿔 URL/이미지 등록을 `registerFrom{Url,Images}` 로 대칭화. 인터페이스 시그니처·컨트롤러 override·서비스 메서드·`WishlistApiExamples` 의 method reference(`binds`)·관련 주석까지 일괄 적용 (`971679a`)
- HTTP 엔드포인트·요청/응답 contract 는 불변(식별자 rename). 컴파일로 override·method reference 정합성을 검증하고, 남은 단독 `register` 참조가 없음을 grep 으로 확인 (`971679a`)
