### PR TITLE
파싱 실패한 토너먼트 아이템 수정 API

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
@@ -10,6 +10,7 @@ import com.depromeet.piki.tournament.controller.dto.CreateTournamentRequest
 import com.depromeet.piki.tournament.controller.dto.CreateTournamentResponse
 import com.depromeet.piki.tournament.controller.dto.RecordMatchRequest
 import com.depromeet.piki.tournament.controller.dto.TournamentDetailResponse
+import com.depromeet.piki.tournament.controller.dto.UpdateTournamentItemRequest
 import com.depromeet.piki.tournament.controller.dto.TournamentItemDetailResponse
 import com.depromeet.piki.tournament.controller.dto.TournamentStartResponse
 import com.depromeet.piki.tournament.controller.dto.TournamentSummaryResponse
@@ -305,6 +306,87 @@ interface TournamentApi {
         @Parameter(description = "토너먼트 ID", example = "1") tournamentId: Long,
         images: List<MultipartFile>?,
     ): ApiResponseBody<AddTournamentItemsFromImagesResponse>
+
+    @Operation(
+        summary = "토너먼트 아이템 수정",
+        description = """
+            파싱 실패(FAILED) 상태인 토너먼트 아이템을 유저가 직접 보정한다.
+            수정 성공 시 아이템 상태가 FAILED → READY 로 전환된다.
+            수정 가능 필드: 이름, 가격, 가격 단위, 이미지 URL (null 이면 기존 값 유지).
+            READY·PROCESSING 아이템은 수정 불가(409). 아이템을 등록한 본인만 수정 가능.
+            이름은 수정 후에도 반드시 존재해야 한다 — 기존 이름이 없고 name 도 미입력이면 400.
+        """,
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "수정 성공 (FAILED → READY 전환)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청 (이름 없이 수정 시도 · 이름 1자 미만 512자 초과 · 가격 음수 · 가격단위 8자 초과 · 이미지 URL 2048자 초과)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "미인증 (JWT 토큰 없음 또는 유효하지 않음)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "403",
+                description = "권한 없음 (토너먼트 참여자가 아님 · 아이템을 등록한 본인이 아님)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "토너먼트를 찾을 수 없음 · 토너먼트 아이템을 찾을 수 없음",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "409",
+                description = "상태 충돌 (PENDING이 아닌 토너먼트 · READY 또는 PROCESSING 상태 아이템)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun updateItem(
+        @Parameter(hidden = true) userId: UUID,
+        @Parameter(description = "토너먼트 ID", example = "1") tournamentId: Long,
+        @Parameter(description = "토너먼트 아이템 ID", example = "10") tournamentItemId: Long,
+        request: UpdateTournamentItemRequest,
+    ): ApiResponseBody<Unit>
 
     @Operation(
         summary = "토너먼트 아이템 삭제",

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
@@ -10,10 +10,10 @@ import com.depromeet.piki.tournament.controller.dto.CreateTournamentRequest
 import com.depromeet.piki.tournament.controller.dto.CreateTournamentResponse
 import com.depromeet.piki.tournament.controller.dto.RecordMatchRequest
 import com.depromeet.piki.tournament.controller.dto.TournamentDetailResponse
-import com.depromeet.piki.tournament.controller.dto.UpdateTournamentItemRequest
 import com.depromeet.piki.tournament.controller.dto.TournamentItemDetailResponse
 import com.depromeet.piki.tournament.controller.dto.TournamentStartResponse
 import com.depromeet.piki.tournament.controller.dto.TournamentSummaryResponse
+import com.depromeet.piki.tournament.controller.dto.UpdateTournamentItemRequest
 import com.depromeet.piki.tournament.domain.TournamentStatus
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApiExamples.kt
@@ -63,6 +63,15 @@ class TournamentApiExamples(
                         )
                     }
 
