### PR TITLE
OpenAPI 응답 example 전수 부착

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/auth/controller/AuthApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/controller/AuthApiExamples.kt
@@ -94,14 +94,7 @@ class AuthApiExamples(
                             name = "로그아웃 성공",
                             payload = ApiResponseBody.ok(LogoutResponse()),
                         )
-                        add(
-                            status = HttpStatus.UNAUTHORIZED,
-                            name = "인증 필요",
-                            payload =
-                                ApiResponseBody.fail<Unit>(
-                                    category = ErrorCategory.UNAUTHORIZED,
-                                ),
-                        )
+                        unauthorized()
                     }
 
                 handlerMethod.binds(DevAuthController::createDevUser) ->
@@ -134,25 +127,11 @@ class AuthApiExamples(
                             payload =
                                 ApiResponseBody.fail<Unit>(
                                     category = ErrorCategory.INVALID_INPUT,
-                                    detail = "nickname: must not be blank",
+                                    detail = "nickname: 닉네임은 필수입니다.",
                                 ),
                         )
-                        add(
-                            status = HttpStatus.UNAUTHORIZED,
-                            name = "인증 필요",
-                            payload =
-                                ApiResponseBody.fail<Unit>(
-                                    category = ErrorCategory.UNAUTHORIZED,
-                                ),
-                        )
-                        add(
-                            status = HttpStatus.FORBIDDEN,
-                            name = "GUEST 권한 없음 (MEMBER 토큰으로 호출 불가)",
-                            payload =
-                                ApiResponseBody.fail<Unit>(
-                                    category = ErrorCategory.FORBIDDEN,
-                                ),
-                        )
+                        unauthorized()
+                        forbidden("GUEST 권한 없음 (MEMBER 토큰으로 호출 불가)")
                         add(
                             status = HttpStatus.CONFLICT,
                             name = "이미 사용 중인 닉네임",
@@ -204,22 +183,8 @@ class AuthApiExamples(
                                     category = ErrorCategory.CONFLICT,
                                 ),
                         )
-                        add(
-                            status = HttpStatus.UNAUTHORIZED,
-                            name = "인증 필요",
-                            payload =
-                                ApiResponseBody.fail<Unit>(
-                                    category = ErrorCategory.UNAUTHORIZED,
-                                ),
-                        )
-                        add(
-                            status = HttpStatus.FORBIDDEN,
-                            name = "GUEST 권한 없음 (MEMBER 토큰으로 호출 불가)",
-                            payload =
-                                ApiResponseBody.fail<Unit>(
-                                    category = ErrorCategory.FORBIDDEN,
-                                ),
-                        )
+                        unauthorized()
+                        forbidden("GUEST 권한 없음 (MEMBER 토큰으로 호출 불가)")
                     }
             }
             operation

--- a/src/main/kotlin/com/depromeet/piki/auth/controller/AuthApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/controller/AuthApiExamples.kt
@@ -137,6 +137,31 @@ class AuthApiExamples(
                                     detail = "nickname: must not be blank",
                                 ),
                         )
+                        add(
+                            status = HttpStatus.UNAUTHORIZED,
+                            name = "인증 필요",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.UNAUTHORIZED,
+                                ),
+                        )
+                        add(
+                            status = HttpStatus.FORBIDDEN,
+                            name = "GUEST 권한 없음 (MEMBER 토큰으로 호출 불가)",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.FORBIDDEN,
+                                ),
+                        )
+                        add(
+                            status = HttpStatus.CONFLICT,
+                            name = "이미 사용 중인 닉네임",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.CONFLICT,
+                                    detail = "이미 사용 중인 닉네임입니다.",
+                                ),
+                        )
                     }
 
                 handlerMethod.binds(DevAuthController::issueTokenForUser) ->
@@ -177,6 +202,22 @@ class AuthApiExamples(
                             payload =
                                 ApiResponseBody.fail<Unit>(
                                     category = ErrorCategory.CONFLICT,
+                                ),
+                        )
+                        add(
+                            status = HttpStatus.UNAUTHORIZED,
+                            name = "인증 필요",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.UNAUTHORIZED,
+                                ),
+                        )
+                        add(
+                            status = HttpStatus.FORBIDDEN,
+                            name = "GUEST 권한 없음 (MEMBER 토큰으로 호출 불가)",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.FORBIDDEN,
                                 ),
                         )
                     }

--- a/src/main/kotlin/com/depromeet/piki/auth/controller/dto/DevUserCreateRequest.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/controller/dto/DevUserCreateRequest.kt
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.NotBlank
 
 @Schema(description = "개발용 MEMBER 생성 요청")
 data class DevUserCreateRequest(
-    @field:NotBlank
+    @field:NotBlank(message = "닉네임은 필수입니다.")
     @field:Schema(description = "닉네임", example = "홍길동", requiredMode = Schema.RequiredMode.REQUIRED)
     val nickname: String,
 )

--- a/src/main/kotlin/com/depromeet/piki/common/openapi/OpenApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/common/openapi/OpenApiExamples.kt
@@ -1,5 +1,7 @@
 package com.depromeet.piki.common.openapi
 
+import com.depromeet.piki.common.exception.ErrorCategory
+import com.depromeet.piki.common.response.ApiResponseBody
 import io.swagger.v3.oas.models.Operation
 import io.swagger.v3.oas.models.examples.Example
 import io.swagger.v3.oas.models.media.Content
@@ -42,4 +44,13 @@ class OperationExamples(
         val example = Example().value(objectMapper.convertValue(payload, Any::class.java))
         mediaType.examples = (mediaType.examples ?: linkedMapOf()).apply { put(name, example) }
     }
+
+    // Security 필터 단(ApiResponseSecurityErrorHandlers)이 내려보내는 401/403 은 detail 없이 fail(category) 라
+    // 전 엔드포인트에 같은 example 이 반복된다. 그 보일러플레이트를 한 자리로 모은다.
+    // (도메인 예외 403 처럼 detail 이 있는 응답은 그대로 add 를 직접 쓴다.)
+    fun unauthorized(name: String = "인증 필요") =
+        add(HttpStatus.UNAUTHORIZED, name, ApiResponseBody.fail<Unit>(category = ErrorCategory.UNAUTHORIZED))
+
+    fun forbidden(name: String) =
+        add(HttpStatus.FORBIDDEN, name, ApiResponseBody.fail<Unit>(category = ErrorCategory.FORBIDDEN))
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApiExamples.kt
@@ -1,5 +1,6 @@
 package com.depromeet.piki.tournament.controller
 
+import com.depromeet.piki.common.exception.ErrorCategory
 import com.depromeet.piki.common.openapi.OpenApiObjectMapper
 import com.depromeet.piki.common.openapi.binds
 import com.depromeet.piki.common.openapi.examples
@@ -48,6 +49,14 @@ class TournamentApiExamples(
                                     ),
                                 ),
                         )
