### PR TITLE
nginx IP별 레이트리밋 — 비싼 Gemini 경로 + 전역 2층

### DIFF
--- a/infra/nginx/api.depromeet18team3.cloud.conf
+++ b/infra/nginx/api.depromeet18team3.cloud.conf
@@ -71,22 +71,36 @@ server {
         return 403;
     }
 
+    # 레이트리밋 초과(429)를 ApiResponseBody 모양 JSON 으로 내린다 (위 limit_req_status 429 와 짝).
+    # nginx 가 앱 앞에서 끊어 GlobalExceptionHandler 를 못 거치므로, 클라이언트가 "모든 응답=ApiResponseBody"
+    # 로 파싱해도 깨지지 않게 같은 스키마({data, detail, pageResponse})를 고정 JSON 으로 흉내낸다.
+    # 주의: ApiResponseBody 필드가 바뀌면 이 JSON 도 손으로 맞춰야 한다(컴파일러가 못 잡는 drift).
+    # 완전한 해법은 후속 userId 앱 레이어 레이트리밋(GlobalExceptionHandler 가 진짜 ApiResponseBody 를 만든다).
+    error_page 429 = @rate_limited;
+    location @rate_limited {
+        default_type application/json;
+        add_header Retry-After 1 always;
+        return 429 '{"data":null,"detail":"요청이 너무 잦습니다. 잠시 후 다시 시도해 주세요.","pageResponse":{"nextCursor":null,"hasNext":false}}';
+    }
+
     # --- 비싼 Gemini 경로: IP별 레이트리밋 적용 ---
     # burst=20 nodelay: 순간 연타·모바일 CGNAT(여러 사용자가 한 공인 IP 뒤에 묶임)는 흡수하되,
     # 지속적인 폭주만 429 로 막는다. nodelay 라 burst 분은 지연 없이 즉시 통과한다.
     #
     # 토너먼트 아이템 추가 — /{tournamentId}/items/link(링크 추출) · /items/images(이미지 OCR). 둘 다 POST 전용 경로.
