### PR TITLE
세션 마무리 스킬 책임 재정리 — check read-only화·close 단독 완결

### DIFF
--- a/.claude/commands/session-check.md
+++ b/.claude/commands/session-check.md
@@ -1,4 +1,4 @@
-세션을 종료해도 되는지 점검한다 — 기본은 현재 워크트리/브랜치만 read-only로 훑고, 정리 가능한 항목(현재 스코프)은 셀렉트로 처리한다. 인자 `all` 을 주면 전체 워크트리·브랜치·PR을 함께 스윕한다. 점검만 하며, 워크트리 정리(close)는 하지 않는다 — close 는 `/session-close` 를 직접 호출할 때만 일어난다.
+세션을 종료해도 되는지 **read-only로 점검**한다 — 기본은 현재 워크트리/브랜치만 훑고, 인자 `all` 을 주면 전체 워크트리·브랜치·PR을 함께 스윕한다. **어떤 변경도 하지 않는다** — 커밋·푸시·브랜치 삭제·prune·워크트리 정리(close) 모두 직접 실행하지 않고, 무엇을 어떤 도구로 정리할지 **안내만** 한다. 실제 정리는 `/commit`·`git push`·`/session-close` 등으로 사용자가 한다.
 
 ## 모드
 
@@ -14,11 +14,11 @@
 
 ## 원칙
 
-- **점검만 한다 — close 는 하지 않는다.** session-check 는 상태를 점검하고, 동의받은 정리 셀렉트(커밋/푸시/브랜치 삭제/prune)까지만 한다. **워크트리를 나가거나 지우는 close 는 절대 하지 않고, `/session-close` 를 자동 호출하지도 않는다.** 닫아도 안전하다고 판단되면 사용자에게 `/session-close` 를 직접 입력하라고 **안내만** 한다 (아래 `## 절차` 6).
-- **읽기 먼저, 변경은 동의 후.** 모든 점검은 read-only로 먼저 끝낸다. 커밋·푸시·브랜치 삭제·prune 같은 변경 동작은 `AskUserQuestion` 셀렉트로 사용자가 고른 것만 수행한다.
-- **액션 가능한 항목만 셀렉트.** 처리 선택지가 있는 항목(uncommitted, 미푸시, 미삭제 브랜치, prunable 워크트리)만 셀렉트를 띄운다. 정보성 항목(CI 실패, 리뷰 대기, 새 TODO, 다른 워크트리 dirty)은 셀렉트 없이 리포트만 한다. **액션 가능한 게 하나도 없으면 셀렉트를 아예 띄우지 않고 리포트로 끝낸다.**
-- **체크아웃 전환 금지.** 브랜치를 갈아타지 않는다 — 다른 워크트리/브랜치는 `git -C <path>` 와 ref 연산(push, branch -d, worktree prune)으로만 다룬다. 메인 체크아웃이 작업 중 외부에서 바뀌는 환경이므로 격리한다.
-- **파괴적 동작 안 함.** untracked 파일 삭제, `git checkout -- .`, stash drop, 강제 푸시는 스킬이 하지 않는다. 커밋은 반드시 `/commit` 으로 위임한다(컨벤션 보존).
+- **read-only — 점검·안내만, 변경 없음.** session-check 는 상태를 **읽기만** 한다. 커밋·푸시·브랜치 삭제·prune·워크트리 제거(close) 등 **어떤 변경도 직접 하지 않는다.** 정리가 필요하면 "무엇을 어떤 도구(`/commit`·`git push`·`git branch -D`·`/session-close`)로 정리하라"고 **안내만** 한다. `/session-close` 를 자동 호출하지도 않는다 (아래 `## 절차` 6).
+- **`AskUserQuestion` 을 띄우지 않는다.** 점검이 전부 read-only 라 "무엇을 처리할지" 사용자에게 고르게 할 게 없다. 상태를 보여주고 정리 방법을 안내하는 것으로 끝낸다.
+- **정리 안내 vs 정보성.** 처리 방법이 있는 항목(uncommitted, 미푸시, 미삭제 브랜치, prunable 워크트리)은 "무엇을 어떤 도구로 정리할지" 안내한다. 그 외(CI 실패, 리뷰 대기, 새 TODO, 다른 워크트리 dirty)는 정보성 리포트. 어느 쪽이든 **실행하지 않고 보여주기만** 한다.
+- **체크아웃 전환 금지.** 브랜치를 갈아타지 않는다 — 다른 워크트리/브랜치는 `git -C <path>` 로 **읽기만** 한다(status·for-each-ref 등). 메인 체크아웃이 작업 중 외부에서 바뀌는 환경이므로 격리한다.
+- **파괴적 동작은 더더욱 안 함.** read-only 라 변경 자체를 안 하지만, 특히 untracked 파일 삭제·`git checkout -- .`·stash drop·강제 푸시처럼 되돌리기 어려운 동작은 안내에서도 권하지 않는다. 커밋은 `/commit`(컨벤션 보존)으로 안내한다.
 - **이모지·체크기호 금지.** 굵게·불릿으로만 상태를 표시한다.
 
 ## 점검 항목
