### PR TITLE
admin 백오피스 기능 요청 수집함

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/admin/feature/AdminFeatureRequest.kt
+++ b/src/main/kotlin/com/depromeet/piki/admin/feature/AdminFeatureRequest.kt
@@ -1,0 +1,63 @@
+package com.depromeet.piki.admin.feature
+
+import com.depromeet.piki.common.domain.LongBaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Table
+
+/**
+ * admin 백오피스 기능 요청 한 건. 팀원이 한 줄로 남기는 인박스 항목.
+ *
+ * 생성 검증(blank 금지·길이)은 [create] 팩토리에 모으고 주 생성자를 private 로 막는다 —
+ * kotlin("plugin.jpa") 의 no-arg 생성자가 invokeInitializers 로 init 블록을 실제 실행하는데,
+ * Hibernate 하이드레이션 시점엔 title 이 아직 안 채워져 init 의 require 가 깨지기 때문이다.
+ * 그래서 불변식을 init 이 아니라 팩토리에 둔다(Item 이 상태-의존 불변식을 from/markReady 에 둔 것과 같은 결).
+ */
+@Entity
+@Table(name = "admin_feature_requests")
+class AdminFeatureRequest private constructor(
+    title: String,
+    createdBy: String,
+) : LongBaseEntity() {
+    @Column(name = "title", nullable = false, length = TITLE_MAX_LENGTH)
+    var title: String = title
+        protected set
+
+    @Column(name = "created_by", nullable = false, length = 100)
+    val createdBy: String = createdBy
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 16)
+    var status: AdminFeatureRequestStatus = AdminFeatureRequestStatus.NEW
+        protected set
+
+    // 검토 완료 표시를 오간다. NEW↔DONE 토글 — 잘못 눌러도 한 번 더 누르면 원복된다.
+    // 도메인이 자기 상태 전이를 책임진다(서비스가 if 로 분기하지 않는다).
+    fun toggleStatus() {
+        status =
+            when (status) {
+                AdminFeatureRequestStatus.NEW -> AdminFeatureRequestStatus.DONE
+                AdminFeatureRequestStatus.DONE -> AdminFeatureRequestStatus.NEW
+            }
+    }
+
+    companion object {
+        const val TITLE_MAX_LENGTH = 200
+
+        // 유일한 생성 경로. 불변식(blank 금지·길이·작성자)을 여기서 검사한다.
+        // 검증 실패는 입력 경계(컨트롤러 폼·서비스)가 먼저 거르므로 정상 흐름에선 닿지 않는다 —
+        // 닿으면 폼을 우회한 호출이고, admin 도구라 require 로 막고 컨트롤러가 IllegalArgumentException 을 잡아 flash 로 보여준다.
+        fun create(
+            title: String,
+            createdBy: String,
+        ): AdminFeatureRequest {
+            val trimmed = title.trim()
+            require(trimmed.isNotBlank()) { "기능 요청 제목은 비어 있을 수 없습니다." }
+            require(trimmed.length <= TITLE_MAX_LENGTH) { "기능 요청 제목은 ${TITLE_MAX_LENGTH}자를 초과할 수 없습니다." }
+            require(createdBy.isNotBlank()) { "작성자(admin) 가 비어 있습니다." }
+            return AdminFeatureRequest(trimmed, createdBy)
+        }
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/admin/feature/AdminFeatureRequestController.kt
+++ b/src/main/kotlin/com/depromeet/piki/admin/feature/AdminFeatureRequestController.kt
@@ -1,0 +1,69 @@
+package com.depromeet.piki.admin.feature
+
+import com.depromeet.piki.admin.config.ConditionalOnAdminEnabled
+import io.swagger.v3.oas.annotations.Hidden
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.servlet.mvc.support.RedirectAttributes
+import java.security.Principal
+
+/**
+ * 백오피스 기능 요청 인박스 페이지.
+ *
+ * 모인 요청을 보여주고, 한 줄 제목으로 새 요청을 남기거나 처리 상태를 토글한다. 등록·토글은 PRG(POST-Redirect-Get)
+ * 패턴 — 성공/실패를 flash 로 전달해 새로고침 중복 제출을 막는다. `@Hidden` 으로 OpenAPI 문서에서 제외한다.
+ */
+@Controller
+@Hidden
+@ConditionalOnAdminEnabled
+class AdminFeatureRequestController(
+    private val service: AdminFeatureRequestService,
+) {
+    @GetMapping("/admin/feature-requests")
+    fun list(model: Model): String {
+        model.addAttribute("requests", service.recent())
+        return "admin/feature-requests"
+    }
+
+    @PostMapping("/admin/feature-requests")
+    fun create(
+        @RequestParam title: String,
+        principal: Principal,
+        redirectAttributes: RedirectAttributes,
+    ): String {
+        try {
+            service.create(title, principal.name)
+            redirectAttributes.addFlashAttribute("message", "기능 요청을 등록했습니다.")
+        } catch (e: IllegalArgumentException) {
+            // 폼 입력 검증 실패 — 사용자에게 사유를 보여주고 폼으로 돌려보낸다.
+            log.info("admin 기능 요청 등록 입력 오류: {}", e.message)
+            redirectAttributes.addFlashAttribute("error", e.message)
+        }
+        return "redirect:/admin/feature-requests"
+    }
+
+    @PostMapping("/admin/feature-requests/{id}/status")
+    fun toggleStatus(
+        @PathVariable id: Long,
+        principal: Principal,
+        redirectAttributes: RedirectAttributes,
+    ): String {
+        try {
+            service.toggleStatus(id, principal.name)
+            redirectAttributes.addFlashAttribute("message", "처리 상태를 변경했습니다.")
+        } catch (e: IllegalArgumentException) {
+            log.info("admin 기능 요청 상태 변경 오류: {}", e.message)
+            redirectAttributes.addFlashAttribute("error", e.message)
+        }
+        return "redirect:/admin/feature-requests"
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(AdminFeatureRequestController::class.java)
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/admin/feature/AdminFeatureRequestRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/admin/feature/AdminFeatureRequestRepository.kt
@@ -1,0 +1,22 @@
+package com.depromeet.piki.admin.feature
+
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.Repository
+
+/**
+ * 기능 요청 저장소. 삭제는 노출하지 않는다(인박스는 상태 토글로 닫지 물리 삭제하지 않는다).
+ *
+ * 넓은 JpaRepository 대신 save·조회만 가진 좁은 Repository 로 둔다(AdminAuditLogRepository 와 같은 결) —
+ * delete* 가 열리면 인박스 항목이 통째로 사라질 수 있다. 상태 변경은 managed 엔티티의 dirty checking 으로 반영된다.
+ */
+interface AdminFeatureRequestRepository : Repository<AdminFeatureRequest, Long> {
+    fun save(entity: AdminFeatureRequest): AdminFeatureRequest
+
+    fun findById(id: Long): AdminFeatureRequest?
+
+    // 삭제되지 않은 요청을 createdAt 내림차순으로 limit 개. 동률(같은 createdAt)에서 결과가 요청마다
+    // 달라지지 않도록 id 를 보조 정렬 키로 둔다(ItemJpaRepository.findRecent 와 같은 규약). limit 은 Pageable 로 주입.
+    @Query("select r from AdminFeatureRequest r where r.deletedAt is null order by r.createdAt desc, r.id desc")
+    fun findRecent(pageable: Pageable): List<AdminFeatureRequest>
+}

--- a/src/main/kotlin/com/depromeet/piki/admin/feature/AdminFeatureRequestService.kt
+++ b/src/main/kotlin/com/depromeet/piki/admin/feature/AdminFeatureRequestService.kt
@@ -1,0 +1,70 @@
+package com.depromeet.piki.admin.feature
+
+import com.depromeet.piki.admin.audit.AdminAuditService
+import com.depromeet.piki.admin.config.ConditionalOnAdminEnabled
+import org.springframework.data.domain.PageRequest
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * 개발 서버 백오피스의 기능 요청 인박스 작업.
+ *
+ * 조회는 readOnly, 등록·상태변경은 영속화 + 감사 기록을 한 트랜잭션으로 묶는다. 외부 호출이 없어 트랜잭션 안에서 끝낸다.
+ */
+@Service
+@ConditionalOnAdminEnabled
+class AdminFeatureRequestService(
+    private val repository: AdminFeatureRequestRepository,
+    private val auditService: AdminAuditService,
+) {
+    @Transactional(readOnly = true)
+    fun recent(limit: Int = DEFAULT_LIMIT): List<AdminFeatureRequest> =
+        repository.findRecent(PageRequest.of(0, limit.coerceIn(1, MAX_LIMIT)))
+
+    @Transactional
+    fun create(
+        title: String,
+        adminUsername: String,
+    ): AdminFeatureRequest {
+        val saved = repository.save(AdminFeatureRequest.create(title, adminUsername))
+        auditService.record(
+            adminUsername = adminUsername,
+            actionType = ACTION_CREATE,
+            toolName = TOOL_NAME,
+            parameters = mapOf("title" to saved.title),
+            resultStatus = "SUCCESS",
+            resultSummary = "id=${saved.getId()}",
+            requestMessage = null,
+        )
+        return saved
+    }
+
+    @Transactional
+    fun toggleStatus(
+        id: Long,
+        adminUsername: String,
+    ) {
+        // 정상 흐름은 목록의 토글 버튼으로만 닿지만, 다른 탭에서 이미 처리된 항목 등 경합으로는 없는 id 가 올 수 있다.
+        // admin 도구라 require 결과(IllegalArgumentException)를 컨트롤러가 잡아 flash 로 보여준다.
+        val request = repository.findById(id) ?: throw IllegalArgumentException("존재하지 않는 기능 요청입니다.")
+        request.toggleStatus()
+        // 명시 save 없이 managed 엔티티의 dirty checking 으로 트랜잭션 커밋 시 update 된다.
+        auditService.record(
+            adminUsername = adminUsername,
+            actionType = ACTION_TOGGLE_STATUS,
+            toolName = TOOL_NAME,
+            parameters = mapOf("id" to id, "status" to request.status.name),
+            resultStatus = "SUCCESS",
+            resultSummary = "id=$id, status=${request.status}",
+            requestMessage = null,
+        )
+    }
+
+    companion object {
+        const val DEFAULT_LIMIT = 50
+        private const val MAX_LIMIT = 200
+        private const val TOOL_NAME = "feature-requests"
+        private const val ACTION_CREATE = "CREATE_FEATURE_REQUEST"
+        private const val ACTION_TOGGLE_STATUS = "TOGGLE_FEATURE_REQUEST_STATUS"
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/admin/feature/AdminFeatureRequestStatus.kt
+++ b/src/main/kotlin/com/depromeet/piki/admin/feature/AdminFeatureRequestStatus.kt
@@ -1,0 +1,13 @@
+package com.depromeet.piki.admin.feature
+
+/**
+ * 기능 요청 처리 상태. 인박스 운영에 필요한 최소 두 단계만 둔다.
+ *
+ * NEW  — 막 접수돼 아직 검토 안 함.
+ * DONE — 검토 완료(이슈로 승격했거나 반려해 더 볼 필요 없음). "반려"와 "완료"를 따로 나누지 않는다 —
+ *        v1 인박스엔 "더 볼지 말지" 만 필요하고, 세부 사유는 승격된 GitHub 이슈가 가진다.
+ */
+enum class AdminFeatureRequestStatus {
+    NEW,
+    DONE,
+}

--- a/src/main/resources/db/migration/V20260531213259__create_admin_feature_requests.sql
+++ b/src/main/resources/db/migration/V20260531213259__create_admin_feature_requests.sql
@@ -1,0 +1,15 @@
+-- admin 백오피스 기능 요청 수집함. 팀원이 "있으면 하는 admin 기능" 을 한 줄로 남기는 인박스.
+-- 정책: FK 없음(admin 계정은 InMemory 라 users 와 무관) / 테이블명 복수형 / utf8mb4.
+-- created_at/updated_at/deleted_at 은 LongBaseEntity 컬럼 규약을 따른다(ddl-auto=validate 통과용).
+CREATE TABLE admin_feature_requests (
+    id          BIGINT       NOT NULL AUTO_INCREMENT,
+    title       VARCHAR(200) NOT NULL COMMENT '기능 요청 한 줄 제목',
+    status      VARCHAR(16)  NOT NULL COMMENT 'NEW(접수) / DONE(검토 완료)',
+    created_by  VARCHAR(100) NOT NULL COMMENT '작성 admin (InMemory 계정명)',
+    created_at  DATETIME(6)  NOT NULL,
+    updated_at  DATETIME(6)  NOT NULL,
+    deleted_at  DATETIME(6)  NULL,
+    PRIMARY KEY (id),
+    KEY idx_admin_feature_requests_created_at (created_at),
+    KEY idx_admin_feature_requests_status (status)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/src/main/resources/templates/admin/feature-requests.html
+++ b/src/main/resources/templates/admin/feature-requests.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{admin/fragments/layout :: head('기능 요청 - PIKI 백오피스')}"></head>
+<body>
+<div class="bo-shell">
+    <div th:replace="~{admin/fragments/layout :: sidebar('feature-requests')}"></div>
+    <main class="bo-main">
+        <header class="bo-header">
+            <h1>기능 요청</h1>
+        </header>
+        <section class="bo-content">
+            <p class="bo-desc">백오피스에 있으면 하는 기능을 한 줄로 남겨주세요. 모인 요청을 검토해 GitHub 이슈로 승격합니다.</p>
+            <p class="bo-message" th:if="${message}" th:text="${message}"></p>
+            <p class="bo-error" th:if="${error}" th:text="${error}"></p>
+
+            <div class="bo-panel">
+                <h2>요청 남기기</h2>
+                <form th:action="@{/admin/feature-requests}" method="post">
+                    <div class="bo-field">
+                        <label for="title">요청 내용 (한 줄, 최대 200자)</label>
+                        <input type="text" id="title" name="title" maxlength="200" required
+                               placeholder="예: item 목록에서 추출 실패(FAILED) 항목만 필터로 보기">
+                    </div>
+                    <button type="submit">등록</button>
+                </form>
+            </div>
+
+            <div class="bo-panel">
+                <h2>모인 요청</h2>
+                <table class="bo-table">
+                    <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>요청 내용</th>
+                        <th>상태</th>
+                        <th>작성자</th>
+                        <th>작성일</th>
+                        <th>처리</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr th:each="req : ${requests}">
+                        <td th:text="${req.idOrNull}">-</td>
+                        <td th:text="${req.title}">-</td>
+                        <td th:text="${req.status.name() == 'NEW'} ? '접수' : '처리됨'">-</td>
+                        <td th:text="${req.createdBy}">-</td>
+                        <td th:text="${req.createdAt}">-</td>
+                        <td>
+                            <form th:action="@{/admin/feature-requests/{id}/status(id=${req.idOrNull})}" method="post">
+                                <button type="submit"
+                                        th:text="${req.status.name() == 'NEW'} ? '처리함' : '되돌리기'">토글</button>
+                            </form>
+                        </td>
+                    </tr>
+                    <tr th:if="${#lists.isEmpty(requests)}">
+                        <td colspan="6">아직 등록된 요청이 없습니다.</td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+    </main>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/admin/fragments/layout.html
+++ b/src/main/resources/templates/admin/fragments/layout.html
@@ -21,6 +21,8 @@
     <nav class="bo-nav">
         <a th:href="@{/admin}" th:classappend="${active == 'home'} ? ' active' : ''">대시보드</a>
         <a th:href="@{/admin/items}" th:classappend="${active == 'items'} ? ' active' : ''">실험 데이터</a>
+        <a th:href="@{/admin/feature-requests}"
+           th:classappend="${active == 'feature-requests'} ? ' active' : ''">기능 요청</a>
     </nav>
     <form th:action="@{/admin/logout}" method="post" class="bo-logout">
         <button type="submit">로그아웃</button>

--- a/src/main/resources/templates/admin/home.html
+++ b/src/main/resources/templates/admin/home.html
@@ -15,6 +15,10 @@
                     <h2>실험 데이터</h2>
                     <p>샘플 상품을 추가하고 최근 등록된 item 을 조회합니다.</p>
                 </a>
+                <a th:href="@{/admin/feature-requests}" class="bo-card">
+                    <h2>기능 요청</h2>
+                    <p>백오피스에 있으면 하는 기능을 남기고 모인 요청을 검토합니다.</p>
+                </a>
                 <div class="bo-card bo-card-disabled">
                     <h2>추가 기능</h2>
                     <p>백오피스 기능이 순차적으로 추가될 예정입니다.</p>

--- a/src/test/kotlin/com/depromeet/piki/admin/feature/AdminFeatureRequestControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/admin/feature/AdminFeatureRequestControllerIntegrationTest.kt
@@ -1,0 +1,121 @@
+package com.depromeet.piki.admin.feature
+
+import com.depromeet.piki.admin.audit.AdminAuditLogRepository
+import com.depromeet.piki.support.IntegrationTestSupport
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.domain.PageRequest
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.flash
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.context.WebApplicationContext
+import kotlin.test.assertEquals
+
+@Transactional
+class AdminFeatureRequestControllerIntegrationTest : IntegrationTestSupport() {
+    @Autowired
+    private lateinit var webApplicationContext: WebApplicationContext
+
+    @Autowired
+    private lateinit var repository: AdminFeatureRequestRepository
+
+    @Autowired
+    private lateinit var adminAuditLogRepository: AdminAuditLogRepository
+
+    private fun mockMvc(): MockMvc =
+        MockMvcBuilders
+            .webAppContextSetup(webApplicationContext)
+            .apply<DefaultMockMvcBuilder>(springSecurity())
+            .build()
+
+    @Test
+    fun `미인증으로 기능 요청 페이지에 접근하면 로그인 페이지로 리다이렉트된다`() {
+        mockMvc()
+            .perform(get("/admin/feature-requests"))
+            .andExpect(status().is3xxRedirection)
+    }
+
+    @Test
+    fun `로그인하면 기능 요청 페이지가 200 으로 렌더된다`() {
+        mockMvc()
+            .perform(get("/admin/feature-requests").with(user("admin").roles("ADMIN")))
+            .andExpect(status().isOk)
+    }
+
+    @Test
+    fun `CSRF 토큰 없이 요청을 등록하면 403 이 반환된다`() {
+        mockMvc()
+            .perform(
+                post("/admin/feature-requests")
+                    .with(user("admin").roles("ADMIN"))
+                    .param("title", "새 기능"),
+            ).andExpect(status().isForbidden)
+    }
+
+    @Test
+    fun `요청을 등록하면 NEW 로 저장되고 감사 로그에 SUCCESS 로 기록된 뒤 목록으로 리다이렉트된다`() {
+        mockMvc()
+            .perform(
+                post("/admin/feature-requests")
+                    .with(user("admin").roles("ADMIN"))
+                    .with(csrf())
+                    .param("title", "item 목록 추출 실패 필터"),
+            ).andExpect(status().is3xxRedirection)
+            .andExpect(redirectedUrl("/admin/feature-requests"))
+            .andExpect(flash().attributeExists("message"))
+
+        val saved = repository.findRecent(PageRequest.of(0, 10))
+        assertEquals(1, saved.size)
+        assertEquals("item 목록 추출 실패 필터", saved.first().title)
+        assertEquals(AdminFeatureRequestStatus.NEW, saved.first().status)
+
+        // findAll 은 순서를 보장하지 않으므로 방금 요청의 로그를 action/tool 로 특정해 단언한다.
+        val log =
+            adminAuditLogRepository.findAll().single {
+                it.toolName == "feature-requests" && it.actionType == "CREATE_FEATURE_REQUEST"
+            }
+        assertEquals("SUCCESS", log.resultStatus)
+        assertEquals("admin", log.adminUsername)
+    }
+
+    @Test
+    fun `공백만 있는 제목으로 등록하면 저장되지 않고 오류 메시지와 함께 리다이렉트된다`() {
+        mockMvc()
+            .perform(
+                post("/admin/feature-requests")
+                    .with(user("admin").roles("ADMIN"))
+                    .with(csrf())
+                    .param("title", "   "),
+            ).andExpect(status().is3xxRedirection)
+            .andExpect(redirectedUrl("/admin/feature-requests"))
+            .andExpect(flash().attributeExists("error"))
+
+        assertEquals(0, repository.findRecent(PageRequest.of(0, 10)).size)
+    }
+
+    @Test
+    fun `상태를 토글하면 NEW 에서 DONE 으로 바뀐다`() {
+        val saved = repository.save(AdminFeatureRequest.create("토글 대상", "admin"))
+        val id = saved.getId()
+
+        mockMvc()
+            .perform(
+                post("/admin/feature-requests/{id}/status", id)
+                    .with(user("admin").roles("ADMIN"))
+                    .with(csrf()),
+            ).andExpect(status().is3xxRedirection)
+            .andExpect(redirectedUrl("/admin/feature-requests"))
+            .andExpect(flash().attributeExists("message"))
+
+        assertEquals(AdminFeatureRequestStatus.DONE, repository.findById(id)?.status)
+    }
+}

--- a/src/test/kotlin/com/depromeet/piki/admin/feature/AdminFeatureRequestTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/admin/feature/AdminFeatureRequestTest.kt
@@ -1,0 +1,57 @@
+package com.depromeet.piki.admin.feature
+
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class AdminFeatureRequestTest {
+    @Test
+    fun `제목과 작성자로 생성하면 NEW 상태로 시작한다`() {
+        val request = AdminFeatureRequest.create("item 목록 추출 실패 필터", "admin")
+
+        assertEquals(AdminFeatureRequestStatus.NEW, request.status)
+        assertEquals("item 목록 추출 실패 필터", request.title)
+        assertEquals("admin", request.createdBy)
+    }
+
+    @Test
+    fun `제목 앞뒤 공백은 제거되어 저장된다`() {
+        val request = AdminFeatureRequest.create("   여백 있는 제목   ", "admin")
+
+        assertEquals("여백 있는 제목", request.title)
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["", "   ", "\t", "\n"])
+    fun `빈 제목이나 공백만 있는 제목으로 생성하면 예외가 발생한다`(blank: String) {
+        assertFailsWith<IllegalArgumentException> { AdminFeatureRequest.create(blank, "admin") }
+    }
+
+    @Test
+    fun `200자 제목은 허용되고 201자는 예외가 발생한다`() {
+        val maxTitle = "가".repeat(AdminFeatureRequest.TITLE_MAX_LENGTH)
+
+        assertEquals(AdminFeatureRequest.TITLE_MAX_LENGTH, AdminFeatureRequest.create(maxTitle, "admin").title.length)
+        assertFailsWith<IllegalArgumentException> {
+            AdminFeatureRequest.create("가".repeat(AdminFeatureRequest.TITLE_MAX_LENGTH + 1), "admin")
+        }
+    }
+
+    @Test
+    fun `작성자가 비어 있으면 예외가 발생한다`() {
+        assertFailsWith<IllegalArgumentException> { AdminFeatureRequest.create("제목", "") }
+    }
+
+    @Test
+    fun `toggleStatus 는 NEW 와 DONE 을 오간다`() {
+        val request = AdminFeatureRequest.create("제목", "admin")
+
+        request.toggleStatus()
+        assertEquals(AdminFeatureRequestStatus.DONE, request.status)
+
+        request.toggleStatus()
+        assertEquals(AdminFeatureRequestStatus.NEW, request.status)
+    }
+}


### PR DESCRIPTION
## Situation
- admin 백오피스에 다음으로 무슨 기능을 넣을지 불확실했다. 후보(상품·토너먼트 조회·생성, 추출 디버깅 등)를 우선순위로 추측해 나열하던 중, 데이터 "생성"형 기능(샘플 상품 추가 등)은 클라이언트가 완성되면 효용이 죽는다는 점이 드러났다.
- "토너먼트 진행 직전 상황 만들기" 같은 QA 시드도 검토했으나, 결국 DB 쿼리·테스트 픽스처로 되는 수준이면 admin UI 로 만들 가치가 낮다는 결론에 닿았다.

## Task
- 무엇을 만들지 "추측"하는 비용을 "수집"으로 대체한다. admin 을 쓰는 팀원이 필요한 기능을 그 자리에서 한 줄로 남기고, 모인 요청을 보고 우선순위를 정한다.
- 데이터 생성형(한시적 가치)이 아니라, 클라이언트 완성 후에도 사는 영구 가치 도구를 먼저 만든다.

## Action
### 설계 결정
- 수집 범위를 admin 기능 요청 전용으로 좁혔다 — GitHub 이슈·Notion 과 역할이 겹치지 않게, "admin 을 쓰다 떠오른 admin 개선 아이디어를 맥락 안 잃고 0마찰로 남기는 인박스"로 한정했다. 진짜배기는 GitHub 이슈로 승격하는 초안 단계다.
- 입력은 제목 한 줄만. 상세는 승격 시 이슈에서 작성한다.
- 상태는 NEW/DONE 두 단계만 — 인박스엔 "더 볼지 말지"만 필요하고 세부 사유는 승격된 이슈가 가진다.

### 구현
- 엔티티 검증을 정적 팩토리 `create()` 에 모으고 주 생성자를 private 로 막았다 — `plugin.jpa` 의 `invokeInitializers` 가 `init` 블록을 하이드레이션 시점에 실행해, `init` 에 둔 `require` 가 `Item` 처럼 깨지기 때문이다(`Item` 이 상태-의존 불변식을 `from`·`markReady` 로 뺀 것과 같은 결).
- 물리 삭제를 막기 위해 넓은 `JpaRepository` 대신 save·조회만 가진 좁은 `Repository` 로 뒀다(`AdminAuditLogRepository` 와 같은 패턴). 상태 토글은 managed 엔티티 dirty checking 으로 반영된다.
- 등록·토글 모두 PRG(POST-Redirect-Get) 패턴, 기존 `AdminAuditService` 로 모든 작업을 감사 기록, `@ConditionalOnAdminEnabled` 로 dev 전용·운영 자동 비활성.
- 사이드바·홈 카드에 메뉴를 더하고, admin 도메인 컨벤션(`require` + 컨트롤러 `catch(IllegalArgumentException)` → flash)을 `AdminItemController` 와 일관되게 따랐다.

### 검토했으나 채택하지 않음
- 토너먼트 시드(특정 라운드로 점프) 기능 — QA 셋업 비용이 크긴 하나(16강이면 외부 추출 16회 + 매치 14회), 결국 DB 쿼리·픽스처로 되는 개발자용이라 admin UI 대신 보류했다.

## Result
- dev 서버 백오피스에 기능 요청 인박스가 추가됐다(`GET /admin/feature-requests` 목록·등록 폼, `POST` 등록, `POST /{id}/status` 상태 토글). 모든 작업은 감사 로그로 추적된다.
- 단위 9건 + 통합 6건 테스트 통과, 전체 회귀 통과.
- 운영 전제: 입력이 0마찰이고 모인 요청을 주기적으로 본다는 두 조건이 충족돼야 ROI 가 양수다. 안 보면 죽은 폼이 되므로 검토 → 이슈 승격 루틴이 따라야 한다.

---
## 연관 이슈

- 
