### PR TITLE
토너먼트 삭제 API — PENDING·COMPLETED 허용, IN_PROGRESS 차단, 소프트 딜리트

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
@@ -389,6 +389,69 @@ interface TournamentApi {
     ): ApiResponseBody<Unit>
 
     @Operation(
+        summary = "토너먼트 삭제",
+        description = "PENDING 또는 COMPLETED 상태의 토너먼트를 삭제한다. 토너먼트 소유자만 삭제할 수 있으며, IN_PROGRESS 상태에서는 삭제할 수 없다.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "토너먼트 삭제 성공",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "미인증 (JWT 토큰 없음 또는 유효하지 않음)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "403",
+                description = "권한 없음 (토너먼트 참여자가 아님 · 토너먼트 소유자가 아님)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "토너먼트를 찾을 수 없음",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "409",
+                description = "상태 충돌 (IN_PROGRESS 토너먼트는 삭제 불가)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun deleteTournament(
+        @Parameter(hidden = true) userId: UUID,
+        @Parameter(description = "토너먼트 ID", example = "1") tournamentId: Long,
+    ): ApiResponseBody<Unit>
+
+    @Operation(
         summary = "토너먼트 아이템 삭제",
         description = "PENDING 상태의 토너먼트에서 아이템을 제거한다. 아이템을 추가한 본인 또는 토너먼트 소유자만 삭제할 수 있다.",
     )

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
@@ -707,7 +707,6 @@ interface TournamentApi {
         request: UpdateTournamentItemRequest,
     ): ApiResponseBody<Unit>
 
-   
     @Operation(
         summary = "토너먼트 삭제",
         description = "PENDING 또는 COMPLETED 상태의 토너먼트를 삭제한다. 토너먼트 소유자만 삭제할 수 있으며, IN_PROGRESS 상태에서는 삭제할 수 없다.",
@@ -770,7 +769,7 @@ interface TournamentApi {
         @Parameter(hidden = true) userId: UUID,
         @Parameter(description = "토너먼트 ID", example = "1") tournamentId: Long,
     ): ApiResponseBody<Unit>
-  
+
     @Operation(
         summary = "토너먼트 아이템 삭제",
         description = "PENDING 상태의 토너먼트에서 아이템을 제거한다. 아이템을 추가한 본인 또는 토너먼트 소유자만 삭제할 수 있다.",
@@ -829,4 +828,9 @@ interface TournamentApi {
             ),
         ],
     )
+    fun deleteItem(
+        @Parameter(hidden = true) userId: UUID,
+        @Parameter(description = "토너먼트 ID", example = "1") tournamentId: Long,
+        @Parameter(description = "토너먼트 아이템 ID", example = "10") tournamentItemId: Long,
+    ): ApiResponseBody<Unit>
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApiExamples.kt
@@ -72,6 +72,15 @@ class TournamentApiExamples(
                         )
                     }
 