@@ -37,7 +37,7 @@ git status --porcelain        # staged / unstaged / untracked
 git stash list                # 남은 stash
 ```
 
-- uncommitted(staged + unstaged) → **액션**: `/commit` 호출 / stash / 그대로 둠
+- uncommitted(staged + unstaged) → **정리 안내**: 커밋하려면 `/commit`, 또는 stash / 그대로 둠. 여기선 실행하지 않는다.
 - untracked → 그중 `.md`·스크래치 파일은 작업 부산물일 수 있으니 따로 표시한다(삭제는 안 함, 커밋 여부는 `/commit` 판단에 위임).
 - stash 잔여 → **정보성** 리포트만 (apply/drop은 위험하므로 자동 처리하지 않는다).
 
@@ -51,7 +51,7 @@ gh pr list --author "@me" --state open --head "$BR" --json number,title,headRefN
 ```
 
 - `%(upstream:track)` 가 `[gone]` → 현재 브랜치의 upstream(원격 추적 브랜치)이 삭제됨 = **머지된 신호**. 단 현재 브랜치는 정의상 현재 워크트리에 체크아웃돼 있어 `git branch -D` 로 삭제 불가다. → **액션 아님, 안내**: "이 브랜치는 머지됨 → 워크트리째 정리하려면 `/session-close`." (session-close 가 워크트리 제거 + 브랜치 삭제를 함께 처리한다.)
-- upstream 이 없음(=한 번도 push 안 됨)이거나 ahead → **액션**: `git push`(필요 시 `-u`) / 그대로 둠. `[gone]` 과 혼동하지 않는다 — `[gone]` 은 push 가 아니라 머지 신호다.
+- upstream 이 없음(=한 번도 push 안 됨)이거나 ahead → **정리 안내**: `git push`(필요 시 `-u`) 하면 됨(여기선 실행 안 함). `[gone]` 과 혼동하지 않는다 — `[gone]` 은 push 가 아니라 머지 신호다.
 - 현재 브랜치 PR의 CI 실패(`statusCheckRollup` 에 FAILURE)·리뷰 대기(`reviewDecision` 가 REVIEW_REQUIRED / CHANGES_REQUESTED) → **정보성** 리포트.
 
 ### C. 전체 워크트리·브랜치 스윕 (`all` 모드 한정)