+                        add(
+                            status = HttpStatus.UNAUTHORIZED,
+                            name = "인증 필요",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.UNAUTHORIZED,
+                                ),
+                        )
                     }
 
                 handlerMethod.binds(TournamentController::create) ->
@@ -56,6 +65,23 @@ class TournamentApiExamples(
                             status = HttpStatus.CREATED,
                             name = "생성 성공",
                             payload = ApiResponseBody.created(CreateTournamentResponse(tournamentId = 1)),
+                        )
+                        add(
+                            status = HttpStatus.BAD_REQUEST,
+                            name = "이름 미입력",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.INVALID_INPUT,
+                                    detail = "name: must not be blank",
+                                ),
+                        )
+                        add(
+                            status = HttpStatus.UNAUTHORIZED,
+                            name = "인증 필요",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.UNAUTHORIZED,
+                                ),
                         )
                     }
 
@@ -98,6 +124,50 @@ class TournamentApiExamples(
                                     ),
                                 ),
                             ),
+                        )
+                        add(
+                            status = HttpStatus.BAD_REQUEST,
+                            name = "아이템 수 미충족 (2~32개)",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.INVALID_INPUT,
+                                    detail = "토너먼트 아이템은 최소 2개, 최대 32개여야 합니다.",
+                                ),
+                        )
+                        add(
+                            status = HttpStatus.UNAUTHORIZED,
+                            name = "인증 필요",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.UNAUTHORIZED,
+                                ),
+                        )
+                        add(
+                            status = HttpStatus.FORBIDDEN,
+                            name = "토너먼트 권한 없음",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.FORBIDDEN,
+                                    detail = "해당 토너먼트에 대한 권한이 없습니다.",
+                                ),
+                        )
+                        add(
+                            status = HttpStatus.NOT_FOUND,
+                            name = "토너먼트를 찾을 수 없음",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.NOT_FOUND,
+                                    detail = "토너먼트를 찾을 수 없습니다.",
+                                ),
+                        )
+                        add(
+                            status = HttpStatus.CONFLICT,
+                            name = "PENDING 상태 아님",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.CONFLICT,
+                                    detail = "PENDING 상태인 토너먼트에만 수행할 수 있습니다.",
+                                ),
                         )
                     }
 
@@ -153,6 +223,50 @@ class TournamentApiExamples(
                                     ),
                                 ),
                             ),
+                        )
+                        add(
+                            status = HttpStatus.BAD_REQUEST,
+                            name = "승자가 대결 아이템이 아님",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.INVALID_INPUT,
+                                    detail = "승자는 대결한 두 아이템 중 하나여야 합니다.",
+                                ),
+                        )
+                        add(
+                            status = HttpStatus.UNAUTHORIZED,
+                            name = "인증 필요",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.UNAUTHORIZED,
+                                ),
+                        )
+                        add(
+                            status = HttpStatus.FORBIDDEN,
+                            name = "토너먼트 권한 없음",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.FORBIDDEN,
+                                    detail = "해당 토너먼트에 대한 권한이 없습니다.",
+                                ),
+                        )
+                        add(
+                            status = HttpStatus.NOT_FOUND,
+                            name = "토너먼트를 찾을 수 없음",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.NOT_FOUND,
+                                    detail = "토너먼트를 찾을 수 없습니다.",
+                                ),
+                        )
+                        add(
+                            status = HttpStatus.CONFLICT,
+                            name = "진행 중 토너먼트 아님",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.CONFLICT,
+                                    detail = "진행 중인 토너먼트에만 수행할 수 있습니다.",
+                                ),
                         )
                     }
 
@@ -306,6 +420,32 @@ class TournamentApiExamples(
                                     ),
                                 ),
                         )
+                        add(
+                            status = HttpStatus.UNAUTHORIZED,
+                            name = "인증 필요",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.UNAUTHORIZED,
+                                ),
+                        )
+                        add(
+                            status = HttpStatus.FORBIDDEN,
+                            name = "토너먼트 권한 없음",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.FORBIDDEN,
+                                    detail = "해당 토너먼트에 대한 권한이 없습니다.",
+                                ),
+                        )
+                        add(
+                            status = HttpStatus.NOT_FOUND,
+                            name = "토너먼트를 찾을 수 없음",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.NOT_FOUND,
+                                    detail = "토너먼트를 찾을 수 없습니다.",
+                                ),
+                        )
                     }
 
                 handlerMethod.binds(TournamentController::deleteTournament) ->
@@ -314,6 +454,41 @@ class TournamentApiExamples(
                             status = HttpStatus.OK,
                             name = "토너먼트 삭제 성공",
                             payload = ApiResponseBody.ok<Unit>(),
+                        )
+                        add(
+                            status = HttpStatus.UNAUTHORIZED,
+                            name = "인증 필요",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.UNAUTHORIZED,
+                                ),
+                        )
+                        add(
+                            status = HttpStatus.FORBIDDEN,
+                            name = "토너먼트 권한 없음",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.FORBIDDEN,
+                                    detail = "해당 토너먼트에 대한 권한이 없습니다.",
+                                ),
+                        )
+                        add(
+                            status = HttpStatus.NOT_FOUND,
+                            name = "토너먼트를 찾을 수 없음",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.NOT_FOUND,
+                                    detail = "토너먼트를 찾을 수 없습니다.",
+                                ),
+                        )
+                        add(
+                            status = HttpStatus.CONFLICT,
+                            name = "진행 중 토너먼트 삭제 불가",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.CONFLICT,
+                                    detail = "진행 중인 토너먼트는 삭제할 수 없습니다.",
+                                ),
                         )
                     }
             }

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApiExamples.kt
@@ -49,14 +49,7 @@ class TournamentApiExamples(
                                     ),
                                 ),
                         )
-                        add(
-                            status = HttpStatus.UNAUTHORIZED,
-                            name = "인증 필요",
-                            payload =
-                                ApiResponseBody.fail<Unit>(
-                                    category = ErrorCategory.UNAUTHORIZED,
-                                ),
-                        )
+                        unauthorized()
                     }
 
                 handlerMethod.binds(TournamentController::create) ->
@@ -72,17 +65,10 @@ class TournamentApiExamples(
                             payload =
                                 ApiResponseBody.fail<Unit>(
                                     category = ErrorCategory.INVALID_INPUT,
-                                    detail = "name: must not be blank",
+                                    detail = "name: 토너먼트 이름은 필수입니다.",
                                 ),
                         )
-                        add(
-                            status = HttpStatus.UNAUTHORIZED,
-                            name = "인증 필요",
-                            payload =
-                                ApiResponseBody.fail<Unit>(
-                                    category = ErrorCategory.UNAUTHORIZED,
-                                ),
-                        )
+                        unauthorized()
                     }
 
                 handlerMethod.binds(TournamentController::start) ->
@@ -134,14 +120,7 @@ class TournamentApiExamples(
                                     detail = "토너먼트 아이템은 최소 2개, 최대 32개여야 합니다.",
                                 ),
                         )
