### PR TITLE
닉네임 자동 생성을 단일 IN 쿼리로 교체해 500 방지

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/user/repository/UserJpaRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/user/repository/UserJpaRepository.kt
@@ -2,6 +2,8 @@ package com.depromeet.piki.user.repository
 
 import com.depromeet.piki.user.domain.User
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import java.util.UUID
 
 interface UserJpaRepository : JpaRepository<User, UUID> {
@@ -11,4 +13,9 @@ interface UserJpaRepository : JpaRepository<User, UUID> {
         nickname: String,
         id: UUID,
     ): Boolean
+
+    @Query("SELECT u.nickname FROM User u WHERE u.nickname IN :nicknames")
+    fun findNicknamesIn(
+        @Param("nicknames") nicknames: Collection<String>,
+    ): List<String>
 }

--- a/src/main/kotlin/com/depromeet/piki/user/repository/UserRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/user/repository/UserRepository.kt
@@ -18,4 +18,6 @@ interface UserRepository {
         nickname: String,
         excludeUserId: UUID,
     ): Boolean
+
+    fun findNicknamesIn(candidates: Collection<String>): List<String>
 }

--- a/src/main/kotlin/com/depromeet/piki/user/repository/UserRepositoryImpl.kt
+++ b/src/main/kotlin/com/depromeet/piki/user/repository/UserRepositoryImpl.kt
@@ -21,4 +21,7 @@ class UserRepositoryImpl(
         nickname: String,
         excludeUserId: UUID,
     ): Boolean = userJpaRepository.existsByNicknameAndIdNot(nickname, excludeUserId)
+
+    override fun findNicknamesIn(candidates: Collection<String>): List<String> =
+        userJpaRepository.findNicknamesIn(candidates)
 }