@@ -72,11 +72,11 @@ git -C "<worktree_path>" status --porcelain
 ```
 
 - 현재 세션 워크트리가 아닌 다른 워크트리에 dirty/untracked → **정보성** 리포트(거기서 정리하라고 안내). 커밋은 여기서 하지 않는다.
-- prunable 워크트리 → **액션**: `git worktree prune` / 그대로 둠
-- 현재 브랜치가 아닌 다른 브랜치가 `[gone]`(머지됐는데 안 지움) → **액션**: 삭제.
-  - **삭제는 `git branch -D` 를 쓴다.** squash/rebase 머지된 브랜치는 커밋이 현재 HEAD 의 ancestor 가 아니라 `git branch -d`(안전 삭제)가 "not fully merged" 로 거부한다. `[gone]` 은 원격에서 이미 사라진 머지 완료 브랜치라 force 삭제(`-D`)가 안전하다. 확신이 필요하면 `gh pr list --state merged --json headRefName` 로 머지 여부를 교차 확인한다.
-  - 단, 그 브랜치가 어느 워크트리에 체크아웃돼 있으면(위 `git worktree list` 의 branch 칼럼으로 판별) 삭제 불가 → 삭제 대신 "그 워크트리 먼저 정리 필요"로 안내한다(워크트리 제거는 사용자가 명시할 때만).
-- 다른 브랜치의 upstream 없음/ahead → **액션**: `git push`(필요 시 `-u`). 다른 워크트리에 물린 브랜치는 `git -C <path> push` 로 격리한다.
+- prunable 워크트리 → **정리 안내**: `git worktree prune` 하면 됨(여기선 실행 안 함).
+- 현재 브랜치가 아닌 다른 브랜치가 `[gone]`(머지됐는데 안 지움) → **정리 안내**: `git branch -D <branch>` 로 삭제 가능(여기선 실행 안 함).
+  - **삭제는 `git branch -D` 를 권한다.** squash/rebase 머지된 브랜치는 커밋이 현재 HEAD 의 ancestor 가 아니라 `git branch -d`(안전 삭제)가 "not fully merged" 로 거부한다. `[gone]` 은 원격에서 이미 사라진 머지 완료 브랜치라 force 삭제(`-D`)가 안전하다. 확신이 필요하면 `gh pr list --state merged --json headRefName` 로 머지 여부를 교차 확인하라고 함께 안내한다.
+  - 단, 그 브랜치가 어느 워크트리에 체크아웃돼 있으면(위 `git worktree list` 의 branch 칼럼으로 판별) `git branch -D` 가 거부된다 → "그 워크트리부터 `/session-close` 로 정리"라고 안내한다.
+- 다른 브랜치의 upstream 없음/ahead → **정리 안내**: `git push`(필요 시 `-u`), 다른 워크트리에 물린 브랜치는 `git -C <path> push`.
 - 다른 열린 본인 PR의 CI 실패·리뷰 대기 → **정보성** 리포트.
 
 ### D. 작업 흔적 (기본·전역 공통, 정보성)
@@ -92,30 +92,28 @@ git diff origin/dev...HEAD -- ':(exclude).claude/**' | grep -nE '^\+[^+].*(TODO|
 - `.claude/**` 는 pathspec 으로 제외한다 — 이 스킬 문서처럼 산문에 "TODO"·"FIXME" 단어가 들어가면 코드 TODO 가 아닌데도 잡히는 오탐을 막기 위함.
 - 현재 브랜치 PR에 미해결 CodeRabbit/사람 리뷰 thread가 있으면 건수만 알리고 `/coderabbit` 로 처리하라고 안내한다(여기서 처리하지 않는다).
 
-## 액션 처리 (AskUserQuestion)
+## 정리 안내 (변경은 하지 않는다)
 
-- 위에서 **액션** 으로 표시된 항목 중 실제로 건수가 있는 것만 모아 **한 번의** `AskUserQuestion` 에 질문으로 담는다(질문 최대 4개). 건수 0인 항목은 질문에 넣지 않는다.
-- 한 항목에 대상이 여러 개면(예: 미삭제 브랜치 여러 개) `multiSelect: true` 로 어떤 걸 처리할지 고르게 한다.
-- **액션 가능한 항목이 하나도 없으면 `AskUserQuestion` 을 호출하지 않는다.**
-- 선택 결과대로만 실행하고, 각 실행 후 결과(커밋 해시 / 푸시 결과 / 삭제된 브랜치명)를 짧게 보고한다.
-- 정리 셀렉트는 커밋/푸시/브랜치 삭제/prune 까지다. **워크트리 정리(close)는 셀렉트에 넣지 않는다** — close 는 `/session-close` 전용이다.
+- 점검에서 **정리 안내** 로 표시된 항목은, 최종 리포트에 "무엇을 어떤 도구로 정리하면 되는지"를 한 줄씩 적어준다. **`AskUserQuestion` 을 띄우지 않고, 어떤 변경도 실행하지 않는다.**
+- 도구 매핑: 커밋은 `/commit`, 푸시는 `git push`, 미삭제 머지 브랜치는 `git branch -D`, prunable 워크트리는 `git worktree prune`, 워크트리 제거+브랜치 삭제+연결 이슈 닫기는 `/session-close` — 각 항목 옆에 해당 도구를 명시한다.
+- 정리를 실제로 하는 건 사용자다. session-check 는 "여기까지가 현황, 정리는 이 도구로" 까지만 한다.
 
 ## 최종 리포트 형식
 
-점검이 끝나면(액션을 했다면 그 이후 상태로) 다음 형식으로 요약한다. 이모지 없이 굵게·불릿으로. 전역(`all`) 모드일 때만 다른 워크트리/브랜치 줄을 포함한다.
+점검이 끝나면 다음 형식으로 요약한다(read-only 라 항상 점검 시점 그대로의 상태다). 이모지 없이 굵게·불릿으로. 전역(`all`) 모드일 때만 다른 워크트리/브랜치 줄을 포함한다. **정리 필요** 항목은 줄 끝에 어떤 도구로 정리할지 함께 적는다.
 
 ```
 ## 세션 마무리 점검 (<기본 | 전역(all)>)
 
 브랜치: <현재 브랜치>
 
-**정리 안 됨 (주의 <M>건)**
-- (현재) uncommitted <n>건 — staged <a> / unstaged <b> / untracked <c>
-- 미푸시: <branch> ahead <n>
-- 머지됨(현재 브랜치): <branch> (upstream [gone]) — 정리는 /session-close
+**정리 필요 (주의 <M>건)** — 각 줄 끝의 도구로 사용자가 직접 정리
+- (현재) uncommitted <n>건 (staged <a> / unstaged <b> / untracked <c>) → /commit
+- 미푸시: <branch> ahead <n> → git push
+- 머지됨(현재 브랜치): <branch> (upstream [gone]) → /session-close
 - CI 실패: PR #<num> (정보성)
-- [all] (워크트리 <name>) dirty <n>건
-- [all] 미삭제(머지됨): 로컬 브랜치 <branch> (upstream [gone])
+- [all] (워크트리 <name>) dirty <n>건 (정보성 — 거기서 정리)
+- [all] 미삭제(머지됨): 로컬 브랜치 <branch> (upstream [gone]) → git branch -D
 
 **안전**
 - stash 없음 / 새 TODO 없음
@@ -128,8 +126,8 @@ git diff origin/dev...HEAD -- ':(exclude).claude/**' | grep -nE '^\+[^+].*(TODO|
 1. 인자에 `all` 이 포함됐는지로 모드를 정한다 (없으면 기본).
 2. read-only로 상태를 수집한다 — 기본 모드는 A·B·D, 전역(`all`) 모드는 A·B·C·D.
 3. 최종 리포트 형식으로 현재 상태를 먼저 보여준다.
-4. 액션 가능한 항목이 있으면 `AskUserQuestion` 으로 처리 여부를 받고, 고른 것만 실행한다(없으면 이 단계 생략).
-5. 실행 결과를 반영해 한 줄 결론(닫아도 안전 / 남은 주의 N건)으로 마무리한다.
+4. 정리가 필요한 항목은 리포트에 "무엇을 어떤 도구로 정리할지" 함께 적는다. **실행하거나 `AskUserQuestion` 을 띄우지 않는다.**
+5. 한 줄 결론(닫아도 안전 / 남은 주의 N건)으로 마무리한다.
 6. **close 는 하지 않는다 — 안내만 한다.** 결론이 "닫아도 안전"이고, 현재 워크트리(`CUR`)가 메인 체크아웃이 아니면서 머지+clean 인 **제거 대상 sub-worktree** 일 때, 사용자에게 **안내만** 한다:
    - "이 워크트리를 정리하고 마무리하려면 **`/session-close`** 를 입력하세요."
    - **`/session-close` 를 `Skill` 도구로 자동 호출하지 않는다.** close 는 사용자가 직접 호출할 때만 일어난다.

--- a/.claude/commands/session-close.md
+++ b/.claude/commands/session-close.md
@@ -1,8 +1,8 @@
-세션 작업을 마무리한다 — `/session-check` 로 "닫아도 안전"이 확인된 뒤, 지금 들어가 있는 작업 워크트리를 (머지+clean 일 때만) 나가면서 제거하고, 사용자에게 `/clear` 입력을 안내한다. `/session-check` 의 짝(teardown) 스킬.
+세션 작업을 마무리한다 — 지금 들어가 있는 작업 워크트리를 (**머지+clean 을 자체 점검해** 그럴 때만) 나가면서 제거하고, 머지로 닫혔어야 할 연결 이슈가 아직 열려 있으면 동의받아 닫은 뒤, 사용자에게 `/clear` 입력을 안내한다. **자체 점검으로 단독 동작**하므로 `/session-check` 를 먼저 안 거쳐도 되고, `/session-check` 는 변경 없이 미리 보는 read-only 프리뷰다. `/session-check` 의 짝(teardown) 스킬.
 
 ## 언제 쓰나
 
-- `/session-check` 결과가 "닫아도 안전"이고, 지금 작업하던 워크트리를 정리하고 세션을 끝내려 할 때.
+- 지금 작업하던 워크트리를 정리하고 세션을 끝내려 할 때. `/session-check` 를 먼저 부르지 않아도 close 가 자체 점검한다 (check 는 변경 없이 미리 보고 싶을 때 쓰는 선택적 read-only 프리뷰).
 - **항상 사용자가 직접 호출한다.** `/session-check` 는 점검만 하고 이 스킬을 자동 호출하지 않는다 — 닫아도 안전하면 사용자에게 `/session-close` 입력을 안내할 뿐이다. close(워크트리 제거)는 이 스킬을 명시적으로 호출할 때만 일어난다.
 
 ## 전제 — 작업 중엔 워크트리에 "들어가 있다"
@@ -11,10 +11,11 @@
 
 ## 원칙
 
-- **머지+clean 일 때만 제거.** uncommitted 가 있거나 브랜치가 아직 머지 안 됐으면 **거부**한다(작업 유실 방지). session-check 통과를 전제하되 자체 재확인한다.
+- **머지+clean 일 때만 제거.** uncommitted 가 있거나 브랜치가 아직 머지 안 됐으면 **거부**한다(작업 유실 방지). **session-check 없이도 단독으로 안전한지 자체 점검**한다 — 아래 절차 2 의 clean·머지 판정이 그 점검이다.
 - **제거는 `ExitWorktree` 로 한다.** `ExitWorktree({action:"remove"})` 가 워크트리 나가기 + 디렉터리/브랜치 삭제 + cwd 복원(메인으로)을 한 번에 처리한다 — "자기가 선 폴더를 자기가 못 지운다"는 문제를 도구가 해결한다. 수동 `git -C ... worktree remove` 보다 안전·정석.
 - **현재 작업 1개만.** 다른 워크트리·머지된 다른 stale 브랜치는 안 건드린다(별도 세션 몫).
 - **임시파일도 함께 정리한다.** 워크트리를 제거할 때, 이 브랜치가 `/tmp` 에 남긴 `/pr`·`/notion-board` 임시파일(`pr_body_$SLUG.md`·`nb_*_$SLUG.json`)도 지운다. **현재 브랜치 것만** — 동시에 도는 다른 세션의 파일은 안 건드린다("현재 1개만"과 같은 결). `session-close` 를 안 거치고 떠난 세션·중단 작업의 누수는 다음 `/pr`·`/notion-board` 진입의 mtime prune 이 회수한다.
+- **머지로 닫혔어야 할 연결 이슈가 열려 있으면 닫는다.** 이 레포는 `/pr` 이 PR 본문에 `close #N` 을 박아 머지 시 GitHub 가 연결 이슈를 자동으로 닫는다. 그런데 브랜치명에서 이슈 번호 추출이 실패해 키워드가 안 박혔거나(주된 사각), 머지 후 누가 이슈를 다시 열었거나 하면 머지됐는데도 이슈가 open 으로 남는다. 워크트리를 제거하기 전(아직 `$BR` 이 유효한 시점)에 이 누락을 점검해 **사용자 동의 후** 닫는다. 후속 작업 때문에 일부러 열어둔 이슈를 자동으로 닫지 않도록 닫기 전 확인을 거친다(머지+clean 이 확인된 뒤에만 점검한다 — 미머지 브랜치의 이슈는 건드리지 않는다). 단 브랜치명에 번호가 없고 PR 본문에도 `close` 키워드가 없으면 어느 이슈와 엮였는지 추적할 단서가 없어 이 점검도 못 잡는다 — 연결 정보 자체가 없는 한계다.
 - **`/clear` 는 자동 호출 불가.** 스킬은 빌트인 슬래시 커맨드를 못 부른다(claude-code-guide 확인). 정리 후 사용자에게 `/clear` 입력을 안내하는 것으로 끝낸다.
 - **이모지·체크기호 금지.** 굵게·불릿으로만 표시한다.
 
@@ -46,14 +47,29 @@ gh pr list --head "$BR" --state merged --json number,headRefName \
 - **dirty** (status 비어있지 않음) → **거부.** "uncommitted N건 — 먼저 `/commit` 하거나 `/session-check`." 중단.
 - **미머지** (위 merged PR 카운트가 0) → **거부.** "브랜치 `$BR` 미머지 — PR 머지 후 다시." 중단. (열린 PR 만 있는 경우도 여기 해당 — 머지 전이므로 삭제 금지.)
 - 둘 다 통과(clean + 머지됨) → **제거한다**:
-  1. 이 브랜치가 `/tmp` 에 남긴 임시파일을 먼저 정리한다 (작업이 끝났으므로). **현재 브랜치 슬러그 것만** 지워 동시에 도는 다른 세션 파일은 건드리지 않는다. 별도 bash 호출이라 슬러그를 다시 구한다 (`$BR` 은 유지되지 않음):
+  1. **머지로 닫혔어야 할 연결 이슈가 아직 열려 있는지 점검한다.** ExitWorktree 가 cwd·브랜치를 날리기 전, 아직 워크트리 안이라 `$BR` 이 유효한 이 시점에 한다. 머지된 PR 이 공식적으로 닫기로 한 이슈(`closingIssuesReferences`)와 브랜치명에서 추출한 이슈 번호(`/pr` 과 동일 규칙 `^[a-z]+/(\d+)-`)를 합쳐, 그중 아직 OPEN 인 것을 찾는다. 별도 bash 호출이라 `$BR`·PR 번호를 다시 구한다:
+     ```bash
+     BR=$(git rev-parse --abbrev-ref HEAD)
+     PR=$(gh pr list --head "$BR" --state merged --json number,headRefName \
+       --jq '[.[] | select(.headRefName == "'"$BR"'")][0].number // empty')   # 머지 확인 통과했으므로 비지 않음
+     { gh pr view "$PR" --json closingIssuesReferences --jq '.closingIssuesReferences[].number';
+       echo "$BR" | sed -nE 's#^[a-z]+/([0-9]+)-.*#\1#p'; } | sort -un | while read -r N; do
+         gh issue view "$N" --json number,state --jq 'select(.state=="OPEN") | .number'
+     done   # 출력된 번호 = 머지됐는데 안 닫힌 이슈
+     ```
+     - **출력이 비어 있으면** (OPEN 이슈 없음) 바로 2번으로. 정상이다 — 자동닫힘이 동작했거나 연결 이슈가 없다.
+     - **OPEN 이슈가 있으면** `AskUserQuestion` 으로 어떤 걸 닫을지 받는다(`multiSelect`, 기본 추천은 전부 닫기). 일부러 열어둔 이슈를 자동으로 닫지 않기 위함이다. 고른 것만 닫는다:
+       ```bash
+       gh issue close "$N" --reason completed --comment "PR #$PR 머지로 닫음 (자동닫힘 누락 보정)"
+       ```
+  2. 이 브랜치가 `/tmp` 에 남긴 임시파일을 정리한다 (작업이 끝났으므로). **현재 브랜치 슬러그 것만** 지워 동시에 도는 다른 세션 파일은 건드리지 않는다. 별도 bash 호출이라 슬러그를 다시 구한다 (`$BR` 은 유지되지 않음):
      ```bash
      SLUG=$(git branch --show-current | tr '/' '_')
      rm -f /tmp/pr_body_"$SLUG".md /tmp/nb_*_"$SLUG".json 2>/dev/null
      ```
-  2. `ExitWorktree({action: "remove"})` 를 호출한다.
-  3. 거부하면서 변경 목록을 돌려주면 — clean 은 이미 확인했으니 그 목록은 **squash-merge 커밋(원래 브랜치 dev 의 ancestor 가 아닌 것)** 인 false alarm 이다. 이때만 `ExitWorktree({action: "remove", discard_changes: true})` 로 재호출한다. (clean·머지를 확인하기 **전에는 절대** `discard_changes: true` 를 주지 않는다.)
-  4. ExitWorktree 가 **no-op** 이라고 하면(이번 세션의 `EnterWorktree` 로 들어간 워크트리가 아님 — 이전 세션·수동 생성 등), **fallback** 으로 메인에서 ref 연산한다. 이건 이 스킬의 **마지막 bash 호출**이어야 한다(`$CUR` 삭제 시 cwd 가 사라짐 — 세 명령 모두 `-C "$MAIN"` 이라 cwd 비의존):
+  3. `ExitWorktree({action: "remove"})` 를 호출한다.
+  4. 거부하면서 변경 목록을 돌려주면 — clean 은 이미 확인했으니 그 목록은 **squash-merge 커밋(원래 브랜치 dev 의 ancestor 가 아닌 것)** 인 false alarm 이다. 이때만 `ExitWorktree({action: "remove", discard_changes: true})` 로 재호출한다. (clean·머지를 확인하기 **전에는 절대** `discard_changes: true` 를 주지 않는다.)
+  5. ExitWorktree 가 **no-op** 이라고 하면(이번 세션의 `EnterWorktree` 로 들어간 워크트리가 아님 — 이전 세션·수동 생성 등), **fallback** 으로 메인에서 ref 연산한다. 이건 이 스킬의 **마지막 bash 호출**이어야 한다(`$CUR` 삭제 시 cwd 가 사라짐 — 세 명령 모두 `-C "$MAIN"` 이라 cwd 비의존):
      ```bash
      git -C "$MAIN" worktree remove "$CUR" && git -C "$MAIN" branch -D "$BR" && git -C "$MAIN" worktree prune
      ```


### PR DESCRIPTION
## Situation
- `/session-close` 가 머지+clean 을 확인해 워크트리를 정리하지만, 머지로 닫혔어야 할 연결 이슈가 자동닫힘 누락으로 열린 채 남는 경우를 보정하지 않았다.
- `/pr` 은 PR 본문에 close #N 을 박아 머지 시 GitHub 가 이슈를 자동으로 닫지만, 브랜치명에서 이슈 번호 추출이 실패하면 키워드가 안 박혀 자동닫힘이 동작하지 않는다 (실제로 PR #305 가 이 사각 — 브랜치 feat/wishlist-bulk-delete, closingIssuesReferences 비어 있음).
- 또한 `/session-check` 가 이름("점검")과 달리 동의 후 커밋·푸시·브랜치삭제·prune 같은 변경까지 수행하고 있어 "read-only 점검" 이라는 직관과 어긋나 있었다.

## Task
- session-close 가 워크트리를 제거하기 전, 머지로 닫혔어야 할 연결 이슈를 점검해 동의받아 닫도록 한다.
- session-check 를 순수 read-only 로 되돌리고, check(점검) / close(변경) 의 책임 경계를 명확히 한다.

## Action
### session-close — 이슈 자동닫힘 누락 보정
- 워크트리 제거 직전(아직 브랜치명이 유효한 시점)에, 머지된 PR 의 closingIssuesReferences(PR 공식 연결)와 브랜치명 번호 추출을 합쳐 아직 OPEN 인 이슈를 탐지.
- 후속 작업으로 일부러 열어둔 이슈를 자동으로 닫지 않도록, 닫기 전 AskUserQuestion 으로 확인하고 고른 것만 gh issue close.
- 번호도 close 키워드도 없으면 어느 이슈와 엮였는지 추적할 단서가 없어 못 잡는 한계는 솔직히 명시.

### session-check — 순수 read-only 화
- 모든 "액션" 을 "정리 안내" 로 전환. AskUserQuestion 과 실제 변경(커밋·푸시·브랜치삭제·prune)을 전부 제거.
- 리포트의 "정리 필요" 항목 옆에 어떤 도구로 정리할지 명시 (→ /commit, → git push, → git branch -D, → /session-close).

### 책임 경계 — 통합 대신 분리 유지
- "check 하나로 합치고 close 를 없앨까" 도 검토했으나, 점검과 파괴적 워크트리 제거(브랜치 삭제 포함)를 분리하는 게 안전장치라 두 스킬을 남겼다.
- 대신 close 가 자체 점검(머지+clean 재확인)으로 단독 동작함을 명시해 "check+close 2번 호출 강제" 오해를 해소 — 평소엔 close 만, check 는 변경 없이 미리 보는 선택적 프리뷰.

## Result
- `/session-check` = 순수 read-only 프리뷰(선택). 부작용 없이 "닫아도 되나" · "흘린 거 없나" 만 확인.
- `/session-close` = 단독 완결. 점검 내장 + 연결 이슈 닫기 + tmp 정리 + 워크트리 제거 + 브랜치 삭제.
- 스킬 문서만 변경, 빌드·테스트 영향 없음.

---
## 연관 이슈

- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated session-check to operate as a read-only preview, providing guidance on cleanup items without automatic execution.
  * Enhanced session-close with improved safety checks and explicit issue tracking verification before worktree removal.
  * Clarified scope and conditions for cleanup actions with tool mappings documented in reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->