-                        add(
-                            status = HttpStatus.UNAUTHORIZED,
-                            name = "인증 필요",
-                            payload =
-                                ApiResponseBody.fail<Unit>(
-                                    category = ErrorCategory.UNAUTHORIZED,
-                                ),
-                        )
+                        unauthorized()
                         add(
                             status = HttpStatus.FORBIDDEN,
                             name = "토너먼트 권한 없음",
@@ -233,14 +212,7 @@ class TournamentApiExamples(
                                     detail = "승자는 대결한 두 아이템 중 하나여야 합니다.",
                                 ),
                         )
-                        add(
-                            status = HttpStatus.UNAUTHORIZED,
-                            name = "인증 필요",
-                            payload =
-                                ApiResponseBody.fail<Unit>(
-                                    category = ErrorCategory.UNAUTHORIZED,
-                                ),
-                        )
+                        unauthorized()
                         add(
                             status = HttpStatus.FORBIDDEN,
                             name = "토너먼트 권한 없음",
@@ -420,14 +392,7 @@ class TournamentApiExamples(
                                     ),
                                 ),
                         )
-                        add(
-                            status = HttpStatus.UNAUTHORIZED,
-                            name = "인증 필요",
-                            payload =
-                                ApiResponseBody.fail<Unit>(
-                                    category = ErrorCategory.UNAUTHORIZED,
-                                ),
-                        )
+                        unauthorized()
                         add(
                             status = HttpStatus.FORBIDDEN,
                             name = "토너먼트 권한 없음",
@@ -455,14 +420,7 @@ class TournamentApiExamples(
                             name = "토너먼트 삭제 성공",
                             payload = ApiResponseBody.ok<Unit>(),
                         )
-                        add(
-                            status = HttpStatus.UNAUTHORIZED,
-                            name = "인증 필요",
-                            payload =
-                                ApiResponseBody.fail<Unit>(
-                                    category = ErrorCategory.UNAUTHORIZED,
-                                ),
-                        )
+                        unauthorized()
                         add(
                             status = HttpStatus.FORBIDDEN,
                             name = "토너먼트 권한 없음",

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentItemApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentItemApiExamples.kt
@@ -38,17 +38,10 @@ class TournamentItemApiExamples(
                             payload =
                                 ApiResponseBody.fail<Unit>(
                                     category = ErrorCategory.INVALID_INPUT,
-                                    detail = "itemIds: size must be between 1 and 32",
+                                    detail = "itemIds: 아이템은 1개 이상 32개 이하여야 합니다.",
                                 ),
                         )
-                        add(
-                            status = HttpStatus.UNAUTHORIZED,
-                            name = "인증 필요",
-                            payload =
-                                ApiResponseBody.fail<Unit>(
-                                    category = ErrorCategory.UNAUTHORIZED,
-                                ),
-                        )
+                        unauthorized()
                         add(
                             status = HttpStatus.FORBIDDEN,
                             name = "위시리스트에 없는 아이템 포함",
@@ -94,14 +87,7 @@ class TournamentItemApiExamples(
                                     detail = "유효한 URL 형식이 아닙니다.",
                                 ),
                         )
-                        add(
-                            status = HttpStatus.UNAUTHORIZED,
-                            name = "인증 필요",
-                            payload =
-                                ApiResponseBody.fail<Unit>(
-                                    category = ErrorCategory.UNAUTHORIZED,
-                                ),
-                        )
+                        unauthorized()
                         add(
                             status = HttpStatus.FORBIDDEN,
                             name = "토너먼트 권한 없음",
@@ -151,14 +137,7 @@ class TournamentItemApiExamples(
                                     detail = "이미지는 최소 1개, 최대 5개까지 전송할 수 있습니다.",
                                 ),
                         )
-                        add(
-                            status = HttpStatus.UNAUTHORIZED,
-                            name = "인증 필요",
-                            payload =
-                                ApiResponseBody.fail<Unit>(
-                                    category = ErrorCategory.UNAUTHORIZED,
-                                ),
-                        )
+                        unauthorized()
                         add(
                             status = HttpStatus.FORBIDDEN,
                             name = "토너먼트 권한 없음",
@@ -212,14 +191,7 @@ class TournamentItemApiExamples(
                                     detail = "상품명을 입력해야 합니다.",
                                 ),
                         )
-                        add(
-                            status = HttpStatus.UNAUTHORIZED,
-                            name = "인증 필요",
-                            payload =
-                                ApiResponseBody.fail<Unit>(
-                                    category = ErrorCategory.UNAUTHORIZED,
-                                ),
-                        )
+                        unauthorized()
                         add(
                             status = HttpStatus.FORBIDDEN,
                             name = "토너먼트 권한 없음",
@@ -256,14 +228,7 @@ class TournamentItemApiExamples(
                             name = "아이템 삭제 성공",
                             payload = ApiResponseBody.ok<Unit>(),
                         )
-                        add(
-                            status = HttpStatus.UNAUTHORIZED,
-                            name = "인증 필요",
-                            payload =
-                                ApiResponseBody.fail<Unit>(
-                                    category = ErrorCategory.UNAUTHORIZED,
-                                ),
-                        )
+                        unauthorized()
                         add(
                             status = HttpStatus.FORBIDDEN,
                             name = "토너먼트 권한 없음",
@@ -350,14 +315,7 @@ class TournamentItemApiExamples(
                                 ),
                             ),
                         )
-                        add(
-                            status = HttpStatus.UNAUTHORIZED,
-                            name = "인증 필요",
-                            payload =
-                                ApiResponseBody.fail<Unit>(
-                                    category = ErrorCategory.UNAUTHORIZED,
-                                ),
-                        )
+                        unauthorized()
                         add(
                             status = HttpStatus.FORBIDDEN,
                             name = "토너먼트 권한 없음",

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentItemApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentItemApiExamples.kt
@@ -32,6 +32,50 @@ class TournamentItemApiExamples(
                                 AddTournamentItemsFromWishResponse(tournamentItemIds = listOf(10L, 11L)),
                             ),
                         )
+                        add(
+                            status = HttpStatus.BAD_REQUEST,
+                            name = "itemIds 개수 위반 (1~32개)",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.INVALID_INPUT,
+                                    detail = "itemIds: size must be between 1 and 32",
+                                ),
+                        )
+                        add(
+                            status = HttpStatus.UNAUTHORIZED,
+                            name = "인증 필요",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.UNAUTHORIZED,
+                                ),
+                        )
+                        add(
+                            status = HttpStatus.FORBIDDEN,
+                            name = "위시리스트에 없는 아이템 포함",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.FORBIDDEN,
+                                    detail = "위시리스트에 없는 아이템은 토너먼트에 추가할 수 없습니다.",
+                                ),
+                        )
+                        add(
+                            status = HttpStatus.NOT_FOUND,
+                            name = "토너먼트를 찾을 수 없음",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.NOT_FOUND,
+                                    detail = "토너먼트를 찾을 수 없습니다.",
+                                ),
+                        )
+                        add(
+                            status = HttpStatus.CONFLICT,
+                            name = "PENDING 상태 아님",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.CONFLICT,
+                                    detail = "PENDING 상태인 토너먼트에만 수행할 수 있습니다.",
+                                ),
+                        )
                     }
 
                 handlerMethod.binds(TournamentItemController::addItemFromLink) ->