--- a/src/main/kotlin/com/depromeet/piki/user/service/UserService.kt
+++ b/src/main/kotlin/com/depromeet/piki/user/service/UserService.kt
@@ -14,11 +14,10 @@ class UserService(
     private val userRepository: UserRepository,
 ) {
     companion object {
-        private const val MAX_NICKNAME_ATTEMPTS = 10
         private const val DICEBEAR_BASE_URL = "https://api.dicebear.com/9.x/bottts/svg?seed="
 
         // 형용사 32 × 동물 32 = 1024 조합. 모든 조합이 닉네임 10자 제한 이하가 되도록
-        // 형용사는 5자 이하, 동물은 3자 이하로 유지한다(최대 5+1+3=9자). 풀 고갈 근본 대응은 #312.
+        // 형용사는 5자 이하, 동물은 3자 이하로 유지한다(최대 5+1+3=9자).
         private val NICKNAME_PREFIXES =
             listOf(
                 "날뛰는",
@@ -89,6 +88,9 @@ class UserService(
                 "청설모",
                 "살쾡이",
             )
+        private val NICKNAME_POOL: List<String> by lazy {
+            NICKNAME_PREFIXES.flatMap { prefix -> NICKNAME_ANIMALS.map { animal -> "$prefix $animal" } }
+        }
     }
 
     @Transactional
@@ -185,10 +187,7 @@ class UserService(
     private fun dicebearUrl(userId: UUID): String = "$DICEBEAR_BASE_URL$userId"
 
     private fun generateUniqueGuestNickname(): String {
-        repeat(MAX_NICKNAME_ATTEMPTS) {
-            val candidate = "${NICKNAME_PREFIXES.random()} ${NICKNAME_ANIMALS.random()}"
-            if (!userRepository.existsByNickname(candidate)) return candidate
-        }
-        throw UserException.nicknameGenerationFailed()
+        val taken = userRepository.findNicknamesIn(NICKNAME_POOL).toSet()
+        return (NICKNAME_POOL - taken).randomOrNull() ?: throw UserException.nicknameGenerationFailed()
     }
 }

--- a/src/test/kotlin/com/depromeet/piki/auth/controller/AuthControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/controller/AuthControllerIntegrationTest.kt
@@ -14,6 +14,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.context.WebApplicationContext
 import tools.jackson.databind.ObjectMapper
+import kotlin.test.assertNotEquals
 
 @Transactional
 class AuthControllerIntegrationTest : IntegrationTestSupport() {
@@ -121,5 +122,21 @@ class AuthControllerIntegrationTest : IntegrationTestSupport() {
         mockMvc()
             .perform(post("/api/v1/auth/logout").contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isUnauthorized)
+    }
+
+    @Test
+    fun `POST auth guest - 연속 두 번 호출하면 서로 다른 닉네임이 발급된다`() {
+        val firstResult =
+            mockMvc()
+                .perform(post("/api/v1/auth/guest").contentType(MediaType.APPLICATION_JSON).header("X-Client-Type", "app"))
+                .andReturn()
+        val secondResult =
+            mockMvc()
+                .perform(post("/api/v1/auth/guest").contentType(MediaType.APPLICATION_JSON).header("X-Client-Type", "app"))
+                .andReturn()
+
+        val firstNickname = objectMapper.readTree(firstResult.response.contentAsString).at("/data/user/nickname").asText()
+        val secondNickname = objectMapper.readTree(secondResult.response.contentAsString).at("/data/user/nickname").asText()
+        assertNotEquals(firstNickname, secondNickname)
     }
 }

--- a/src/test/kotlin/com/depromeet/piki/tournament/service/TournamentServiceTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/service/TournamentServiceTest.kt
@@ -158,6 +158,9 @@ class TournamentServiceTest {
             nickname: String,
             excludeUserId: UUID,
         ): Boolean = users.values.any { it.nickname == nickname && it.id != excludeUserId }
+
+        override fun findNicknamesIn(candidates: Collection<String>): List<String> =
+            users.values.map { it.nickname }.filter { it in candidates }
     }
 
     private class TestTournamentItemRepository : TournamentItemRepository {


### PR DESCRIPTION
## Situation
- 기존 generateUniqueGuestNickname()은 random() + 10회 retry 방식으로, 같은 조합을 반복 시도할 수 있어 1024개 풀이 충분히 남아있어도 nicknameGenerationFailed(500)이 종종 발생했다
- retry 횟수를 늘려도 근본적으로 중복 시도를 막을 수 없는 구조였다

## Task
- 10회 한도 안에서 반드시 미사용 닉네임을 찾도록 보장
- 검토한 두 가지 방안 — (A) 전체 풀 shuffle 후 순차 탐색(최악 1024 쿼리), (B) 단일 IN 쿼리로 사용 중인 닉네임을 한 번에 조회 후 차집합에서 랜덤 픽 — 중 성능과 단순함이 모두 우월한 B를 선택

## Action
- `UserJpaRepository`: `@Query("SELECT u.nickname FROM User u WHERE u.nickname IN :nicknames")`로 `findNicknamesIn` 추가
- `UserRepository` / `UserRepositoryImpl`: 위임 계층 추가
- `UserService.generateUniqueGuestNickname()`: 전체 1024 조합을 IN 쿼리 1번으로 조회 후 사용 중인 닉네임을 set으로 뺀 뒤 `randomOrNull()`로 픽. `MAX_NICKNAME_ATTEMPTS` 상수 및 retry 루프 제거
- `NICKNAME_POOL`: `lazy` 초기화로 앱 기동 시 1회 계산 후 재사용
- `AuthControllerIntegrationTest`: 연속 두 번 게스트 생성 시 서로 다른 닉네임이 발급되는지 검증 추가
- `TournamentServiceTest.TestUserRepository`: `UserRepository` 인터페이스에 추가된 `findNicknamesIn` 구현 추가

## Result
- 500은 1024개가 전부 소진됐을 때만 발생하도록 보장
- DB 쿼리 횟수: 최대 10회 → 1회로 감소

---
## 연관 이슈

- close #321


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **리팩터링**
  * 게스트 닉네임 생성 로직을 최적화했습니다. 사용 중인 닉네임을 일괄 조회하여 더 효율적으로 중복 없는 고유한 닉네임을 생성합니다.

* **테스트**
  * 게스트 인증 API 연속 호출 시 서로 다른 닉네임이 발급되는지 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->