### PR TITLE
PR·Notion 보드 스킬의 임시파일 동시성 격리와 자동 정리

### DIFF
--- a/.claude/commands/notion-board.md
+++ b/.claude/commands/notion-board.md
@@ -17,6 +17,8 @@
   [ -z "$NOTION_TOKEN" ] && eval "$(grep '^export NOTION_TOKEN=' ~/.zshrc 2>/dev/null)"
   ```
 - **모든 Notion 호출은 HTTP 200 을 확인한다.** read(카드 조회·본문 조회)가 비-200이면 그 단계에서 멈추고 보드 반영을 생략한다(best-effort). 비-200 응답을 본문인 양 파싱하면 401/403/429/5xx 를 "카드 없음"·"미기록"으로 오인해 잘못 진행한다. 카드 생성(`mode=issue`)·append·상태 PATCH 도 200 이 아니면 사용자에게 보고하고 멈춘다.
+- **임시파일은 브랜치별 경로로 격리한다.** Notion 호출의 응답·요청 임시파일(`nb_cards`/`nb_created`/`nb_body`/`nb_append`/`nb_create`)은 고정 이름이 아니라 `/tmp/<이름>_$SLUG.json` 을 쓴다 (`SLUG` = 브랜치명의 `/` 를 `_` 로 치환). 두 워크트리 세션이 동시에 보드 반영을 돌려도 파일이 안 겹친다. 셸 변수는 bash 호출 간 유지되지 않으므로 각 bash 블록은 `SLUG=$(git branch --show-current | tr '/' '_')` 를 자기 안에서 다시 구한다. **quoted heredoc(`<<'PY'`) 안에선 `$SLUG` 가 확장되지 않으므로, `python3` 가 여는 파일 경로는 셸에서 argv 로 넘겨 `sys.argv[1]` 로 받는다.**
+- **진입 시 stale 정리.** 2단계 시작에서 7일 넘게 안 건드린 `nb_*.json` 임시파일을 mtime 기준으로 지운다 — `session-close` 를 안 거치고 중단된 작업의 누수를 회수하되, 동시 세션의 최신 파일은 보존한다. 임시파일은 지워져도 API 재조회로 재생성돼 손실이 없으므로, 진행 중 작업을 안 건드리도록 임계값을 넉넉히 둔다.
 
 ## 상수
 
@@ -57,14 +59,16 @@
 
 ```bash
 [ -z "$NOTION_TOKEN" ] && eval "$(grep '^export NOTION_TOKEN=' ~/.zshrc 2>/dev/null)"
+SLUG=$(git branch --show-current | tr '/' '_')
+find /tmp/ -maxdepth 1 -name 'nb_*.json' -mmin +10080 -delete 2>/dev/null   # 진입 정리: 7일+ stale 누수 회수, 최신 파일 보존 (임시파일은 재조회로 재생성돼 손실 없으니 임계값 넉넉히). /tmp/ trailing slash 필수 (macOS /tmp 는 /private/tmp symlink — 슬래시 없으면 find no-op), -mmin +10080 = 7일 초과 (-mtime 은 +1일 반올림)
 DB=5a0c800c-72cf-8307-8297-8124d888ca79
 code=$(curl -s -X POST "https://api.notion.com/v1/databases/$DB/query" \
   -H "Authorization: Bearer $NOTION_TOKEN" -H "Notion-Version: 2022-06-28" -H "Content-Type: application/json" \
-  --data '{"page_size":100}' -o /tmp/nb_cards.json -w "%{http_code}")
+  --data '{"page_size":100}' -o /tmp/nb_cards_$SLUG.json -w "%{http_code}")
 [ "$code" = "200" ] || { echo "Notion query 실패 (HTTP $code) — 보드 반영 생략"; exit 0; }
-python3 - <<'PY'
-import json
-d=json.load(open('/tmp/nb_cards.json'))
+python3 - "/tmp/nb_cards_$SLUG.json" <<'PY'
+import json, sys
+d=json.load(open(sys.argv[1]))
 for p in d.get('results',[]):
     pr=p['properties']
     title=''.join(t['plain_text'] for t in pr['프로젝트명']['title'])