@@ -40,6 +84,50 @@ class TournamentItemApiExamples(
                             status = HttpStatus.OK,
                             name = "링크 아이템 추가 성공",
                             payload = ApiResponseBody.ok(AddTournamentItemFromLinkResponse(tournamentItemId = 1L)),
+                        )
+                        add(
+                            status = HttpStatus.BAD_REQUEST,
+                            name = "URL 형식 오류",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.INVALID_INPUT,
+                                    detail = "유효한 URL 형식이 아닙니다.",
+                                ),
+                        )
+                        add(
+                            status = HttpStatus.UNAUTHORIZED,
+                            name = "인증 필요",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.UNAUTHORIZED,
+                                ),
+                        )
+                        add(
+                            status = HttpStatus.FORBIDDEN,
+                            name = "토너먼트 권한 없음",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.FORBIDDEN,
+                                    detail = "해당 토너먼트에 대한 권한이 없습니다.",
+                                ),
+                        )
+                        add(
+                            status = HttpStatus.NOT_FOUND,
+                            name = "토너먼트를 찾을 수 없음",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.NOT_FOUND,
+                                    detail = "토너먼트를 찾을 수 없습니다.",
+                                ),
+                        )
+                        add(
+                            status = HttpStatus.CONFLICT,
+                            name = "PENDING 상태 아님",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.CONFLICT,
+                                    detail = "PENDING 상태인 토너먼트에만 수행할 수 있습니다.",
+                                ),
                         )
                     }
 
@@ -53,6 +141,50 @@ class TournamentItemApiExamples(
                                     tournamentItemIds = listOf(1L, 2L, 3L),
                                 ),
                             ),
+                        )
+                        add(
+                            status = HttpStatus.BAD_REQUEST,
+                            name = "이미지 개수 위반 (1~5개)",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.INVALID_INPUT,
+                                    detail = "이미지는 최소 1개, 최대 5개까지 전송할 수 있습니다.",
+                                ),
+                        )
+                        add(
+                            status = HttpStatus.UNAUTHORIZED,
+                            name = "인증 필요",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.UNAUTHORIZED,
+                                ),
+                        )
+                        add(
+                            status = HttpStatus.FORBIDDEN,
+                            name = "토너먼트 권한 없음",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.FORBIDDEN,
+                                    detail = "해당 토너먼트에 대한 권한이 없습니다.",
+                                ),
+                        )
+                        add(
+                            status = HttpStatus.NOT_FOUND,
+                            name = "토너먼트를 찾을 수 없음",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.NOT_FOUND,
+                                    detail = "토너먼트를 찾을 수 없습니다.",
+                                ),
+                        )
+                        add(
+                            status = HttpStatus.CONFLICT,
+                            name = "PENDING 상태 아님",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.CONFLICT,
+                                    detail = "PENDING 상태인 토너먼트에만 수행할 수 있습니다.",
+                                ),
                         )
                     }
 
@@ -71,6 +203,50 @@ class TournamentItemApiExamples(
                                 detail = "이미지 저장에 실패했습니다. 잠시 후 다시 시도해 주세요.",
                             ),
                         )
+                        add(
+                            status = HttpStatus.BAD_REQUEST,
+                            name = "상품명 없이 보정 시도",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.INVALID_INPUT,
+                                    detail = "상품명을 입력해야 합니다.",
+                                ),
+                        )
+                        add(
+                            status = HttpStatus.UNAUTHORIZED,
+                            name = "인증 필요",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.UNAUTHORIZED,
+                                ),
+                        )
+                        add(
+                            status = HttpStatus.FORBIDDEN,
+                            name = "토너먼트 권한 없음",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.FORBIDDEN,
+                                    detail = "해당 토너먼트에 대한 권한이 없습니다.",
+                                ),
+                        )
+                        add(
+                            status = HttpStatus.NOT_FOUND,
+                            name = "토너먼트를 찾을 수 없음",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.NOT_FOUND,
+                                    detail = "토너먼트를 찾을 수 없습니다.",
+                                ),
+                        )
+                        add(
+                            status = HttpStatus.CONFLICT,
+                            name = "이미 등록 완료(READY) 항목",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.CONFLICT,
+                                    detail = "이미 등록 완료된 상품은 수정할 수 없습니다.",
+                                ),
+                        )
                     }
 
                 handlerMethod.binds(TournamentItemController::deleteItem) ->
@@ -79,6 +255,32 @@ class TournamentItemApiExamples(
                             status = HttpStatus.OK,
                             name = "아이템 삭제 성공",
                             payload = ApiResponseBody.ok<Unit>(),
+                        )
+                        add(
+                            status = HttpStatus.UNAUTHORIZED,
+                            name = "인증 필요",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.UNAUTHORIZED,
+                                ),
+                        )
+                        add(
+                            status = HttpStatus.FORBIDDEN,
+                            name = "토너먼트 권한 없음",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.FORBIDDEN,
+                                    detail = "해당 토너먼트에 대한 권한이 없습니다.",
+                                ),
+                        )
+                        add(
+                            status = HttpStatus.NOT_FOUND,
+                            name = "토너먼트/아이템을 찾을 수 없음",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.NOT_FOUND,
+                                    detail = "토너먼트를 찾을 수 없습니다.",
+                                ),
                         )
                     }
 
@@ -147,6 +349,32 @@ class TournamentItemApiExamples(
                                     status = ItemStatus.FAILED,
                                 ),
                             ),
