### PR TITLE
토너먼트 아이템 단건 조회 응답에 원본 링크(sourceUrl) 추가

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
@@ -634,6 +634,7 @@ interface TournamentApi {
             - PROCESSING: 파싱 진행 중 (name·price·imageUrl 은 null)
             - READY: 파싱 완료 (모든 필드 채워짐)
             - FAILED: 파싱 실패 (상품 페이지 아님 또는 추출 불가)
+            sourceUrl: 등록 시 입력한 원본 링크. 이미지로 등록한 경우 null.
             토너먼트 참여자만 조회할 수 있다.
         """,
     )

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApiExamples.kt
@@ -357,14 +357,31 @@ class TournamentApiExamples(
                     operation.examples(openApiObjectMapper.delegate) {
                         add(
                             status = HttpStatus.OK,
-                            name = "READY - 파싱 완료",
+                            name = "READY - 파싱 완료 (링크 등록)",
                             payload = ApiResponseBody.ok(
                                 TournamentItemDetailResponse(
                                     tournamentItemId = 10,
                                     itemId = 100,
+                                    sourceUrl = "https://www.nike.com/kr/t/air-max/example",
                                     name = "나이키 에어맥스",
                                     imageUrl = "https://cdn.example.com/items/1.jpg",
                                     price = 129_000,
+                                    currency = "KRW",
+                                    status = ItemStatus.READY,
+                                ),
+                            ),
+                        )
+                        add(
+                            status = HttpStatus.OK,
+                            name = "READY - 파싱 완료 (이미지 등록, sourceUrl=null)",
+                            payload = ApiResponseBody.ok(
+                                TournamentItemDetailResponse(
+                                    tournamentItemId = 11,
+                                    itemId = 101,
+                                    sourceUrl = null,
+                                    name = "아디다스 울트라부스트",
+                                    imageUrl = "https://cdn.example.com/items/2.jpg",
+                                    price = 189_000,
                                     currency = "KRW",
                                     status = ItemStatus.READY,
                                 ),
@@ -377,6 +394,7 @@ class TournamentApiExamples(
                                 TournamentItemDetailResponse(
                                     tournamentItemId = 10,
                                     itemId = 100,
+                                    sourceUrl = "https://www.nike.com/kr/t/air-max/example",
                                     name = null,
                                     imageUrl = null,
                                     price = null,
@@ -392,6 +410,7 @@ class TournamentApiExamples(
                                 TournamentItemDetailResponse(
                                     tournamentItemId = 10,
                                     itemId = 100,
+                                    sourceUrl = "https://www.nike.com/kr/t/air-max/example",
                                     name = null,
                                     imageUrl = null,
                                     price = null,

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/dto/TournamentItemDetailResponse.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/dto/TournamentItemDetailResponse.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonInclude
 data class TournamentItemDetailResponse(
     val tournamentItemId: Long,
     val itemId: Long,
+    val sourceUrl: String?,
     val name: String?,
     val imageUrl: String?,
     val price: Int?,
@@ -19,6 +20,7 @@ data class TournamentItemDetailResponse(
             TournamentItemDetailResponse(
                 tournamentItemId = detail.tournamentItemId,
                 itemId = detail.itemId,
+                sourceUrl = detail.sourceUrl,
                 name = detail.name,
                 imageUrl = detail.imageUrl,
                 price = detail.price,

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
@@ -236,7 +236,7 @@ class TournamentService(
         return TournamentItemDetail(
             tournamentItemId = tournamentItem.getId(),
             itemId = item.getId(),
-            sourceUrl = item.link?.value?.toString(),
+            sourceUrl = item.link?.toString(),
             name = item.name,
             imageUrl = item.imageUrl,
             price = item.currentPrice,

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
@@ -236,6 +236,7 @@ class TournamentService(
         return TournamentItemDetail(
             tournamentItemId = tournamentItem.getId(),
             itemId = item.getId(),
+            sourceUrl = item.link?.value?.toString(),
             name = item.name,
             imageUrl = item.imageUrl,
             price = item.currentPrice,

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/dto/TournamentItemDetail.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/dto/TournamentItemDetail.kt
@@ -5,6 +5,7 @@ import com.depromeet.piki.item.domain.ItemStatus
 data class TournamentItemDetail(
     val tournamentItemId: Long,
     val itemId: Long,
+    val sourceUrl: String?,
     val name: String?,
     val imageUrl: String?,
     val price: Int?,

--- a/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
@@ -3,6 +3,7 @@ package com.depromeet.piki.tournament.controller
 import com.depromeet.piki.auth.infrastructure.jwt.JwtProvider
 import com.depromeet.piki.item.domain.Item
 import com.depromeet.piki.item.domain.ItemStatus
+import com.depromeet.piki.product.domain.ProductLink
 import com.depromeet.piki.item.repository.ItemJpaRepository
 import com.depromeet.piki.support.IntegrationTestSupport
 import com.depromeet.piki.support.StubImageParsingWorker
@@ -1101,6 +1102,33 @@ class TournamentControllerTest : IntegrationTestSupport() {
             .andExpect(jsonPath("$.data.name").value("나이키 에어맥스"))
             .andExpect(jsonPath("$.data.price").value(129_000))
             .andExpect(jsonPath("$.data.currency").value("KRW"))
+            .andExpect(jsonPath("$.data.status").value("READY"))
+            // 이미지·위시 등록 아이템은 sourceUrl 이 없어 응답에 포함되지 않는다
+            .andExpect(jsonPath("$.data.sourceUrl").doesNotExist())
+    }
+
+    @Test
+    fun `GET tournaments-id-items-tournamentItemId 는 링크 등록 아이템의 sourceUrl 을 반환한다`() {
+        val mockMvc = buildMockMvc()
+        val tournamentId = createTournament(mockMvc)
+        val sourceUrl = "https://www.nike.com/kr/t/air-max/example"
+        val linkItem = itemJpaRepository.save(
+            Item(
+                link = ProductLink.parse(sourceUrl),
+                name = "나이키",
+                currentPrice = 100_000,
+                currency = "KRW",
+            ),
+        )
+        tournamentItemJpaRepository.save(TournamentItem(tournamentId = tournamentId, itemId = linkItem.getId(), userId = userId))
+        val tournamentItemId = tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId).first().getId()
+
+        mockMvc
+            .perform(
+                get("/api/v1/tournaments/$tournamentId/items/$tournamentItemId")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(userId)),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.sourceUrl").value(sourceUrl))
             .andExpect(jsonPath("$.data.status").value("READY"))
     }
 


### PR DESCRIPTION
## Situation
- 토너먼트 아이템 단건 조회(`GET /tournaments/{id}/items/{itemId}`) 응답에 원본 링크가 없어 클라이언트가 아이템의 출처 URL을 알 방법이 없었다.
- 이미지로 등록한 아이템은 원본 링크가 없으므로 null, 링크로 등록한 아이템만 URL을 반환해야 한다는 요구가 존재했다.

## Task
- 단건 조회 응답에 `sourceUrl` 필드를 추가해 클라이언트가 원본 URL에 바로 접근할 수 있게 한다.

## Action
- `TournamentItemDetail`(서비스 DTO)·`TournamentItemDetailResponse`(컨트롤러 DTO)에 `sourceUrl: String?` 필드 추가
- `TournamentService.getTournamentItem()`에서 `item.link?.value?.toString()`으로 채움
- 이미지 등록 아이템은 `link = null`이라 `@JsonInclude(NON_NULL)` 정책에 의해 응답에서 자동 제외
- `TournamentApi` description 및 `TournamentApiExamples`에 `sourceUrl` 포함 예시 반영
- DB 컬럼명(`source_url`)과 맞춰 `sourceUrl`로 네이밍 — 도메인 필드명 `link`(`ProductLink` 타입)와 다른 레벨이므로 일관성 문제 없음

## Result
- 링크 등록 아이템은 `sourceUrl`에 원본 URL, 이미지 등록 아이템은 응답 필드 자체가 없음
- API 문서(description·examples)가 실제 응답과 일치

---
## 연관 이슈

- close #333


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Tournament item 상세 조회 API 응답에 `sourceUrl` 필드 추가 (링크 등록 시 원본 URL 반환, 이미지 등록 시 null)

* **테스트**
  * `sourceUrl` 필드 포함 여부 검증 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->