@@ -99,7 +103,8 @@ PY
 
 ```bash
 [ -z "$NOTION_TOKEN" ] && eval "$(grep '^export NOTION_TOKEN=' ~/.zshrc 2>/dev/null)"
-cat > /tmp/nb_create.json <<'JSON'
+SLUG=$(git branch --show-current | tr '/' '_')
+cat > /tmp/nb_create_$SLUG.json <<'JSON'
 {"parent":{"database_id":"5a0c800c-72cf-8307-8297-8124d888ca79"},
  "properties":{
    "프로젝트명":{"title":[{"text":{"content":"[BE] <카드 제목>"}}]},
@@ -108,9 +113,12 @@ cat > /tmp/nb_create.json <<'JSON'
 JSON
 code=$(curl -s -X POST "https://api.notion.com/v1/pages" \
   -H "Authorization: Bearer $NOTION_TOKEN" -H "Notion-Version: 2022-06-28" -H "Content-Type: application/json" \
-  --data @/tmp/nb_create.json -o /tmp/nb_created.json -w "%{http_code}")
+  --data @/tmp/nb_create_$SLUG.json -o /tmp/nb_created_$SLUG.json -w "%{http_code}")
 [ "$code" = "200" ] || { echo "카드 생성 실패 (HTTP $code) — 보드 반영 생략"; exit 0; }
-python3 -c "import json;print(json.load(open('/tmp/nb_created.json'))['id'])"
+python3 - "/tmp/nb_created_$SLUG.json" <<'PY'
+import json, sys
+print(json.load(open(sys.argv[1]))['id'])
+PY
 ```
 
 - 출력된 page id 가 `<PAGE_ID>`. `프로젝트명`·`상태` 외 property(`파트`/`시작일`/`마감일`/`담당자`/`진행률`)는 **세팅하지 않는다** — 사람 몫.
@@ -122,12 +130,13 @@ python3 -c "import json;print(json.load(open('/tmp/nb_created.json'))['id'])"
 
 ```bash
 [ -z "$NOTION_TOKEN" ] && eval "$(grep '^export NOTION_TOKEN=' ~/.zshrc 2>/dev/null)"
+SLUG=$(git branch --show-current | tr '/' '_')
 code=$(curl -s "https://api.notion.com/v1/blocks/<PAGE_ID>/children?page_size=100" \
-  -H "Authorization: Bearer $NOTION_TOKEN" -H "Notion-Version: 2022-06-28" -o /tmp/nb_body.json -w "%{http_code}")
+  -H "Authorization: Bearer $NOTION_TOKEN" -H "Notion-Version: 2022-06-28" -o /tmp/nb_body_$SLUG.json -w "%{http_code}")
 [ "$code" = "200" ] || { echo "카드 본문 조회 실패 (HTTP $code) — 보드 반영 생략"; exit 0; }
-python3 - <<'PY'
-import json
-d=json.load(open('/tmp/nb_body.json'))
+python3 - "/tmp/nb_body_$SLUG.json" <<'PY'
+import json, sys
+d=json.load(open(sys.argv[1]))
 heading=False; already=False
 TOKEN='<MATCH_TOKEN>'   # mode=pr: 'PR #<번호>', mode=issue: '이슈 #<번호>'
 for b in d.get('results',[]):
@@ -144,7 +153,7 @@ PY
 
 ### 5. append (개발 로그)
 
-`/tmp/nb_append.json` 을 만든다 — `개발 로그` heading 이 **없을 때만**(3b 신규 카드는 항상 없음) heading_3 을 먼저 포함, 이어서 bullet (전체를 링크로):
+`/tmp/nb_append_$SLUG.json` 을 만든다 (`SLUG` = 브랜치명의 `/`→`_`, 전제 규칙) — `개발 로그` heading 이 **없을 때만**(3b 신규 카드는 항상 없음) heading_3 을 먼저 포함, 이어서 bullet (전체를 링크로):
 
 - `mode=pr`: bullet 텍스트 = `PR #<번호> <사람이 읽는 PR 제목> (<KST 오늘 날짜>)`, link = `<PR_URL>`.
 - `mode=issue`: bullet 텍스트 = `이슈 #<번호> <이슈 제목> (<KST 오늘 날짜>)`, link = `<이슈 URL>`.