+                        )
+                        add(
+                            status = HttpStatus.UNAUTHORIZED,
+                            name = "인증 필요",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.UNAUTHORIZED,
+                                ),
+                        )
+                        add(
+                            status = HttpStatus.FORBIDDEN,
+                            name = "토너먼트 권한 없음",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.FORBIDDEN,
+                                    detail = "해당 토너먼트에 대한 권한이 없습니다.",
+                                ),
+                        )
+                        add(
+                            status = HttpStatus.NOT_FOUND,
+                            name = "토너먼트/아이템을 찾을 수 없음",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.NOT_FOUND,
+                                    detail = "토너먼트를 찾을 수 없습니다.",
+                                ),
                         )
                     }
             }

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/dto/AddTournamentItemsRequest.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/dto/AddTournamentItemsRequest.kt
@@ -4,7 +4,7 @@ import com.depromeet.piki.tournament.service.dto.AddTournamentItemsFromWish
 import jakarta.validation.constraints.Size
 
 data class AddTournamentItemsRequest(
-    @field:Size(min = 1, max = 32)
+    @field:Size(min = 1, max = 32, message = "아이템은 1개 이상 32개 이하여야 합니다.")
     val itemIds: List<Long>,
 ) {
     fun toAddTournamentItemsFromWish(tournamentId: Long): AddTournamentItemsFromWish =

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/dto/CreateTournamentRequest.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/dto/CreateTournamentRequest.kt
@@ -4,7 +4,7 @@ import com.depromeet.piki.tournament.service.dto.CreateTournament
 import jakarta.validation.constraints.NotBlank
 
 data class CreateTournamentRequest(
-    @field:NotBlank
+    @field:NotBlank(message = "토너먼트 이름은 필수입니다.")
     val name: String,
 ) {
     fun toCreateTournament(): CreateTournament = CreateTournament(name = name)

--- a/src/main/kotlin/com/depromeet/piki/user/controller/DevUserApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/user/controller/DevUserApiExamples.kt
@@ -1,0 +1,95 @@
+package com.depromeet.piki.user.controller
+
+import com.depromeet.piki.auth.controller.dto.GuestCreateResponse
+import com.depromeet.piki.auth.service.dto.TokenPair
+import com.depromeet.piki.common.exception.ErrorCategory
+import com.depromeet.piki.common.openapi.OpenApiObjectMapper
+import com.depromeet.piki.common.openapi.binds
+import com.depromeet.piki.common.openapi.examples
+import com.depromeet.piki.common.response.ApiResponseBody
+import com.depromeet.piki.common.response.PageResponse
+import com.depromeet.piki.user.controller.dto.DevUserSummaryResponse
+import com.depromeet.piki.user.controller.dto.UserResponse
+import com.depromeet.piki.user.domain.IdentityType
+import org.springdoc.core.customizers.OperationCustomizer
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpStatus
+import java.util.UUID
+
+@Configuration
+class DevUserApiExamples(
+    private val openApiObjectMapper: OpenApiObjectMapper,
+) {
+    @Bean
+    fun devUserOpenApiExamples(): OperationCustomizer =
+        OperationCustomizer { operation, handlerMethod ->
+            when {
+                handlerMethod.binds(DevUserController::listUsers) ->
+                    operation.examples(openApiObjectMapper.delegate) {
+                        add(
+                            status = HttpStatus.OK,
+                            name = "유저 목록 (다음 페이지 있음)",
+                            payload =
+                                ApiResponseBody.ok(
+                                    data =
+                                        listOf(
+                                            DevUserSummaryResponse(
+                                                userId = UUID.fromString("8f1a3c2b-9d44-4e2a-9b12-1a2b3c4d5e6f"),
+                                                nickname = "뛰어다니는 강아지",
+                                            ),
+                                            DevUserSummaryResponse(
+                                                userId = UUID.fromString("3b9c1d2e-4f5a-4b6c-8d7e-9f0a1b2c3d4e"),
+                                                nickname = "홍길동",
+                                            ),
+                                        ),
+                                    pageResponse = PageResponse(nextCursor = "1", hasNext = true),
+                                ),
+                        )
+                    }
+
+                handlerMethod.binds(DevUserController::getUser) ->
+                    operation.examples(openApiObjectMapper.delegate) {
+                        add(
+                            status = HttpStatus.OK,
+                            name = "유저 + 토큰 발급 성공",
+                            payload =
+                                ApiResponseBody.ok(
+                                    GuestCreateResponse(
+                                        user =
+                                            UserResponse(
+                                                id = UUID.fromString("3b9c1d2e-4f5a-4b6c-8d7e-9f0a1b2c3d4e"),
+                                                nickname = "홍길동",
+                                                profileImage =
+                                                    "https://api.dicebear.com/9.x/bottts/svg?seed=3b9c1d2e-4f5a-4b6c-8d7e-9f0a1b2c3d4e",
+                                                identityType = IdentityType.MEMBER,
+                                            ),
+                                        tokenPair =
+                                            TokenPair(
+                                                accessToken = "eyJhbGciOiJIUzI1NiJ9.access",
+                                                refreshToken = "eyJhbGciOiJIUzI1NiJ9.refresh",
+                                            ),
+                                    ),
+                                ),
+                        )
+                        add(
+                            status = HttpStatus.NOT_FOUND,
+                            name = "userId 에 해당하는 유저 없음",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.NOT_FOUND,
+                                ),
+                        )
+                        add(
+                            status = HttpStatus.CONFLICT,
+                            name = "탈퇴된 유저 — 토큰 발급 거부",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.CONFLICT,
+                                ),
+                        )
+                    }
+            }
+            operation
+        }
+}

--- a/src/main/kotlin/com/depromeet/piki/user/controller/UserApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/user/controller/UserApiExamples.kt
@@ -29,14 +29,7 @@ class UserApiExamples(
                             name = "내 정보 조회 성공",
                             payload = ApiResponseBody.ok(sampleUser()),
                         )
-                        add(
-                            status = HttpStatus.UNAUTHORIZED,
-                            name = "인증 필요",
-                            payload =
-                                ApiResponseBody.fail<Unit>(
-                                    category = ErrorCategory.UNAUTHORIZED,
-                                ),
-                        )
+                        unauthorized()
                         add(
                             status = HttpStatus.NOT_FOUND,
                             name = "유저 없음 (JWT 유효하나 DB에 없음)",
@@ -72,14 +65,7 @@ class UserApiExamples(
                                     detail = "이미 사용 중인 닉네임입니다.",
                                 ),
                         )
-                        add(
-                            status = HttpStatus.UNAUTHORIZED,
-                            name = "인증 필요",
-                            payload =
-                                ApiResponseBody.fail<Unit>(
-                                    category = ErrorCategory.UNAUTHORIZED,
-                                ),
-                        )
+                        unauthorized()
                         add(
                             status = HttpStatus.NOT_FOUND,
                             name = "유저 없음 (JWT 유효하나 DB에 없음)",
@@ -111,14 +97,7 @@ class UserApiExamples(
                                     detail = "nickname 은 10자 이하여야 한다.",
                                 ),
                         )
-                        add(
-                            status = HttpStatus.UNAUTHORIZED,
-                            name = "인증 필요",
-                            payload =
-                                ApiResponseBody.fail<Unit>(
-                                    category = ErrorCategory.UNAUTHORIZED,
-                                ),
-                        )
+                        unauthorized()
                     }
             }
             operation

--- a/src/main/kotlin/com/depromeet/piki/user/controller/UserApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/user/controller/UserApiExamples.kt
@@ -37,6 +37,14 @@ class UserApiExamples(
                                     category = ErrorCategory.UNAUTHORIZED,
                                 ),
                         )
+                        add(
+                            status = HttpStatus.NOT_FOUND,
+                            name = "유저 없음 (JWT 유효하나 DB에 없음)",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.NOT_FOUND,
+                                ),
+                        )
                     }
 
                 handlerMethod.binds(UserController::updateMe) ->
@@ -64,6 +72,22 @@ class UserApiExamples(
                                     detail = "이미 사용 중인 닉네임입니다.",
                                 ),
                         )
