### PR TITLE
로그 콘솔 패턴 정리 — Grafana 가독성 개선 (KST 통일·중복 메타 제거)

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -116,3 +116,18 @@ management:
       # Zipkin 등 외부 export 가 없어 모든 요청을 추적해도 비용은 span 생성 + MDC put/remove 뿐.
       # 모든 응답·로그에 traceId 가 빠짐없이 찍히도록 1.0 으로 둔다 (기본 0.1 이면 일부 요청에 누락).
       probability: 1.0
+
+logging:
+  pattern:
+    # 운영 로그는 Grafana(Loki)에서 본다. Grafana 가 줄 앞에 수집시각(KST)+레벨을 자동으로 붙이므로,
+    # Spring Boot 기본 콘솔 패턴의 시각·레벨과 겹쳐 한 줄에 시각·레벨이 두 번씩 나온다. 게다가 운영 컨테이너
+    # JVM 은 UTC 라 Spring 시각이 Grafana 의 KST 표시와 9시간 어긋나 더 헷갈린다.
+    #
+    # 그래서 콘솔 패턴을 직접 정의한다:
+    #  - 시각을 Asia/Seoul 로 고정해 Grafana 표시(KST)와 맞춘다 (JVM 타임존은 안 건드린다 — now() 등 도메인 시각에
+    #    영향 주지 않도록 로그 출력에서만 KST 로 포맷. DB 는 serverTimezone=UTC 유지).
+    #  - PID·--- ·application name([PIKI])을 뺀다. 단일 컨테이너라 PID 는 항상 1 이고, 서비스 구분은 Loki 의
+    #    container 라벨(team3-blue/green)이 이미 한다 — 줄마다 반복할 가치가 없다.
+    #  - traceId/spanId 는 한 요청의 전체 로그를 묶는 추적 키라 유지한다 (sampling 1.0 이라 항상 채워진다).
+    # 색상(%clr)은 쓰지 않는다 — non-TTY(컨테이너 stdout)에선 어차피 plain 이고, 로컬 콘솔 색상보다 패턴 단순함을 택한다.
+    console: "%d{yyyy-MM-dd HH:mm:ss.SSS, Asia/Seoul} %-5level [%thread] [%X{traceId:-},%X{spanId:-}] %logger{36} : %msg%n%wEx"


### PR DESCRIPTION
## Situation
- 모니터링(Grafana/Loki)에서 로그를 볼 때 한 줄에 **시각·레벨이 두 번씩** 찍혀 읽기 어려웠다 (직전 trace 전파 PR 작업 중 로그를 보다 발견).
- Grafana 가 모든 로그 줄 앞에 수집시각(KST)+레벨을 자동으로 붙이는데, Spring Boot 기본 콘솔 패턴도 시각·레벨을 포함해 겹친 것이 원인. 게다가 운영 컨테이너 JVM 은 UTC 라 Spring 시각이 Grafana 의 KST 표시와 **9시간 어긋나** 더 헷갈렸다.

## Task
- Spring 로그 콘솔 패턴을 Grafana(Loki) 환경에 맞게 정리해 로그 한 줄을 읽기 쉽게 만든다.

## Action
- `logging.pattern.console` 을 직접 정의했다.
  - **시각**: `Asia/Seoul` 로 고정해 Grafana 의 KST 표시와 맞췄다. JVM 타임존은 건드리지 않아 도메인 `now()` 에 영향이 없고 DB 는 `serverTimezone=UTC` 를 유지한다 (로그 출력에서만 KST 포맷).
  - **제거**: PID(단일 컨테이너라 항상 1)·`---`·application name(`[PIKI]`). 서비스 구분은 Loki 의 `container` 라벨(team3-blue/green)이 이미 하므로 줄마다 반복할 가치가 없다.
  - **유지**: 레벨·thread·traceId/spanId(한 요청의 로그를 묶는 추적 키)·logger·msg.
- `logback-spring.xml` 대신 `application.yml` 한 줄로 뒀다 — 기존 logback 파일이 없고 프로파일 분기(`@Profile` 미사용)도 없어 단순함을 택했다.
- "시각·레벨까지 빼고 Grafana 표시에만 위임"하는 더 깔끔한 안도 검토했으나, `docker logs`·로컬 콘솔·`/var/log` 백업의 시각 보존을 위해 **시각은 KST 로 유지**하는 쪽을 택했다.

## Result
- 로그 한 줄이 정리됐다 (로컬 bootRun 확인):
  - before: `2026-06-02T10:04:06.414Z INFO 1 --- [PIKI] [nio-8080-exec-8] [traceId-spanId] logger : msg` (+ Grafana 가 앞에 KST 시각·레벨)
  - after: `2026-06-02 20:49:53.596 INFO [main] [traceId,spanId] logger : msg`
- 시각이 KST 로 통일돼 Grafana 표시와 어긋나지 않고, PID·`---`·`[PIKI]` 노이즈가 사라졌다.
- 로컬 bootRun 으로 패턴 적용을 실제 확인 (시각 KST·노이즈 제거·MDC traceId 키 인식). 운영에선 sampling 1.0 이라 `[traceId,spanId]` 가 항상 채워진다.

---
## 연관 이슈

- 