@@ -164,9 +173,10 @@ PY
 
 ```bash
 [ -z "$NOTION_TOKEN" ] && eval "$(grep '^export NOTION_TOKEN=' ~/.zshrc 2>/dev/null)"
+SLUG=$(git branch --show-current | tr '/' '_')
 code=$(curl -s -X PATCH "https://api.notion.com/v1/blocks/<PAGE_ID>/children" \
   -H "Authorization: Bearer $NOTION_TOKEN" -H "Notion-Version: 2022-06-28" -H "Content-Type: application/json" \
-  --data @/tmp/nb_append.json -o /dev/null -w "%{http_code}")
+  --data @/tmp/nb_append_$SLUG.json -o /dev/null -w "%{http_code}")
 echo "append HTTP $code"; [ "$code" = "200" ] || echo "append 실패 — 사용자에게 보고"
 ```
 

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -12,6 +12,9 @@
 
 ```bash
 CURRENT_BRANCH=$(git branch --show-current)
+# 진입 정리: 7일 넘게 안 건드린 stale PR 본문 임시파일 제거 (session-close 를 안 거친 중단 작업의 누수를 회수 — mtime 기준이라 동시 세션의 최신 파일은 안 건드림). 임시파일은 지워져도 gh pr view 로 재생성돼 손실이 없으므로, 진행 중 장기 PR(리뷰 대기 등 며칠 걸침)을 절대 안 건드리도록 임계값을 넉넉히 7일로 둔다.
+# -mmin +10080 = 7일(10080분) 초과. -mtime 계열은 find 에서 +1일 반올림되니 -mmin 으로 명시. /tmp/ 의 trailing slash 필수 — macOS /tmp 는 /private/tmp symlink 라, 슬래시 없으면 find 가 symlink 를 안 따라가 0건(조용한 no-op)이 된다.
+find /tmp/ -maxdepth 1 -name 'pr_body_*.md' -mmin +10080 -delete 2>/dev/null
 # base 후보 (아래 0-B 의 $BASE 결정과 동일 우선순위: origin/dev → 레포 default → main)
 if git rev-parse --verify origin/dev >/dev/null 2>&1; then
   BASE_GUESS=dev
@@ -52,6 +55,8 @@ gh pr view --json url,number,body,baseRefName 2>/dev/null
   BASE=$(gh pr view --json baseRefName --jq '.baseRefName')
   ```
 - `$ARGUMENTS` 에 사용자가 base 명시한 경우 (`/pr main` 같은) 그 값을 우선 (create 모드 한정 — update 모드에서 base 변경하지 않는다).
+
+**임시파일 경로 규칙 (동시 세션 격리)** — PR 본문 임시파일은 고정 `/tmp/pr_body.md` 가 아니라 **브랜치별 경로** `/tmp/pr_body_$SLUG.md` 를 쓴다 (`SLUG` = 브랜치명의 `/` 를 `_` 로 치환, 예: `chore/skill-tmp` → `/tmp/pr_body_chore_skill-tmp.md`). 워크트리는 브랜치당 하나라(스택 금지) 브랜치별 경로면 두 워크트리 세션이 동시에 `/pr` 을 돌려도 본문 파일이 안 겹친다 — 고정 경로일 때 한 세션이 다른 세션의 본문을 덮어쓰던 race 를 막는다. 아래 3-A·3-B 의 본문 파일 경로는 모두 이 규칙을 따른다. **셸 변수는 bash 호출 간 유지되지 않으므로, 본문 파일을 다루는 각 bash 블록은 `SLUG=$(git branch --show-current | tr '/' '_')` 를 자기 안에서 다시 구한다.** (Write 도구로 본문을 저장할 때도 같은 경로를 쓴다 — Claude 가 현재 브랜치명으로 슬러그를 박는다.)
 
 ### 1단계: 정보 수집
 
