### PR TITLE
GET /auth/{provider}/url - redirectUri 동적 지정 지원

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/auth/controller/OAuthUrlApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/controller/OAuthUrlApi.kt
@@ -36,7 +36,7 @@ interface OAuthUrlApi {
             ),
             ApiResponse(
                 responseCode = "400",
-                description = "지원하지 않는 provider",
+                description = "잘못된 요청 (지원하지 않는 provider · 허용되지 않은 redirect_uri)",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,

--- a/src/main/kotlin/com/depromeet/piki/auth/controller/OAuthUrlApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/controller/OAuthUrlApi.kt
@@ -49,5 +49,10 @@ interface OAuthUrlApi {
     fun getAuthUrl(
         @Parameter(description = "소셜 제공자", example = "kakao", schema = Schema(allowableValues = ["kakao", "google"]))
         provider: String,
+        @Parameter(
+            description = "redirect_uri 동적 지정 (생략 시 서버 기본값 사용). 로컬 개발 등 프로덕션과 다른 콜백 URL 이 필요할 때 사용.",
+            example = "http://localhost:3000/auth/callback/google",
+        )
+        redirectUri: String?,
     ): ApiResponseBody<OAuthUrlResponse>
 }

--- a/src/main/kotlin/com/depromeet/piki/auth/controller/OAuthUrlApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/controller/OAuthUrlApiExamples.kt
@@ -45,6 +45,15 @@ class OAuthUrlApiExamples(
                                 detail = "지원하지 않는 소셜 로그인 제공자입니다.",
                             ),
                     )
+                    add(
+                        status = HttpStatus.BAD_REQUEST,
+                        name = "허용되지 않은 redirect_uri",
+                        payload =
+                            ApiResponseBody.fail<Unit>(
+                                category = ErrorCategory.INVALID_INPUT,
+                                detail = "허용되지 않은 redirect_uri 입니다.",
+                            ),
+                    )
                 }
             }
             operation