+                handlerMethod.binds(TournamentController::updateItem) ->
+                    operation.examples(openApiObjectMapper.delegate) {
+                        add(
+                            status = HttpStatus.OK,
+                            name = "수정 성공 (FAILED → READY)",
+                            payload = ApiResponseBody.ok<Unit>(),
+                        )
+                    }
+
                 handlerMethod.binds(TournamentController::deleteItem) ->
                     operation.examples(openApiObjectMapper.delegate) {
                         add(

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentController.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentController.kt
@@ -10,6 +10,7 @@ import com.depromeet.piki.tournament.controller.dto.CreateTournamentRequest
 import com.depromeet.piki.tournament.controller.dto.CreateTournamentResponse
 import com.depromeet.piki.tournament.controller.dto.RecordMatchRequest
 import com.depromeet.piki.tournament.controller.dto.TournamentDetailResponse
+import com.depromeet.piki.tournament.controller.dto.UpdateTournamentItemRequest
 import com.depromeet.piki.tournament.controller.dto.TournamentItemDetailResponse
 import com.depromeet.piki.tournament.controller.dto.TournamentStartResponse
 import com.depromeet.piki.tournament.controller.dto.TournamentSummaryResponse
@@ -22,6 +23,7 @@ import org.springframework.http.MediaType
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -78,6 +80,17 @@ class TournamentController(
         // required=false + orEmpty 로 항상 서비스 검증(invalidImageCount, 400)에 닿게 한다.
         val tournamentItemIds = tournamentItemService.addItemsFromImages(userId, tournamentId, images.orEmpty())
         return ApiResponseBody.ok(AddTournamentItemsFromImagesResponse(tournamentItemIds))
+    }
+
+    @PatchMapping("/{tournamentId}/items/{tournamentItemId}")
+    override fun updateItem(
+        @AuthenticationPrincipal userId: UUID,
+        @PathVariable tournamentId: Long,
+        @PathVariable tournamentItemId: Long,
+        @Valid @RequestBody request: UpdateTournamentItemRequest,
+    ): ApiResponseBody<Unit> {
+        tournamentService.updateItem(userId, request.toUpdateTournamentItem(tournamentId, tournamentItemId))
+        return ApiResponseBody.ok()
     }
 
     @DeleteMapping("/{tournamentId}/items/{tournamentItemId}")

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentController.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentController.kt
@@ -10,10 +10,10 @@ import com.depromeet.piki.tournament.controller.dto.CreateTournamentRequest
 import com.depromeet.piki.tournament.controller.dto.CreateTournamentResponse
 import com.depromeet.piki.tournament.controller.dto.RecordMatchRequest
 import com.depromeet.piki.tournament.controller.dto.TournamentDetailResponse
-import com.depromeet.piki.tournament.controller.dto.UpdateTournamentItemRequest
 import com.depromeet.piki.tournament.controller.dto.TournamentItemDetailResponse
 import com.depromeet.piki.tournament.controller.dto.TournamentStartResponse
 import com.depromeet.piki.tournament.controller.dto.TournamentSummaryResponse
+import com.depromeet.piki.tournament.controller.dto.UpdateTournamentItemRequest
 import com.depromeet.piki.tournament.domain.TournamentStatus
 import com.depromeet.piki.tournament.service.TournamentItemService
 import com.depromeet.piki.tournament.service.TournamentService

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/dto/UpdateTournamentItemRequest.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/dto/UpdateTournamentItemRequest.kt
@@ -1,0 +1,29 @@
+package com.depromeet.piki.tournament.controller.dto
+
+import com.depromeet.piki.tournament.service.dto.UpdateTournamentItem
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.Size
+
+data class UpdateTournamentItemRequest(
+    @field:Size(min = 1, max = 512)
+    val name: String?,
+    @field:Min(0)
+    val price: Int?,
+    @field:Size(max = 8)
+    val currency: String?,
+    @field:Size(max = 2048)
+    val imageUrl: String?,
+) {
+    fun toUpdateTournamentItem(
+        tournamentId: Long,
+        tournamentItemId: Long,
+    ): UpdateTournamentItem =
+        UpdateTournamentItem(
+            tournamentId = tournamentId,
+            tournamentItemId = tournamentItemId,
+            name = name,
+            price = price,
+            currency = currency,
+            imageUrl = imageUrl,
+        )
+}

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
@@ -18,6 +18,7 @@ import com.depromeet.piki.tournament.service.dto.TournamentDetail
 import com.depromeet.piki.tournament.service.dto.TournamentItemDetail
 import com.depromeet.piki.tournament.service.dto.TournamentStartResult
 import com.depromeet.piki.tournament.service.dto.TournamentSummary
+import com.depromeet.piki.tournament.service.dto.UpdateTournamentItem
 import com.depromeet.piki.user.repository.UserRepository
 import com.depromeet.piki.wishlist.repository.WishRepository
 import org.springframework.stereotype.Service
@@ -381,6 +382,34 @@ class TournamentService(
 
         val deleted = tournamentItemRepository.deleteIfPending(tournamentItemId, tournamentId)
         if (deleted == 0) throw TournamentException.notPendingTournament()
+    }
+
+    @Transactional
+    fun updateItem(
+        userId: UUID,
+        command: UpdateTournamentItem,
+    ) {
+        val tournament =
+            tournamentRepository.findTournamentById(command.tournamentId)
+                ?: throw TournamentException.notFoundTournament()
+        if (!tournament.isPending()) throw TournamentException.notPendingTournament()
+        tournamentUserRepository.findByTournamentIdAndUserId(command.tournamentId, userId)
+            ?: throw TournamentException.forbiddenTournament()
+        val tournamentItem =
+            tournamentItemRepository.findById(command.tournamentItemId)
+                ?: throw TournamentException.notFoundTournamentItem()
+        if (tournamentItem.tournamentId != command.tournamentId) throw TournamentException.notFoundTournamentItem()
+        if (tournamentItem.userId != userId) throw TournamentException.forbiddenTournament()
+        val item =
+            itemRepository.findById(tournamentItem.itemId)
+                ?: error("item 없음 — tournamentItemId=${command.tournamentItemId}, itemId=${tournamentItem.itemId}")
+        item.recover(
+            name = command.name,
+            currentPrice = command.price,
+            imageUrl = command.imageUrl,
+            currency = command.currency,
+        )
+        itemRepository.save(item)
     }
 
     private fun toItemDetail(

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
@@ -409,7 +409,6 @@ class TournamentService(
             imageUrl = command.imageUrl,
             currency = command.currency,
         )
-        itemRepository.save(item)
     }
 
     private fun toItemDetail(

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/dto/UpdateTournamentItem.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/dto/UpdateTournamentItem.kt
@@ -1,0 +1,10 @@
+package com.depromeet.piki.tournament.service.dto
+
+data class UpdateTournamentItem(
+    val tournamentId: Long,
+    val tournamentItemId: Long,
+    val name: String?,
+    val price: Int?,
+    val currency: String?,
+    val imageUrl: String?,
+)

--- a/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
@@ -884,6 +884,40 @@ class TournamentControllerTest : IntegrationTestSupport() {
     }
 
     @Test
+    fun `PATCH tournaments-id-items-itemId 에서 PROCESSING 아이템이면 409 를 반환한다`() {
+        val mockMvc = buildMockMvc()
+        val tournamentId = createTournament(mockMvc)
+        val processingItem = itemJpaRepository.save(Item(status = ItemStatus.PROCESSING))
+        tournamentItemJpaRepository.save(TournamentItem(tournamentId = tournamentId, itemId = processingItem.getId(), userId = userId))
+        val tournamentItemId = tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId).first().getId()
+
+        mockMvc
+            .perform(
+                patch("/api/v1/tournaments/$tournamentId/items/$tournamentItemId")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(userId))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"name":"수정 시도"}"""),
+            ).andExpect(status().isConflict)
+    }
+
+    @Test
+    fun `PATCH tournaments-id-items-itemId 에서 IN_PROGRESS 토너먼트이면 409 를 반환한다`() {
+        val mockMvc = buildMockMvc()
+        val (tournamentId, item1Id) = startTournamentWith2Items(mockMvc)
+        val failedItem = itemJpaRepository.save(Item(status = ItemStatus.FAILED))
+        tournamentItemJpaRepository.save(TournamentItem(tournamentId = tournamentId, itemId = failedItem.getId(), userId = userId))
+        val tournamentItemId = tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId).last().getId()
+
+        mockMvc
+            .perform(
+                patch("/api/v1/tournaments/$tournamentId/items/$tournamentItemId")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(userId))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"name":"수정 시도","price":10000,"currency":"KRW"}"""),
+            ).andExpect(status().isConflict)
+    }
+
+    @Test
     fun `PATCH tournaments-id-items-itemId 에서 아이템 등록자가 아니면 403 을 반환한다`() {
         val mockMvc = buildMockMvc()
         val tournamentId = createTournament(mockMvc)

--- a/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
@@ -28,6 +28,7 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -840,6 +841,81 @@ class TournamentControllerTest : IntegrationTestSupport() {
                 delete("/api/v1/tournaments/$tournamentId1/items/$itemOfTournament2")
                     .header(HttpHeaders.AUTHORIZATION, authHeader(userId)),
             ).andExpect(status().isNotFound)
+    }
+
+    @Test
+    fun `PATCH tournaments-id-items-itemId 는 FAILED 아이템을 수정하고 READY 로 전환한다`() {
+        val mockMvc = buildMockMvc()
+        val tournamentId = createTournament(mockMvc)
+        val failedItem = itemJpaRepository.save(Item(status = ItemStatus.FAILED))
+        tournamentItemJpaRepository.save(TournamentItem(tournamentId = tournamentId, itemId = failedItem.getId(), userId = userId))
+        val tournamentItemId = tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId).first().getId()
+
+        mockMvc
+            .perform(
+                patch("/api/v1/tournaments/$tournamentId/items/$tournamentItemId")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(userId))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"name":"수정된 이름","price":50000,"currency":"KRW"}"""),
+            ).andExpect(status().isOk)
+
+        val updated = itemJpaRepository.findById(failedItem.getId()).get()
+        assertEquals("수정된 이름", updated.name)
+        assertEquals(50000, updated.currentPrice)
+        assertEquals("KRW", updated.currency)
+        assertEquals(ItemStatus.READY, updated.status)
+    }
+
+    @Test
+    fun `PATCH tournaments-id-items-itemId 에서 READY 아이템이면 409 를 반환한다`() {
+        val mockMvc = buildMockMvc()
+        val tournamentId = createTournament(mockMvc)
+        val readyItemId = saveWishItem()
+        addItemsToTournament(mockMvc, tournamentId, userId, readyItemId)
+        val tournamentItemId = tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId).first().getId()
+
+        mockMvc
+            .perform(
+                patch("/api/v1/tournaments/$tournamentId/items/$tournamentItemId")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(userId))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"name":"수정 시도"}"""),
+            ).andExpect(status().isConflict)
+    }
+
+    @Test
+    fun `PATCH tournaments-id-items-itemId 에서 아이템 등록자가 아니면 403 을 반환한다`() {
+        val mockMvc = buildMockMvc()
+        val tournamentId = createTournament(mockMvc)
+        tournamentUserJpaRepository.save(TournamentUser(tournamentId = tournamentId, userId = otherUserId))
+        val failedItem = itemJpaRepository.save(Item(status = ItemStatus.FAILED))
+        tournamentItemJpaRepository.save(TournamentItem(tournamentId = tournamentId, itemId = failedItem.getId(), userId = otherUserId))
+        val tournamentItemId = tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId).first().getId()
+
+        mockMvc
+            .perform(
+                patch("/api/v1/tournaments/$tournamentId/items/$tournamentItemId")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(userId))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"name":"수정 시도"}"""),
+            ).andExpect(status().isForbidden)
+    }
+
+    @Test
+    fun `PATCH tournaments-id-items-itemId 에서 이름 없이 수정하면 400 을 반환한다`() {
+        val mockMvc = buildMockMvc()
+        val tournamentId = createTournament(mockMvc)
+        val failedItem = itemJpaRepository.save(Item(status = ItemStatus.FAILED))
+        tournamentItemJpaRepository.save(TournamentItem(tournamentId = tournamentId, itemId = failedItem.getId(), userId = userId))
+        val tournamentItemId = tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId).first().getId()
+
+        mockMvc
+            .perform(
+                patch("/api/v1/tournaments/$tournamentId/items/$tournamentItemId")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(userId))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"price":50000}"""),
+            ).andExpect(status().isBadRequest)
     }
 
     @Test