-    location ~ ^/api/v1/tournaments/[^/]+/items/(link|images)$ {
+    # /?$ : trailing slash 변형(.../link/)도 같은 비싼 경로로 묶어 piki_llm 우회를 막는다.
+    location ~ ^/api/v1/tournaments/[^/]+/items/(link|images)/?$ {
         limit_req zone=piki_llm burst=20 nodelay;
         proxy_pass http://team3;
     }
     # 위시 등록(POST = 링크 추출). 같은 경로의 GET(목록 조회)은 map 의 빈 키로 제한에서 제외된다.
-    location = /api/v1/wishlists {
+    # /?$ : trailing slash 변형(/api/v1/wishlists/)도 같은 경로로 묶어 piki_llm 우회를 막는다.
+    location ~ ^/api/v1/wishlists/?$ {
         limit_req zone=piki_llm burst=20 nodelay;
         proxy_pass http://team3;
     }
     # 위시 이미지 등록(POST = 이미지 OCR).
-    location = /api/v1/wishlists/images {
+    location ~ ^/api/v1/wishlists/images/?$ {
         limit_req zone=piki_llm burst=20 nodelay;
         proxy_pass http://team3;
     }

--- a/infra/nginx/api.depromeet18team3.cloud.conf
+++ b/infra/nginx/api.depromeet18team3.cloud.conf
@@ -12,10 +12,44 @@ upstream team3 {
     include /etc/nginx/team3-upstream.conf;
 }
 
+# --- 레이트리밋: 비싼 Gemini 호출(링크 추출·이미지 OCR)만 IP별로 제한한다 ---
+# 목적은 Gemini 호출 폭주로 인한 비용·자원(톰캣 스레드·DB 커넥션) 고갈 방어다. 일반 조회·CRUD 는 제한하지 않는다.
+#
+# 이건 거친 1차 그물이다 — 일부러 느슨하게 둬서 정상 유저 오탐(CGNAT·공유망)을 0 으로 하고 명백한 flood 만 막는다.
+# 정밀한 비용·공정성 제어(인증 사용자별 "하루 N회" quota)는 앱 레이어 후속 작업(userId + Redis)이 맡는다.
+# 둘은 대체가 아니라 보완이다: IP 는 미인증·flood 1차 차단, userId 는 인증 후 정밀 quota.
+#
+# POST 만 카운트 키에 담는다 — 비싼 경로는 전부 POST 이고, 같은 경로의 GET(위시 목록 조회)·기타 메서드는
+# 빈 키가 되어 limit_req 가 카운트에서 제외한다(nginx 는 키가 빈 문자열인 요청을 세지 않는다).
+# 그래서 location 을 메서드별로 쪼개지 않고도 POST 만 정확히 잡는다.
+#
+# $binary_remote_addr 을 키로 쓴다 — EIP 직결(앞단에 ALB/CloudFront 없음)이라 이게 진짜 클라이언트 IP 다.
+# 단일 노드(blue/green 도 한 박스)라 shared memory zone 카운터가 IP 별로 정확하다.
+# (앞단 LB 를 도입하면 $remote_addr 이 LB IP 로 바뀌어 전 요청이 한 버킷에 묶이므로, 그때 real_ip 모듈 +
+#  X-Forwarded-For 로 키를 바꿔야 한다.)
+map $request_method $piki_llm_limit_key {
+    POST    $binary_remote_addr;
+    default "";
+}
+limit_req_zone $piki_llm_limit_key zone=piki_llm:10m rate=30r/m;   # 분당 30회 / IP(느슨), zone 10m ≈ IP 16만 개 추적
+limit_req_status 429;                                              # 초과 시 기본 503 대신 429 Too Many Requests
+
 server {
     server_name api.depromeet18team3.cloud;
 
     client_max_body_size 25M;
+
+    # 공통 proxy 설정 — 아래 proxy_pass location 들이 상속한다(actuator 403 location 은 프록시하지 않아 무관).
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+
+    # OCR 등 LLM 호출 엔드포인트는 앱이 Gemini read-timeout(30s) + 재시도까지 최악 약 60s 를 쓸 수 있다.
+    # nginx 기본 60s 로는 앱이 502 + 실패 사유를 내려보내기 직전에 잘려 504(사유 없음)가 클라이언트로 나간다.
+    # 앱 최악치보다 여유 있게 두어, 느린 호출도 앱이 끝까지 응답해 사유를 전달하게 한다.
+    # (근본 단축은 앱 측 read-timeout/재시도 조정 — 별도 작업)
+    proxy_read_timeout 90s;
 
     # actuator 엔드포인트는 외부에 노출하지 않는다. 메트릭(/actuator/prometheus)·health 는
     # EC2 내부의 Grafana Alloy 가 localhost 컨테이너 포트로 직접 scrape 하므로 nginx 를 거치지 않는다.
@@ -29,19 +63,29 @@ server {
         return 403;
     }
 
+    # --- 비싼 Gemini 경로: IP별 레이트리밋 적용 ---
+    # burst=20 nodelay: 순간 연타·모바일 CGNAT(여러 사용자가 한 공인 IP 뒤에 묶임)는 흡수하되,
+    # 지속적인 폭주만 429 로 막는다. nodelay 라 burst 분은 지연 없이 즉시 통과한다.
+    #
+    # 토너먼트 아이템 추가 — /{tournamentId}/items/link(링크 추출) · /items/images(이미지 OCR). 둘 다 POST 전용 경로.
+    location ~ ^/api/v1/tournaments/[^/]+/items/(link|images)$ {
+        limit_req zone=piki_llm burst=20 nodelay;
+        proxy_pass http://team3;
+    }
+    # 위시 등록(POST = 링크 추출). 같은 경로의 GET(목록 조회)은 map 의 빈 키로 제한에서 제외된다.
+    location = /api/v1/wishlists {
+        limit_req zone=piki_llm burst=20 nodelay;
+        proxy_pass http://team3;
+    }
+    # 위시 이미지 등록(POST = 이미지 OCR).
+    location = /api/v1/wishlists/images {
+        limit_req zone=piki_llm burst=20 nodelay;
+        proxy_pass http://team3;
+    }
+
+    # 그 외 모든 경로 — 레이트리밋 없음.
     location / {
         proxy_pass http://team3;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-
-        # OCR 등 LLM 호출 엔드포인트는 앱이 Gemini read-timeout(30s) + 재시도까지
-        # 최악 약 60s 를 쓸 수 있다. nginx 기본 60s 로는 앱이 502 + 실패 사유를 내려보내기
-        # 직전에 잘려 504(사유 없음)가 클라이언트로 나간다. 앱 최악치보다 여유 있게 두어,
-        # 느린 호출도 앱이 끝까지 응답해 사유를 전달하게 한다.
-        # (근본 단축은 앱 측 read-timeout/재시도 조정 — 별도 작업)
-        proxy_read_timeout 90s;
     }
 
     listen 443 ssl;

--- a/infra/nginx/api.depromeet18team3.cloud.conf
+++ b/infra/nginx/api.depromeet18team3.cloud.conf
@@ -12,8 +12,8 @@ upstream team3 {
     include /etc/nginx/team3-upstream.conf;
 }
 
-# --- 레이트리밋: 비싼 Gemini 호출(링크 추출·이미지 OCR)만 IP별로 제한한다 ---
-# 목적은 Gemini 호출 폭주로 인한 비용·자원(톰캣 스레드·DB 커넥션) 고갈 방어다. 일반 조회·CRUD 는 제한하지 않는다.
+# --- 레이트리밋(1/2): 비싼 Gemini 호출(링크 추출·이미지 OCR)을 IP별로 타이트하게 제한한다 ---
+# 목적은 Gemini 호출 폭주로 인한 비용·자원(톰캣 스레드·DB 커넥션) 고갈 방어다. (일반 경로의 느슨한 전역 그물은 2/2 참고.)
 #
 # 이건 거친 1차 그물이다 — 일부러 느슨하게 둬서 정상 유저 오탐(CGNAT·공유망)을 0 으로 하고 명백한 flood 만 막는다.
 # 정밀한 비용·공정성 제어(인증 사용자별 "하루 N회" quota)는 앱 레이어 후속 작업(userId + Redis)이 맡는다.
@@ -32,7 +32,15 @@ map $request_method $piki_llm_limit_key {
     default "";
 }
 limit_req_zone $piki_llm_limit_key zone=piki_llm:10m rate=30r/m;   # 분당 30회 / IP(느슨), zone 10m ≈ IP 16만 개 추적
-limit_req_status 429;                                              # 초과 시 기본 503 대신 429 Too Many Requests
+
+# --- 레이트리밋(2/2): 전역 — 모든 경로(메서드 무관)에 아주 느슨한 IP별 그물 ---
+# 일반 조회·CRUD 도 무제한이면 스크래핑·flood 에 노출된다. 다만 일반 경로는 정상 트래픽이 비싼 경로보다
+# 훨씬 잦아(화면 1개에 GET 여럿 동시 호출·무한스크롤) 같은 강도면 정상 사용자가 막힌다. 그래서 1/2 보다
+# 훨씬 느슨하게 둬 명백한 폭주만 컷한다. 키는 raw $binary_remote_addr(메서드·경로 무관 전부 카운트).
+# 비싼 경로는 piki_llm(초당 0.5)이 이보다 훨씬 타이트해 지배하므로, 그쪽 location 엔 이 zone 을 겹치지 않는다.
+limit_req_zone $binary_remote_addr zone=piki_general:10m rate=20r/s;   # 초당 20회 / IP(아주 느슨)
+
+limit_req_status 429;                                              # 초과 시 기본 503 대신 429 Too Many Requests (두 zone 공통)
 
 server {
     server_name api.depromeet18team3.cloud;
@@ -83,8 +91,9 @@ server {
         proxy_pass http://team3;
     }
 
-    # 그 외 모든 경로 — 레이트리밋 없음.
+    # 그 외 모든 경로 — 전역 느슨한 그물(piki_general). 정상 화면 로딩·무한스크롤은 무영향, 명백한 폭주만 429.
     location / {
+        limit_req zone=piki_general burst=40 nodelay;
         proxy_pass http://team3;
     }
 


### PR DESCRIPTION
## Situation
- API 에 비싼 외부 호출이 있다 — Gemini 링크 추출(위시 등록·토너먼트 link)과 이미지 OCR(위시 이미지·토너먼트 images). 최악 약 90s 까지 잡는 무거운 호출이다.
- 한 IP 가 이 경로들을 폭주시키면 Gemini 비용은 물론 톰캣 스레드·DB 커넥션이 묶여 다른 API 까지 latency 가 번진다. 그런데 지금까지 어떤 레이트리밋도 없었다.
- 인프라는 EIP 직결(앞단에 ALB/CloudFront 없음) + 단일 노드(blue/green 도 한 박스)다. 이 구조가 nginx IP 기반 제한에 유리하다.

## Task
- 비싼 Gemini 호출 폭주를 앱 앞단(nginx)에서 IP별로 막는 1차 방어를 둔다.
- 논의 핵심: "IP별이면 충분한가, 결국 userId별까지 필요한가." → IP 는 거친 1차 그물, userId 는 정밀 칼로 **역할을 나누기로** 결론. 이번엔 IP 만, userId 정밀 quota 는 후속.
- 일반 조회·CRUD 는 건드리지 않고 비싼 경로만 정확히 잡아야 한다.

## Action

### 적용 범위와 키 설계
- 비싼 Gemini 경로 4개에만 `limit_req` 적용 — `POST /api/v1/wishlists`(링크 추출), `POST /api/v1/wishlists/images`(OCR), `POST /api/v1/tournaments/{id}/items/link`·`/items/images`. 일반 경로는 제한 없음.
- `map $request_method` 로 **POST 만 카운트 키에 담는다.** 같은 경로의 GET(위시 목록 조회)·기타 메서드는 빈 키가 되어 nginx 가 세지 않는다 — location 을 메서드별로 쪼개지 않고 POST 만 잡는 트릭.
- 키는 `$binary_remote_addr`. EIP 직결이라 이게 진짜 클라이언트 IP 이고, 단일 노드라 shared memory zone 카운터가 IP 별로 정확하다. (앞단 LB 도입 시 `real_ip` 모듈로 키를 바꿔야 한다는 점을 주석에 남김.)

### 느슨한 1차 그물 정책
- 일부러 느슨하게 — 분당 30회 + `burst=20 nodelay`. CGNAT·공유망(한 공인 IP 뒤 여러 사용자) 오탐을 0 에 가깝게 두고 명백한 flood 만 막는다.
- userId 별 정밀 quota("하루 N회")는 앱 레이어 후속 작업으로 분리. 비싼 경로 4개가 전부 인증 필수라 userId quota 가 잘 맞고, 그쪽은 429 를 `ApiResponseBody.fail` 로 내려 응답 포맷도 일관되게 가져갈 수 있다. IP 와 userId 는 대체가 아니라 보완(IP 는 미인증·flood, userId 는 인증 후 비용·공정성).

### 정리·검증
- 초과 시 `limit_req_status 429`(기본 503 대신). 단 이 429 바디는 `ApiResponseBody` 래퍼를 거치지 않는다(앱 앞 nginx 가 끊으므로) — 일관 포맷이 필요하면 `error_page` JSON 흉내 또는 위 userId 앱 레이어로.
- `proxy_set_header`·`proxy_read_timeout 90s` 공통 설정을 location 에서 server 레벨로 올려 중복 제거.
- docker nginx 로 `nginx -t` 문법 검증 통과(ssl 인증서·upstream include 는 검증용 더미로 우회). 실제 배포 검증은 deploy.yml 의 `nginx -t` 가 한 번 더 한다.

## Result
- 비싼 Gemini 경로의 IP별 폭주가 앱에 닿기 전 nginx 에서 429 로 끊긴다. 일반 조회·CRUD 는 영향 없음.
- 느슨한 설정이라 정상 사용자(연속 아이템 추가 등)는 막히지 않는다. 운영 트래픽을 보며 `rate`/`burst` 조정 가능.
- 후속: userId 별 정밀 quota(앱 레이어, Redis 이미 가동 중). 이번 nginx 설정과 충돌 없이 위에 얹는 보완 레이어다.

---
## 연관 이슈

- 

## Updates

### 전역(일반 경로) 레이트리밋 추가 — 2층 구조로 확장
- 비싼 Gemini 경로만 막던 1층에서, 모든 경로에 아주 느슨한 전역 그물(`piki_general`, 초당 20 + `burst=40 nodelay`)을 더해 2층으로 확장했다. 일반 조회·CRUD 도 무제한이면 스크래핑·flood 에 노출되기 때문 — "호출이 과한 건 좋을 게 없다"는 판단. (`585e6d0`)
- 다만 일반 경로는 정상 트래픽(화면당 GET 여럿·무한스크롤)이 비싼 경로보다 훨씬 잦아, 같은 강도면 정상 사용자가 막힌다. 그래서 비싼 경로(분당 30)보다 훨씬 느슨하게(초당 20) 둬 명백한 폭주만 컷하는 거친 그물로 설계했다. (`585e6d0`)
- 키는 raw `$binary_remote_addr`(메서드·경로 무관 전부 카운트). `location /` 에만 적용했다 — 비싼 경로는 `piki_llm`(초당 0.5)이 이보다 타이트해 지배하므로 겹치지 않는다. docker `nginx -t` 재검증 통과. (`585e6d0`)

### CodeRabbit 리뷰 대응
- (A) 레이트리밋 429 가 nginx 기본 응답이라 클라이언트의 "모든 응답=ApiResponseBody" 파싱이 깨질 수 있다는 지적 → `error_page 429 = @rate_limited` 로 같은 스키마(`{data, detail, pageResponse}`) 고정 JSON + `Retry-After` 반환. #309 로 바디에서 status·code 가 빠져 동적 필드가 없어 정확히 흉내 가능. docker 로 429 응답이 `application/json` + `Retry-After` + 해당 JSON 바디임을 런타임 확인. (`edac946`)
- (B) `location =`·`...$` 만으로는 trailing slash 변형(`/api/v1/wishlists/` 등)이 `location /` 로 떨어져 `piki_llm` 우회 가능 → 세 비싼 경로를 정규식 + `/?$` 로 묶어 차단. Spring trailing-slash 매칭이 기본 false 라 앱은 404(비싼 호출 미실행)지만 방어적으로. (`edac946`)
- 검증 중 발견: nginx `return` 은 rewrite phase 라 `limit_req`(preaccess phase)보다 먼저 실행돼 우회된다. 실제 conf 는 `proxy_pass` 라 정상 동작하며, 런타임 미니 테스트만 `proxy_pass` 백엔드로 고쳐 재현했다.

## 레이트리밋 정책 요약 (2층)
| 층 | zone | 대상 | 한도 | 키 |
|---|---|---|---|---|
| 1/2 | `piki_llm` | 비싼 Gemini 경로 4개(POST) | 분당 30 + burst 20 | POST 만(`map`) → `$binary_remote_addr` |
| 2/2 | `piki_general` | 그 외 모든 경로 | 초당 20 + burst 40 | raw `$binary_remote_addr` |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **인프라**
  * API에 IP 기반 레이트리밋을 도입하여 일부 고비용 POST 경로에 대해 더 엄격한 제한을 적용했습니다.
  * 그 외 엔드포인트에는 느슨한 전역 제한을 적용하여 전체 안정성을 향상시켰습니다.
  * 프록시 응답 제한이 90초로 설정되었습니다.
* **버그 픽스**
  * 레이트 리밋(429) 발생 시 클라이언트에 항상 일관된 JSON 에러 응답을 반환하도록 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

