### PR TITLE
전역 예외 핸들링 — 표준 MVC 예외를 500 대신 올바른 4xx 로 매핑

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/common/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/depromeet/piki/common/exception/GlobalExceptionHandler.kt
@@ -2,14 +2,23 @@ package com.depromeet.piki.common.exception
 
 import com.depromeet.piki.common.response.ApiResponseBody
 import org.slf4j.LoggerFactory
+import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatusCode
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.context.request.WebRequest
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
 
+// ResponseEntityExceptionHandler 를 상속해 Spring 표준 MVC 예외(HttpMessageNotReadable·메서드 미지원·
+// 미디어타입 미지원·필수 파라미터 누락·타입 불일치 등)를 올바른 4xx 로 처리한다.
+// 상속 전에는 이들이 아래 catch-all `Exception` 에 먼저 잡혀 전부 500 으로 샜다 — 클라이언트 입력 실수가
+// 서버 오류로 응답되던 전역 갭(#300). RESEH 의 표준 핸들러가 status 를 정하고, handleExceptionInternal
+// override 가 응답 바디만 우리 ApiResponseBody 포맷으로 통일한다. catch-all 은 예상 못한 서버 버그만 500.
 @RestControllerAdvice
-class GlobalExceptionHandler {
+class GlobalExceptionHandler : ResponseEntityExceptionHandler() {
     private val log = LoggerFactory.getLogger(javaClass)
 
     @ExceptionHandler(BaseException::class)
@@ -20,21 +29,6 @@ class GlobalExceptionHandler {
         return ResponseEntity
             .status(status)
             .body(ApiResponseBody.fail(category, status, e.message))
-    }
-
-    @ExceptionHandler(MethodArgumentNotValidException::class)
-    fun handleValidation(e: MethodArgumentNotValidException): ResponseEntity<ApiResponseBody<Nothing>> {
-        // 첫 번째 위반 필드만 사용자 메시지로 노출. 나머지는 로그로.
-        // 응답 스키마는 다른 4xx 와 동일하게 ApiResponseBody 로 통일한다.
-        val first = e.bindingResult.fieldErrors.firstOrNull()
-        val detail =
-            first
-                ?.let { "${it.field}: ${it.defaultMessage ?: "유효하지 않은 값입니다."}" }
-                ?: "요청 본문 검증 실패"
-        log.info("[ValidationException] {}", e.bindingResult.fieldErrors)
-        return ResponseEntity
-            .status(HttpStatus.BAD_REQUEST)
-            .body(ApiResponseBody.fail(ErrorCategory.INVALID_INPUT, HttpStatus.BAD_REQUEST, detail))
     }
 
     @ExceptionHandler(IllegalArgumentException::class)
@@ -52,4 +46,47 @@ class GlobalExceptionHandler {
             .status(HttpStatus.INTERNAL_SERVER_ERROR)
             .body(ApiResponseBody.fail(ErrorCategory.SERVER_ERROR, HttpStatus.INTERNAL_SERVER_ERROR))
     }
+
+    // RESEH 의 모든 표준 예외 핸들러가 최종적으로 이 메서드를 거쳐 응답 바디를 만든다 → ApiResponseBody 로 통일.
+    // status 는 RESEH 가 정한 값을 그대로 쓰고(예: HttpMessageNotReadable→400, 메서드 미지원→405, 미디어타입→415),
+    // 바디만 우리 래퍼로 교체한다.
+    override fun handleExceptionInternal(
+        ex: Exception,
+        body: Any?,
+        headers: HttpHeaders,
+        statusCode: HttpStatusCode,
+        request: WebRequest,
+    ): ResponseEntity<Any>? {
+        val status = HttpStatus.valueOf(statusCode.value())
+        // 5xx 는 서버 버그 신호이므로 스택 트레이스와 함께 error 로, 4xx(클라 계약 위반)는 info 로 남긴다.
+        if (status.is5xxServerError) {
+            log.error("[{}] {}", ex.javaClass.simpleName, ex.message, ex)
+        } else {
+            log.info("[{}] {} → {}", ex.javaClass.simpleName, ex.message, status.value())
+        }
+        val wrapped: ApiResponseBody<Nothing> = ApiResponseBody.fail(categoryOf(status), status, detailOf(ex))
+        return ResponseEntity.status(statusCode).headers(headers).body(wrapped)
+    }
+
+    // status → 우리 ErrorCategory. 인증/권한/리소스/충돌은 각자, 그 외 4xx 는 입력 오류, 5xx 는 서버 오류.
+    private fun categoryOf(status: HttpStatus): ErrorCategory =
+        when {
+            status == HttpStatus.UNAUTHORIZED -> ErrorCategory.UNAUTHORIZED
+            status == HttpStatus.FORBIDDEN -> ErrorCategory.FORBIDDEN
+            status == HttpStatus.NOT_FOUND -> ErrorCategory.NOT_FOUND
+            status == HttpStatus.CONFLICT -> ErrorCategory.CONFLICT
+            status.is4xxClientError -> ErrorCategory.INVALID_INPUT
+            else -> ErrorCategory.SERVER_ERROR
+        }
+
+    // 검증 실패만 첫 위반 필드를 노출해 사용자 수정을 돕는다. 그 외 표준 예외는 내부 메시지(파서 세부 등)를
+    // 노출하지 않도록 null 로 두어, fail 이 category 의 고정 문구로 응답하게 한다(detail 노이즈·정보 누출 방지).
+    private fun detailOf(ex: Exception): String? =
+        when (ex) {
+            is MethodArgumentNotValidException ->
+                ex.bindingResult.fieldErrors.firstOrNull()
+                    ?.let { "${it.field}: ${it.defaultMessage ?: "유효하지 않은 값입니다."}" }
+                    ?: "요청 본문 검증 실패"
+            else -> null
+        }
 }

--- a/src/test/kotlin/com/depromeet/piki/common/exception/GlobalExceptionHandlerIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/common/exception/GlobalExceptionHandlerIntegrationTest.kt
@@ -1,0 +1,84 @@
+package com.depromeet.piki.common.exception
+
+import com.depromeet.piki.support.IntegrationTestSupport
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.context.WebApplicationContext
+import tools.jackson.databind.ObjectMapper
+
+// Spring 표준 MVC 예외가 catch-all 에 먹혀 전부 500 으로 새던 갭(#300)의 회귀 가드.
+// 각 케이스가 (1) 올바른 4xx status (2) ApiResponseBody contract(status·code·detail) 를 단언한다.
+@Transactional
+class GlobalExceptionHandlerIntegrationTest : IntegrationTestSupport() {
+    @Autowired
+    private lateinit var webApplicationContext: WebApplicationContext
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    private fun mockMvc(): MockMvc =
+        MockMvcBuilders
+            .webAppContextSetup(webApplicationContext)
+            .apply<DefaultMockMvcBuilder>(springSecurity())
+            .build()
+
+    @Test
+    fun `깨진 JSON body 는 500 이 아니라 400 으로 매핑된다`() {
+        mockMvc()
+            .perform(
+                post("/api/v1/auth/login/google").contentType(MediaType.APPLICATION_JSON).content("{ broken json "),
+            ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value("BAD_REQUEST"))
+            .andExpect(jsonPath("$.detail").isString)
+    }
+
+    @Test
+    fun `지원하지 않는 Content-Type 은 500 이 아니라 415 로 매핑된다`() {
+        mockMvc()
+            .perform(
+                post("/api/v1/auth/login/google").contentType(MediaType.TEXT_PLAIN).content("hello"),
+            ).andExpect(status().isUnsupportedMediaType)
+            .andExpect(jsonPath("$.status").value(415))
+            .andExpect(jsonPath("$.code").value("UNSUPPORTED_MEDIA_TYPE"))
+    }
+
+    @Test
+    fun `refresh 의 malformed body 는 500 이 아니라 400 으로 매핑된다`() {
+        mockMvc()
+            .perform(
+                post("/api/v1/auth/token/refresh").contentType(MediaType.APPLICATION_JSON).content("{ bad "),
+            ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value("BAD_REQUEST"))
+    }
+
+    @Test
+    fun `경로변수 타입 불일치(UUID 자리에 문자열)는 500 이 아니라 400 으로 매핑된다`() {
+        // /api/v1/dev/{userId}/token 은 GUEST 권한이 필요하므로 게스트 토큰으로 통과시킨 뒤,
+        // userId 자리에 UUID 가 아닌 문자열을 넣어 MethodArgumentTypeMismatchException 을 유발한다.
+        val guestResponse =
+            mockMvc()
+                .perform(post("/api/v1/auth/guest").header("X-Client-Type", "app"))
+                .andReturn()
+                .response.contentAsString
+        val guestToken = objectMapper.readTree(guestResponse).at("/data/accessToken").asString()
+
+        mockMvc()
+            .perform(
+                post("/api/v1/dev/not-a-uuid/token").header(HttpHeaders.AUTHORIZATION, "Bearer $guestToken"),
+            ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value("BAD_REQUEST"))
+    }
+}

--- a/src/test/kotlin/com/depromeet/piki/common/exception/GlobalExceptionHandlerIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/common/exception/GlobalExceptionHandlerIntegrationTest.kt
@@ -1,12 +1,14 @@
 package com.depromeet.piki.common.exception
 
 import com.depromeet.piki.support.IntegrationTestSupport
+import org.hamcrest.Matchers.containsString
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -80,5 +82,41 @@ class GlobalExceptionHandlerIntegrationTest : IntegrationTestSupport() {
             ).andExpect(status().isBadRequest)
             .andExpect(jsonPath("$.status").value(400))
             .andExpect(jsonPath("$.code").value("BAD_REQUEST"))
+    }
+
+    @Test
+    fun `검증 실패(@Valid 위반)는 400 으로 매핑되고 detail 에 첫 필드 에러를 노출한다`() {
+        // refresh 는 @Valid + TokenRefreshRequest(@NotBlank) 라, refreshToken 이 빈 문자열이면
+        // MethodArgumentNotValidException → detailOf 가 "{field}: ..." 를 노출하는 분기를 탄다.
+        mockMvc()
+            .perform(
+                post("/api/v1/auth/token/refresh")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"refreshToken":""}"""),
+            ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value("BAD_REQUEST"))
+            .andExpect(jsonPath("$.detail", containsString("refreshToken")))
+    }
+
+    @Test
+    fun `POST 전용 엔드포인트에 GET 하면 500 이 아니라 405 로 매핑된다`() {
+        // /api/v1/dev/{userId}/token 은 POST 전용 + GUEST 권한 필요. 게스트 토큰으로 보안을 통과시킨 뒤
+        // GET 으로 호출해 HttpRequestMethodNotSupportedException(405) 을 유발한다.
+        val guest =
+            objectMapper.readTree(
+                mockMvc()
+                    .perform(post("/api/v1/auth/guest").header("X-Client-Type", "app"))
+                    .andReturn()
+                    .response.contentAsString,
+            )
+        val guestId = guest.at("/data/user/id").asString()
+        val guestToken = guest.at("/data/accessToken").asString()
+
+        mockMvc()
+            .perform(get("/api/v1/dev/$guestId/token").header(HttpHeaders.AUTHORIZATION, "Bearer $guestToken"))
+            .andExpect(status().isMethodNotAllowed)
+            .andExpect(jsonPath("$.status").value(405))
+            .andExpect(jsonPath("$.code").value("METHOD_NOT_ALLOWED"))
     }
 }


### PR DESCRIPTION
## Situation
- #162(소셜 로그인)·#166(cookie/body) 작업 중 발견: 잘못된 요청에도 500 이 나는 케이스. 로컬에서 `POST /auth/login` 에 body 없이 보냈더니 `Required request body is missing` → 500. refresh API 의 malformed body 도 같은 증상.
- 원인은 전역 — `GlobalExceptionHandler` 의 catch-all `@ExceptionHandler(Exception)` 이 Spring 표준 MVC 예외(HttpMessageNotReadable·메서드 미지원·미디어타입·타입 불일치 등)를 먼저 가로채, 본래 4xx 여야 할 게 전부 500 으로 응답됐다.

## Task
- 내 엔드포인트(auth·oauth·user·dev)의 잘못된 500 을 올바른 4xx 로 고친다.
- `GlobalExceptionHandler` 는 전역 컴포넌트라 한 번 고치면 전 엔드포인트에 적용된다 → 전수조사했더니 내 것뿐 아니라 wishlist·item, tournament 도 같은 갭이었다. 어차피 공유 핸들러라 한 번에 같이 해결.

## Action
- `GlobalExceptionHandler` 가 `ResponseEntityExceptionHandler` 를 상속 → 표준 MVC 예외가 올바른 status 로: 깨진/빈 body·필수 파라미터 누락·path 변수 타입 불일치 → 400, 메서드 미지원 → 405, Content-Type 미지원 → 415.
- `handleExceptionInternal` override 로 응답 바디만 우리 `ApiResponseBody`(status·code·detail) 로 통일. catch-all `Exception` 은 "예상 못한 서버 버그"만 500.
- 로깅 유지: 5xx 는 스택트레이스+error, 4xx 는 info. detail 은 내부 메시지 노출 대신 category 고정 문구(검증 실패만 첫 위반 필드).
- 기존 `handleValidation(MethodArgumentNotValid)` 제거 — RESEH 가 처리, detail·code(BAD_REQUEST) 는 동일 보존.
- refresh API(@RequestBody nullable)의 malformed/`{}` body 500→400 도 함께.
- 통합 테스트(`GlobalExceptionHandlerIntegrationTest`): 깨진 JSON 400 · Content-Type 415 · refresh malformed 400 · path 변수 타입 불일치 400 회귀 가드.

## Result
- **파일은 `GlobalExceptionHandler.kt` 하나 + 테스트만. 남의 파일은 한 줄도 안 건드림.** 전역 공유라 아래 엔드포인트의 malformed-요청 응답이 **500 → 올바른 4xx 로 개선**(순수 개선, 깨지는 동작 없음):
  - 내 영역: `auth/login`, `token/refresh`, `users/me`(PATCH·nickname/check), `dev/{userId}/token`, `dev/users/{userId}`
  - wishlist·item, tournament — @RequestBody·path 변수 엔드포인트
- 전체 테스트 스위트 통과 (위 영역 테스트 포함 전부 초록). "malformed 입력에 500" 을 단언한 테스트가 없었으므로 의도된 500 아니었음.
- 🙏 @m-a-king @1o18z — 의도된 동작인지 아닌지는 제가 판단 못 해서, 일단 제 엔드포인트 고치는 김에 전역 핸들러라 같이 걸렸습니다. wishlist·item·tournament 의 malformed/타입오류 요청 응답이 500→4xx 로 바뀌니, 혹시 의도와 어긋나는 곳 있으면 봐주세요. (per-endpoint `@ApiResponses` 에 새 400/415 일괄 문서화는 framework 4xx 라 후속/팀 합의로 둠)

---
## 연관 이슈

- close #300


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 전역 예외 응답을 일관된 API 응답 바디로 통합하여 모든 예외에 대해 표준화된 상태·코드·detail 구조 반환
  * 검증 오류는 400으로, 지원하지 않는 콘텐츠/메서드/경로 변수 오류 등은 적절한 4xx 상태로 일관되게 매핑
  * 검증 실패 시 첫 필드 에러를 detail에 포함하여 사용자에게 명확한 오류 정보 제공

* **테스트**
  * 다양한 잘못된 요청 시나리오(잘못된 JSON, 콘텐츠형식, malformed body, 경로변수 타입 불일치, `@Valid` 위반, 잘못된 메서드)에 대한 통합 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->