+                        add(
+                            status = HttpStatus.UNAUTHORIZED,
+                            name = "인증 필요",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.UNAUTHORIZED,
+                                ),
+                        )
+                        add(
+                            status = HttpStatus.NOT_FOUND,
+                            name = "유저 없음 (JWT 유효하나 DB에 없음)",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.NOT_FOUND,
+                                ),
+                        )
                     }
 
                 handlerMethod.binds(UserController::checkNickname) ->
@@ -85,6 +109,14 @@ class UserApiExamples(
                                 ApiResponseBody.fail<Unit>(
                                     category = ErrorCategory.INVALID_INPUT,
                                     detail = "nickname 은 10자 이하여야 한다.",
+                                ),
+                        )
+                        add(
+                            status = HttpStatus.UNAUTHORIZED,
+                            name = "인증 필요",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.UNAUTHORIZED,
                                 ),
                         )
                     }

--- a/src/main/kotlin/com/depromeet/piki/wishlist/controller/WishlistApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/wishlist/controller/WishlistApiExamples.kt
@@ -38,22 +38,8 @@ class WishlistApiExamples(
                                 detail = "지원하지 않는 URL 형식입니다.",
                             ),
                     )
-                    add(
-                        status = HttpStatus.UNAUTHORIZED,
-                        name = "인증 필요",
-                        payload =
-                            ApiResponseBody.fail<Unit>(
-                                category = ErrorCategory.UNAUTHORIZED,
-                            ),
-                    )
-                    add(
-                        status = HttpStatus.FORBIDDEN,
-                        name = "권한 없음 (MEMBER 필요)",
-                        payload =
-                            ApiResponseBody.fail<Unit>(
-                                category = ErrorCategory.FORBIDDEN,
-                            ),
-                    )
+                    unauthorized()
+                    forbidden("권한 없음 (MEMBER 필요)")
                 }
             }
             if (handlerMethod.binds(WishlistController::getWishlist)) {
@@ -94,22 +80,8 @@ class WishlistApiExamples(
                                 detail = "유효하지 않은 cursor 입니다.",
                             ),
                     )
-                    add(
-                        status = HttpStatus.UNAUTHORIZED,
-                        name = "인증 필요",
-                        payload =
-                            ApiResponseBody.fail<Unit>(
-                                category = ErrorCategory.UNAUTHORIZED,
-                            ),
-                    )
-                    add(
-                        status = HttpStatus.FORBIDDEN,
-                        name = "권한 없음 (MEMBER 필요)",
-                        payload =
-                            ApiResponseBody.fail<Unit>(
-                                category = ErrorCategory.FORBIDDEN,
-                            ),
-                    )
+                    unauthorized()
+                    forbidden("권한 없음 (MEMBER 필요)")
                 }
             }
             if (handlerMethod.binds(WishlistController::getWish)) {
@@ -137,14 +109,7 @@ class WishlistApiExamples(
                                 detail = "존재하지 않는 위시리스트 항목입니다.",
                             ),
                     )
-                    add(
-                        status = HttpStatus.UNAUTHORIZED,
-                        name = "인증 필요",
-                        payload =
-                            ApiResponseBody.fail<Unit>(
-                                category = ErrorCategory.UNAUTHORIZED,
-                            ),
-                    )
+                    unauthorized()
                 }
             }
             if (handlerMethod.binds(WishlistController::recoverWishItem)) {
@@ -217,14 +182,7 @@ class WishlistApiExamples(
                                 detail = "이미지 저장에 실패했습니다. 잠시 후 다시 시도해 주세요.",
                             ),
                     )
-                    add(
-                        status = HttpStatus.UNAUTHORIZED,
-                        name = "인증 필요",
-                        payload =
-                            ApiResponseBody.fail<Unit>(
-                                category = ErrorCategory.UNAUTHORIZED,
-                            ),
-                    )
+                    unauthorized()
                 }
             }
             if (handlerMethod.binds(WishlistController::deleteWish)) {
@@ -243,14 +201,7 @@ class WishlistApiExamples(
                                 detail = "해당 위시 아이템에 접근할 권한이 없습니다.",
                             ),
                     )
-                    add(
-                        status = HttpStatus.UNAUTHORIZED,
-                        name = "인증 필요",
-                        payload =
-                            ApiResponseBody.fail<Unit>(
-                                category = ErrorCategory.UNAUTHORIZED,
-                            ),
-                    )
+                    unauthorized()
                 }
             }
             if (handlerMethod.binds(WishlistController::deleteWishes)) {
@@ -278,14 +229,7 @@ class WishlistApiExamples(
                                 detail = "해당 위시 아이템에 접근할 권한이 없습니다.",
                             ),
                     )
-                    add(
-                        status = HttpStatus.UNAUTHORIZED,
-                        name = "인증 필요",
-                        payload =
-                            ApiResponseBody.fail<Unit>(
-                                category = ErrorCategory.UNAUTHORIZED,
-                            ),
-                    )
+                    unauthorized()
                 }
             }
             if (handlerMethod.binds(WishlistController::registerFromImages)) {
@@ -313,22 +257,8 @@ class WishlistApiExamples(
                                 detail = ProductImage.unsupportedMimeTypeMessage("image/gif"),
                             ),
                     )
-                    add(
-                        status = HttpStatus.UNAUTHORIZED,
-                        name = "인증 필요",
-                        payload =
-                            ApiResponseBody.fail<Unit>(
-                                category = ErrorCategory.UNAUTHORIZED,
-                            ),
-                    )
-                    add(
-                        status = HttpStatus.FORBIDDEN,
-                        name = "권한 없음 (MEMBER 필요)",
-                        payload =
-                            ApiResponseBody.fail<Unit>(
-                                category = ErrorCategory.FORBIDDEN,
-                            ),
-                    )
+                    unauthorized()
+                    forbidden("권한 없음 (MEMBER 필요)")
                 }
             }
             operation

--- a/src/main/kotlin/com/depromeet/piki/wishlist/controller/WishlistApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/wishlist/controller/WishlistApiExamples.kt
@@ -38,6 +38,22 @@ class WishlistApiExamples(
                                 detail = "지원하지 않는 URL 형식입니다.",
                             ),
                     )
+                    add(
+                        status = HttpStatus.UNAUTHORIZED,
+                        name = "인증 필요",
+                        payload =
+                            ApiResponseBody.fail<Unit>(
+                                category = ErrorCategory.UNAUTHORIZED,
+                            ),
+                    )
+                    add(
+                        status = HttpStatus.FORBIDDEN,
+                        name = "권한 없음 (MEMBER 필요)",
+                        payload =
+                            ApiResponseBody.fail<Unit>(
+                                category = ErrorCategory.FORBIDDEN,
+                            ),
+                    )
                 }
             }
             if (handlerMethod.binds(WishlistController::getWishlist)) {
@@ -69,6 +85,31 @@ class WishlistApiExamples(
                                 pageResponse = PageResponse(nextCursor = null, hasNext = false),
                             ),
                     )