+                handlerMethod.binds(TournamentController::deleteTournament) ->
+                    operation.examples(openApiObjectMapper.delegate) {
+                        add(
+                            status = HttpStatus.OK,
+                            name = "토너먼트 삭제 성공",
+                            payload = ApiResponseBody.ok<Unit>(),
+                        )
+                    }
+
                 handlerMethod.binds(TournamentController::deleteItem) ->
                     operation.examples(openApiObjectMapper.delegate) {
                         add(

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentController.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentController.kt
@@ -93,6 +93,15 @@ class TournamentController(
         return ApiResponseBody.ok()
     }
 
+    @DeleteMapping("/{tournamentId}")
+    override fun deleteTournament(
+        @AuthenticationPrincipal userId: UUID,
+        @PathVariable tournamentId: Long,
+    ): ApiResponseBody<Unit> {
+        tournamentService.deleteTournament(userId, tournamentId)
+        return ApiResponseBody.ok()
+    }
+
     @DeleteMapping("/{tournamentId}/items/{tournamentItemId}")
     override fun deleteItem(
         @AuthenticationPrincipal userId: UUID,

--- a/src/main/kotlin/com/depromeet/piki/tournament/domain/Tournament.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/domain/Tournament.kt
@@ -44,6 +44,10 @@ class Tournament(
 
     fun isInProgress(): Boolean = status == TournamentStatus.IN_PROGRESS
 
+    fun softDelete() {
+        deletedAt = java.time.LocalDateTime.now()
+    }
+
     companion object {
         internal const val FINAL_ROUND_SIZE = 2
     }

--- a/src/main/kotlin/com/depromeet/piki/tournament/domain/TournamentHistory.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/domain/TournamentHistory.kt
@@ -4,6 +4,7 @@ import com.depromeet.piki.common.domain.LongBaseEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Table
+import java.time.LocalDateTime
 
 @Entity
 @Table(name = "tournament_histories")
@@ -18,4 +19,8 @@ class TournamentHistory(
     val secondTournamentItemId: Long,
     @Column(name = "selected_tournament_item_id", nullable = false)
     val selectedTournamentItemId: Long,
-) : LongBaseEntity()
+) : LongBaseEntity() {
+    fun softDelete() {
+        deletedAt = LocalDateTime.now()
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/tournament/domain/TournamentItem.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/domain/TournamentItem.kt
@@ -4,6 +4,7 @@ import com.depromeet.piki.common.domain.LongBaseEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Table
+import java.time.LocalDateTime
 import java.util.UUID
 
 // 토너먼트에 올라간 아이템. 게스트·회원이 추가한 item 을 토너먼트가 참조하는 연결 엔티티.
@@ -22,5 +23,9 @@ class TournamentItem(
     init {
         require(tournamentId > 0) { "tournamentId 는 양수여야 한다: $tournamentId" }
         require(itemId > 0) { "itemId 는 양수여야 한다: $itemId" }
+    }
+
+    fun softDelete() {
+        deletedAt = LocalDateTime.now()
     }
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/domain/TournamentUser.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/domain/TournamentUser.kt
@@ -4,6 +4,7 @@ import com.depromeet.piki.common.domain.LongBaseEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Table
+import java.time.LocalDateTime
 import java.util.UUID
 
 // 어떤 유저가 어떤 토너먼트에 참여했는지를 명시 관리하는 매핑 테이블.
@@ -19,5 +20,9 @@ class TournamentUser(
     // 엔티티 불변식 — 0·음수는 존재할 수 없는 참조다. 정상 흐름에선 닿지 않고, 닿으면 코드 버그.
     init {
         require(tournamentId > 0) { "tournamentId 는 양수여야 한다: $tournamentId" }
+    }
+
+    fun softDelete() {
+        deletedAt = LocalDateTime.now()
     }
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentHistoryJpaRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentHistoryJpaRepository.kt
@@ -1,8 +1,16 @@
 package com.depromeet.piki.tournament.repository
 
 import com.depromeet.piki.tournament.domain.TournamentHistory
+import java.time.LocalDateTime
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 
 interface TournamentHistoryJpaRepository : JpaRepository<TournamentHistory, Long> {
-    fun findAllByTournamentIdOrderByCurrentRoundAscIdAsc(tournamentId: Long): List<TournamentHistory>
+    fun findAllByTournamentIdAndDeletedAtIsNullOrderByCurrentRoundAscIdAsc(tournamentId: Long): List<TournamentHistory>
+
+    @Modifying
+    @Query("UPDATE TournamentHistory h SET h.deletedAt = :now WHERE h.tournamentId = :tournamentId AND h.deletedAt IS NULL")
+    fun softDeleteAllByTournamentId(@Param("tournamentId") tournamentId: Long, @Param("now") now: LocalDateTime)
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentHistoryJpaRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentHistoryJpaRepository.kt
@@ -2,14 +2,7 @@ package com.depromeet.piki.tournament.repository
 
 import com.depromeet.piki.tournament.domain.TournamentHistory
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Modifying
-import org.springframework.data.jpa.repository.Query
-import org.springframework.data.repository.query.Param
 
 interface TournamentHistoryJpaRepository : JpaRepository<TournamentHistory, Long> {
     fun findAllByTournamentIdOrderByCurrentRoundAscIdAsc(tournamentId: Long): List<TournamentHistory>
-
-    @Modifying
-    @Query("DELETE FROM TournamentHistory h WHERE h.tournamentId = :tournamentId")
-    fun deleteAllByTournamentId(@Param("tournamentId") tournamentId: Long)
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentHistoryJpaRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentHistoryJpaRepository.kt
@@ -2,7 +2,14 @@ package com.depromeet.piki.tournament.repository
 
 import com.depromeet.piki.tournament.domain.TournamentHistory
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 
 interface TournamentHistoryJpaRepository : JpaRepository<TournamentHistory, Long> {
     fun findAllByTournamentIdOrderByCurrentRoundAscIdAsc(tournamentId: Long): List<TournamentHistory>
+
+    @Modifying
+    @Query("DELETE FROM TournamentHistory h WHERE h.tournamentId = :tournamentId")
+    fun deleteAllByTournamentId(@Param("tournamentId") tournamentId: Long)
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentItemJpaRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentItemJpaRepository.kt
@@ -25,4 +25,8 @@ interface TournamentItemJpaRepository : JpaRepository<TournamentItem, Long> {
         @Param("tournamentId") tournamentId: Long,
         @Param("status") status: TournamentStatus = TournamentStatus.PENDING,
     ): Int
+
+    @Modifying
+    @Query("DELETE FROM TournamentItem t WHERE t.tournamentId = :tournamentId")
+    fun deleteAllByTournamentId(@Param("tournamentId") tournamentId: Long)
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentItemJpaRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentItemJpaRepository.kt
@@ -26,7 +26,4 @@ interface TournamentItemJpaRepository : JpaRepository<TournamentItem, Long> {
         @Param("status") status: TournamentStatus = TournamentStatus.PENDING,
     ): Int
 
-    @Modifying
-    @Query("DELETE FROM TournamentItem t WHERE t.tournamentId = :tournamentId")
-    fun deleteAllByTournamentId(@Param("tournamentId") tournamentId: Long)
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentItemJpaRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentItemJpaRepository.kt
@@ -2,28 +2,37 @@ package com.depromeet.piki.tournament.repository
 
 import com.depromeet.piki.tournament.domain.TournamentItem
 import com.depromeet.piki.tournament.domain.TournamentStatus
+import java.time.LocalDateTime
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 
 interface TournamentItemJpaRepository : JpaRepository<TournamentItem, Long> {
-    fun countByTournamentId(tournamentId: Long): Int
+    fun countByTournamentIdAndDeletedAtIsNull(tournamentId: Long): Int
 
-    fun findAllByTournamentIdOrderByIdAsc(tournamentId: Long): List<TournamentItem>
+    fun findByIdAndDeletedAtIsNull(id: Long): TournamentItem?
 
-    @Query("SELECT t.id FROM TournamentItem t WHERE t.tournamentId = :tournamentId ORDER BY t.id ASC")
+    @Query("SELECT t FROM TournamentItem t WHERE t.tournamentId = :tournamentId AND t.deletedAt IS NULL ORDER BY t.id ASC")
+    fun findAllByTournamentIdAndNotDeleted(@Param("tournamentId") tournamentId: Long): List<TournamentItem>
+
+    @Query("SELECT t.id FROM TournamentItem t WHERE t.tournamentId = :tournamentId AND t.deletedAt IS NULL ORDER BY t.id ASC")
     fun findIdsByTournamentId(@Param("tournamentId") tournamentId: Long): List<Long>
 
     @Modifying
     @Query(
-        "DELETE FROM TournamentItem t WHERE t.id = :id AND t.tournamentId = :tournamentId " +
-            "AND EXISTS (SELECT 1 FROM Tournament tour WHERE tour.id = :tournamentId AND tour.status = :status)",
+        "UPDATE TournamentItem t SET t.deletedAt = :now WHERE t.id = :id AND t.tournamentId = :tournamentId " +
+            "AND t.deletedAt IS NULL " +
+            "AND EXISTS (SELECT 1 FROM Tournament tour WHERE tour.id = :tournamentId AND tour.status = :status AND tour.deletedAt IS NULL)",
     )
-    fun deleteIfPending(
+    fun softDeleteIfPending(
         @Param("id") id: Long,
         @Param("tournamentId") tournamentId: Long,
         @Param("status") status: TournamentStatus = TournamentStatus.PENDING,
+        @Param("now") now: LocalDateTime,
     ): Int
 
+    @Modifying
+    @Query("UPDATE TournamentItem t SET t.deletedAt = :now WHERE t.tournamentId = :tournamentId AND t.deletedAt IS NULL")
+    fun softDeleteAllByTournamentId(@Param("tournamentId") tournamentId: Long, @Param("now") now: LocalDateTime)
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentItemRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentItemRepository.kt
@@ -21,4 +21,6 @@ interface TournamentItemRepository {
         id: Long,
         tournamentId: Long,
     ): Int
+
+    fun deleteAllByTournamentId(tournamentId: Long)
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentItemRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentItemRepository.kt
@@ -17,8 +17,10 @@ interface TournamentItemRepository {
 
     fun delete(tournamentItem: TournamentItem)
 
-    fun deleteIfPending(
+    fun softDeleteIfPending(
         id: Long,
         tournamentId: Long,
     ): Int
+
+    fun softDeleteAllByTournamentId(tournamentId: Long)
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentItemRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentItemRepository.kt
@@ -15,8 +15,6 @@ interface TournamentItemRepository {
 
     fun findById(id: Long): TournamentItem?
 
-    fun delete(tournamentItem: TournamentItem)
-
     fun softDeleteIfPending(
         id: Long,
         tournamentId: Long,

--- a/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentItemRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentItemRepository.kt
@@ -21,6 +21,4 @@ interface TournamentItemRepository {
         id: Long,
         tournamentId: Long,
     ): Int
-
-    fun deleteAllByTournamentId(tournamentId: Long)
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentItemRepositoryImpl.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentItemRepositoryImpl.kt
@@ -23,8 +23,6 @@ class TournamentItemRepositoryImpl(
 
     override fun findById(id: Long): TournamentItem? = tournamentItemJpaRepository.findByIdAndDeletedAtIsNull(id)
 
-    override fun delete(tournamentItem: TournamentItem) = tournamentItemJpaRepository.delete(tournamentItem)
-
     override fun softDeleteIfPending(
         id: Long,
         tournamentId: Long,

--- a/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentItemRepositoryImpl.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentItemRepositoryImpl.kt
@@ -1,7 +1,7 @@
 package com.depromeet.piki.tournament.repository
 
 import com.depromeet.piki.tournament.domain.TournamentItem
-import org.springframework.data.repository.findByIdOrNull
+import java.time.LocalDateTime
 import org.springframework.stereotype.Repository
 
 @Repository
@@ -10,22 +10,27 @@ class TournamentItemRepositoryImpl(
 ) : TournamentItemRepository {
     override fun saveAll(items: List<TournamentItem>): List<TournamentItem> = tournamentItemJpaRepository.saveAll(items)
 
-    override fun countByTournamentId(tournamentId: Long): Int = tournamentItemJpaRepository.countByTournamentId(tournamentId)
+    override fun countByTournamentId(tournamentId: Long): Int =
+        tournamentItemJpaRepository.countByTournamentIdAndDeletedAtIsNull(tournamentId)
 
     override fun findIdsByTournamentId(tournamentId: Long): List<Long> =
         tournamentItemJpaRepository.findIdsByTournamentId(tournamentId)
 
     override fun findAllByTournamentId(tournamentId: Long): List<TournamentItem> =
-        tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId)
+        tournamentItemJpaRepository.findAllByTournamentIdAndNotDeleted(tournamentId)
 
     override fun findByIds(ids: List<Long>): List<TournamentItem> = tournamentItemJpaRepository.findAllById(ids)
 
-    override fun findById(id: Long): TournamentItem? = tournamentItemJpaRepository.findByIdOrNull(id)
+    override fun findById(id: Long): TournamentItem? = tournamentItemJpaRepository.findByIdAndDeletedAtIsNull(id)
 
     override fun delete(tournamentItem: TournamentItem) = tournamentItemJpaRepository.delete(tournamentItem)
 
-    override fun deleteIfPending(
+    override fun softDeleteIfPending(
         id: Long,
         tournamentId: Long,
-    ): Int = tournamentItemJpaRepository.deleteIfPending(id, tournamentId)
+    ): Int = tournamentItemJpaRepository.softDeleteIfPending(id, tournamentId, now = LocalDateTime.now())
+
+    override fun softDeleteAllByTournamentId(tournamentId: Long) {
+        tournamentItemJpaRepository.softDeleteAllByTournamentId(tournamentId, LocalDateTime.now())
+    }
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentItemRepositoryImpl.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentItemRepositoryImpl.kt
@@ -28,8 +28,4 @@ class TournamentItemRepositoryImpl(
         id: Long,
         tournamentId: Long,
     ): Int = tournamentItemJpaRepository.deleteIfPending(id, tournamentId)
-
-    override fun deleteAllByTournamentId(tournamentId: Long) {
-        tournamentItemJpaRepository.deleteAllByTournamentId(tournamentId)
-    }
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentItemRepositoryImpl.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentItemRepositoryImpl.kt
@@ -28,4 +28,8 @@ class TournamentItemRepositoryImpl(
         id: Long,
         tournamentId: Long,
     ): Int = tournamentItemJpaRepository.deleteIfPending(id, tournamentId)
+
+    override fun deleteAllByTournamentId(tournamentId: Long) {
+        tournamentItemJpaRepository.deleteAllByTournamentId(tournamentId)
+    }
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentJpaRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentJpaRepository.kt
@@ -8,13 +8,16 @@ import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
 
 interface TournamentJpaRepository : JpaRepository<Tournament, Long> {
+    fun findByIdAndDeletedAtIsNull(id: Long): Tournament?
+
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("SELECT t FROM Tournament t WHERE t.id = :id")
+    @Query("SELECT t FROM Tournament t WHERE t.id = :id AND t.deletedAt IS NULL")
     fun findByIdForUpdate(id: Long): Tournament?
-    fun findByIdInAndStatusInOrderByCreatedAtDesc(
+
+    fun findByIdInAndStatusInAndDeletedAtIsNullOrderByCreatedAtDesc(
         ids: List<Long>,
         statuses: List<TournamentStatus>,
     ): List<Tournament>
 
-    fun findByIdInOrderByCreatedAtDesc(ids: List<Long>): List<Tournament>
+    fun findByIdInAndDeletedAtIsNullOrderByCreatedAtDesc(ids: List<Long>): List<Tournament>
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentRepository.kt
@@ -19,8 +19,4 @@ interface TournamentRepository {
         ids: List<Long>,
         statuses: List<TournamentStatus>?,
     ): List<Tournament>
-
-    fun deleteTournamentById(tournamentId: Long)
-
-    fun deleteHistoriesByTournamentId(tournamentId: Long)
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentRepository.kt
@@ -19,4 +19,6 @@ interface TournamentRepository {
         ids: List<Long>,
         statuses: List<TournamentStatus>?,
     ): List<Tournament>
+
+    fun softDeleteHistoriesByTournamentId(tournamentId: Long)
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentRepository.kt
@@ -19,4 +19,8 @@ interface TournamentRepository {
         ids: List<Long>,
         statuses: List<TournamentStatus>?,
     ): List<Tournament>
+
+    fun deleteTournamentById(tournamentId: Long)
+
+    fun deleteHistoriesByTournamentId(tournamentId: Long)
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentRepositoryImpl.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.depromeet.piki.tournament.repository
 import com.depromeet.piki.tournament.domain.Tournament
 import com.depromeet.piki.tournament.domain.TournamentHistory
 import com.depromeet.piki.tournament.domain.TournamentStatus
+import java.time.LocalDateTime
 import org.springframework.stereotype.Repository
 
 @Repository
@@ -23,7 +24,11 @@ class TournamentRepositoryImpl(
         tournamentJpaRepository.findByIdForUpdate(tournamentId)
 
     override fun findTournamentHistoriesByTournamentId(tournamentId: Long): List<TournamentHistory> =
-        tournamentHistoryJpaRepository.findAllByTournamentIdOrderByCurrentRoundAscIdAsc(tournamentId)
+        tournamentHistoryJpaRepository.findAllByTournamentIdAndDeletedAtIsNullOrderByCurrentRoundAscIdAsc(tournamentId)
+
+    override fun softDeleteHistoriesByTournamentId(tournamentId: Long) {
+        tournamentHistoryJpaRepository.softDeleteAllByTournamentId(tournamentId, LocalDateTime.now())
+    }
 
     override fun findByIdsAndStatuses(
         ids: List<Long>,

--- a/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentRepositoryImpl.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentRepositoryImpl.kt
@@ -36,4 +36,12 @@ class TournamentRepositoryImpl(
             ?.let { tournamentJpaRepository.findByIdInAndStatusInOrderByCreatedAtDesc(ids, it) }
             ?: tournamentJpaRepository.findByIdInOrderByCreatedAtDesc(ids)
     }
+
+    override fun deleteTournamentById(tournamentId: Long) {
+        tournamentJpaRepository.deleteById(tournamentId)
+    }
+
+    override fun deleteHistoriesByTournamentId(tournamentId: Long) {
+        tournamentHistoryJpaRepository.deleteAllByTournamentId(tournamentId)
+    }
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentRepositoryImpl.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentRepositoryImpl.kt
@@ -3,7 +3,6 @@ package com.depromeet.piki.tournament.repository
 import com.depromeet.piki.tournament.domain.Tournament
 import com.depromeet.piki.tournament.domain.TournamentHistory
 import com.depromeet.piki.tournament.domain.TournamentStatus
-import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Repository
 
 @Repository
@@ -18,7 +17,7 @@ class TournamentRepositoryImpl(
     }
 
     override fun findTournamentById(tournamentId: Long): Tournament? =
-        tournamentJpaRepository.findByIdOrNull(tournamentId)
+        tournamentJpaRepository.findByIdAndDeletedAtIsNull(tournamentId)
 
     override fun findTournamentByIdForUpdate(tournamentId: Long): Tournament? =
         tournamentJpaRepository.findByIdForUpdate(tournamentId)
@@ -33,15 +32,7 @@ class TournamentRepositoryImpl(
         if (ids.isEmpty()) return emptyList()
         return statuses
             ?.takeIf { it.isNotEmpty() }
-            ?.let { tournamentJpaRepository.findByIdInAndStatusInOrderByCreatedAtDesc(ids, it) }
-            ?: tournamentJpaRepository.findByIdInOrderByCreatedAtDesc(ids)
-    }
-
-    override fun deleteTournamentById(tournamentId: Long) {
-        tournamentJpaRepository.deleteById(tournamentId)
-    }
-
-    override fun deleteHistoriesByTournamentId(tournamentId: Long) {
-        tournamentHistoryJpaRepository.deleteAllByTournamentId(tournamentId)
+            ?.let { tournamentJpaRepository.findByIdInAndStatusInAndDeletedAtIsNullOrderByCreatedAtDesc(ids, it) }
+            ?: tournamentJpaRepository.findByIdInAndDeletedAtIsNullOrderByCreatedAtDesc(ids)
     }
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentUserJpaRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentUserJpaRepository.kt
@@ -2,7 +2,6 @@ package com.depromeet.piki.tournament.repository
 
 import com.depromeet.piki.tournament.domain.TournamentUser
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import java.util.UUID
@@ -21,8 +20,4 @@ interface TournamentUserJpaRepository : JpaRepository<TournamentUser, Long> {
     fun findByTournamentId(tournamentId: Long): List<TournamentUser>
 
     fun findByTournamentIdIn(tournamentIds: Collection<Long>): List<TournamentUser>
-
-    @Modifying
-    @Query("DELETE FROM TournamentUser tu WHERE tu.tournamentId = :tournamentId")
-    fun deleteAllByTournamentId(@Param("tournamentId") tournamentId: Long)
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentUserJpaRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentUserJpaRepository.kt
@@ -2,6 +2,7 @@ package com.depromeet.piki.tournament.repository
 
 import com.depromeet.piki.tournament.domain.TournamentUser
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import java.util.UUID
@@ -20,4 +21,8 @@ interface TournamentUserJpaRepository : JpaRepository<TournamentUser, Long> {
     fun findByTournamentId(tournamentId: Long): List<TournamentUser>
 
     fun findByTournamentIdIn(tournamentIds: Collection<Long>): List<TournamentUser>
+
+    @Modifying
+    @Query("DELETE FROM TournamentUser tu WHERE tu.tournamentId = :tournamentId")
+    fun deleteAllByTournamentId(@Param("tournamentId") tournamentId: Long)
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentUserJpaRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentUserJpaRepository.kt
@@ -1,23 +1,32 @@
 package com.depromeet.piki.tournament.repository
 
 import com.depromeet.piki.tournament.domain.TournamentUser
+import java.time.LocalDateTime
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import java.util.UUID
 
 interface TournamentUserJpaRepository : JpaRepository<TournamentUser, Long> {
-    fun findByTournamentIdAndUserId(
+    fun findByTournamentIdAndUserIdAndDeletedAtIsNull(
         tournamentId: Long,
         userId: UUID,
     ): TournamentUser?
 
-    @Query("SELECT tu.tournamentId FROM TournamentUser tu WHERE tu.userId = :userId")
+    @Query("SELECT tu.tournamentId FROM TournamentUser tu WHERE tu.userId = :userId AND tu.deletedAt IS NULL")
     fun findTournamentIdsByUserId(
         @Param("userId") userId: UUID,
     ): List<Long>
 
-    fun findByTournamentId(tournamentId: Long): List<TournamentUser>
+    fun findByTournamentIdAndDeletedAtIsNull(tournamentId: Long): List<TournamentUser>
 
-    fun findByTournamentIdIn(tournamentIds: Collection<Long>): List<TournamentUser>
+    @Query("SELECT tu FROM TournamentUser tu WHERE tu.tournamentId IN :tournamentIds AND tu.deletedAt IS NULL")
+    fun findByTournamentIdInAndNotDeleted(
+        @Param("tournamentIds") tournamentIds: Collection<Long>,
+    ): List<TournamentUser>
+
+    @Modifying
+    @Query("UPDATE TournamentUser tu SET tu.deletedAt = :now WHERE tu.tournamentId = :tournamentId AND tu.deletedAt IS NULL")
+    fun softDeleteAllByTournamentId(@Param("tournamentId") tournamentId: Long, @Param("now") now: LocalDateTime)
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentUserRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentUserRepository.kt
@@ -16,6 +16,4 @@ interface TournamentUserRepository {
     fun findByTournamentId(tournamentId: Long): List<TournamentUser>
 
     fun findByTournamentIds(tournamentIds: List<Long>): List<TournamentUser>
-
-    fun deleteAllByTournamentId(tournamentId: Long)
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentUserRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentUserRepository.kt
@@ -16,4 +16,6 @@ interface TournamentUserRepository {
     fun findByTournamentId(tournamentId: Long): List<TournamentUser>
 
     fun findByTournamentIds(tournamentIds: List<Long>): List<TournamentUser>
+
+    fun softDeleteAllByTournamentId(tournamentId: Long)
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentUserRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentUserRepository.kt
@@ -16,4 +16,6 @@ interface TournamentUserRepository {
     fun findByTournamentId(tournamentId: Long): List<TournamentUser>
 
     fun findByTournamentIds(tournamentIds: List<Long>): List<TournamentUser>
+
+    fun deleteAllByTournamentId(tournamentId: Long)
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentUserRepositoryImpl.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentUserRepositoryImpl.kt
@@ -27,4 +27,8 @@ class TournamentUserRepositoryImpl(
         } else {
             tournamentUserJpaRepository.findByTournamentIdIn(tournamentIds)
         }
+
+    override fun deleteAllByTournamentId(tournamentId: Long) {
+        tournamentUserJpaRepository.deleteAllByTournamentId(tournamentId)
+    }
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentUserRepositoryImpl.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentUserRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.depromeet.piki.tournament.repository
 
 import com.depromeet.piki.tournament.domain.TournamentUser
+import java.time.LocalDateTime
 import org.springframework.stereotype.Repository
 import java.util.UUID
 
@@ -13,18 +14,22 @@ class TournamentUserRepositoryImpl(
     override fun findByTournamentIdAndUserId(
         tournamentId: Long,
         userId: UUID,
-    ): TournamentUser? = tournamentUserJpaRepository.findByTournamentIdAndUserId(tournamentId, userId)
+    ): TournamentUser? = tournamentUserJpaRepository.findByTournamentIdAndUserIdAndDeletedAtIsNull(tournamentId, userId)
 
     override fun findTournamentIdsByUserId(userId: UUID): List<Long> =
         tournamentUserJpaRepository.findTournamentIdsByUserId(userId)
 
     override fun findByTournamentId(tournamentId: Long): List<TournamentUser> =
-        tournamentUserJpaRepository.findByTournamentId(tournamentId)
+        tournamentUserJpaRepository.findByTournamentIdAndDeletedAtIsNull(tournamentId)
 
     override fun findByTournamentIds(tournamentIds: List<Long>): List<TournamentUser> =
         if (tournamentIds.isEmpty()) {
             emptyList()
         } else {
-            tournamentUserJpaRepository.findByTournamentIdIn(tournamentIds)
+            tournamentUserJpaRepository.findByTournamentIdInAndNotDeleted(tournamentIds)
         }
+
+    override fun softDeleteAllByTournamentId(tournamentId: Long) {
+        tournamentUserJpaRepository.softDeleteAllByTournamentId(tournamentId, LocalDateTime.now())
+    }
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentUserRepositoryImpl.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentUserRepositoryImpl.kt
@@ -27,8 +27,4 @@ class TournamentUserRepositoryImpl(
         } else {
             tournamentUserJpaRepository.findByTournamentIdIn(tournamentIds)
         }
-
-    override fun deleteAllByTournamentId(tournamentId: Long) {
-        tournamentUserJpaRepository.deleteAllByTournamentId(tournamentId)
-    }
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentException.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentException.kt
@@ -143,6 +143,13 @@ class TournamentException private constructor(
                 HttpStatus.BAD_REQUEST,
             )
 
+        fun inProgressTournamentCannotBeDeleted(): TournamentException =
+            TournamentException(
+                "진행 중인 토너먼트는 삭제할 수 없습니다.",
+                ErrorCategory.CONFLICT,
+                HttpStatus.CONFLICT,
+            )
+
         fun statusNotSupported(): TournamentException =
             TournamentException(
                 "해당 상태의 토너먼트 조회는 아직 지원되지 않습니다.",

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
@@ -357,6 +357,25 @@ class TournamentService(
     }
 
     @Transactional
+    fun deleteTournament(
+        userId: UUID,
+        tournamentId: Long,
+    ) {
+        val tournament =
+            tournamentRepository.findTournamentById(tournamentId)
+                ?: throw TournamentException.notFoundTournament()
+        val tournamentUser =
+            tournamentUserRepository.findByTournamentIdAndUserId(tournamentId, userId)
+                ?: throw TournamentException.forbiddenTournament()
+        if (tournamentUser.getId() != tournament.ownerTournamentUserId) throw TournamentException.forbiddenTournament()
+        if (tournament.isInProgress()) throw TournamentException.inProgressTournamentCannotBeDeleted()
+        tournamentRepository.deleteHistoriesByTournamentId(tournamentId)
+        tournamentItemRepository.deleteAllByTournamentId(tournamentId)
+        tournamentUserRepository.deleteAllByTournamentId(tournamentId)
+        tournamentRepository.deleteTournamentById(tournamentId)
+    }
+
+    @Transactional
     fun deleteItem(
         userId: UUID,
         tournamentId: Long,

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
@@ -369,10 +369,7 @@ class TournamentService(
                 ?: throw TournamentException.forbiddenTournament()
         if (tournamentUser.getId() != tournament.ownerTournamentUserId) throw TournamentException.forbiddenTournament()
         if (tournament.isInProgress()) throw TournamentException.inProgressTournamentCannotBeDeleted()
-        tournamentRepository.deleteHistoriesByTournamentId(tournamentId)
-        tournamentItemRepository.deleteAllByTournamentId(tournamentId)
-        tournamentUserRepository.deleteAllByTournamentId(tournamentId)
-        tournamentRepository.deleteTournamentById(tournamentId)
+        tournament.softDelete()
     }
 
     @Transactional

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
@@ -362,7 +362,7 @@ class TournamentService(
         tournamentId: Long,
     ) {
         val tournament =
-            tournamentRepository.findTournamentById(tournamentId)
+            tournamentRepository.findTournamentByIdForUpdate(tournamentId)
                 ?: throw TournamentException.notFoundTournament()
         val tournamentUser =
             tournamentUserRepository.findByTournamentIdAndUserId(tournamentId, userId)

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
@@ -369,6 +369,9 @@ class TournamentService(
                 ?: throw TournamentException.forbiddenTournament()
         if (tournamentUser.getId() != tournament.ownerTournamentUserId) throw TournamentException.forbiddenTournament()
         if (tournament.isInProgress()) throw TournamentException.inProgressTournamentCannotBeDeleted()
+        tournamentRepository.softDeleteHistoriesByTournamentId(tournamentId)
+        tournamentItemRepository.softDeleteAllByTournamentId(tournamentId)
+        tournamentUserRepository.softDeleteAllByTournamentId(tournamentId)
         tournament.softDelete()
     }
 
@@ -396,7 +399,7 @@ class TournamentService(
             if (!isTournamentOwner) throw TournamentException.forbiddenTournament()
         }
 
-        val deleted = tournamentItemRepository.deleteIfPending(tournamentItemId, tournamentId)
+        val deleted = tournamentItemRepository.softDeleteIfPending(tournamentItemId, tournamentId)
         if (deleted == 0) throw TournamentException.notPendingTournament()
     }
 

--- a/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
@@ -1382,6 +1382,22 @@ class TournamentControllerTest : IntegrationTestSupport() {
             ).andExpect(status().isNotFound)
     }
 
+    @Test
+    fun `DELETE tournaments-id 소프트 딜리트 후 조회하면 404 를 반환한다`() {
+        val mockMvc = buildMockMvc()
+        val tournamentId = createTournament(mockMvc)
+        mockMvc.perform(
+            delete("/api/v1/tournaments/$tournamentId")
+                .header(HttpHeaders.AUTHORIZATION, authHeader(userId)),
+        )
+
+        mockMvc
+            .perform(
+                get("/api/v1/tournaments/$tournamentId")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(userId)),
+            ).andExpect(status().isNotFound)
+    }
+
     private fun startTournamentWith2Items(mockMvc: MockMvc): TournamentStart {
         val tournamentId = createTournament(mockMvc)
         addItemsToTournament(mockMvc, tournamentId, userId, saveWishItem(name = "아이템1"), saveWishItem(name = "아이템2"))

--- a/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
@@ -283,7 +283,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
             post("/api/v1/tournaments/$tournamentId/start")
                 .header(HttpHeaders.AUTHORIZATION, authHeader(userId)),
         )
-        val items = tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId)
+        val items = tournamentItemJpaRepository.findAllByTournamentIdAndNotDeleted(tournamentId)
         val ti1 = items[0].getId()
         val ti2 = items[1].getId()
         val ti3 = items[2].getId()
@@ -440,7 +440,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
                 .header(HttpHeaders.AUTHORIZATION, authHeader(userId)),
         )
         // start 는 가격 오름차순 반환 → ti1~ti4 순 — 클라이언트 페어링: [0]vs[1], [2]vs[3]
-        val items = tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId)
+        val items = tournamentItemJpaRepository.findAllByTournamentIdAndNotDeleted(tournamentId)
         val ti1 = items[0].getId()
         val ti2 = items[1].getId()
         val ti3 = items[2].getId()
@@ -527,7 +527,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
                 .header(HttpHeaders.AUTHORIZATION, authHeader(userId)),
         )
 
-        val allItems = tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId)
+        val allItems = tournamentItemJpaRepository.findAllByTournamentIdAndNotDeleted(tournamentId)
         // 6번의 매치 기록 — 1라운드(currentRound=32), 각 2개씩 소진 → ti[0]~ti[11] 등장
         repeat(6) { i ->
             val first = allItems[i * 2].getId()
@@ -574,7 +574,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
             post("/api/v1/tournaments/$tournamentId/start")
                 .header(HttpHeaders.AUTHORIZATION, authHeader(userId)),
         )
-        val items = tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId)
+        val items = tournamentItemJpaRepository.findAllByTournamentIdAndNotDeleted(tournamentId)
         val ti1 = items[0].getId()
         val ti2 = items[1].getId()
 
@@ -755,7 +755,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
         val mockMvc = buildMockMvc()
         val tournamentId = createTournament(mockMvc)
         addItemsToTournament(mockMvc, tournamentId, userId, saveWishItem(), saveWishItem())
-        val itemId = tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId).first().getId()
+        val itemId = tournamentItemJpaRepository.findAllByTournamentIdAndNotDeleted(tournamentId).first().getId()
 
         mockMvc
             .perform(
@@ -763,7 +763,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
                     .header(HttpHeaders.AUTHORIZATION, authHeader(userId)),
             ).andExpect(status().isOk)
 
-        val remaining = tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId)
+        val remaining = tournamentItemJpaRepository.findAllByTournamentIdAndNotDeleted(tournamentId)
         assertEquals(1, remaining.size)
         assertTrue(remaining.none { it.getId() == itemId })
     }
@@ -785,7 +785,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
         val mockMvc = buildMockMvc()
         val tournamentId = createTournament(mockMvc)
         addItemsToTournament(mockMvc, tournamentId, userId, saveWishItem(), saveWishItem())
-        val itemId = tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId).first().getId()
+        val itemId = tournamentItemJpaRepository.findAllByTournamentIdAndNotDeleted(tournamentId).first().getId()
 
         mockMvc
             .perform(
@@ -800,7 +800,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
         val tournamentId = createTournament(mockMvc)
         tournamentUserJpaRepository.save(TournamentUser(tournamentId = tournamentId, userId = otherUserId))
         addItemsToTournament(mockMvc, tournamentId, otherUserId, saveWishItem(otherUserId), saveWishItem(otherUserId))
-        val itemId = tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId).first().getId()
+        val itemId = tournamentItemJpaRepository.findAllByTournamentIdAndNotDeleted(tournamentId).first().getId()
 
         mockMvc
             .perform(
@@ -809,7 +809,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
             ).andExpect(status().isOk)
 
         assertTrue(
-            tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId).none { it.getId() == itemId },
+            tournamentItemJpaRepository.findAllByTournamentIdAndNotDeleted(tournamentId).none { it.getId() == itemId },
         )
     }
 
@@ -849,7 +849,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
         val tournamentId = createTournament(mockMvc)
         val failedItem = itemJpaRepository.save(Item(status = ItemStatus.FAILED))
         tournamentItemJpaRepository.save(TournamentItem(tournamentId = tournamentId, itemId = failedItem.getId(), userId = userId))
-        val tournamentItemId = tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId).first().getId()
+        val tournamentItemId = tournamentItemJpaRepository.findAllByTournamentIdAndNotDeleted(tournamentId).first().getId()
 
         mockMvc
             .perform(
@@ -872,7 +872,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
         val tournamentId = createTournament(mockMvc)
         val readyItemId = saveWishItem()
         addItemsToTournament(mockMvc, tournamentId, userId, readyItemId)
-        val tournamentItemId = tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId).first().getId()
+        val tournamentItemId = tournamentItemJpaRepository.findAllByTournamentIdAndNotDeleted(tournamentId).first().getId()
 
         mockMvc
             .perform(
@@ -889,7 +889,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
         val tournamentId = createTournament(mockMvc)
         val processingItem = itemJpaRepository.save(Item(status = ItemStatus.PROCESSING))
         tournamentItemJpaRepository.save(TournamentItem(tournamentId = tournamentId, itemId = processingItem.getId(), userId = userId))
-        val tournamentItemId = tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId).first().getId()
+        val tournamentItemId = tournamentItemJpaRepository.findAllByTournamentIdAndNotDeleted(tournamentId).first().getId()
 
         mockMvc
             .perform(
@@ -906,7 +906,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
         val (tournamentId, item1Id) = startTournamentWith2Items(mockMvc)
         val failedItem = itemJpaRepository.save(Item(status = ItemStatus.FAILED))
         tournamentItemJpaRepository.save(TournamentItem(tournamentId = tournamentId, itemId = failedItem.getId(), userId = userId))
-        val tournamentItemId = tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId).last().getId()
+        val tournamentItemId = tournamentItemJpaRepository.findAllByTournamentIdAndNotDeleted(tournamentId).last().getId()
 
         mockMvc
             .perform(
@@ -924,7 +924,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
         tournamentUserJpaRepository.save(TournamentUser(tournamentId = tournamentId, userId = otherUserId))
         val failedItem = itemJpaRepository.save(Item(status = ItemStatus.FAILED))
         tournamentItemJpaRepository.save(TournamentItem(tournamentId = tournamentId, itemId = failedItem.getId(), userId = otherUserId))
-        val tournamentItemId = tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId).first().getId()
+        val tournamentItemId = tournamentItemJpaRepository.findAllByTournamentIdAndNotDeleted(tournamentId).first().getId()
 
         mockMvc
             .perform(
@@ -941,7 +941,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
         val tournamentId = createTournament(mockMvc)
         val failedItem = itemJpaRepository.save(Item(name = "기존 이름", status = ItemStatus.FAILED))
         tournamentItemJpaRepository.save(TournamentItem(tournamentId = tournamentId, itemId = failedItem.getId(), userId = userId))
-        val tournamentItemId = tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId).first().getId()
+        val tournamentItemId = tournamentItemJpaRepository.findAllByTournamentIdAndNotDeleted(tournamentId).first().getId()
 
         mockMvc
             .perform(
@@ -963,7 +963,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
         val tournamentId = createTournament(mockMvc)
         val failedItem = itemJpaRepository.save(Item(status = ItemStatus.FAILED))
         tournamentItemJpaRepository.save(TournamentItem(tournamentId = tournamentId, itemId = failedItem.getId(), userId = userId))
-        val tournamentItemId = tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId).first().getId()
+        val tournamentItemId = tournamentItemJpaRepository.findAllByTournamentIdAndNotDeleted(tournamentId).first().getId()
 
         mockMvc
             .perform(
@@ -993,7 +993,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
                     .andReturn()
 
             val tournamentItemId = objectMapper.readTree(result.response.contentAsString)["data"]["tournamentItemId"].asLong()
-            val tournamentItem = tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId).also {
+            val tournamentItem = tournamentItemJpaRepository.findAllByTournamentIdAndNotDeleted(tournamentId).also {
                 assertEquals(1, it.size)
             }.first()
             assertEquals(tournamentItemId, tournamentItem.getId())
@@ -1063,7 +1063,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
                 .andExpect(jsonPath("$.data.tournamentItemIds").isArray)
                 .andExpect(jsonPath("$.data.tournamentItemIds.length()").value(2))
 
-            assertEquals(2, tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId).size)
+            assertEquals(2, tournamentItemJpaRepository.findAllByTournamentIdAndNotDeleted(tournamentId).size)
         } finally {
             stubImageParsingWorker.enabled = true
         }
@@ -1222,7 +1222,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
         val tournamentId = createTournament(mockMvc)
         val itemId = saveWishItem(name = "나이키 에어맥스", price = 129_000)
         addItemsToTournament(mockMvc, tournamentId, userId, itemId)
-        val tournamentItemId = tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId).first().getId()
+        val tournamentItemId = tournamentItemJpaRepository.findAllByTournamentIdAndNotDeleted(tournamentId).first().getId()
 
         mockMvc
             .perform(
@@ -1253,7 +1253,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
             ),
         )
         tournamentItemJpaRepository.save(TournamentItem(tournamentId = tournamentId, itemId = linkItem.getId(), userId = userId))
-        val tournamentItemId = tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId).first().getId()
+        val tournamentItemId = tournamentItemJpaRepository.findAllByTournamentIdAndNotDeleted(tournamentId).first().getId()
 
         mockMvc
             .perform(
@@ -1270,7 +1270,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
         val tournamentId = createTournament(mockMvc)
         val processingItemId = itemJpaRepository.save(Item(status = ItemStatus.PROCESSING)).getId()
         tournamentItemJpaRepository.save(TournamentItem(tournamentId = tournamentId, itemId = processingItemId, userId = userId))
-        val tournamentItemId = tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId).first().getId()
+        val tournamentItemId = tournamentItemJpaRepository.findAllByTournamentIdAndNotDeleted(tournamentId).first().getId()
 
         mockMvc
             .perform(
@@ -1288,7 +1288,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
         val mockMvc = buildMockMvc()
         val tournamentId = createTournament(mockMvc)
         addItemsToTournament(mockMvc, tournamentId, userId, saveWishItem())
-        val tournamentItemId = tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId).first().getId()
+        val tournamentItemId = tournamentItemJpaRepository.findAllByTournamentIdAndNotDeleted(tournamentId).first().getId()
 
         mockMvc
             .perform(
@@ -1326,7 +1326,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
         val tournamentId1 = createTournament(mockMvc, "토너먼트1")
         val tournamentId2 = createTournament(mockMvc, "토너먼트2")
         addItemsToTournament(mockMvc, tournamentId2, userId, saveWishItem())
-        val itemOfTournament2 = tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId2).first().getId()
+        val itemOfTournament2 = tournamentItemJpaRepository.findAllByTournamentIdAndNotDeleted(tournamentId2).first().getId()
 
         mockMvc
             .perform(
@@ -1405,7 +1405,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
             post("/api/v1/tournaments/$tournamentId/start")
                 .header(HttpHeaders.AUTHORIZATION, authHeader(userId)),
         )
-        val items = tournamentItemJpaRepository.findAllByTournamentIdOrderByIdAsc(tournamentId)
+        val items = tournamentItemJpaRepository.findAllByTournamentIdAndNotDeleted(tournamentId)
         return TournamentStart(
             tournamentId = tournamentId,
             item1Id = items[0].getId(),

--- a/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
@@ -1335,6 +1335,53 @@ class TournamentControllerTest : IntegrationTestSupport() {
             ).andExpect(status().isNotFound)
     }
 
+    @Test
+    fun `DELETE tournaments-id 는 소유자가 PENDING 토너먼트를 삭제하면 200 을 반환한다`() {
+        val mockMvc = buildMockMvc()
+        val tournamentId = createTournament(mockMvc)
+
+        mockMvc
+            .perform(
+                delete("/api/v1/tournaments/$tournamentId")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(userId)),
+            ).andExpect(status().isOk)
+    }
+
+    @Test
+    fun `DELETE tournaments-id 에서 IN_PROGRESS 토너먼트 삭제 시도 시 409 를 반환한다`() {
+        val mockMvc = buildMockMvc()
+        val (tournamentId) = startTournamentWith2Items(mockMvc)
+
+        mockMvc
+            .perform(
+                delete("/api/v1/tournaments/$tournamentId")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(userId)),
+            ).andExpect(status().isConflict)
+    }
+
+    @Test
+    fun `DELETE tournaments-id 에서 소유자가 아닌 사용자가 요청하면 403 을 반환한다`() {
+        val mockMvc = buildMockMvc()
+        val tournamentId = createTournament(mockMvc)
+
+        mockMvc
+            .perform(
+                delete("/api/v1/tournaments/$tournamentId")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(otherUserId)),
+            ).andExpect(status().isForbidden)
+    }
+
+    @Test
+    fun `DELETE tournaments-id 에서 존재하지 않는 토너먼트이면 404 를 반환한다`() {
+        val mockMvc = buildMockMvc()
+
+        mockMvc
+            .perform(
+                delete("/api/v1/tournaments/999999")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(userId)),
+            ).andExpect(status().isNotFound)
+    }
+
     private fun startTournamentWith2Items(mockMvc: MockMvc): TournamentStart {
         val tournamentId = createTournament(mockMvc)
         addItemsToTournament(mockMvc, tournamentId, userId, saveWishItem(name = "아이템1"), saveWishItem(name = "아이템2"))

--- a/src/test/kotlin/com/depromeet/piki/tournament/service/TournamentServiceTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/service/TournamentServiceTest.kt
@@ -28,6 +28,7 @@ import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -56,10 +57,6 @@ class TournamentServiceTest {
 
         override fun findByTournamentIds(tournamentIds: List<Long>): List<TournamentUser> =
             users.filter { it.tournamentId in tournamentIds }
-
-        override fun deleteAllByTournamentId(tournamentId: Long) {
-            users.removeAll { it.tournamentId == tournamentId }
-        }
 
         private fun setEntityId(
             entity: LongBaseEntity,
@@ -205,10 +202,6 @@ class TournamentServiceTest {
             return 1
         }
 
-        override fun deleteAllByTournamentId(tournamentId: Long) {
-            items.removeAll { it.tournamentId == tournamentId }
-        }
-
         private fun setEntityId(
             entity: LongBaseEntity,
             id: Long,
@@ -237,9 +230,17 @@ class TournamentServiceTest {
             histories.add(history)
         }
 
-        override fun findTournamentById(tournamentId: Long): Tournament? = tournaments[tournamentId]
+        override fun findTournamentById(tournamentId: Long): Tournament? {
+            val tournament = tournaments[tournamentId] ?: return null
+            tournament.deletedAt ?: return tournament
+            return null
+        }
 
-        override fun findTournamentByIdForUpdate(tournamentId: Long): Tournament? = tournaments[tournamentId]
+        override fun findTournamentByIdForUpdate(tournamentId: Long): Tournament? {
+            val tournament = tournaments[tournamentId] ?: return null
+            tournament.deletedAt ?: return tournament
+            return null
+        }
 
         override fun findTournamentHistoriesByTournamentId(tournamentId: Long): List<TournamentHistory> =
             histories.filter { it.tournamentId == tournamentId }
@@ -252,14 +253,6 @@ class TournamentServiceTest {
                 .filter { it.getId() in ids }
                 .filter { statuses.isNullOrEmpty() || it.status in statuses }
                 .sortedByDescending { it.createdAt }
-
-        override fun deleteTournamentById(tournamentId: Long) {
-            tournaments.remove(tournamentId)
-        }
-
-        override fun deleteHistoriesByTournamentId(tournamentId: Long) {
-            histories.removeAll { it.tournamentId == tournamentId }
-        }
 
         private fun setEntityId(
             entity: LongBaseEntity,
@@ -1129,20 +1122,20 @@ class TournamentServiceTest {
     }
 
     @Test
-    fun `deleteTournament 는 PENDING 토너먼트를 소유자가 삭제하면 연관 데이터가 모두 제거된다`() {
+    fun `deleteTournament 는 PENDING 토너먼트를 소유자가 소프트 딜리트한다`() {
         val tournamentId = service.create(userId, CreateTournament("삭제 대상"))
         testWishRepository.addWish(userId, 1L, 2L)
         service.addItemsFromWish(userId, AddTournamentItemsFromWish(tournamentId, listOf(1L, 2L)))
 
         service.deleteTournament(userId, tournamentId)
 
-        assertEquals(null, repository.tournaments[tournamentId])
-        assertEquals(0, tournamentItemRepository.items.count { it.tournamentId == tournamentId })
-        assertEquals(0, tournamentUserRepository.users.count { it.tournamentId == tournamentId })
+        assertNotNull(repository.tournaments[tournamentId]!!.deletedAt)
+        // 소프트 딜리트 후 findTournamentById 는 null 을 반환한다
+        assertEquals(null, repository.findTournamentById(tournamentId))
     }
 
     @Test
-    fun `deleteTournament 는 COMPLETED 토너먼트도 삭제할 수 있다`() {
+    fun `deleteTournament 는 COMPLETED 토너먼트도 소프트 딜리트할 수 있다`() {
         val tournamentId = createAndStart(listOf(1L, 2L))
         val items = tournamentItemRepository.findAllByTournamentId(tournamentId)
         service.recordMatch(
@@ -1152,7 +1145,7 @@ class TournamentServiceTest {
 
         service.deleteTournament(userId, tournamentId)
 
-        assertEquals(null, repository.tournaments[tournamentId])
+        assertNotNull(repository.tournaments[tournamentId]!!.deletedAt)
     }
 
     @Test

--- a/src/test/kotlin/com/depromeet/piki/tournament/service/TournamentServiceTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/service/TournamentServiceTest.kt
@@ -58,6 +58,10 @@ class TournamentServiceTest {
         override fun findByTournamentIds(tournamentIds: List<Long>): List<TournamentUser> =
             users.filter { it.tournamentId in tournamentIds }
 
+        override fun softDeleteAllByTournamentId(tournamentId: Long) {
+            users.filter { it.tournamentId == tournamentId }.forEach { it.softDelete() }
+        }
+
         private fun setEntityId(
             entity: LongBaseEntity,
             id: Long,
@@ -176,13 +180,14 @@ class TournamentServiceTest {
                 item
             }
 
-        override fun countByTournamentId(tournamentId: Long): Int = items.count { it.tournamentId == tournamentId }
+        override fun countByTournamentId(tournamentId: Long): Int =
+            items.count { it.tournamentId == tournamentId && (it.deletedAt?.let { false } ?: true) }
 
         override fun findIdsByTournamentId(tournamentId: Long): List<Long> =
-            items.filter { it.tournamentId == tournamentId }.map { it.getId() }
+            items.filter { it.tournamentId == tournamentId && (it.deletedAt?.let { false } ?: true) }.map { it.getId() }
 
         override fun findAllByTournamentId(tournamentId: Long): List<TournamentItem> =
-            items.filter { it.tournamentId == tournamentId }
+            items.filter { it.tournamentId == tournamentId && (it.deletedAt?.let { false } ?: true) }
 
         override fun findByIds(ids: List<Long>): List<TournamentItem> =
             items.filter { it.getId() in ids }
@@ -193,13 +198,18 @@ class TournamentServiceTest {
             items.remove(tournamentItem)
         }
 
-        override fun deleteIfPending(
+        override fun softDeleteIfPending(
             id: Long,
             tournamentId: Long,
         ): Int {
             val item = items.find { it.getId() == id && it.tournamentId == tournamentId } ?: return 0
-            items.remove(item)
+            item.deletedAt?.let { return 0 }
+            item.softDelete()
             return 1
+        }
+
+        override fun softDeleteAllByTournamentId(tournamentId: Long) {
+            items.filter { it.tournamentId == tournamentId }.forEach { it.softDelete() }
         }
 
         private fun setEntityId(
@@ -253,6 +263,10 @@ class TournamentServiceTest {
                 .filter { it.getId() in ids }
                 .filter { statuses.isNullOrEmpty() || it.status in statuses }
                 .sortedByDescending { it.createdAt }
+
+        override fun softDeleteHistoriesByTournamentId(tournamentId: Long) {
+            histories.filter { it.tournamentId == tournamentId }.forEach { it.softDelete() }
+        }
 
         private fun setEntityId(
             entity: LongBaseEntity,
@@ -1122,7 +1136,7 @@ class TournamentServiceTest {
     }
 
     @Test
-    fun `deleteTournament 는 PENDING 토너먼트를 소유자가 소프트 딜리트한다`() {
+    fun `deleteTournament 는 PENDING 토너먼트를 소유자가 소프트 딜리트하고 연관 데이터도 함께 소프트 딜리트한다`() {
         val tournamentId = service.create(userId, CreateTournament("삭제 대상"))
         testWishRepository.addWish(userId, 1L, 2L)
         service.addItemsFromWish(userId, AddTournamentItemsFromWish(tournamentId, listOf(1L, 2L)))
@@ -1130,8 +1144,10 @@ class TournamentServiceTest {
         service.deleteTournament(userId, tournamentId)
 
         assertNotNull(repository.tournaments[tournamentId]!!.deletedAt)
+        assertTrue(tournamentItemRepository.items.filter { it.tournamentId == tournamentId }.all { it.deletedAt?.let { true } ?: false })
+        assertTrue(tournamentUserRepository.users.filter { it.tournamentId == tournamentId }.all { it.deletedAt?.let { true } ?: false })
         // 소프트 딜리트 후 findTournamentById 는 null 을 반환한다
-        assertEquals(null, repository.findTournamentById(tournamentId))
+        assertNull(repository.findTournamentById(tournamentId))
     }
 
     @Test

--- a/src/test/kotlin/com/depromeet/piki/tournament/service/TournamentServiceTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/service/TournamentServiceTest.kt
@@ -194,10 +194,6 @@ class TournamentServiceTest {
 
         override fun findById(id: Long): TournamentItem? = items.find { it.getId() == id }
 
-        override fun delete(tournamentItem: TournamentItem) {
-            items.remove(tournamentItem)
-        }
-
         override fun softDeleteIfPending(
             id: Long,
             tournamentId: Long,

--- a/src/test/kotlin/com/depromeet/piki/tournament/service/TournamentServiceTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/service/TournamentServiceTest.kt
@@ -1158,6 +1158,7 @@ class TournamentServiceTest {
         service.deleteTournament(userId, tournamentId)
 
         assertNotNull(repository.tournaments[tournamentId]!!.deletedAt)
+        assertTrue(repository.histories.filter { it.tournamentId == tournamentId }.all { it.deletedAt?.let { true } ?: false })
     }
 
     @Test

--- a/src/test/kotlin/com/depromeet/piki/tournament/service/TournamentServiceTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/service/TournamentServiceTest.kt
@@ -57,6 +57,10 @@ class TournamentServiceTest {
         override fun findByTournamentIds(tournamentIds: List<Long>): List<TournamentUser> =
             users.filter { it.tournamentId in tournamentIds }
 
+        override fun deleteAllByTournamentId(tournamentId: Long) {
+            users.removeAll { it.tournamentId == tournamentId }
+        }
+
         private fun setEntityId(
             entity: LongBaseEntity,
             id: Long,
@@ -201,6 +205,10 @@ class TournamentServiceTest {
             return 1
         }
 
+        override fun deleteAllByTournamentId(tournamentId: Long) {
+            items.removeAll { it.tournamentId == tournamentId }
+        }
+
         private fun setEntityId(
             entity: LongBaseEntity,
             id: Long,
@@ -244,6 +252,14 @@ class TournamentServiceTest {
                 .filter { it.getId() in ids }
                 .filter { statuses.isNullOrEmpty() || it.status in statuses }
                 .sortedByDescending { it.createdAt }
+
+        override fun deleteTournamentById(tournamentId: Long) {
+            tournaments.remove(tournamentId)
+        }
+
+        override fun deleteHistoriesByTournamentId(tournamentId: Long) {
+            histories.removeAll { it.tournamentId == tournamentId }
+        }
 
         private fun setEntityId(
             entity: LongBaseEntity,
@@ -1110,5 +1126,64 @@ class TournamentServiceTest {
                 service.addItemsFromWish(userId, AddTournamentItemsFromWish(tournamentId, listOf(1L, 2L)))
             }
         assertEquals(HttpStatus.FORBIDDEN, ex.httpStatus)
+    }
+
+    @Test
+    fun `deleteTournament 는 PENDING 토너먼트를 소유자가 삭제하면 연관 데이터가 모두 제거된다`() {
+        val tournamentId = service.create(userId, CreateTournament("삭제 대상"))
+        testWishRepository.addWish(userId, 1L, 2L)
+        service.addItemsFromWish(userId, AddTournamentItemsFromWish(tournamentId, listOf(1L, 2L)))
+
+        service.deleteTournament(userId, tournamentId)
+
+        assertEquals(null, repository.tournaments[tournamentId])
+        assertEquals(0, tournamentItemRepository.items.count { it.tournamentId == tournamentId })
+        assertEquals(0, tournamentUserRepository.users.count { it.tournamentId == tournamentId })
+    }
+
+    @Test
+    fun `deleteTournament 는 COMPLETED 토너먼트도 삭제할 수 있다`() {
+        val tournamentId = createAndStart(listOf(1L, 2L))
+        val items = tournamentItemRepository.findAllByTournamentId(tournamentId)
+        service.recordMatch(
+            userId,
+            RecordMatch(tournamentId, 2, items[0].getId(), items[1].getId(), items[0].getId()),
+        )
+
+        service.deleteTournament(userId, tournamentId)
+
+        assertEquals(null, repository.tournaments[tournamentId])
+    }
+
+    @Test
+    fun `deleteTournament 는 IN_PROGRESS 토너먼트 삭제 시 409 예외가 발생한다`() {
+        val tournamentId = createAndStart(listOf(1L, 2L))
+
+        val ex = assertFailsWith<TournamentException> { service.deleteTournament(userId, tournamentId) }
+        assertEquals(HttpStatus.CONFLICT, ex.httpStatus)
+    }
+
+    @Test
+    fun `deleteTournament 는 참가자이지만 소유자가 아니면 403 예외가 발생한다`() {
+        val tournamentId = service.create(userId, CreateTournament("토너먼트"))
+        // otherUserId 를 참가자로 추가 (소유자는 userId)
+        tournamentUserRepository.save(TournamentUser(tournamentId = tournamentId, userId = otherUserId))
+
+        val ex = assertFailsWith<TournamentException> { service.deleteTournament(otherUserId, tournamentId) }
+        assertEquals(HttpStatus.FORBIDDEN, ex.httpStatus)
+    }
+
+    @Test
+    fun `deleteTournament 는 소유자가 아니면 403 예외가 발생한다`() {
+        val tournamentId = service.create(userId, CreateTournament("토너먼트"))
+
+        val ex = assertFailsWith<TournamentException> { service.deleteTournament(otherUserId, tournamentId) }
+        assertEquals(HttpStatus.FORBIDDEN, ex.httpStatus)
+    }
+
+    @Test
+    fun `deleteTournament 는 존재하지 않는 토너먼트면 404 예외가 발생한다`() {
+        val ex = assertFailsWith<TournamentException> { service.deleteTournament(userId, 999L) }
+        assertEquals(HttpStatus.NOT_FOUND, ex.httpStatus)
     }
 }


### PR DESCRIPTION
## Situation
- 토너먼트 삭제 API가 없어 사용자가 생성한 토너먼트를 삭제할 수 없었음

## Task
- `DELETE /tournaments/{id}` 엔드포인트 구현 — PENDING·COMPLETED 상태만 허용, IN_PROGRESS 차단, 소유자 전용

## Action

### 소프트 딜리트
- `Tournament.softDelete()` 추가 — 테이블에 이미 `deleted_at` 컬럼이 있어 마이그레이션 불필요
- `TournamentItem`, `TournamentUser`, `TournamentHistory` 세 엔티티에도 `softDelete()` 추가
- JPA 리포지터리 전체 조회 쿼리에 `deletedAt IS NULL` 추가 (Tournament·연관 엔티티 모두)
- `deleteIfPending` → `softDeleteIfPending` (DELETE → UPDATE SET deletedAt) 전환
- `softDeleteAllByTournamentId` bulk UPDATE 추가 — histories → items → users → tournament 순으로 소프트 딜리트

### 삭제 엔드포인트
- `DELETE /api/v1/tournaments/{id}` 추가 — `TournamentController`, `TournamentApi` (OpenAPI 문서), `TournamentApiExamples`
- 서비스 검증 순서: 토너먼트 존재(404) → 소유자(403) → IN_PROGRESS 차단(409)
- `TournamentException.inProgressTournamentCannotBeDeleted()` 팩토리 추가

### 테스트
- 단위 테스트 6종: PENDING·COMPLETED 삭제, IN_PROGRESS 409, 비참가자·참가자&비소유자 403, 없는 토너먼트 404
- 통합 테스트 5종: 200·409·403·404 HTTP contract + 소프트 딜리트 후 GET → 404

## Result
- `DELETE /api/v1/tournaments/{id}` 엔드포인트 노출
- 토너먼트 및 연관 데이터 모두 DB에 보존 (hard delete 없음)
- 기존 아이템 개별 삭제(`deleteItem`)도 soft delete로 통일

---
## 연관 이슈

- close #347


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 토너먼트 삭제 API를 추가했습니다.
  * 삭제 시 토너먼트와 연관된 아이템·참여자·히스토리 등이 일괄적으로 소프트 삭제되어 조회에서 숨겨집니다.

* **Behavior Changes**
  * 개별 아이템 삭제가 물리 삭제에서 소프트 삭제로 전환되었습니다.
  * 진행 중인 토너먼트는 삭제할 수 없도록 제한됩니다.

* **Tests**
  * 토너먼트 삭제 관련 다양한 케이스를 검증하는 테스트들을 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->