--- a/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
@@ -902,6 +902,28 @@ class TournamentControllerTest : IntegrationTestSupport() {
     }
 
     @Test
+    fun `PATCH tournaments-id-items-itemId 는 이름이 있는 FAILED 아이템에 가격만 보내면 이름을 유지하며 200 을 반환한다`() {
+        val mockMvc = buildMockMvc()
+        val tournamentId = createTournament(mockMvc)
+        val failedItem = itemJpaRepository.save(Item(name = "기존 이름", status = ItemStatus.FAILED))
+        tournamentItemJpaRepository.save(TournamentItem(tournamentId = tournamentId, itemId = failedItem.getId(), userId = userId))
+        val tournamentItemId = tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId).first().getId()
+
+        mockMvc
+            .perform(
+                patch("/api/v1/tournaments/$tournamentId/items/$tournamentItemId")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(userId))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"price":50000,"currency":"KRW"}"""),
+            ).andExpect(status().isOk)
+
+        val updated = itemJpaRepository.findById(failedItem.getId()).get()
+        assertEquals("기존 이름", updated.name)
+        assertEquals(50000, updated.currentPrice)
+        assertEquals(ItemStatus.READY, updated.status)
+    }
+
+    @Test
     fun `PATCH tournaments-id-items-itemId 에서 이름 없이 수정하면 400 을 반환한다`() {
         val mockMvc = buildMockMvc()
         val tournamentId = createTournament(mockMvc)


### PR DESCRIPTION
## Situation
- 링크·이미지로 등록한 토너먼트 아이템이 파싱에 실패(FAILED)하면 이름·가격·이미지가 비어 있어 토너먼트 출전이 불가하다.
- 기존에는 아이템을 삭제하고 재등록하는 방법만 있었고, 유저가 직접 값을 보정할 수 있는 수정 API가 없었다.

## Task
- 파싱 실패 아이템을 유저가 직접 보정해 READY 상태로 복구할 수 있는 PATCH 엔드포인트를 추가한다.
- 핵심 결정: 도메인에 이미 존재하는 `Item.recover()` 메서드를 그대로 위임점으로 활용 — 상태 전이(FAILED→READY), 이름 필수 불변식, READY·PROCESSING 차단 로직이 이미 도메인에 구현되어 있다.

## Action

### 구현
- `PATCH /tournaments/{tournamentId}/items/{tournamentItemId}` 엔드포인트 추가
- 수정 가능 필드: 이름(`name`), 가격(`price`), 가격 단위(`currency`), 이미지 URL(`imageUrl`) — 모두 선택, `null` 이면 기존 값 유지
- 수정 성공 시 아이템 상태가 FAILED → READY로 자동 전환
- 권한: 토너먼트 참여자이면서 아이템을 등록한 본인만 수정 가능 (소유자도 불가)
- `itemRepository.save()` 를 명시하지 않고 `@Transactional` dirty checking에 위임 — `WishPersistenceService.recoverItem()` 패턴과 통일

### 이미지 처리 설계 결정
- 이미지는 파일 업로드 없이 URL 문자열(`imageUrl: String?`)로 받는다. `WishlistService.recoverWishItem()`이 S3 업로드 파이프라인까지 포함한 것과 다르게, 토너먼트 아이템 수정은 URL 직접 입력만 허용하는 것으로 합의.

## Result
- FAILED 아이템 보정 후 재등록 없이 토너먼트 출전 가능
- READY·PROCESSING 아이템 수정 시도 → 409, 비소유자 수정 시도 → 403, 이름 없는 상태로 보정 시도 → 400
- 통합 테스트 5종: 성공(상태 전환 검증), READY 아이템→409, 비소유자→403, 이름 없음→400, 기존 이름 있는 아이템 부분 수정→200(이름 유지 검증)
- 이미지 파일 업로드 지원은 이슈 #1번 기획 결정 후 별도 추가 가능한 구조

---
## 연관 이슈

- close #335


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 토너먼트 아이템 수정 API가 추가되었습니다. FAILED 상태의 아이템에 대해 이름·가격·통화·이미지 URL을 부분 수정해 READY로 전환할 수 있으며, 소유자만 사용 가능합니다. 입력 검증(이름 필수/길이, 가격 음수 불가 등)과 상태 제약이 적용됩니다.

* **Tests**
  * 성공 및 오류(상태 충돌, 권한 부족, 입력 검증 등) 시나리오를 포함한 PATCH 엔드포인트 테스트가 추가되었습니다.

* **Documentation**
  * 수정 API에 대한 예시 응답 문서가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->