+                    add(
+                        status = HttpStatus.BAD_REQUEST,
+                        name = "유효하지 않은 cursor",
+                        payload =
+                            ApiResponseBody.fail<Unit>(
+                                category = ErrorCategory.INVALID_INPUT,
+                                detail = "유효하지 않은 cursor 입니다.",
+                            ),
+                    )
+                    add(
+                        status = HttpStatus.UNAUTHORIZED,
+                        name = "인증 필요",
+                        payload =
+                            ApiResponseBody.fail<Unit>(
+                                category = ErrorCategory.UNAUTHORIZED,
+                            ),
+                    )
+                    add(
+                        status = HttpStatus.FORBIDDEN,
+                        name = "권한 없음 (MEMBER 필요)",
+                        payload =
+                            ApiResponseBody.fail<Unit>(
+                                category = ErrorCategory.FORBIDDEN,
+                            ),
+                    )
                 }
             }
             if (handlerMethod.binds(WishlistController::getWish)) {
@@ -94,6 +135,14 @@ class WishlistApiExamples(
                             ApiResponseBody.fail<Unit>(
                                 category = ErrorCategory.NOT_FOUND,
                                 detail = "존재하지 않는 위시리스트 항목입니다.",
+                            ),
+                    )
+                    add(
+                        status = HttpStatus.UNAUTHORIZED,
+                        name = "인증 필요",
+                        payload =
+                            ApiResponseBody.fail<Unit>(
+                                category = ErrorCategory.UNAUTHORIZED,
                             ),
                     )
                 }
@@ -168,6 +217,14 @@ class WishlistApiExamples(
                                 detail = "이미지 저장에 실패했습니다. 잠시 후 다시 시도해 주세요.",
                             ),
                     )
+                    add(
+                        status = HttpStatus.UNAUTHORIZED,
+                        name = "인증 필요",
+                        payload =
+                            ApiResponseBody.fail<Unit>(
+                                category = ErrorCategory.UNAUTHORIZED,
+                            ),
+                    )
                 }
             }
             if (handlerMethod.binds(WishlistController::deleteWish)) {
@@ -184,6 +241,14 @@ class WishlistApiExamples(
                             ApiResponseBody.fail<Unit>(
                                 category = ErrorCategory.FORBIDDEN,
                                 detail = "해당 위시 아이템에 접근할 권한이 없습니다.",
+                            ),
+                    )
+                    add(
+                        status = HttpStatus.UNAUTHORIZED,
+                        name = "인증 필요",
+                        payload =
+                            ApiResponseBody.fail<Unit>(
+                                category = ErrorCategory.UNAUTHORIZED,
                             ),
                     )
                 }
@@ -213,6 +278,14 @@ class WishlistApiExamples(
                                 detail = "해당 위시 아이템에 접근할 권한이 없습니다.",
                             ),
                     )
+                    add(
+                        status = HttpStatus.UNAUTHORIZED,
+                        name = "인증 필요",
+                        payload =
+                            ApiResponseBody.fail<Unit>(
+                                category = ErrorCategory.UNAUTHORIZED,
+                            ),
+                    )
                 }
             }
             if (handlerMethod.binds(WishlistController::registerFromImages)) {
@@ -238,6 +311,22 @@ class WishlistApiExamples(
                             ApiResponseBody.fail<Unit>(
                                 category = ErrorCategory.INVALID_INPUT,
                                 detail = ProductImage.unsupportedMimeTypeMessage("image/gif"),
+                            ),
+                    )
+                    add(
+                        status = HttpStatus.UNAUTHORIZED,
+                        name = "인증 필요",
+                        payload =
+                            ApiResponseBody.fail<Unit>(
+                                category = ErrorCategory.UNAUTHORIZED,
+                            ),
+                    )
+                    add(
+                        status = HttpStatus.FORBIDDEN,
+                        name = "권한 없음 (MEMBER 필요)",
+                        payload =
+                            ApiResponseBody.fail<Unit>(
+                                category = ErrorCategory.FORBIDDEN,
                             ),
                     )
                 }

--- a/src/test/kotlin/com/depromeet/piki/common/controller/DocsAccessIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/common/controller/DocsAccessIntegrationTest.kt
@@ -84,4 +84,33 @@ class DocsAccessIntegrationTest : IntegrationTestSupport() {
             // 보호: operation 에 security 명시 없음 → 최상위 글로벌 Bearer 상속 (문서 UI 에 자물쇠 표시).
             .andExpect(jsonPath("$.paths['/api/v1/dev/users'].post.security").doesNotExist())
     }
+
+    @Test
+    fun `GET v3 api-docs - 선언된 실패 응답에 example payload 가 빠짐없이 부착된다 (응답 전수 문서화 회귀 가드)`() {
+        // OperationExamples.add 는 @ApiResponse 가 선언된 status 에만 example 을 붙인다(없으면 조용히 무시).
+        // 과거 401·일부 4xx 응답에 example 이 통째로 누락돼 있었다. 선언과 example 이 짝을 이루는지 회귀 가드.
+        val mockMvc =
+            MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .apply<DefaultMockMvcBuilder>(springSecurity())
+                .build()
+
+        mockMvc
+            .perform(get("/v3/api-docs"))
+            .andExpect(status().isOk)
+            // wishlist: 모든 메서드에 누락돼 있던 401 (Security MEMBER 요구) example 부착.
+            .andExpect(
+                jsonPath("$.paths['/api/v1/wishlists'].post.responses['401'].content['application/json'].examples").exists(),
+            )
+            // tournament 시작: 실패 example 이 전무했던 409 (상태 충돌) example 부착.
+            .andExpect(
+                jsonPath(
+                    "$.paths['/api/v1/tournaments/{tournamentId}/start'].post.responses['409'].content['application/json'].examples",
+                ).exists(),
+            )
+            // dev 단건 유저: 신규 DevUserApiExamples 빈의 404 example 부착.
+            .andExpect(
+                jsonPath("$.paths['/api/v1/dev/users/{userId}'].get.responses['404'].content['application/json'].examples").exists(),
+            )
+    }
 }

--- a/src/test/kotlin/com/depromeet/piki/common/controller/DocsAccessIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/common/controller/DocsAccessIntegrationTest.kt
@@ -86,9 +86,10 @@ class DocsAccessIntegrationTest : IntegrationTestSupport() {
     }
 
     @Test
