### PR TITLE
allowlist 검증 제거 - redirect_uri 검증 provider 위임

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/auth/controller/OAuthUrlApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/controller/OAuthUrlApi.kt
@@ -36,7 +36,7 @@ interface OAuthUrlApi {
             ),
             ApiResponse(
                 responseCode = "400",
-                description = "잘못된 요청 (지원하지 않는 provider · 허용되지 않은 redirect_uri)",
+                description = "잘못된 요청 (지원하지 않는 provider)",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,

--- a/src/main/kotlin/com/depromeet/piki/auth/controller/OAuthUrlApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/controller/OAuthUrlApiExamples.kt
@@ -45,15 +45,6 @@ class OAuthUrlApiExamples(
                                 detail = "지원하지 않는 소셜 로그인 제공자입니다.",
                             ),
                     )
-                    add(
-                        status = HttpStatus.BAD_REQUEST,
-                        name = "허용되지 않은 redirect_uri",
-                        payload =
-                            ApiResponseBody.fail<Unit>(
-                                category = ErrorCategory.INVALID_INPUT,
-                                detail = "허용되지 않은 redirect_uri 입니다.",
-                            ),
-                    )
                 }
             }
             operation

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthClient.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthClient.kt
@@ -12,10 +12,6 @@ interface OAuthClient {
     // redirectUri 가 null 이면 provider 별 properties 기본값을 사용한다.
     fun buildAuthUrl(state: String, redirectUri: String? = null): String
 
-    // 허용된 redirect_uri 목록. OAuthUrlService 가 검증에 사용한다.
-    // 기본 redirectUri 는 항상 포함. 추가 허용 URI 는 properties.allowedRedirectUris 로 주입.
-    val allowedRedirectUris: List<String>
-
     fun fetchUserInfoByCode(
         code: String,
         redirectUri: String,

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthException.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthException.kt
@@ -33,9 +33,5 @@ class OAuthException private constructor(
         // state 없음 · 만료 · 이미 소비됨 → 401. CSRF 방지용 state 불일치로 요청을 거부.
         fun invalidState(): OAuthException =
             OAuthException("유효하지 않은 state 파라미터입니다. 인가 URL 을 새로 발급받아 다시 시도하세요.", ErrorCategory.UNAUTHORIZED, HttpStatus.UNAUTHORIZED)
-
-        // 허용되지 않은 redirect_uri → 400. 등록된 URI 외 Open Redirect 를 차단한다.
-        fun invalidRedirectUri(): OAuthException =
-            OAuthException("허용되지 않은 redirect_uri 입니다.", ErrorCategory.INVALID_INPUT, HttpStatus.BAD_REQUEST)
     }
 }

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/google/GoogleOAuthClient.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/google/GoogleOAuthClient.kt
@@ -17,8 +17,6 @@ class GoogleOAuthClient(
     private val googleProperties: GoogleProperties,
 ) : OAuthClient {
     override val provider = OAuthProvider.GOOGLE
-    override val allowedRedirectUris: List<String>
-        get() = listOf(googleProperties.redirectUri) + googleProperties.allowedRedirectUris
 
     private val tokenClient = OAuthRestClient.create(TOKEN_BASE_URL)
     private val userInfoClient = OAuthRestClient.create(USER_INFO_BASE_URL)

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/google/GoogleProperties.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/google/GoogleProperties.kt
@@ -15,6 +15,4 @@ data class GoogleProperties(
     val clientSecret: String,
     @field:NotBlank(message = "Google redirect-uri 는 비어 있을 수 없다.")
     val redirectUri: String,
-    // 추가 허용 redirect_uri. 로컬 개발 등에서 필요시 .env.local 에 GOOGLE_ALLOWED_REDIRECT_URIS[0]=http://localhost:... 로 주입.
-    val allowedRedirectUris: List<String> = emptyList(),
 )

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/kakao/KakaoOAuthClient.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/kakao/KakaoOAuthClient.kt
@@ -17,8 +17,6 @@ class KakaoOAuthClient(
     private val kakaoProperties: KakaoProperties,
 ) : OAuthClient {
     override val provider = OAuthProvider.KAKAO
-    override val allowedRedirectUris: List<String>
-        get() = listOf(kakaoProperties.redirectUri) + kakaoProperties.allowedRedirectUris
 
     private val authClient = OAuthRestClient.create(AUTH_BASE_URL)
     private val apiClient = OAuthRestClient.create(API_BASE_URL)

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/kakao/KakaoProperties.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/kakao/KakaoProperties.kt
@@ -15,6 +15,4 @@ data class KakaoProperties(
     val clientSecret: String,
     @field:NotBlank(message = "Kakao redirect-uri 는 비어 있을 수 없다.")
     val redirectUri: String,
-    // 추가 허용 redirect_uri. 로컬 개발 등에서 필요시 .env.local 에 KAKAO_ALLOWED_REDIRECT_URIS[0]=http://localhost:... 로 주입.
-    val allowedRedirectUris: List<String> = emptyList(),
 )

--- a/src/main/kotlin/com/depromeet/piki/auth/service/OAuthUrlService.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/service/OAuthUrlService.kt
@@ -1,7 +1,6 @@
 package com.depromeet.piki.auth.service
 
 import com.depromeet.piki.auth.infrastructure.oauth.OAuthClientRegistry
-import com.depromeet.piki.auth.infrastructure.oauth.OAuthException
 import com.depromeet.piki.auth.infrastructure.oauth.OAuthProvider
 import com.depromeet.piki.auth.infrastructure.redis.OAuthStateStore
 import com.depromeet.piki.auth.service.dto.OAuthUrlResult
@@ -16,9 +15,6 @@ class OAuthUrlService(
     fun buildUrl(provider: OAuthProvider, redirectUri: String? = null): OAuthUrlResult {
         val state = UUID.randomUUID().toString()
         val client = oAuthClientRegistry.resolve(provider)
-        redirectUri?.let { uri ->
-            if (uri !in client.allowedRedirectUris) throw OAuthException.invalidRedirectUri()
-        }
         val url = client.buildAuthUrl(state, redirectUri)
         oAuthStateStore.store(state)
         return OAuthUrlResult(url = url, state = state)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -56,10 +56,14 @@ oauth:
     client-id: ${KAKAO_CLIENT_ID:}
     client-secret: ${KAKAO_CLIENT_SECRET:}
     redirect-uri: ${KAKAO_REDIRECT_URI:}
+    allowed-redirect-uris:
+      - http://localhost:3000/auth/callback/kakao
   google:
     client-id: ${GOOGLE_CLIENT_ID:}
     client-secret: ${GOOGLE_CLIENT_SECRET:}
     redirect-uri: ${GOOGLE_REDIRECT_URI:}
+    allowed-redirect-uris:
+      - http://localhost:3000/auth/callback/google
 
 gemini:
   api-key: ${GEMINI_API_KEY:}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -56,14 +56,10 @@ oauth:
     client-id: ${KAKAO_CLIENT_ID:}
     client-secret: ${KAKAO_CLIENT_SECRET:}
     redirect-uri: ${KAKAO_REDIRECT_URI:}
-    allowed-redirect-uris:
-      - http://localhost:3000/auth/callback/kakao
   google:
     client-id: ${GOOGLE_CLIENT_ID:}
     client-secret: ${GOOGLE_CLIENT_SECRET:}
     redirect-uri: ${GOOGLE_REDIRECT_URI:}
-    allowed-redirect-uris:
-      - http://localhost:3000/auth/callback/google
 
 gemini:
   api-key: ${GEMINI_API_KEY:}

--- a/src/test/kotlin/com/depromeet/piki/auth/controller/OAuthUrlIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/controller/OAuthUrlIntegrationTest.kt
@@ -143,9 +143,8 @@ class OAuthUrlIntegrationTest : IntegrationTestSupport() {
     }
 
     @Test
-    fun `GET auth url - 허용된 redirectUri 를 넘기면 반환된 URL 에 해당 값이 반영된다`() {
+    fun `GET auth url - redirectUri 를 넘기면 반환된 URL 에 해당 값이 반영된다`() {
         val customRedirectUri = "http://localhost:3000/auth/callback/google"
-        googleOAuthClient.allowedRedirectUrisStub = listOf(customRedirectUri)
 
         val response =
             mockMvc()
@@ -157,16 +156,6 @@ class OAuthUrlIntegrationTest : IntegrationTestSupport() {
 
         val url = objectMapper.readTree(response).at("/data/url").asText()
         assert(url.contains(customRedirectUri)) { "반환된 URL 에 customRedirectUri 가 포함되어야 한다: $url" }
-    }
-
-    @Test
-    fun `GET auth url - 허용 목록에 없는 redirectUri 는 400`() {
-        googleOAuthClient.allowedRedirectUrisStub = listOf("https://allowed.example.com/callback")
-
-        mockMvc()
-            .perform(get("/api/v1/auth/google/url").param("redirectUri", "https://evil.example.com/steal"))
-            .andExpect(status().isBadRequest)
-            .andExpect(jsonPath("$.detail").value("허용되지 않은 redirect_uri 입니다."))
     }
 
     @Test

--- a/src/test/kotlin/com/depromeet/piki/support/StubOAuthClient.kt
+++ b/src/test/kotlin/com/depromeet/piki/support/StubOAuthClient.kt
@@ -19,10 +19,6 @@ class StubOAuthClient(
         "https://stub-auth.example.com/oauth/authorize?provider=${provider.name.lowercase()}&state=$state" +
             (redirectUri?.let { "&redirect_uri=$it" } ?: "")
     }
-    // OAuthUrlService 가 redirectUri 검증에 사용한다. 테스트 본문에서 허용할 URI 를 명시 세팅한다.
-    var allowedRedirectUrisStub: List<String> = emptyList()
-    override val allowedRedirectUris: List<String> get() = allowedRedirectUrisStub
-
     override fun buildAuthUrl(state: String, redirectUri: String?): String = buildAuthUrlStub(state, redirectUri)
 
     override fun fetchUserInfoByCode(


### PR DESCRIPTION
## Situation
- PR #351 에서 CodeRabbit 이 Open Redirect 위험을 지적해 서버 측 allowlist 검증을 추가했다
- `OAuthClient.allowedRedirectUris`, `*Properties.allowedRedirectUris`, `OAuthUrlService` 검증 블록, `OAuthException.invalidRedirectUri()` 등이 추가됐다
- 그런데 `application.yml` 에 localhost 를 추가하기 전에 이미 배포가 나가버려, 프론트엔드는 여전히 로컬 테스트 불가 상태가 됐다
- 이 타이밍 문제를 계기로 "서버 측 allowlist 가 정말 필요한가"를 다시 따졌다

## Task
- redirect_uri 검증 책임이 어디에 있는지 판단하고, 불필요한 중복 검증을 제거한다
- 핵심 논점: "Open Redirect 라면 서버가 막아야 하지 않나 vs. redirect_uri 의 유효성 판단 권한은 원래 OAuth provider 에게 있다"

## Action
- allowlist 검증 전체 제거 - `OAuthClient.allowedRedirectUris` 인터페이스 프로퍼티, `Kakao/GoogleProperties.allowedRedirectUris` 필드, `Kakao/GoogleOAuthClient` override, `OAuthException.invalidRedirectUri()`, `OAuthUrlService` 검증 블록, `application.yml` 의 `allowed-redirect-uris` 항목 모두 제거
- `StubOAuthClient.allowedRedirectUrisStub` 제거, 관련 통합 테스트 정리

### 검증 위임 근거
- Google / Kakao / Apple 은 각 provider 콘솔에 등록된 URI 와 완전 일치할 때만 인가 코드를 발급하고, 미등록 URI 는 provider 단에서 즉시 차단한다
- redirect_uri 의 허용 여부를 결정하는 권한은 원래 provider 에게 있다 - 서버 측 allowlist 는 그 권한을 중복 구현한 것이고, 구현 시점 오류(배포 타이밍 등)로 오히려 서비스를 막는 포인트가 됐다
- "보안을 외부에 의존하는 것이 맞나"라는 고민도 있었으나, 여기서 외부는 Google/Kakao 가 직접 제공하는 OAuth 2.0 spec 의 강제 메커니즘 - 우리가 통제 못하는 제3자가 아니라 spec 자체에 권한이 위임돼 있다

## Result
- 코드가 단순해지고, 배포 타이밍에 따른 allowlist 누락 위험이 사라졌다
- 프론트엔드는 `?redirectUri=http://localhost:3000/auth/callback/google` 처럼 임의 URI 를 파라미터로 넘길 수 있다 - 단, 해당 URI 가 Google/Kakao 콘솔에 등록돼 있어야 provider 가 인가 코드를 발급한다
- 전체 테스트 통과

---
## 연관 이슈

- #350 (PR #351 에서 close)