@@ -131,12 +136,13 @@ ISSUE_LABELS=$(gh issue view {번호} --json labels --jq '[.labels[].name] | joi
 ### 3-A. Create 모드 — PR 신규 생성
 
 1. 원격에 푸시되지 않았으면 `git push -u origin {브랜치명}`
-2. 사용자에게 PR 제목과 본문 초안을 보여주고 확인받는다
+2. PR 제목과 본문 초안을 작성해 **`/tmp/pr_body_$SLUG.md` 에 저장(Write)**한 뒤, 사용자에게 보여주고 확인받는다 (경로 규칙은 0단계 참조 — Claude 가 현재 브랜치 슬러그를 박는다).
 3. 확인 후 PR 생성 — assignee / 라벨을 함께 부여한다:
    ```bash
+   SLUG=$(git branch --show-current | tr '/' '_')
    gh pr create --base $BASE \
      --title "{제목}" \
-     --body-file /tmp/pr_body.md \
+     --body-file /tmp/pr_body_$SLUG.md \
      --assignee @me \
      ${ISSUE_LABELS:+--label "$ISSUE_LABELS"}
    ```
@@ -175,9 +181,10 @@ ISSUE_LABELS=$(gh issue view {번호} --json labels --jq '[.labels[].name] | joi
 
 ### 3-B. Update 모드 — 기존 PR 본문 갱신
 
-1. 기존 본문 가져오기:
+1. 기존 본문 가져오기 (브랜치별 경로 — 0단계 규칙):
    ```bash
-   gh pr view --json body --jq '.body' > /tmp/pr_body.md
+   SLUG=$(git branch --show-current | tr '/' '_')
+   gh pr view --json body --jq '.body' > /tmp/pr_body_$SLUG.md
    ```
 2. **이번 추가 변경 내역을 `git log` 로 정확히 식별한다 — 기억·추측에 의존하지 않는다.**
    ```bash
@@ -195,7 +202,7 @@ ISSUE_LABELS=$(gh issue view {번호} --json labels --jq '[.labels[].name] | joi
 5. **기존 본문은 절대 덮어쓰지 않는다.** 갱신본 = 기존 본문 + Updates 항목 추가만.
 6. **제목 변경 필요 검토**: 추가 변경으로 작업 의도/스코프가 바뀌었거나 기존 제목에 오타·부정확한 표현이 있으면 새 제목 제안. 그 외엔 제목 유지.
 7. 사용자에게 갱신본(필요시 새 제목 포함, 변경 이유 짚어서)을 보여주고 확인받는다.
-8. 확인 후 `gh pr edit --body-file /tmp/pr_body.md` 로 갱신. 제목 변경이 있으면 `--title "새 제목"` 추가.
+8. 확인 후 `gh pr edit --body-file /tmp/pr_body_$SLUG.md` 로 갱신 (1번과 같은 브랜치 경로 — 별도 bash 호출이라 `SLUG=$(git branch --show-current | tr '/' '_')` 를 다시 구한다). 제목 변경이 있으면 `--title "새 제목"` 추가.
 9. **CodeRabbit 리뷰 대응** — 이번 변경이 CodeRabbit 리뷰 대응이라면 commit + push 로 끝내지 않는다. CodeRabbit 리뷰(인라인 thread + review body nitpick) 조회·평가·reply·resolve 는 **`/coderabbit` 스킬**로 처리한다. 그 스킬이 author 매칭(GraphQL `reviewThreads` 는 `coderabbitai`, REST `reviews` 는 `coderabbitai[bot]` 이라 `coderabbitai` 로 시작하는지로 판별), nitpick 조회, accept/reject reply·resolve 정책을 담는다. (사람 리뷰 thread 는 작성자가 직접 답하므로 `/coderabbit` 도 건드리지 않는다.)
 
 10. **메타데이터 보정** — 이전 버전 스킬로 만든 PR 은 assignee / 라벨 / Project / Start date 가 비어 있을 수 있다. update 모드에서도 멱등하게 보정한다 (이미 설정돼 있으면 no-op). `item-add` 는 이미 등록된 PR 이면 기존 item id 를 그대로 반환한다.

--- a/.claude/commands/session-close.md
+++ b/.claude/commands/session-close.md
@@ -14,6 +14,7 @@
 - **머지+clean 일 때만 제거.** uncommitted 가 있거나 브랜치가 아직 머지 안 됐으면 **거부**한다(작업 유실 방지). session-check 통과를 전제하되 자체 재확인한다.
 - **제거는 `ExitWorktree` 로 한다.** `ExitWorktree({action:"remove"})` 가 워크트리 나가기 + 디렉터리/브랜치 삭제 + cwd 복원(메인으로)을 한 번에 처리한다 — "자기가 선 폴더를 자기가 못 지운다"는 문제를 도구가 해결한다. 수동 `git -C ... worktree remove` 보다 안전·정석.
 - **현재 작업 1개만.** 다른 워크트리·머지된 다른 stale 브랜치는 안 건드린다(별도 세션 몫).
+- **임시파일도 함께 정리한다.** 워크트리를 제거할 때, 이 브랜치가 `/tmp` 에 남긴 `/pr`·`/notion-board` 임시파일(`pr_body_$SLUG.md`·`nb_*_$SLUG.json`)도 지운다. **현재 브랜치 것만** — 동시에 도는 다른 세션의 파일은 안 건드린다("현재 1개만"과 같은 결). `session-close` 를 안 거치고 떠난 세션·중단 작업의 누수는 다음 `/pr`·`/notion-board` 진입의 mtime prune 이 회수한다.
 - **`/clear` 는 자동 호출 불가.** 스킬은 빌트인 슬래시 커맨드를 못 부른다(claude-code-guide 확인). 정리 후 사용자에게 `/clear` 입력을 안내하는 것으로 끝낸다.
 - **이모지·체크기호 금지.** 굵게·불릿으로만 표시한다.
 
@@ -45,9 +46,14 @@ gh pr list --head "$BR" --state merged --json number,headRefName \
 - **dirty** (status 비어있지 않음) → **거부.** "uncommitted N건 — 먼저 `/commit` 하거나 `/session-check`." 중단.
 - **미머지** (위 merged PR 카운트가 0) → **거부.** "브랜치 `$BR` 미머지 — PR 머지 후 다시." 중단. (열린 PR 만 있는 경우도 여기 해당 — 머지 전이므로 삭제 금지.)
 - 둘 다 통과(clean + 머지됨) → **제거한다**:
-  1. `ExitWorktree({action: "remove"})` 를 호출한다.
-  2. 거부하면서 변경 목록을 돌려주면 — clean 은 이미 확인했으니 그 목록은 **squash-merge 커밋(원래 브랜치 dev 의 ancestor 가 아닌 것)** 인 false alarm 이다. 이때만 `ExitWorktree({action: "remove", discard_changes: true})` 로 재호출한다. (clean·머지를 확인하기 **전에는 절대** `discard_changes: true` 를 주지 않는다.)
-  3. ExitWorktree 가 **no-op** 이라고 하면(이번 세션의 `EnterWorktree` 로 들어간 워크트리가 아님 — 이전 세션·수동 생성 등), **fallback** 으로 메인에서 ref 연산한다. 이건 이 스킬의 **마지막 bash 호출**이어야 한다(`$CUR` 삭제 시 cwd 가 사라짐 — 세 명령 모두 `-C "$MAIN"` 이라 cwd 비의존):
+  1. 이 브랜치가 `/tmp` 에 남긴 임시파일을 먼저 정리한다 (작업이 끝났으므로). **현재 브랜치 슬러그 것만** 지워 동시에 도는 다른 세션 파일은 건드리지 않는다. 별도 bash 호출이라 슬러그를 다시 구한다 (`$BR` 은 유지되지 않음):
+     ```bash
+     SLUG=$(git branch --show-current | tr '/' '_')
+     rm -f /tmp/pr_body_"$SLUG".md /tmp/nb_*_"$SLUG".json 2>/dev/null
+     ```
+  2. `ExitWorktree({action: "remove"})` 를 호출한다.
+  3. 거부하면서 변경 목록을 돌려주면 — clean 은 이미 확인했으니 그 목록은 **squash-merge 커밋(원래 브랜치 dev 의 ancestor 가 아닌 것)** 인 false alarm 이다. 이때만 `ExitWorktree({action: "remove", discard_changes: true})` 로 재호출한다. (clean·머지를 확인하기 **전에는 절대** `discard_changes: true` 를 주지 않는다.)
+  4. ExitWorktree 가 **no-op** 이라고 하면(이번 세션의 `EnterWorktree` 로 들어간 워크트리가 아님 — 이전 세션·수동 생성 등), **fallback** 으로 메인에서 ref 연산한다. 이건 이 스킬의 **마지막 bash 호출**이어야 한다(`$CUR` 삭제 시 cwd 가 사라짐 — 세 명령 모두 `-C "$MAIN"` 이라 cwd 비의존):
      ```bash
      git -C "$MAIN" worktree remove "$CUR" && git -C "$MAIN" branch -D "$BR" && git -C "$MAIN" worktree prune
      ```


### PR DESCRIPTION
## Situation
- `/pr` 이 PR 본문을 고정 경로 `/tmp/pr_body.md` 에 쓰고 `gh --body-file` 로 넘기는 동작을 두고 "왜 tmp 를 거치나" 라는 질문에서 출발 — 셸 이스케이핑(백틱·`$`·따옴표)을 피하고 update 모드에서 기존 본문을 손실 없이 보존하기 위한 정상 설계였음
- 그런데 고정 경로라 두 워크트리 세션이 동시에 `/pr` 을 돌리면 서로의 본문 파일을 덮어쓰는 race 가 있었고, 특히 "사용자 확인 대기" 구간 때문에 race window 가 초·분 단위로 넓었음
- 또 스킬에 정리 단계가 없고 macOS 가 `/tmp` 를 자동으로 안 비워(이 환경엔 periodic clean-tmps 정책 부재), 실제로 임시파일 30여 개가 안 지워지고 쌓여 있었음

## Task
- 고정 경로의 두 결함 — (1) 동시 세션 race (2) 정리 부재로 인한 누적 — 을 함께 해결
- `session-close` 한 곳에만 정리를 의존하면 "스킬을 안 거치고 떠난 세션·PR 안 낸 중단 작업" 이 새는 빈틈을 메움

## Action
- **격리**: 임시파일을 고정 경로 대신 브랜치명 슬러그 경로(`/tmp/pr_body_$SLUG.md`, `nb_*_$SLUG.json`)로 분리. 워크트리는 브랜치당 하나(스택 금지)라 브랜치별 경로면 충돌이 사라짐
- **정리(두 이벤트 piggyback)**: CLAUDE.md 의 worktree 정리 철학(주기 검사 대신 이벤트에 얹기)을 빌려, `/pr`·`/notion-board` 진입 시 stale prune + `session-close` 제거 직전 현재 브랜치 것만 rm. session-close 호출 누락·중단 작업의 누수는 다음 진입 prune 이 회수
- **notion-board argv 전환**: quoted heredoc(`<<'PY'`) 안에선 `$SLUG` 가 확장되지 않아, python 이 여는 파일 경로를 셸 argv 로 넘겨 `sys.argv[1]` 로 받도록 3곳 수정
- **검증으로 잡은 함정 2건**(둘 다 prune 을 조용한 no-op 으로 만들던 것): `find -mtime +1` 이 48h+ 로 반올림되는 문제는 `-mmin` 으로 명시, macOS `/tmp -> private/tmp` symlink 라 `find /tmp` 가 안으로 안 들어가는 문제는 trailing slash(`/tmp/`)로 해결
- **stale 임계값 7일**(`-mmin +10080`): 임시파일은 지워져도 `gh pr view`·API 재조회로 재생성돼 손실이 없으므로, 진행 중 장기 PR 을 안 건드리도록 임계값을 넉넉히 둠

## Result
- 두 워크트리 세션이 동시에 `/pr`·`/notion-board` 를 돌려도 임시파일이 안 겹치고, 쌓인 누수는 다음 진입에 7일 기준으로 자동 회수됨
- 셸 검증 완료: 슬러그 생성·argv heredoc JSON 파싱·rm glob 확장·trailing-slash prune 의 24h+ 포착과 최신 파일 보존 전부 동작 확인
- 변경은 `pr.md`·`notion-board.md`·`session-close.md` 세 스킬 파일 한정 (앱 코드 영향 없음)

---
## 연관 이슈

- 