-    fun `GET v3 api-docs - 선언된 실패 응답에 example payload 가 빠짐없이 부착된다 (응답 전수 문서화 회귀 가드)`() {
+    fun `GET v3 api-docs - 대표 실패 응답에 example payload 가 부착된다 (회귀 가드)`() {
         // OperationExamples.add 는 @ApiResponse 가 선언된 status 에만 example 을 붙인다(없으면 조용히 무시).
         // 과거 401·일부 4xx 응답에 example 이 통째로 누락돼 있었다. 선언과 example 이 짝을 이루는지 회귀 가드.
+        // 전 엔드포인트 전수가 아니라, 광범위 누락이던 대표 케이스(401·409·404)만 spot 검증한다.
         val mockMvc =
             MockMvcBuilders
                 .webAppContextSetup(webApplicationContext)
@@ -100,7 +101,9 @@ class DocsAccessIntegrationTest : IntegrationTestSupport() {
             .andExpect(status().isOk)
             // wishlist: 모든 메서드에 누락돼 있던 401 (Security MEMBER 요구) example 부착.
             .andExpect(
-                jsonPath("$.paths['/api/v1/wishlists'].post.responses['401'].content['application/json'].examples").exists(),
+                jsonPath(
+                    "$.paths['/api/v1/wishlists'].post.responses['401'].content['application/json'].examples",
+                ).exists(),
             )
             // tournament 시작: 실패 example 이 전무했던 409 (상태 충돌) example 부착.
             .andExpect(
@@ -110,7 +113,9 @@ class DocsAccessIntegrationTest : IntegrationTestSupport() {
             )
             // dev 단건 유저: 신규 DevUserApiExamples 빈의 404 example 부착.
             .andExpect(
-                jsonPath("$.paths['/api/v1/dev/users/{userId}'].get.responses['404'].content['application/json'].examples").exists(),
+                jsonPath(
+                    "$.paths['/api/v1/dev/users/{userId}'].get.responses['404'].content['application/json'].examples",
+                ).exists(),
             )
     }
 }


### PR DESCRIPTION
## Situation
- "컨트롤러 메서드 순서를 정렬하면 API docs 순서도 맞춰지나" 논의에서 출발했으나, docs 순서는 springdoc 가 path 문자열 알파벳 + HTTP 메서드 고정순으로 내보내 코드 선언 순서와 무관함을 dev 서버 `/v3/api-docs` 실측으로 확인했다 (코드 정렬로는 docs 순서를 못 바꾼다).
- 그 과정에서 더 근본적인 문제를 발견 — 선언된 응답 코드에 example 이 광범위하게 누락돼 있었다. CLAUDE.md "응답 전수 문서화" 절대 규칙(선언된 모든 응답에 example 부착) 위반 상태로, 특히 401(미인증) example 은 거의 모든 엔드포인트에서 빠져 있었고 Tournament 는 실패 example 이 통째로 없었다.

## Task
- 8개 컨트롤러 전 메서드에 대해 `실제 도달 가능 응답 ↔ @ApiResponse 선언 ↔ example 등록` 3중 대조로 누락·불일치를 가려내고, 선언된 모든 응답에 실제 응답과 일치하는 example 을 빠짐없이 부착한다.

## Action
### 정밀 감사
- 5개 도메인(Wishlist / Tournament / User·DevUser / Auth·DevAuth / OAuth·OAuthUrl)을 병렬로 정밀 감사 — 컨트롤러에서 서비스, 도메인까지 호출 그래프를 추적해 truth-set(Security 401·403 + 도메인 예외 status + Bean Validation 400 + 외부 의존성 5xx)을 확정.
- 핵심 메커니즘 확인: `OperationExamples.add` 는 해당 status 의 `@ApiResponse` 가 선언돼 있어야만 example 을 붙이고 없으면 조용히 무시한다.
- 감사 결과 거의 전부 `MISSING_EXAMPLE`(어노테이션은 정확한데 example 만 누락)이고, 죽은 example과 과잉·누락 어노테이션은 0건이었다. 따라서 `*Api.kt` 는 손대지 않고 `*ApiExamples` 만 보강.

### example 보정
- Wishlist(401·403·cursor 400), Tournament·TournamentItem(실패 example 전무였던 4xx·5xx), User(getMe 404 · updateMe 401·404 · checkNickname 401), Auth 내 DevAuth(createDevUser 401·403·409 · issueTokenForUser 401·403) 누락 보강.
- DevUser 는 전용 Examples 빈이 없어 신규 `DevUserApiExamples` 작성 (listUsers 200, getUser 200·404·409).
- `TournamentApiExamples` 의 `ErrorCategory` import 누락도 함께 정정.

### 정확성 — detail 을 실제 응답과 일치
- Security 단 401·403(권한 미달)은 핸들러가 `fail(category)` 를 detail 없이 내려보내므로 example 도 detail 없이 맞췄다.
- 도메인 예외 4xx·5xx 는 `GlobalExceptionHandler` 가 예외 message 를 detail 로 싣는 동작에 맞춰, 해당 예외의 고정 message 를 detail 로 실어 example 과 실제 응답을 일치시켰다.

### 회귀 가드
- `DocsAccessIntegrationTest` 에 `GET /v3/api-docs` 의 선언된 실패 응답에 example payload 가 실제로 붙는지 단언을 추가 (wishlist 401 · tournament start 409 · dev 단건유저 404 대표).

## Result
- 선언된 모든 응답에 example 부착 완료. OAuth·OAuthUrl 은 이미 완전 정합이라 변경 없음.
- 검증: 컴파일 통과, `GET /v3/api-docs` 직렬화 통과(추가한 모든 example payload 가 에러 없이 spec 에 부착됨을 확인), 전체 테스트 통과.
- docs 의 표시 순서 자체(RCUD 같은 의미순)는 OpenAPI 모델이 `path → HTTP 메서드` 2축으로만 정렬되고 의미 축이 없어 표현 불가라는 결론이라, 이번 범위에서 제외했다.

## 연관 이슈
- 


## Updates

### code-review (xhigh effort) 후속 대응
- **Bean Validation 응답 detail 을 locale 무관 한글로 고정** — DTO 의 `@NotBlank`/`@Size` 에 한글 `message` 를 명시. 기존엔 message 미지정이라 Hibernate Validator 가 요청 locale(로컬 ko / 운영 컨테이너 en)에 따라 해석해 응답 detail 이 영어·한글로 갈렸고, OpenAPI example 과 어긋날 수 있었다. message 를 박아 응답을 환경 무관 한글로 고정하니 example 과 실제 응답 detail 이 항상 일치한다. (`bb333d8`)
- **Security 401/403 example 을 OperationExamples 헬퍼로 추출** — 전 엔드포인트에 반복되던 detail 없는 `fail(UNAUTHORIZED)`/`fail(FORBIDDEN)` 블록(약 30곳, 200여 줄)을 `unauthorized()`/`forbidden()` 호출로 축약. category↔status 짝이 헬퍼 한 자리에 박혀 손으로 맞추다 어긋날 여지를 없앴다. (`5463fe8`)
- **회귀 가드 검증 범위 명확화** — 테스트 이름이 '전수'를 표방했으나 실제로는 3개 대표(wishlists 401 · tournaments start 409 · dev getUser 404)만 단언 — 이름·주석을 '대표 회귀 가드'로 정정해 오신뢰를 막는다. (`b049053`)
