### PR TITLE
OAuth 인가 URL 발급 및 state 기반 CSRF 검증 추가

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/auth/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/config/SecurityConfig.kt
@@ -50,6 +50,9 @@ class SecurityConfig(
                     .permitAll()
                     .requestMatchers(HttpMethod.POST, "/api/v1/auth/guest")
                     .permitAll()
+                    // OAuth 인가 URL 생성 — state 발급 포함. 미인증으로 호출 (로그인 전 단계).
+                    .requestMatchers(HttpMethod.GET, "/api/v1/auth/*/url")
+                    .permitAll()
                     // 소셜 로그인 진입점 — 미인증으로 호출(게스트 토큰은 선택). 게스트 토큰을 보내면 필터가 principal 을 채워 게스트-연결로 동작.
                     .requestMatchers(HttpMethod.POST, "/api/v1/auth/login/*")
                     .permitAll()

--- a/src/main/kotlin/com/depromeet/piki/auth/controller/OAuthApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/controller/OAuthApi.kt
@@ -24,7 +24,8 @@ interface OAuthApi {
             "kakao/google 소셜 로그인. v1(웹)은 body 에 code+redirectUri, v2(SDK)는 body 에 accessToken 을 보낸다. " +
                 "처음 보는 소셜이면 MEMBER 로 가입(닉네임 자동 fill, 이후 수정 가능)하고, 기존이면 로그인한다. " +
                 "게스트 토큰을 함께 보내면 그 게스트 계정에 소셜을 연결+승격해 위시·토너먼트 데이터를 이어준다. " +
-                "응답 토큰은 기본 HttpOnly 쿠키로 내려가며, X-Client-Type: app 일 때만 body 로 내린다.",
+                "응답 토큰은 기본 HttpOnly 쿠키로 내려가며, X-Client-Type: app 일 때만 body 로 내린다. " +
+                "v1 웹 흐름은 GET /auth/{provider}/url 로 발급받은 state 를 body 에 함께 전송하면 CSRF 검증이 활성화된다.",
     )
     // 만료/미인증 클라이언트도 호출하므로 인증 없이 진입 (SecurityConfig 의 permitAll).
     @SecurityRequirements
@@ -50,6 +51,16 @@ interface OAuthApi {
             ApiResponse(
                 responseCode = "400",
                 description = "잘못된 요청 (code+redirectUri 도 accessToken 도 없음 · accessToken 과 code 를 동시 전달 · 지원하지 않는 provider)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "state 검증 실패 (만료·미발급·이미 소비된 state — GET /auth/{provider}/url 로 재발급 필요)",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,

--- a/src/main/kotlin/com/depromeet/piki/auth/controller/OAuthApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/controller/OAuthApiExamples.kt
@@ -55,6 +55,15 @@ class OAuthApiExamples(
                             ),
                     )
                     add(
+                        status = HttpStatus.UNAUTHORIZED,
+                        name = "state 검증 실패 (만료 또는 미발급)",
+                        payload =
+                            ApiResponseBody.fail<Unit>(
+                                category = ErrorCategory.UNAUTHORIZED,
+                                detail = "유효하지 않은 state 파라미터입니다. 인가 URL 을 새로 발급받아 다시 시도하세요.",
+                            ),
+                    )
+                    add(
                         status = HttpStatus.BAD_GATEWAY,
                         name = "소셜 제공자 호출 실패",
                         payload =

--- a/src/main/kotlin/com/depromeet/piki/auth/controller/OAuthUrlApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/controller/OAuthUrlApi.kt
@@ -1,0 +1,53 @@
+package com.depromeet.piki.auth.controller
+
+import com.depromeet.piki.auth.controller.dto.OAuthUrlResponse
+import com.depromeet.piki.common.response.ApiResponseBody
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.security.SecurityRequirements
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.MediaType
+
+@Tag(name = "Auth", description = "인증 API")
+interface OAuthUrlApi {
+    @Operation(
+        summary = "OAuth 인가 URL 생성",
+        description =
+            "provider 인가 페이지 URL 과 CSRF 방지용 state 를 반환한다. " +
+                "FE 는 이 URL 로 사용자를 redirect 하고, provider 콜백에서 받은 state 가 응답의 state 와 일치하는지 검증한 뒤 " +
+                "POST /auth/login/{provider} 에 code · redirectUri · state 를 전송한다.",
+    )
+    @SecurityRequirements
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "인가 URL + state 생성 성공",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "지원하지 않는 provider",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun getAuthUrl(
+        @Parameter(description = "소셜 제공자", example = "kakao", schema = Schema(allowableValues = ["kakao", "google"]))
+        provider: String,
+    ): ApiResponseBody<OAuthUrlResponse>
+}

--- a/src/main/kotlin/com/depromeet/piki/auth/controller/OAuthUrlApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/controller/OAuthUrlApiExamples.kt
@@ -1,0 +1,52 @@
+package com.depromeet.piki.auth.controller
+
+import com.depromeet.piki.auth.controller.dto.OAuthUrlResponse
+import com.depromeet.piki.common.exception.ErrorCategory
+import com.depromeet.piki.common.openapi.OpenApiObjectMapper
+import com.depromeet.piki.common.openapi.binds
+import com.depromeet.piki.common.openapi.examples
+import com.depromeet.piki.common.response.ApiResponseBody
+import org.springdoc.core.customizers.OperationCustomizer
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpStatus
+
+@Configuration
+class OAuthUrlApiExamples(
+    private val openApiObjectMapper: OpenApiObjectMapper,
+) {
+    @Bean
+    fun oAuthUrlOpenApiExamples(): OperationCustomizer =
+        OperationCustomizer { operation, handlerMethod ->
+            if (handlerMethod.binds(OAuthUrlController::getAuthUrl)) {
+                operation.examples(openApiObjectMapper.delegate) {
+                    add(
+                        status = HttpStatus.OK,
+                        name = "카카오 인가 URL 생성 성공",
+                        payload =
+                            ApiResponseBody.ok(
+                                OAuthUrlResponse(
+                                    url =
+                                        "https://kauth.kakao.com/oauth/authorize" +
+                                            "?client_id=kakao-client-id" +
+                                            "&redirect_uri=https%3A%2F%2Fapp.example.com%2Fcallback%2Fkakao" +
+                                            "&response_type=code" +
+                                            "&state=550e8400-e29b-41d4-a716-446655440000",
+                                    state = "550e8400-e29b-41d4-a716-446655440000",
+                                ),
+                            ),
+                    )
+                    add(
+                        status = HttpStatus.BAD_REQUEST,
+                        name = "지원하지 않는 provider",
+                        payload =
+                            ApiResponseBody.fail<Unit>(
+                                category = ErrorCategory.INVALID_INPUT,
+                                detail = "지원하지 않는 소셜 로그인 제공자입니다.",
+                            ),
+                    )
+                }
+            }
+            operation
+        }
+}

--- a/src/main/kotlin/com/depromeet/piki/auth/controller/OAuthUrlController.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/controller/OAuthUrlController.kt
@@ -1,0 +1,25 @@
+package com.depromeet.piki.auth.controller
+
+import com.depromeet.piki.auth.controller.dto.OAuthUrlResponse
+import com.depromeet.piki.auth.infrastructure.oauth.OAuthProvider
+import com.depromeet.piki.auth.service.OAuthUrlService
+import com.depromeet.piki.common.response.ApiResponseBody
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/auth")
+class OAuthUrlController(
+    private val oAuthUrlService: OAuthUrlService,
+) : OAuthUrlApi {
+    @GetMapping("/{provider}/url")
+    override fun getAuthUrl(
+        @PathVariable provider: String,
+    ): ApiResponseBody<OAuthUrlResponse> {
+        val oAuthProvider = OAuthProvider.from(provider)
+        val result = oAuthUrlService.buildUrl(oAuthProvider)
+        return ApiResponseBody.ok(OAuthUrlResponse.from(result))
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/auth/controller/dto/OAuthLoginRequest.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/controller/dto/OAuthLoginRequest.kt
@@ -13,6 +13,11 @@ data class OAuthLoginRequest(
     val redirectUri: String? = null,
     @field:Schema(description = "v2 SDK 흐름 — 모바일 SDK 가 받은 access_token", nullable = true)
     val accessToken: String? = null,
+    @field:Schema(
+        description = "CSRF 방지용 state. GET /auth/{provider}/url 로 발급받은 값을 전송 (v1 웹 흐름 권장·v2 선택). 미전송 시 state 검증을 생략한다.",
+        nullable = true,
+    )
+    val state: String? = null,
 ) {
     // v1(code+redirectUri) XOR v2(accessToken) — 정확히 한 흐름만 유효. 둘 다·둘 다 없음·공백은 400(입력 경계 계약).
     @get:JsonIgnore
@@ -25,5 +30,5 @@ data class OAuthLoginRequest(
         }
 
     fun toCommand(): OAuthLoginCommand =
-        OAuthLoginCommand(code = code, redirectUri = redirectUri, accessToken = accessToken)
+        OAuthLoginCommand(code = code, redirectUri = redirectUri, accessToken = accessToken, state = state)
 }

--- a/src/main/kotlin/com/depromeet/piki/auth/controller/dto/OAuthUrlResponse.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/controller/dto/OAuthUrlResponse.kt
@@ -1,0 +1,16 @@
+package com.depromeet.piki.auth.controller.dto
+
+import com.depromeet.piki.auth.service.dto.OAuthUrlResult
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "OAuth 인가 URL 응답")
+data class OAuthUrlResponse(
+    @field:Schema(description = "사용자를 redirect 시킬 provider 인가 URL (state 포함)")
+    val url: String,
+    @field:Schema(description = "CSRF 방지용 state 값. 로그인 완료 시 POST /auth/login/{provider} 에 함께 전송")
+    val state: String,
+) {
+    companion object {
+        fun from(result: OAuthUrlResult) = OAuthUrlResponse(url = result.url, state = result.state)
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthClient.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthClient.kt
@@ -7,6 +7,10 @@ package com.depromeet.piki.auth.infrastructure.oauth
 interface OAuthClient {
     val provider: OAuthProvider
 
+    // RFC 6749 §4.1 Authorization Code Grant — provider 인가 URL 생성.
+    // state 는 CSRF 방지용 (RFC 6749 §10.12). 호출자가 Redis 에 저장 후 사용자를 이 URL 로 redirect.
+    fun buildAuthUrl(state: String): String
+
     fun fetchUserInfoByCode(
         code: String,
         redirectUri: String,

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthException.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthException.kt
@@ -29,5 +29,9 @@ class OAuthException private constructor(
         // 지원하지 않는 provider (미구현 apple · 오타 등) → 400.
         fun unsupportedProvider(): OAuthException =
             OAuthException("지원하지 않는 소셜 로그인 제공자입니다.", ErrorCategory.INVALID_INPUT, HttpStatus.BAD_REQUEST)
+
+        // state 없음 · 만료 · 이미 소비됨 → 401. CSRF 방지용 state 불일치로 요청을 거부.
+        fun invalidState(): OAuthException =
+            OAuthException("유효하지 않은 state 파라미터입니다. 인가 URL 을 새로 발급받아 다시 시도하세요.", ErrorCategory.UNAUTHORIZED, HttpStatus.UNAUTHORIZED)
     }
 }

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthParams.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthParams.kt
@@ -10,4 +10,8 @@ internal object OAuthParams {
     const val REDIRECT_URI = "redirect_uri"
     const val CODE = "code"
     const val GRANT_TYPE_AUTHORIZATION_CODE = "authorization_code"
+    const val RESPONSE_TYPE = "response_type"
+    const val RESPONSE_TYPE_CODE = "code"
+    const val SCOPE = "scope"
+    const val STATE = "state"
 }

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/google/GoogleOAuthClient.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/google/GoogleOAuthClient.kt
@@ -30,6 +30,7 @@ class GoogleOAuthClient(
             .queryParam(OAuthParams.SCOPE, "email profile")
             .queryParam(OAuthParams.STATE, state)
             .build()
+            .encode()
             .toUriString()
 
     // v1 — 백엔드가 code → access_token 교환 후 v2 메서드를 재사용해 user_info 조회.

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/google/GoogleOAuthClient.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/google/GoogleOAuthClient.kt
@@ -11,6 +11,7 @@ import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.util.LinkedMultiValueMap
 import org.springframework.web.client.body
+import org.springframework.web.util.UriComponentsBuilder
 
 class GoogleOAuthClient(
     private val googleProperties: GoogleProperties,
@@ -19,6 +20,17 @@ class GoogleOAuthClient(
 
     private val tokenClient = OAuthRestClient.create(TOKEN_BASE_URL)
     private val userInfoClient = OAuthRestClient.create(USER_INFO_BASE_URL)
+
+    override fun buildAuthUrl(state: String): String =
+        UriComponentsBuilder
+            .fromUriString(AUTH_URL)
+            .queryParam(OAuthParams.CLIENT_ID, googleProperties.clientId)
+            .queryParam(OAuthParams.REDIRECT_URI, googleProperties.redirectUri)
+            .queryParam(OAuthParams.RESPONSE_TYPE, OAuthParams.RESPONSE_TYPE_CODE)
+            .queryParam(OAuthParams.SCOPE, "email profile")
+            .queryParam(OAuthParams.STATE, state)
+            .build()
+            .toUriString()
 
     // v1 — 백엔드가 code → access_token 교환 후 v2 메서드를 재사용해 user_info 조회.
     override fun fetchUserInfoByCode(
@@ -78,6 +90,7 @@ class GoogleOAuthClient(
     companion object {
         private const val TOKEN_BASE_URL = "https://oauth2.googleapis.com"
         private const val USER_INFO_BASE_URL = "https://www.googleapis.com"
+        private const val AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth"
         private const val TOKEN_PATH = "/token"
         private const val USER_INFO_PATH = "/oauth2/v2/userinfo"
         private const val BEARER_PREFIX = "Bearer "

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/kakao/KakaoOAuthClient.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/kakao/KakaoOAuthClient.kt
@@ -11,6 +11,7 @@ import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.util.LinkedMultiValueMap
 import org.springframework.web.client.body
+import org.springframework.web.util.UriComponentsBuilder
 
 class KakaoOAuthClient(
     private val kakaoProperties: KakaoProperties,
@@ -19,6 +20,16 @@ class KakaoOAuthClient(
 
     private val authClient = OAuthRestClient.create(AUTH_BASE_URL)
     private val apiClient = OAuthRestClient.create(API_BASE_URL)
+
+    override fun buildAuthUrl(state: String): String =
+        UriComponentsBuilder
+            .fromUriString("$AUTH_BASE_URL/oauth/authorize")
+            .queryParam(OAuthParams.CLIENT_ID, kakaoProperties.clientId)
+            .queryParam(OAuthParams.REDIRECT_URI, kakaoProperties.redirectUri)
+            .queryParam(OAuthParams.RESPONSE_TYPE, OAuthParams.RESPONSE_TYPE_CODE)
+            .queryParam(OAuthParams.STATE, state)
+            .build()
+            .toUriString()
 
     // v1 — 백엔드가 code → access_token 교환 후 v2 메서드를 재사용해 user_info 조회.
     override fun fetchUserInfoByCode(

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/redis/OAuthStateStore.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/redis/OAuthStateStore.kt
@@ -1,0 +1,9 @@
+package com.depromeet.piki.auth.infrastructure.redis
+
+interface OAuthStateStore {
+    // state 를 10분 TTL 로 Redis 에 저장한다.
+    fun store(state: String)
+
+    // state 가 유효하면 삭제(1회 사용)하고 true, 없거나 이미 소비됐으면 false.
+    fun consumeIfValid(state: String): Boolean
+}

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/redis/RedisOAuthStateStore.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/redis/RedisOAuthStateStore.kt
@@ -1,0 +1,24 @@
+package com.depromeet.piki.auth.infrastructure.redis
+
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Component
+import java.util.concurrent.TimeUnit
+
+@Component
+class RedisOAuthStateStore(
+    private val redisTemplate: StringRedisTemplate,
+) : OAuthStateStore {
+    override fun store(state: String) {
+        redisTemplate.opsForValue().set(key(state), "1", STATE_TTL_MINUTES, TimeUnit.MINUTES)
+    }
+
+    // DEL 은 키가 있으면 1, 없으면 0 을 반환한다. 1이면 유효한 state 가 원자적으로 소비된 것.
+    // GET + DEL 분리 시 TOCTOU 가 생겨 두 요청이 동시에 통과할 수 있으므로 단일 DEL 로 원자화한다.
+    override fun consumeIfValid(state: String): Boolean = redisTemplate.delete(key(state))
+
+    private fun key(state: String) = "oauth:state:$state"
+
+    companion object {
+        private const val STATE_TTL_MINUTES = 10L
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/auth/service/OAuthLoginService.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/service/OAuthLoginService.kt
@@ -5,6 +5,7 @@ import com.depromeet.piki.auth.infrastructure.oauth.OAuthClientRegistry
 import com.depromeet.piki.auth.infrastructure.oauth.OAuthException
 import com.depromeet.piki.auth.infrastructure.oauth.OAuthProvider
 import com.depromeet.piki.auth.infrastructure.oauth.OAuthUserInfo
+import com.depromeet.piki.auth.infrastructure.redis.OAuthStateStore
 import com.depromeet.piki.auth.service.dto.OAuthLoginCommand
 import com.depromeet.piki.auth.service.dto.SignupResult
 import org.springframework.stereotype.Service
@@ -17,12 +18,18 @@ class OAuthLoginService(
     private val oAuthClientRegistry: OAuthClientRegistry,
     private val socialAccountService: SocialAccountService,
     private val authService: AuthService,
+    private val oAuthStateStore: OAuthStateStore,
 ) {
     fun login(
         provider: OAuthProvider,
         command: OAuthLoginCommand,
         currentUserId: UUID?,
     ): SignupResult {
+        // state 가 있으면 Redis 에서 소비 검증. 없거나 만료된 state 는 401 — CSRF 방지.
+        // state 를 보내지 않으면 검증 생략 (v2 SDK 흐름 · 과도기 호환).
+        command.state?.let { state ->
+            if (!oAuthStateStore.consumeIfValid(state)) throw OAuthException.invalidState()
+        }
         val client = oAuthClientRegistry.resolve(provider)
         val userInfo = fetchUserInfo(client, command) // 외부 호출, tx 밖
         val user = socialAccountService.resolveUser(userInfo, currentUserId) // 영속화, 짧은 tx

--- a/src/main/kotlin/com/depromeet/piki/auth/service/OAuthLoginService.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/service/OAuthLoginService.kt
@@ -27,7 +27,7 @@ class OAuthLoginService(
     ): SignupResult {
         // state 가 있으면 Redis 에서 소비 검증. 없거나 만료된 state 는 401 — CSRF 방지.
         // state 를 보내지 않으면 검증 생략 (v2 SDK 흐름 · 과도기 호환).
-        command.state?.let { state ->
+        command.state?.ifBlank { null }?.let { state ->
             if (!oAuthStateStore.consumeIfValid(state)) throw OAuthException.invalidState()
         }
         val client = oAuthClientRegistry.resolve(provider)

--- a/src/main/kotlin/com/depromeet/piki/auth/service/OAuthUrlService.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/service/OAuthUrlService.kt
@@ -1,0 +1,22 @@
+package com.depromeet.piki.auth.service
+
+import com.depromeet.piki.auth.infrastructure.oauth.OAuthClientRegistry
+import com.depromeet.piki.auth.infrastructure.oauth.OAuthProvider
+import com.depromeet.piki.auth.infrastructure.redis.OAuthStateStore
+import com.depromeet.piki.auth.service.dto.OAuthUrlResult
+import org.springframework.stereotype.Service
+import java.util.UUID
+
+@Service
+class OAuthUrlService(
+    private val oAuthClientRegistry: OAuthClientRegistry,
+    private val oAuthStateStore: OAuthStateStore,
+) {
+    fun buildUrl(provider: OAuthProvider): OAuthUrlResult {
+        val state = UUID.randomUUID().toString()
+        val client = oAuthClientRegistry.resolve(provider)
+        val url = client.buildAuthUrl(state)
+        oAuthStateStore.store(state)
+        return OAuthUrlResult(url = url, state = state)
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/auth/service/dto/OAuthLoginCommand.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/service/dto/OAuthLoginCommand.kt
@@ -2,8 +2,10 @@ package com.depromeet.piki.auth.service.dto
 
 // 소셜 로그인 자격 증명. v1(web): code+redirectUri / v2(SDK): accessToken.
 // 둘 중 하나만 채워져 오며, 서비스가 accessToken 우선으로 흐름을 고른다.
+// state 는 CSRF 방지용 (GET /auth/{provider}/url 에서 발급). null 이면 검증 생략.
 data class OAuthLoginCommand(
     val code: String?,
     val redirectUri: String?,
     val accessToken: String?,
+    val state: String? = null,
 )

--- a/src/main/kotlin/com/depromeet/piki/auth/service/dto/OAuthUrlResult.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/service/dto/OAuthUrlResult.kt
@@ -1,0 +1,6 @@
+package com.depromeet.piki.auth.service.dto
+
+data class OAuthUrlResult(
+    val url: String,
+    val state: String,
+)

--- a/src/test/kotlin/com/depromeet/piki/auth/controller/OAuthUrlIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/controller/OAuthUrlIntegrationTest.kt
@@ -1,0 +1,147 @@
+package com.depromeet.piki.auth.controller
+
+import com.depromeet.piki.auth.infrastructure.oauth.OAuthProvider
+import com.depromeet.piki.auth.infrastructure.oauth.OAuthUserInfo
+import com.depromeet.piki.auth.infrastructure.redis.OAuthStateStore
+import com.depromeet.piki.support.IntegrationTestSupport
+import com.depromeet.piki.support.StubOAuthClient
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.http.MediaType
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.context.WebApplicationContext
+import tools.jackson.databind.ObjectMapper
+
+@Transactional
+class OAuthUrlIntegrationTest : IntegrationTestSupport() {
+    @Autowired
+    private lateinit var webApplicationContext: WebApplicationContext
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @Autowired
+    @Qualifier("googleOAuthClient")
+    private lateinit var googleOAuthClient: StubOAuthClient
+
+    @Autowired
+    private lateinit var oAuthStateStore: OAuthStateStore
+
+    private fun mockMvc(): MockMvc =
+        MockMvcBuilders
+            .webAppContextSetup(webApplicationContext)
+            .apply<DefaultMockMvcBuilder>(springSecurity())
+            .build()
+
+    @Test
+    fun `GET auth url - kakao 인가 URL 과 state 를 반환한다`() {
+        mockMvc()
+            .perform(get("/api/v1/auth/kakao/url"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.url").isString)
+            .andExpect(jsonPath("$.data.state").isString)
+    }
+
+    @Test
+    fun `GET auth url - google 인가 URL 과 state 를 반환한다`() {
+        mockMvc()
+            .perform(get("/api/v1/auth/google/url"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.url").isString)
+            .andExpect(jsonPath("$.data.state").isString)
+    }
+
+    @Test
+    fun `GET auth url - 미지원 provider 는 400`() {
+        mockMvc()
+            .perform(get("/api/v1/auth/apple/url"))
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `state 검증 - 발급된 state 로 로그인하면 200 성공한다`() {
+        val state = extractState(
+            mockMvc()
+                .perform(get("/api/v1/auth/google/url"))
+                .andReturn()
+                .response.contentAsString,
+        )
+        googleOAuthClient.fetchByCodeStub = { _, _ -> OAuthUserInfo(OAuthProvider.GOOGLE, "google_state_ok", null) }
+
+        mockMvc()
+            .perform(
+                post("/api/v1/auth/login/google")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header("X-Client-Type", "app")
+                    .content("""{"code":"auth-code","redirectUri":"https://app/callback","state":"$state"}"""),
+            ).andExpect(status().isOk)
+    }
+
+    @Test
+    fun `state 검증 - 잘못된 state 로 로그인하면 401`() {
+        mockMvc()
+            .perform(get("/api/v1/auth/google/url"))
+            .andExpect(status().isOk)
+
+        mockMvc()
+            .perform(
+                post("/api/v1/auth/login/google")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header("X-Client-Type", "app")
+                    .content("""{"code":"auth-code","redirectUri":"https://app/callback","state":"invalid-state-uuid"}"""),
+            ).andExpect(status().isUnauthorized)
+    }
+
+    @Test
+    fun `state 검증 - 동일 state 로 두 번 로그인하면 두 번째는 401`() {
+        val state = extractState(
+            mockMvc()
+                .perform(get("/api/v1/auth/google/url"))
+                .andReturn()
+                .response.contentAsString,
+        )
+        googleOAuthClient.fetchByCodeStub = { _, _ -> OAuthUserInfo(OAuthProvider.GOOGLE, "google_state_2nd", null) }
+        val loginBody = """{"code":"auth-code","redirectUri":"https://app/callback","state":"$state"}"""
+
+        mockMvc()
+            .perform(
+                post("/api/v1/auth/login/google")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header("X-Client-Type", "app")
+                    .content(loginBody),
+            ).andExpect(status().isOk)
+
+        mockMvc()
+            .perform(
+                post("/api/v1/auth/login/google")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header("X-Client-Type", "app")
+                    .content(loginBody),
+            ).andExpect(status().isUnauthorized)
+    }
+
+    @Test
+    fun `state 없이 로그인 - v2 SDK 흐름은 state 없어도 정상 로그인된다`() {
+        googleOAuthClient.fetchByAccessTokenStub = { OAuthUserInfo(OAuthProvider.GOOGLE, "google_no_state", null) }
+
+        mockMvc()
+            .perform(
+                post("/api/v1/auth/login/google")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header("X-Client-Type", "app")
+                    .content("""{"accessToken":"sdk-token"}"""),
+            ).andExpect(status().isOk)
+    }
+
+    private fun extractState(responseBody: String): String =
+        objectMapper.readTree(responseBody).at("/data/state").asText()
+}

--- a/src/test/kotlin/com/depromeet/piki/support/StubOAuthClient.kt
+++ b/src/test/kotlin/com/depromeet/piki/support/StubOAuthClient.kt
@@ -7,7 +7,7 @@ import com.depromeet.piki.auth.infrastructure.oauth.OAuthUserInfo
 class StubOAuthClient(
     override val provider: OAuthProvider,
 ) : OAuthClient {
-    // v1 (code/redirectUri) / v2 (accessToken) 두 흐름을 각각 stub 한다.
+    // v1 (code/redirectUri) / v2 (accessToken) / URL 생성 흐름을 각각 stub 한다.
     // default 는 모두 throw — 명시 세팅을 빠뜨리면 호출 시점에 즉시 깨지도록 강제.
     var fetchByCodeStub: (String, String) -> OAuthUserInfo = { _, _ ->
         error("stub.fetchByCodeStub 를 테스트 본문에서 명시 세팅해야 한다.")
@@ -15,6 +15,11 @@ class StubOAuthClient(
     var fetchByAccessTokenStub: (String) -> OAuthUserInfo = { _ ->
         error("stub.fetchByAccessTokenStub 를 테스트 본문에서 명시 세팅해야 한다.")
     }
+    var buildAuthUrlStub: (String) -> String = { state ->
+        "https://stub-auth.example.com/oauth/authorize?provider=${provider.name.lowercase()}&state=$state"
+    }
+
+    override fun buildAuthUrl(state: String): String = buildAuthUrlStub(state)
 
     override fun fetchUserInfoByCode(
         code: String,


### PR DESCRIPTION
## Situation
- 기존 소셜 로그인 흐름은 프론트엔드가 직접 OAuth 인가 URL을 생성해 code를 받아 백엔드로 전달하는 방식이었다
- state 파라미터 없이 code만 주고받아 CSRF 공격에 취약한 구조였고, RFC 6749 §10.12 권고를 충족하지 못하는 상태였다
- 백엔드가 state를 발급·검증하는 엔드포인트가 없어 프론트엔드가 자체적으로 CSRF 방어를 할 수 없었다

## Task
- 백엔드가 인가 URL과 state를 함께 발급하는 `GET /api/v1/auth/{provider}/url` 엔드포인트 신설
- 로그인 요청에 state를 함께 보내면 Redis에서 검증·소비하고, 없으면 그냥 통과하는 선택적 CSRF 검증 구조 설계
- 핵심 트레이드오프: state를 필수로 만들면 기존 SDK(access_token) 흐름과 v1 웹 흐름 모두 호환이 깨지므로, state는 옵션으로 두고 있으면 검증, 없으면 통과하도록 결정

## Action

### 인가 URL 생성 엔드포인트
- `GET /api/v1/auth/{provider}/url` 신설 - UUID state 생성 후 Redis에 TTL 10분으로 저장, `{url, state}` 반환
- `OAuthClient` 인터페이스에 `buildAuthUrl(state: String): String` 추가 - Kakao·Google 각각 `UriComponentsBuilder`로 구현
- Google URL에서 `scope=email profile`의 공백을 `.build().encode().toUriString()`으로 퍼센트 인코딩 - `.encode()` 없이 빌드하면 literal space가 URL에 그대로 들어가 Google 인증 서버가 `response_type` 파라미터를 인식 못하는 오류 발생

### state 검증·소비
- `OAuthStateStore` 인터페이스 + `RedisOAuthStateStore` 구현체 - Redis DEL 기반 원자적 소비(TOCTOU 방지)
- `OAuthLoginService`에서 `command.state?.let { if (!consumeIfValid(it)) throw OAuthException.invalidState() }` - state 있을 때만 검증, 없으면 pass
- 동일 state 재사용 시 두 번째 요청에서 즉시 401 반환

### 기반 정비
- SecurityConfig에 `GET /api/v1/auth/*/url` permitAll 추가
- OpenAPI 문서(`OAuthUrlApi`, `OAuthUrlApiExamples`, `OAuthApi`, `OAuthApiExamples`) - 401 state 검증 실패 응답 포함 전수 문서화

## Result
- E2E 검증 완료: `GET /url` → Google 로그인 → code+state 수령 → `POST /login` → 200 + JWT 발급
- 동일 state 재사용 시 401 "유효하지 않은 state 파라미터입니다" 정상 반환
- 기존 v2 SDK 흐름(accessToken만 전송)은 state 없이 그대로 동작 - 하위 호환 유지
- 통합 테스트 7건 추가: URL 생성(kakao/google), 미지원 provider 400, 유효 state 로그인, 무효 state 401, state 재사용 401, state 없는 v2 흐름 200

---
## 연관 이슈

- close #341


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * OAuth 인증 URL 생성 엔드포인트 추가 (`/api/v1/auth/{provider}/url`)
  * CSRF 방지를 위한 state 기반 검증 메커니즘 적용
  * Kakao, Google 소셜 로그인 보안 강화

* **Documentation**
  * OAuth 로그인 API 문서에 state 검증 실패(401) 응답 추가
  * 인증 URL 생성 및 state 관리 프로세스 설명 추강

* **Tests**
  * OAuth 인증 흐름 통합 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Updates

### CodeRabbit 리뷰 대응

- state 빈 문자열("")을 null과 동일하게 처리 - `?.let` 은 null만 걸러내 `""` state가 `consumeIfValid`로 내려가 존재하지 않는 Redis 키를 DEL해 false를 반환, 정상 요청인데도 401이 떨어지는 문제 수정. 같은 파일의 `accessToken`·`code`·`redirectUri`가 이미 쓰는 `ifBlank { null }` 패턴으로 통일 (`c2bb53f`)