--- a/src/main/kotlin/com/depromeet/piki/auth/controller/OAuthUrlController.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/controller/OAuthUrlController.kt
@@ -7,6 +7,7 @@ import com.depromeet.piki.common.response.ApiResponseBody
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -17,9 +18,10 @@ class OAuthUrlController(
     @GetMapping("/{provider}/url")
     override fun getAuthUrl(
         @PathVariable provider: String,
+        @RequestParam(required = false) redirectUri: String?,
     ): ApiResponseBody<OAuthUrlResponse> {
         val oAuthProvider = OAuthProvider.from(provider)
-        val result = oAuthUrlService.buildUrl(oAuthProvider)
+        val result = oAuthUrlService.buildUrl(oAuthProvider, redirectUri)
         return ApiResponseBody.ok(OAuthUrlResponse.from(result))
     }
 }

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthClient.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthClient.kt
@@ -9,7 +9,8 @@ interface OAuthClient {
 
     // RFC 6749 §4.1 Authorization Code Grant — provider 인가 URL 생성.
     // state 는 CSRF 방지용 (RFC 6749 §10.12). 호출자가 Redis 에 저장 후 사용자를 이 URL 로 redirect.
-    fun buildAuthUrl(state: String): String
+    // redirectUri 가 null 이면 provider 별 properties 기본값을 사용한다.
+    fun buildAuthUrl(state: String, redirectUri: String? = null): String
 
     fun fetchUserInfoByCode(
         code: String,

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthClient.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthClient.kt
@@ -12,6 +12,10 @@ interface OAuthClient {
     // redirectUri 가 null 이면 provider 별 properties 기본값을 사용한다.
     fun buildAuthUrl(state: String, redirectUri: String? = null): String
 
+    // 허용된 redirect_uri 목록. OAuthUrlService 가 검증에 사용한다.
+    // 기본 redirectUri 는 항상 포함. 추가 허용 URI 는 properties.allowedRedirectUris 로 주입.
+    val allowedRedirectUris: List<String>
+
     fun fetchUserInfoByCode(
         code: String,
         redirectUri: String,

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthException.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthException.kt
@@ -33,5 +33,9 @@ class OAuthException private constructor(
         // state 없음 · 만료 · 이미 소비됨 → 401. CSRF 방지용 state 불일치로 요청을 거부.
         fun invalidState(): OAuthException =
             OAuthException("유효하지 않은 state 파라미터입니다. 인가 URL 을 새로 발급받아 다시 시도하세요.", ErrorCategory.UNAUTHORIZED, HttpStatus.UNAUTHORIZED)
+
+        // 허용되지 않은 redirect_uri → 400. 등록된 URI 외 Open Redirect 를 차단한다.
+        fun invalidRedirectUri(): OAuthException =
+            OAuthException("허용되지 않은 redirect_uri 입니다.", ErrorCategory.INVALID_INPUT, HttpStatus.BAD_REQUEST)
     }
 }

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/google/GoogleOAuthClient.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/google/GoogleOAuthClient.kt
@@ -21,11 +21,11 @@ class GoogleOAuthClient(
     private val tokenClient = OAuthRestClient.create(TOKEN_BASE_URL)
     private val userInfoClient = OAuthRestClient.create(USER_INFO_BASE_URL)
 
-    override fun buildAuthUrl(state: String): String =
+    override fun buildAuthUrl(state: String, redirectUri: String?): String =
         UriComponentsBuilder
             .fromUriString(AUTH_URL)
             .queryParam(OAuthParams.CLIENT_ID, googleProperties.clientId)
-            .queryParam(OAuthParams.REDIRECT_URI, googleProperties.redirectUri)
+            .queryParam(OAuthParams.REDIRECT_URI, redirectUri ?: googleProperties.redirectUri)
             .queryParam(OAuthParams.RESPONSE_TYPE, OAuthParams.RESPONSE_TYPE_CODE)
             .queryParam(OAuthParams.SCOPE, "email profile")
             .queryParam(OAuthParams.STATE, state)

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/google/GoogleOAuthClient.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/google/GoogleOAuthClient.kt
@@ -17,6 +17,8 @@ class GoogleOAuthClient(
     private val googleProperties: GoogleProperties,
 ) : OAuthClient {
     override val provider = OAuthProvider.GOOGLE
+    override val allowedRedirectUris: List<String>
+        get() = listOf(googleProperties.redirectUri) + googleProperties.allowedRedirectUris
 
     private val tokenClient = OAuthRestClient.create(TOKEN_BASE_URL)
     private val userInfoClient = OAuthRestClient.create(USER_INFO_BASE_URL)

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/google/GoogleProperties.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/google/GoogleProperties.kt
@@ -15,4 +15,6 @@ data class GoogleProperties(
     val clientSecret: String,
     @field:NotBlank(message = "Google redirect-uri 는 비어 있을 수 없다.")
     val redirectUri: String,
+    // 추가 허용 redirect_uri. 로컬 개발 등에서 필요시 .env.local 에 GOOGLE_ALLOWED_REDIRECT_URIS[0]=http://localhost:... 로 주입.
+    val allowedRedirectUris: List<String> = emptyList(),
 )

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/kakao/KakaoOAuthClient.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/kakao/KakaoOAuthClient.kt
@@ -17,6 +17,8 @@ class KakaoOAuthClient(
     private val kakaoProperties: KakaoProperties,
 ) : OAuthClient {
     override val provider = OAuthProvider.KAKAO
+    override val allowedRedirectUris: List<String>
+        get() = listOf(kakaoProperties.redirectUri) + kakaoProperties.allowedRedirectUris
 
     private val authClient = OAuthRestClient.create(AUTH_BASE_URL)
     private val apiClient = OAuthRestClient.create(API_BASE_URL)

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/kakao/KakaoOAuthClient.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/kakao/KakaoOAuthClient.kt
@@ -21,11 +21,11 @@ class KakaoOAuthClient(
     private val authClient = OAuthRestClient.create(AUTH_BASE_URL)
     private val apiClient = OAuthRestClient.create(API_BASE_URL)
 
-    override fun buildAuthUrl(state: String): String =
+    override fun buildAuthUrl(state: String, redirectUri: String?): String =
         UriComponentsBuilder
             .fromUriString("$AUTH_BASE_URL/oauth/authorize")
             .queryParam(OAuthParams.CLIENT_ID, kakaoProperties.clientId)
-            .queryParam(OAuthParams.REDIRECT_URI, kakaoProperties.redirectUri)
+            .queryParam(OAuthParams.REDIRECT_URI, redirectUri ?: kakaoProperties.redirectUri)
             .queryParam(OAuthParams.RESPONSE_TYPE, OAuthParams.RESPONSE_TYPE_CODE)
             .queryParam(OAuthParams.STATE, state)
             .build()

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/kakao/KakaoProperties.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/kakao/KakaoProperties.kt
@@ -15,4 +15,6 @@ data class KakaoProperties(
     val clientSecret: String,
     @field:NotBlank(message = "Kakao redirect-uri 는 비어 있을 수 없다.")
     val redirectUri: String,
+    // 추가 허용 redirect_uri. 로컬 개발 등에서 필요시 .env.local 에 KAKAO_ALLOWED_REDIRECT_URIS[0]=http://localhost:... 로 주입.
+    val allowedRedirectUris: List<String> = emptyList(),
 )

--- a/src/main/kotlin/com/depromeet/piki/auth/service/OAuthUrlService.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/service/OAuthUrlService.kt
@@ -1,6 +1,7 @@
 package com.depromeet.piki.auth.service
 
 import com.depromeet.piki.auth.infrastructure.oauth.OAuthClientRegistry
+import com.depromeet.piki.auth.infrastructure.oauth.OAuthException
 import com.depromeet.piki.auth.infrastructure.oauth.OAuthProvider
 import com.depromeet.piki.auth.infrastructure.redis.OAuthStateStore
 import com.depromeet.piki.auth.service.dto.OAuthUrlResult
@@ -15,6 +16,9 @@ class OAuthUrlService(
     fun buildUrl(provider: OAuthProvider, redirectUri: String? = null): OAuthUrlResult {
         val state = UUID.randomUUID().toString()
         val client = oAuthClientRegistry.resolve(provider)
+        redirectUri?.let { uri ->
+            if (uri !in client.allowedRedirectUris) throw OAuthException.invalidRedirectUri()
+        }
         val url = client.buildAuthUrl(state, redirectUri)
         oAuthStateStore.store(state)
         return OAuthUrlResult(url = url, state = state)

--- a/src/main/kotlin/com/depromeet/piki/auth/service/OAuthUrlService.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/service/OAuthUrlService.kt
@@ -12,10 +12,10 @@ class OAuthUrlService(
     private val oAuthClientRegistry: OAuthClientRegistry,
     private val oAuthStateStore: OAuthStateStore,
 ) {
-    fun buildUrl(provider: OAuthProvider): OAuthUrlResult {
+    fun buildUrl(provider: OAuthProvider, redirectUri: String? = null): OAuthUrlResult {
         val state = UUID.randomUUID().toString()
         val client = oAuthClientRegistry.resolve(provider)
-        val url = client.buildAuthUrl(state)
+        val url = client.buildAuthUrl(state, redirectUri)
         oAuthStateStore.store(state)
         return OAuthUrlResult(url = url, state = state)
     }

--- a/src/test/kotlin/com/depromeet/piki/auth/controller/OAuthUrlIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/controller/OAuthUrlIntegrationTest.kt
@@ -142,6 +142,31 @@ class OAuthUrlIntegrationTest : IntegrationTestSupport() {
             ).andExpect(status().isOk)
     }
 
+    @Test
+    fun `GET auth url - redirectUri 쿼리 파라미터를 넘기면 반환된 URL 에 해당 값이 반영된다`() {
+        val customRedirectUri = "http://localhost:3000/auth/callback/google"
+
+        val response =
+            mockMvc()
+                .perform(get("/api/v1/auth/google/url").param("redirectUri", customRedirectUri))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.data.url").isString)
+                .andReturn()
+                .response.contentAsString
+
+        val url = objectMapper.readTree(response).at("/data/url").asText()
+        assert(url.contains(customRedirectUri)) { "반환된 URL 에 customRedirectUri 가 포함되어야 한다: $url" }
+    }
+
+    @Test
+    fun `GET auth url - redirectUri 생략 시 기본 redirect URI 로 URL 이 생성된다`() {
+        mockMvc()
+            .perform(get("/api/v1/auth/google/url"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.url").isString)
+            .andExpect(jsonPath("$.data.state").isString)
+    }
+
     private fun extractState(responseBody: String): String =
         objectMapper.readTree(responseBody).at("/data/state").asText()
 }

--- a/src/test/kotlin/com/depromeet/piki/auth/controller/OAuthUrlIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/controller/OAuthUrlIntegrationTest.kt
@@ -143,8 +143,9 @@ class OAuthUrlIntegrationTest : IntegrationTestSupport() {
     }
 
     @Test
-    fun `GET auth url - redirectUri 쿼리 파라미터를 넘기면 반환된 URL 에 해당 값이 반영된다`() {
+    fun `GET auth url - 허용된 redirectUri 를 넘기면 반환된 URL 에 해당 값이 반영된다`() {
         val customRedirectUri = "http://localhost:3000/auth/callback/google"
+        googleOAuthClient.allowedRedirectUrisStub = listOf(customRedirectUri)
 
         val response =
             mockMvc()
@@ -156,6 +157,16 @@ class OAuthUrlIntegrationTest : IntegrationTestSupport() {
 
         val url = objectMapper.readTree(response).at("/data/url").asText()
         assert(url.contains(customRedirectUri)) { "반환된 URL 에 customRedirectUri 가 포함되어야 한다: $url" }
+    }
+
+    @Test
+    fun `GET auth url - 허용 목록에 없는 redirectUri 는 400`() {
+        googleOAuthClient.allowedRedirectUrisStub = listOf("https://allowed.example.com/callback")
+
+        mockMvc()
+            .perform(get("/api/v1/auth/google/url").param("redirectUri", "https://evil.example.com/steal"))
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.detail").value("허용되지 않은 redirect_uri 입니다."))
     }
 
     @Test

--- a/src/test/kotlin/com/depromeet/piki/support/StubOAuthClient.kt
+++ b/src/test/kotlin/com/depromeet/piki/support/StubOAuthClient.kt
@@ -15,11 +15,12 @@ class StubOAuthClient(
     var fetchByAccessTokenStub: (String) -> OAuthUserInfo = { _ ->
         error("stub.fetchByAccessTokenStub 를 테스트 본문에서 명시 세팅해야 한다.")
     }
-    var buildAuthUrlStub: (String) -> String = { state ->
-        "https://stub-auth.example.com/oauth/authorize?provider=${provider.name.lowercase()}&state=$state"
+    var buildAuthUrlStub: (String, String?) -> String = { state, redirectUri ->
+        "https://stub-auth.example.com/oauth/authorize?provider=${provider.name.lowercase()}&state=$state" +
+            (redirectUri?.let { "&redirect_uri=$it" } ?: "")
     }
 
-    override fun buildAuthUrl(state: String): String = buildAuthUrlStub(state)
+    override fun buildAuthUrl(state: String, redirectUri: String?): String = buildAuthUrlStub(state, redirectUri)
 
     override fun fetchUserInfoByCode(
         code: String,

--- a/src/test/kotlin/com/depromeet/piki/support/StubOAuthClient.kt
+++ b/src/test/kotlin/com/depromeet/piki/support/StubOAuthClient.kt
@@ -19,6 +19,9 @@ class StubOAuthClient(
         "https://stub-auth.example.com/oauth/authorize?provider=${provider.name.lowercase()}&state=$state" +
             (redirectUri?.let { "&redirect_uri=$it" } ?: "")
     }
+    // OAuthUrlService 가 redirectUri 검증에 사용한다. 테스트 본문에서 허용할 URI 를 명시 세팅한다.
+    var allowedRedirectUrisStub: List<String> = emptyList()
+    override val allowedRedirectUris: List<String> get() = allowedRedirectUrisStub
 
     override fun buildAuthUrl(state: String, redirectUri: String?): String = buildAuthUrlStub(state, redirectUri)
 


### PR DESCRIPTION
## Situation
- `GET /api/v1/auth/{provider}/url` 이 redirect_uri 를 서버 properties 에 하드코딩된 프로덕션 URI 로만 생성했다
- 프론트엔드가 로컬 개발 환경에서 테스트할 때 `http://localhost:3000/auth/callback/google` 같은 로컬 URI 가 필요한데, 서버는 항상 프로덕션 URI 만 반환해 로컬 E2E 테스트가 불가능한 상황이었다
- repo.secrets 에 localhost 를 추가하는 방법도 검토했으나, secrets 는 환경별 단일 값이라 프로덕션 URI 를 그대로 두면서 로컬 URI 를 동시에 제공할 수 없어 기각했다

## Task
- `GET /auth/{provider}/url?redirectUri=...` 쿼리 파라미터로 redirect_uri 를 동적 지정할 수 있게 한다
- 파라미터 생략 시 properties 기본값(프로덕션 URI) fallback — 기존 동작 보장

## Action
- `OAuthClient.buildAuthUrl(state, redirectUri: String? = null)` - 인터페이스 시그니처에 Optional redirectUri 추가
- `KakaoOAuthClient` / `GoogleOAuthClient`: `redirectUri ?: properties.redirectUri` Elvis fallback
- `OAuthUrlService` / `Controller` / `Api` 레이어 전파 및 OpenAPI `@Parameter` 문서화
- `StubOAuthClient` 동일 시그니처로 갱신
- 통합 테스트 2건 추가: redirectUri 파라미터 반영 / 생략 시 기본값 동작

## Result
- 프론트엔드가 로컬 개발 시 `?redirectUri=http://localhost:3000/auth/callback/google` 로 동적 지정 가능
- 파라미터 없이 호출하면 기존 프로덕션 URI 그대로 — 하위 호환 유지
- 전체 테스트 통과 확인

---
## 연관 이슈

- close #350

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * OAuth 인증 요청 시 커스텀 리다이렉트 URI를 지정할 수 있도록 지원 추가

* **테스트**
  * 커스텀 리다이렉트 URI 반영 및 기본값 사용에 대한 통합 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->