### PR TITLE
Wishlist API summary 에 위시리스트 접두어 복원

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/wishlist/controller/WishlistApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/wishlist/controller/WishlistApi.kt
@@ -18,7 +18,7 @@ import java.util.UUID
 @Tag(name = "Wishlist", description = "위시리스트 등록/조회/복구/삭제 API")
 interface WishlistApi {
     @Operation(
-        summary = "등록 (URL)",
+        summary = "위시리스트 등록 (URL)",
         description = """
             상품 페이지 URL 을 받아 위시리스트에 등록한다. 메타데이터(이름/가격/이미지) 추출은 외부 LLM 호출이라
             오래 걸리므로 동기로 기다리지 않는다. 등록 즉시 item.status=PROCESSING 인 항목을 201 로 반환하고,
@@ -76,7 +76,7 @@ interface WishlistApi {
     ): ApiResponseBody<WishItemResponse>
 
     @Operation(
-        summary = "조회 (다건)",
+        summary = "위시리스트 조회 (다건)",
         description = """
             로그인한 유저 본인의 위시리스트를 최신 등록순(id desc)으로 조회한다.
             cursor 페이지네이션: 직전 응답의 pageResponse.nextCursor 를 다음 요청 cursor 로 그대로 전달한다.
@@ -139,7 +139,7 @@ interface WishlistApi {
     ): ApiResponseBody<List<WishItemResponse>>
 
     @Operation(
-        summary = "조회 (단건)",
+        summary = "위시리스트 조회 (단건)",
         description = """
             wishId 로 위시 항목 하나를 조회한다. 응답 모양은 목록 조회 항목과 같은 WishItemResponse(wish + item).
             본인 위시만 조회 가능하며, item 을 직접 노출하지 않고 위시 소유 단위로 권한을 검증한다.
@@ -196,7 +196,7 @@ interface WishlistApi {
     ): ApiResponseBody<WishItemResponse>
 
     @Operation(
-        summary = "복구 (추출 실패 보정)",
+        summary = "위시 항목 복구 (추출 실패 보정)",
         description = """
             추출에 실패(item.status=FAILED)한 위시 항목의 상품 정보를 사용자가 직접 채워 복구한다(multipart/form-data).
             텍스트(이름·현재가·통화)는 form 필드로, 이미지는 image 파트로 받는다 — 이미지는 URL 이 아니라 파일로만 받아
@@ -290,7 +290,7 @@ interface WishlistApi {
     ): ApiResponseBody<WishItemResponse>
 
     @Operation(
-        summary = "삭제 (단건)",
+        summary = "위시리스트 삭제 (단건)",
         description = """
             위시 항목을 삭제한다(soft delete). 멱등 — 이미 없거나 삭제된 항목이면 아무 일도 하지 않고 성공한다.
             존재하는 항목은 본인 위시만 삭제 가능하다. 삭제된 항목은 조회 결과에서 제외된다.
@@ -336,7 +336,7 @@ interface WishlistApi {
     ): ApiResponseBody<Unit>
 
     @Operation(
-        summary = "삭제 (다건)",
+        summary = "위시리스트 삭제 (다건)",
         description = """
             위시 항목 여러 개를 한 번에 멱등 삭제한다(soft delete). 요청 목록 중 없거나 이미 삭제된 id 는
             무시하고(목표 상태 달성) 성공으로 처리한다. 단 존재하는 항목 중 본인 소유가 아닌 위시가 하나라도
@@ -397,7 +397,7 @@ interface WishlistApi {
     ): ApiResponseBody<Unit>
 
     @Operation(
-        summary = "등록 (이미지)",
+        summary = "위시리스트 등록 (이미지)",
         description = """
             상품 페이지를 캡처한 이미지 1~5장을 받아, 각 이미지를 PROCESSING 상태의 위시 항목으로 즉시 등록하고 목록을 반환한다.
             실제 상품 정보 추출(Gemini Vision)은 백그라운드에서 비동기로 진행되어 각 항목을 READY 또는 FAILED 로 전이시킨다.


### PR DESCRIPTION
## Situation
- PR #314 에서 Wishlist API 의 summary 에서 "위시리스트" 접두어를 떼고 `등록 (URL)` · `조회 (단건)` 식으로 정리해 dev 에 머지됐다.
- 이후 "태그(`Wishlist`) 밖 맥락(목록 외 화면·검색 등)에서는 어느 도메인 동작인지 안 드러나 접두어가 필요하다"는 피드백을 받았다. 다만 `(URL)` · `(단건)` 같은 **괄호 한정어 스타일은 좋다**는 평가였다.

## Task
- summary 에 `위시리스트` 접두어를 **복원**하되, 괄호 한정어 스타일은 **유지**한다. (접두어 제거만 되돌리는 부분 forward-fix)

## Action
- summary 7개를 `위시리스트 ... (한정어)` 로 되돌렸다:

  | 메서드 | #314 (현재 dev) | 이 PR |
  |---|---|---|
  | `registerFromUrl` | 등록 (URL) | 위시리스트 등록 (URL) |
  | `registerFromImages` | 등록 (이미지) | 위시리스트 등록 (이미지) |
  | `getWishlist` | 조회 (다건) | 위시리스트 조회 (다건) |
  | `getWish` | 조회 (단건) | 위시리스트 조회 (단건) |
  | `deleteWish` | 삭제 (단건) | 위시리스트 삭제 (단건) |
  | `deleteWishes` | 삭제 (다건) | 위시리스트 삭제 (다건) |
  | `recoverWishItem` | 복구 (추출 실패 보정) | 위시 항목 복구 (추출 실패 보정) |

- 복구는 위시 항목(item) 단위 보정이라 `위시 항목 복구 (추출 실패 보정)` 로 뒀다.
- `@Operation` 의 `summary` 문자열만 변경 — `register→registerFromUrl` 같은 #314 의 메서드 rename 은 그대로 두고, **눈에 보이는 부제만** 손봤다. 동작·응답 contract 불변.

## Result
- 탭 밖에서도 도메인이 드러나면서, 괄호 한정어로 입력 소스·조회 범위를 구분하는 효과는 그대로 유지된다.
- 코드 변경은 summary 문자열 7개뿐.

---
## 연관 이슈

- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 문서
- 위시리스트 API 엔드포인트의 Swagger/OpenAPI 문서 레이블이 업데이트되었습니다. URL 등록, 조회, 복구, 삭제, 이미지 등록 등 각 기능의 설명이 더 명확해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->