### PR TITLE
비동기 executor 워커 스레드로 trace context 전파 (워커 로그 traceId 단절 해소)

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/common/config/AsyncConfig.kt
+++ b/src/main/kotlin/com/depromeet/piki/common/config/AsyncConfig.kt
@@ -3,6 +3,7 @@ package com.depromeet.piki.common.config
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.core.task.support.ContextPropagatingTaskDecorator
 import org.springframework.scheduling.annotation.EnableAsync
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
 import java.util.concurrent.Executor
@@ -21,6 +22,11 @@ class AsyncConfig {
             maxPoolSize = 8
             queueCapacity = 100
             setThreadNamePrefix("item-parsing-")
+            // 부모(톰캣) 스레드의 trace context·MDC·observation 을 워커 스레드로 전파한다. trace context 는
+            // ThreadLocal 기반이라 이게 없으면 @Async 경계에서 끊겨, 워커 로그에 traceId 가 빈 채로 찍혀
+            // 한 요청의 전체 로그를 Loki 에서 traceId 로 추적할 수 없다. context-propagation(micrometer) 의
+            // ContextSnapshot 으로 등록된 모든 ThreadLocalAccessor(brave trace context·MDC 등)를 전파한다.
+            setTaskDecorator(ContextPropagatingTaskDecorator())
             // 포화 시 기본 AbortPolicy 로 거부한다. 호출 스레드(톰캣)에서 동기 실행하는 CallerRunsPolicy 는
             // 외부 LLM 호출(최대 60s)로 톰캣 워커 풀을 고갈시켜 무관한 API 까지 번지므로 쓰지 않는다.
             // 거부는 호출부(WishlistService.register, TournamentItemService.addItemsFromImages 등)가 잡아
@@ -45,6 +51,8 @@ class AsyncConfig {
             maxPoolSize = 4
             queueCapacity = 200
             setThreadNamePrefix("notification-")
+            // itemParsingExecutor 와 같은 이유로 trace context·MDC 를 워커 스레드로 전파해 알림 로그를 원 요청과 묶는다.
+            setTaskDecorator(ContextPropagatingTaskDecorator())
             setRejectedExecutionHandler { _, executor ->
                 log.warn(
                     "알림 executor 포화로 태스크 거부 — 알림 1건 유실 (activeCount={}, queueSize={})",

--- a/src/test/kotlin/com/depromeet/piki/common/config/AsyncTracePropagationIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/common/config/AsyncTracePropagationIntegrationTest.kt
@@ -1,0 +1,84 @@
+package com.depromeet.piki.common.config
+
+import com.depromeet.piki.support.IntegrationTestSupport
+import io.micrometer.observation.Observation
+import io.micrometer.observation.ObservationRegistry
+import io.micrometer.tracing.Tracer
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.TestFactory
+import org.slf4j.MDC
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.ApplicationContext
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executor
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+// 비동기 executor 가 부모 요청의 trace context 를 워커 스레드로 전파하는지 검증한다.
+// ContextPropagatingTaskDecorator 가 없으면 trace context(ThreadLocal)가 @Async 경계에서 끊겨
+// 워커 로그에 traceId 가 빈 채로 찍혀, 한 요청의 전체 로그를 traceId 로 추적할 수 없다 (회귀 가드).
+//
+// 특정 executor 를 하드코딩하지 않고 컨텍스트의 모든 ThreadPoolTaskExecutor 빈을 순회한다 —
+// AsyncConfig 에 executor 가 새로 추가돼도 별도 테스트 추가 없이 자동으로 trace 전파가 검증된다.
+// 별도 스레드 동작 검증이라 @Transactional 자동 롤백 패턴을 쓰지 않는다 (DB 는 건드리지 않는다).
+class AsyncTracePropagationIntegrationTest : IntegrationTestSupport() {
+    @Autowired
+    private lateinit var tracer: Tracer
+
+    @Autowired
+    private lateinit var observationRegistry: ObservationRegistry
+
+    @Autowired
+    private lateinit var applicationContext: ApplicationContext
+
+    @TestFactory
+    fun `모든 async executor 가 워커 스레드로 부모 요청의 trace context 를 전파한다`(): List<DynamicTest> {
+        val executors = applicationContext.getBeansOfType(ThreadPoolTaskExecutor::class.java)
+        // 자동 순회가 AsyncConfig 의 executor 를 실제로 커버하는지 가드 — 빈 맵이거나 누락되면 테스트가 무의미해진다.
+        assertTrue(
+            AsyncConfig.ITEM_PARSING_EXECUTOR in executors && AsyncConfig.NOTIFICATION_EXECUTOR in executors,
+            "AsyncConfig 의 executor 빈이 순회 대상에 포함돼야 한다 (현재: ${executors.keys})",
+        )
+        return executors.map { (name, executor) ->
+            DynamicTest.dynamicTest("$name 은 trace context 를 워커 스레드로 전파한다") {
+                assertTracePropagated(executor)
+            }
+        }
+    }
+
+    private fun assertTracePropagated(executor: Executor) {
+        val workerTraceId = CompletableFuture<String?>()
+        val workerMdc = CompletableFuture<String?>()
+
+        // 실제 HTTP 요청처럼 Observation 으로 trace scope 를 연다 — brave span 과 MDC(traceId)가 함께 채워진다.
+        val observation = Observation.start("test.parent", observationRegistry)
+        val scope = observation.openScope()
+        val parentTraceId: String?
+        try {
+            parentTraceId = tracer.currentSpan()?.context()?.traceId()
+            // execute 호출 시점(부모 scope 안)에 TaskDecorator 가 ContextSnapshot 을 캡처한다.
+            executor.execute {
+                workerTraceId.complete(tracer.currentSpan()?.context()?.traceId())
+                workerMdc.complete(MDC.get("traceId"))
+            }
+        } finally {
+            scope.close()
+            observation.stop()
+        }
+
+        assertNotNull(parentTraceId, "부모 스레드에 trace context 가 있어야 한다 (없으면 Tracer autoconfig 회귀)")
+        assertEquals(
+            parentTraceId,
+            workerTraceId.get(3, TimeUnit.SECONDS),
+            "워커 스레드의 span traceId 가 부모와 일치해야 한다",
+        )
+        assertEquals(
+            parentTraceId,
+            workerMdc.get(3, TimeUnit.SECONDS),
+            "워커 스레드의 MDC traceId 가 부모와 일치해야 한다 (로그 correlation 의 본질)",
+        )
+    }
+}


### PR DESCRIPTION
## Situation
- 모니터링에서 한 요청의 로그를 traceId 로 따라가다 보면, `@Async` 워커(`item-parsing-*`·`notification-*`) 스레드 로그의 traceId 자리가 빈 채로 찍혀 추적이 끊겼다.
- HTTP 스레드(`nio-8080-exec-*`)에는 traceId 가 정상으로 찍히는데(brave-context-slf4j 의 MDC decorator), 작업이 비동기 워커로 넘어가는 순간 사라졌다.

## Task
- `@Async` 경계에서 trace context 가 워커 스레드로 전파되게 해, 워커 로그도 부모 요청과 같은 traceId 로 묶이게 한다.

## Action
- **원인**: `ThreadPoolTaskExecutor` 를 `TaskDecorator` 없이 만들어, ThreadLocal 기반인 trace context·MDC 가 워커 스레드로 복사되지 않았다.
- 두 executor(`itemParsingExecutor`·`notificationExecutor`)에 `ContextPropagatingTaskDecorator` 를 달았다. micrometer `context-propagation` 이 이미 transitive 의존성으로 있어 **추가 의존성 없이** brave span·MDC·observation 을 한 번에 전파한다.
- 검증 테스트는 특정 executor 를 하드코딩하지 않고 컨텍스트의 모든 `ThreadPoolTaskExecutor` 빈을 순회하는 `@TestFactory` 로 작성 — AsyncConfig 에 executor 가 추가돼도 별도 테스트 없이 자동으로 trace 전파가 검증된다.
- decorator 를 임시 제거하면 두 검증이 모두 FAIL 함을 negative control 로 확인해, 테스트가 무심코 통과하지 않고 실제 회귀를 잡는지 보장했다.

## Result
- 워커 스레드 로그에도 부모 요청과 동일한 traceId 가 찍혀, 한 요청의 전체 로그를 Loki 에서 traceId 로 추적할 수 있다.
- 워커의 span traceId·MDC traceId 가 부모와 일치함을 통합 테스트로 단언, 전체 테스트 그린.

---
## 연관 이슈

- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Tests**
  * 비동기 작업 실행 시 context 전파 동작을 검증하는 통합 테스트가 추가되었습니다.

* **Chores**
  * 비동기 실행 환경에서 context 전파 설정이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->