### PR TITLE
OAuth provider 에러 정밀 분류 (502 일괄 → 401/400/502)

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/auth/controller/OAuthApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/controller/OAuthApi.kt
@@ -50,7 +50,9 @@ interface OAuthApi {
             ),
             ApiResponse(
                 responseCode = "400",
-                description = "잘못된 요청 (code+redirectUri 도 accessToken 도 없음 · accessToken 과 code 를 동시 전달 · 지원하지 않는 provider)",
+                description =
+                    "잘못된 요청 (code+redirectUri 도 accessToken 도 없음 · accessToken 과 code 를 동시 전달 · 지원하지 않는 provider · " +
+                        "provider 인가코드(code) 가 만료/재사용/무효 — 재로그인으로 새 code 를 받아 재시도)",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,
@@ -60,7 +62,9 @@ interface OAuthApi {
             ),
             ApiResponse(
                 responseCode = "401",
-                description = "state 검증 실패 (만료·미발급·이미 소비된 state — GET /auth/{provider}/url 로 재발급 필요)",
+                description =
+                    "인증 실패 (state 검증 실패: 만료·미발급·이미 소비된 state — GET /auth/{provider}/url 로 재발급 필요 · " +
+                        "provider access token 무효/만료 — 재로그인으로 새 토큰을 받아 재시도)",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,
@@ -70,7 +74,10 @@ interface OAuthApi {
             ),
             ApiResponse(
                 responseCode = "502",
-                description = "소셜 제공자(Kakao/Google) 호출 실패 (네트워크·토큰 교환 실패·user_info 조회 실패 등)",
+                description =
+                    "소셜 제공자 호출 경계 실패 (응답 body 의 category 로 구분) — " +
+                        "(1) provider 장애(네트워크·5xx·점검·user_info 조회 실패·미지 에러코드 fallback): RETRYABLE, 동일 요청으로 재시도 가능 / " +
+                        "(2) 우리 OAuth 설정·요청 오류(client_id/secret·client_secret JWT·필수 인자 누락 등): SERVER_ERROR, 재시도 무의미·서버 설정 수정 필요",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,

--- a/src/main/kotlin/com/depromeet/piki/auth/controller/OAuthApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/controller/OAuthApiExamples.kt
@@ -55,6 +55,15 @@ class OAuthApiExamples(
                             ),
                     )
                     add(
+                        status = HttpStatus.BAD_REQUEST,
+                        name = "인가코드(code) 만료/재사용/무효",
+                        payload =
+                            ApiResponseBody.fail<Unit>(
+                                category = ErrorCategory.INVALID_INPUT,
+                                detail = "소셜 로그인 인가 정보가 만료되었거나 유효하지 않습니다. 다시 시도해 주세요.",
+                            ),
+                    )
+                    add(
                         status = HttpStatus.UNAUTHORIZED,
                         name = "state 검증 실패 (만료 또는 미발급)",
                         payload =
@@ -64,12 +73,30 @@ class OAuthApiExamples(
                             ),
                     )
                     add(
+                        status = HttpStatus.UNAUTHORIZED,
+                        name = "provider access token 무효/만료 (재로그인 필요)",
+                        payload =
+                            ApiResponseBody.fail<Unit>(
+                                category = ErrorCategory.UNAUTHORIZED,
+                                detail = "소셜 로그인 토큰이 유효하지 않습니다. 다시 로그인해 주세요.",
+                            ),
+                    )
+                    add(
                         status = HttpStatus.BAD_GATEWAY,
-                        name = "소셜 제공자 호출 실패",
+                        name = "소셜 제공자 장애 (RETRYABLE — 재시도 가능)",
                         payload =
                             ApiResponseBody.fail<Unit>(
                                 category = ErrorCategory.RETRYABLE,
                                 detail = "소셜 로그인 제공자 호출에 실패했습니다.",
+                            ),
+                    )
+                    add(
+                        status = HttpStatus.BAD_GATEWAY,
+                        name = "우리 OAuth 설정/요청 오류 (SERVER_ERROR — 재시도 무의미)",
+                        payload =
+                            ApiResponseBody.fail<Unit>(
+                                category = ErrorCategory.SERVER_ERROR,
+                                detail = "소셜 로그인 설정 오류가 발생했습니다.",
                             ),
                     )
                 }

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthException.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthException.kt
@@ -33,5 +33,35 @@ class OAuthException private constructor(
         // state 없음 · 만료 · 이미 소비됨 → 401. CSRF 방지용 state 불일치로 요청을 거부.
         fun invalidState(): OAuthException =
             OAuthException("유효하지 않은 state 파라미터입니다. 인가 URL 을 새로 발급받아 다시 시도하세요.", ErrorCategory.UNAUTHORIZED, HttpStatus.UNAUTHORIZED)
+
+        // provider 인가코드(code)가 만료/재사용/무효 — 멀쩡한 클라가 정상 요청으로 도달 가능(계약) → 400.
+        // 재로그인으로 새 code 를 받아 재시도하면 해소된다. 원문은 cause 로만, message 는 고정 문구.
+        fun invalidGrant(): OAuthException =
+            OAuthException(
+                "소셜 로그인 인가 정보가 만료되었거나 유효하지 않습니다. 다시 시도해 주세요.",
+                ErrorCategory.INVALID_INPUT,
+                HttpStatus.BAD_REQUEST,
+            )
+
+        // provider access token 무효/만료 — 클라가 정상 요청으로 도달 가능(계약) → 401.
+        // 재로그인으로 새 토큰을 받아야 해소된다. 원문은 cause 로만, message 는 고정 문구.
+        fun invalidProviderToken(): OAuthException =
+            OAuthException(
+                "소셜 로그인 토큰이 유효하지 않습니다. 다시 로그인해 주세요.",
+                ErrorCategory.UNAUTHORIZED,
+                HttpStatus.UNAUTHORIZED,
+            )
+
+        // 우리 OAuth 설정/요청 오류(client_id/secret · client_secret JWT · 필수 인자 누락 등) — 외부 호출 경계에서
+        // provider 가 "네 자격/요청이 틀렸다"고 거부한 것. GeminiApiException.clientError 와 같은 결로 502 + SERVER_ERROR:
+        // status 502 = 외부 호출 경계 실패, category SERVER_ERROR = 재시도해도 무의미한 우리 서버 문제(알림 신호).
+        // 정상 클라 요청으로 해소 불가. 원인은 cause 로만 보존하고 message 는 고정 문구(원문 비노출).
+        fun misconfigured(cause: Throwable): OAuthException =
+            OAuthException(
+                "소셜 로그인 설정 오류가 발생했습니다.",
+                ErrorCategory.SERVER_ERROR,
+                HttpStatus.BAD_GATEWAY,
+                cause,
+            )
     }
 }

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthProviderErrorLogging.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthProviderErrorLogging.kt
@@ -15,8 +15,10 @@ import org.slf4j.Logger
 //   - 우리 설정/요청 오류·provider 장애·미지 코드 fallback(SERVER_ERROR·RETRYABLE): 외부 호출 실패 → warn.
 //
 // body 는 provider 의 "에러 응답" 이라 access token 등 자격증명을 echo 하지 않아(요청이 아니라 응답) 로깅이 안전하다.
-// 다만 로그 폭주를 막기 위해 길이를 제한한다.
+// 다만 (1) 로그 폭주를 막기 위해 길이를 제한하고, (2) provider·프록시가 개행 섞인 HTML 에러 페이지를 주면
+// 로그 한 줄이 여러 줄로 찢어져 운영 파서·알람이 깨지므로(log injection) 제어문자를 공백으로 정규화한다.
 private const val MAX_BODY_LOG_LENGTH = 500
+private val CONTROL_CHARS = Regex("[\\p{Cntrl}]")
 
 fun logOAuthProviderError(
     log: Logger,
@@ -26,7 +28,7 @@ fun logOAuthProviderError(
     body: String,
     category: ErrorCategory,
 ) {
-    val snippet = body.take(MAX_BODY_LOG_LENGTH)
+    val snippet = body.replace(CONTROL_CHARS, " ").take(MAX_BODY_LOG_LENGTH)
     when (category) {
         ErrorCategory.INVALID_INPUT, ErrorCategory.UNAUTHORIZED ->
             log.info("[OAuth {} {}] 클라 자격/요청 오류 status={} category={} body={}", provider, endpoint, status, category, snippet)

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthProviderErrorLogging.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthProviderErrorLogging.kt
@@ -1,0 +1,43 @@
+package com.depromeet.piki.auth.infrastructure.oauth
+
+import com.depromeet.piki.common.exception.ErrorCategory
+import org.slf4j.Logger
+
+// provider(Google·Kakao·Apple) 의 OAuth 에러 응답을 관측 가능하게 남긴다.
+//
+// 왜 필요한가: 분류기는 우리가 아는 코드만 정밀 매핑하고 문서에 없는(혹은 provider 가 새로 추가한) 코드는
+// 안전하게 502 RETRYABLE 로 fallback 한다. 그런데 그 원본을 로그로 남기지 않으면 미지 코드가 조용히 502 로
+// 묻혀 우리가 영영 알 수 없다(GlobalExceptionHandler 는 고정 message 만 info 로 찍고 원본 body·cause 는 안 남긴다).
+// 이 함수가 provider 원본을 남겨, 새 코드가 뜨면 우리가 보고 분류 set 에 추가(또는 alert)할 수 있게 한다.
+//
+// 레벨은 분류 결과 category 를 따른다 (CLAUDE.md 로깅 레벨):
+//   - 클라 자격/요청 오류(INVALID_INPUT·UNAUTHORIZED): 서버 입장에선 정상 동작 → info.
+//   - 우리 설정/요청 오류·provider 장애·미지 코드 fallback(SERVER_ERROR·RETRYABLE): 외부 호출 실패 → warn.
+//
+// body 는 provider 의 "에러 응답" 이라 access token 등 자격증명을 echo 하지 않아(요청이 아니라 응답) 로깅이 안전하다.
+// 다만 로그 폭주를 막기 위해 길이를 제한한다.
+private const val MAX_BODY_LOG_LENGTH = 500
+
+fun logOAuthProviderError(
+    log: Logger,
+    provider: String,
+    endpoint: String,
+    status: Int,
+    body: String,
+    category: ErrorCategory,
+) {
+    val snippet = body.take(MAX_BODY_LOG_LENGTH)
+    when (category) {
+        ErrorCategory.INVALID_INPUT, ErrorCategory.UNAUTHORIZED ->
+            log.info("[OAuth {} {}] 클라 자격/요청 오류 status={} category={} body={}", provider, endpoint, status, category, snippet)
+        else ->
+            log.warn(
+                "[OAuth {} {}] provider 에러 (미지 코드면 502 fallback — 분류 set 추가 검토 대상) status={} category={} body={}",
+                provider,
+                endpoint,
+                status,
+                category,
+                snippet,
+            )
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/apple/AppleOAuthClient.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/apple/AppleOAuthClient.kt
@@ -7,6 +7,7 @@ import com.depromeet.piki.auth.infrastructure.oauth.OAuthProvider
 import com.depromeet.piki.auth.infrastructure.oauth.OAuthRestClient
 import com.depromeet.piki.auth.infrastructure.oauth.OAuthUserInfo
 import com.depromeet.piki.auth.infrastructure.oauth.apple.dto.AppleTokenResponse
+import com.depromeet.piki.auth.infrastructure.oauth.logOAuthProviderError
 import io.jsonwebtoken.Claims
 import io.jsonwebtoken.Header
 import io.jsonwebtoken.Jwts
@@ -15,6 +16,7 @@ import io.jsonwebtoken.security.Jwks
 import org.slf4j.LoggerFactory
 import org.springframework.http.MediaType
 import org.springframework.util.LinkedMultiValueMap
+import org.springframework.web.client.RestClientResponseException
 import org.springframework.web.client.body
 import org.springframework.web.util.UriComponentsBuilder
 import java.security.Key
@@ -74,6 +76,11 @@ class AppleOAuthClient(
                     .retrieve()
                     .body<AppleTokenResponse>()
                     ?: error("Apple token response body is null")
+            } catch (e: RestClientResponseException) {
+                // token 교환 HTTP 에러 응답은 시맨틱 기반으로 분류한다 (invalid_grant→400 · 설정오류→502/SERVER_ERROR · 그 외→502).
+                val exception = AppleOAuthErrorClassifier.classify(e.statusCode, e.responseBodyAsString, e)
+                logOAuthProviderError(log, "Apple", "token", e.statusCode.value(), e.responseBodyAsString, exception.category)
+                throw exception
             } catch (e: Exception) {
                 throw OAuthException.providerError(e)
             }

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/apple/AppleOAuthErrorClassifier.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/apple/AppleOAuthErrorClassifier.kt
@@ -1,0 +1,65 @@
+package com.depromeet.piki.auth.infrastructure.oauth.apple
+
+import com.depromeet.piki.auth.infrastructure.oauth.OAuthException
+import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatusCode
+import tools.jackson.databind.json.JsonMapper
+
+// Apple token endpoint(/auth/token) 의 HTTP 에러 응답을 시맨틱 기반으로 재매핑하는 순수 함수.
+// Spring·DB 의존 없이 (status, body) 만으로 분류해 단위 테스트로 분기를 망라한다
+// (CLAUDE.md 테스트 결정트리 (6) 외부 호출 결과 분기).
+//
+// 견고함의 3원칙 (PLAN.md):
+// 1. 메시지 문자열에 의존 금지 — Apple ErrorResponse 는 안정 필드가 `error` 코드 하나뿐이고
+//    `error_description` 은 미보장이라 의존하지 않는다.
+// 2. provider HTTP status 그대로 전달 금지 — Apple 은 우리 설정 오류(invalid_client)도 400 으로 준다.
+//    바디의 `error` 코드로 시맨틱 재매핑(→ 500 / 400)한다.
+// 3. 미지의 코드 → 502 fallback — 파싱 실패·HTTP≠400·미지 error 코드는 안전하게 provider 장애로 본다.
+//
+// id_token(JWT) 검증 실패는 이 분류 대상이 아니다 — AppleOAuthClient 가 별도로 providerError(502) 로 처리한다.
+object AppleOAuthErrorClassifier {
+    // Apple token endpoint 의 표준 에러 코드. invalid_grant 만 클라가 정상 요청으로 도달 가능(계약)하고,
+    // 나머지는 우리 client_secret JWT·요청 구성 오류(우리 설정 버그)다.
+    private const val ERROR_INVALID_GRANT = "invalid_grant"
+    private val MISCONFIGURED_ERROR_CODES =
+        setOf(
+            "invalid_client",
+            "invalid_request",
+            "unauthorized_client",
+            "unsupported_grant_type",
+            "invalid_scope",
+        )
+
+    // Apple token endpoint 는 에러를 전부 이 HTTP status 로 준다. 그 외 status 는 outage·장애 신호(매직넘버 대신 의미로).
+    private val TOKEN_ERROR_HTTP_STATUS = HttpStatus.BAD_REQUEST.value()
+
+    // Apple ErrorResponse 의 단일 안정 필드명.
+    private const val FIELD_ERROR = "error"
+
+    private val jsonMapper = JsonMapper.builder().build()
+
+    // status·body 로 token 교환 에러를 분류한다. cause 는 디버깅용 원인(원래 던져진 예외)으로,
+    // 502 fallback 에 한해 cause 체인을 보존한다.
+    fun classify(
+        status: HttpStatusCode,
+        body: String,
+        cause: Throwable,
+    ): OAuthException {
+        // Apple token endpoint 는 에러를 전부 HTTP 400 으로 준다. 그 외 status 는 Apple outage·장애 신호.
+        if (status.value() != TOKEN_ERROR_HTTP_STATUS) return OAuthException.providerError(cause)
+
+        val error = parseErrorCode(body) ?: return OAuthException.providerError(cause)
+
+        if (error == ERROR_INVALID_GRANT) return OAuthException.invalidGrant()
+        if (error in MISCONFIGURED_ERROR_CODES) return OAuthException.misconfigured(cause)
+
+        // 문서에 없는 미지의 error 코드 → 안전하게 provider 장애로 fallback.
+        return OAuthException.providerError(cause)
+    }
+
+    // Apple ErrorResponse 의 단일 `error` 필드만 추출한다. error_description 등 다른 필드엔 의존하지 않는다.
+    // 파싱 실패(non-JSON·필드 부재)는 null 을 돌려 호출부가 502 fallback 으로 보낸다.
+    private fun parseErrorCode(body: String): String? =
+        runCatching { jsonMapper.readTree(body).get(FIELD_ERROR)?.asString() }
+            .getOrNull()
+}

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/google/GoogleOAuthClient.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/google/GoogleOAuthClient.kt
@@ -7,16 +7,23 @@ import com.depromeet.piki.auth.infrastructure.oauth.OAuthRestClient
 import com.depromeet.piki.auth.infrastructure.oauth.OAuthUserInfo
 import com.depromeet.piki.auth.infrastructure.oauth.google.dto.GoogleTokenResponse
 import com.depromeet.piki.auth.infrastructure.oauth.google.dto.GoogleUserInfoResponse
+import com.depromeet.piki.auth.infrastructure.oauth.logOAuthProviderError
+import org.slf4j.LoggerFactory
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
+import org.springframework.http.client.ClientHttpResponse
 import org.springframework.util.LinkedMultiValueMap
+import org.springframework.util.StreamUtils
 import org.springframework.web.client.body
 import org.springframework.web.util.UriComponentsBuilder
+import java.nio.charset.StandardCharsets
 
 class GoogleOAuthClient(
     private val googleProperties: GoogleProperties,
 ) : OAuthClient {
     override val provider = OAuthProvider.GOOGLE
+
+    private val log = LoggerFactory.getLogger(javaClass)
 
     private val tokenClient = OAuthRestClient.create(TOKEN_BASE_URL)
     private val userInfoClient = OAuthRestClient.create(USER_INFO_BASE_URL)
@@ -74,6 +81,8 @@ class GoogleOAuthClient(
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                 .body(params)
                 .retrieve()
+                // 4xx/5xx 응답은 바디를 classifier 로 분류해 401/400/500/502 OAuthException 으로 throw.
+                .onStatus({ it.isError }) { _, res -> throwClassified(GoogleOAuthEndpoint.TOKEN, res) }
                 .body<GoogleTokenResponse>()
                 ?: error("Google token response body is null")
         return response.accessToken
@@ -85,8 +94,23 @@ class GoogleOAuthClient(
             .uri(USER_INFO_PATH)
             .header(HttpHeaders.AUTHORIZATION, "$BEARER_PREFIX$accessToken")
             .retrieve()
+            // access_token 무효/만료(HTTP 401)는 invalidProviderToken(401), 그 외는 502 fallback.
+            .onStatus({ it.isError }) { _, res -> throwClassified(GoogleOAuthEndpoint.USER_INFO, res) }
             .body<GoogleUserInfoResponse>()
             ?: error("Google user info response body is null")
+
+    // 에러 응답 바디·status 를 순수 함수 classifier 로 분류해 throw. 분류 결과는 OAuthException 이라
+    // runProvider 의 catch (e: OAuthException) { throw e } 가 그대로 통과시켜 정확한 status 가 내려간다.
+    private fun throwClassified(
+        endpoint: GoogleOAuthEndpoint,
+        response: ClientHttpResponse,
+    ): Nothing {
+        val statusCode = response.statusCode.value()
+        val body = StreamUtils.copyToString(response.body, StandardCharsets.UTF_8)
+        val exception = GoogleOAuthErrorClassifier.classify(endpoint, statusCode, body)
+        logOAuthProviderError(log, "Google", endpoint.name, statusCode, body, exception.category)
+        throw exception
+    }
 
     companion object {
         private const val TOKEN_BASE_URL = "https://oauth2.googleapis.com"

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/google/GoogleOAuthErrorClassifier.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/google/GoogleOAuthErrorClassifier.kt
@@ -35,6 +35,9 @@ object GoogleOAuthErrorClassifier {
     // userinfo 에서 access_token 무효/만료를 가리키는 HTTP status (매직넘버 대신 의미로 분기).
     private val USER_INFO_UNAUTHORIZED_STATUS = HttpStatus.UNAUTHORIZED.value()
 
+    // userinfo 403(PERMISSION_DENIED) — scope 부족 등 우리 OAuth 권한/설정 문제. 재시도 무의미 → SERVER_ERROR.
+    private val USER_INFO_FORBIDDEN_STATUS = HttpStatus.FORBIDDEN.value()
+
     /**
      * @param endpoint 호출 종류 (token 교환 vs userinfo). 같은 status·바디라도 해석이 다르다.
      * @param statusCode provider 가 내려준 HTTP status (4xx/5xx).
@@ -65,14 +68,17 @@ object GoogleOAuthErrorClassifier {
         }
     }
 
-    // userinfo: access_token 무효/만료는 HTTP 401 로 온다 — status 401 을 1차 신호로 → 401.
-    // 그 외(403/5xx/연결실패 등)는 502 fallback 으로 둔다 (403 scope 부족 케이스 판단은 별도 후속).
+    // userinfo: access_token 무효/만료는 HTTP 401 로 온다 — status 401 을 1차 신호로 → 401(클라).
+    // 403(PERMISSION_DENIED)은 scope 부족 등 우리 OAuth 권한/설정 문제라 재시도해도 소용없으므로
+    // misconfigured(502 SERVER_ERROR)로 분리해 잘못된 재시도를 막고 서버 설정 오류 알림이 가게 한다.
+    // 그 외(5xx·연결실패 등)는 provider 장애로 보고 502 RETRYABLE fallback.
     private fun classifyUserInfo(
         statusCode: Int,
         cause: Throwable?,
     ): OAuthException =
         when (statusCode) {
             USER_INFO_UNAUTHORIZED_STATUS -> OAuthException.invalidProviderToken()
+            USER_INFO_FORBIDDEN_STATUS -> OAuthException.misconfigured(toCause(cause))
             else -> OAuthException.providerError(toCause(cause))
         }
 

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/google/GoogleOAuthErrorClassifier.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/google/GoogleOAuthErrorClassifier.kt
@@ -1,0 +1,98 @@
+package com.depromeet.piki.auth.infrastructure.oauth.google
+
+import com.depromeet.piki.auth.infrastructure.oauth.OAuthException
+import org.springframework.http.HttpStatus
+import tools.jackson.core.JacksonException
+import tools.jackson.databind.json.JsonMapper
+
+/**
+ * Google OAuth provider 의 에러 응답을 [OAuthException] 으로 분류하는 순수 함수.
+ *
+ * PLAN.md Google 매핑표 + '견고함의 3원칙' 을 따른다:
+ *  1. 메시지 문자열(`error_description`)에 의존하지 않는다 — 안정 필드(`error` 코드 / HTTP status)로만 분기.
+ *  2. provider HTTP status 를 그대로 전달하지 않고 시맨틱 기반으로 재매핑한다.
+ *  3. 미지의 코드·파싱 실패는 502 [OAuthException.providerError] 로 안전하게 fallback.
+ *
+ * 분류 우선순위: HTTP status 1차 → 안정 바디 필드(`error`) 2차 → 502 fallback 3차.
+ *
+ * Spring · RestClient 에 의존하지 않아 단위 테스트로 분기를 망라한다
+ * (CLAUDE.md 테스트 결정트리 (6) 외부 호출 결과 분기).
+ */
+object GoogleOAuthErrorClassifier {
+    // 분류는 순수 함수라 Spring 주입 ObjectMapper 를 받지 않고 자체 mapper 를 둔다 (불변·스레드세이프).
+    private val jsonMapper: JsonMapper = JsonMapper.builder().build()
+
+    // token endpoint (RFC 6749 §5.2) — 우리 설정 오류를 가리키는 안정 `error` 코드들 → 500.
+    private val MISCONFIG_TOKEN_ERRORS =
+        setOf("invalid_client", "unauthorized_client", "unsupported_grant_type", "invalid_scope")
+
+    // token endpoint — 클라(또는 보수 매핑)로 도달 가능한 `error` 코드들 → 400.
+    private val CLIENT_TOKEN_ERRORS = setOf("invalid_grant", "invalid_request")
+
+    // RFC 6749 token 에러의 top-level 안정 필드명.
+    private const val FIELD_ERROR = "error"
+
+    // userinfo 에서 access_token 무효/만료를 가리키는 HTTP status (매직넘버 대신 의미로 분기).
+    private val USER_INFO_UNAUTHORIZED_STATUS = HttpStatus.UNAUTHORIZED.value()
+
+    /**
+     * @param endpoint 호출 종류 (token 교환 vs userinfo). 같은 status·바디라도 해석이 다르다.
+     * @param statusCode provider 가 내려준 HTTP status (4xx/5xx).
+     * @param body provider 응답 바디 원문. 파싱 실패해도 안전하게 fallback.
+     * @param cause 원본 예외(`RestClientResponseException` 등). message 노출 없이 cause 로만 보존.
+     */
+    fun classify(
+        endpoint: GoogleOAuthEndpoint,
+        statusCode: Int,
+        body: String,
+        cause: Throwable? = null,
+    ): OAuthException =
+        when (endpoint) {
+            GoogleOAuthEndpoint.TOKEN -> classifyToken(body, cause)
+            GoogleOAuthEndpoint.USER_INFO -> classifyUserInfo(statusCode, cause)
+        }
+
+    // token endpoint: HTTP status 가 400/401 로 혼재 가능 → 안정 `error` 코드로 판별 (PLAN.md 표).
+    private fun classifyToken(
+        body: String,
+        cause: Throwable?,
+    ): OAuthException {
+        val error = readErrorCode(body) ?: return OAuthException.providerError(toCause(cause))
+        return when (error) {
+            in CLIENT_TOKEN_ERRORS -> OAuthException.invalidGrant()
+            in MISCONFIG_TOKEN_ERRORS -> OAuthException.misconfigured(toCause(cause))
+            else -> OAuthException.providerError(toCause(cause)) // 미지의 error 코드 → 502 fallback
+        }
+    }
+
+    // userinfo: access_token 무효/만료는 HTTP 401 로 온다 — status 401 을 1차 신호로 → 401.
+    // 그 외(403/5xx/연결실패 등)는 502 fallback 으로 둔다 (403 scope 부족 케이스 판단은 별도 후속).
+    private fun classifyUserInfo(
+        statusCode: Int,
+        cause: Throwable?,
+    ): OAuthException =
+        when (statusCode) {
+            USER_INFO_UNAUTHORIZED_STATUS -> OAuthException.invalidProviderToken()
+            else -> OAuthException.providerError(toCause(cause))
+        }
+
+    // RFC 6749 표준 token 에러는 top-level `error` 문자열. 파싱 실패·미존재 시 null → 호출부가 502 fallback.
+    private fun readErrorCode(body: String): String? =
+        runCatching {
+            jsonMapper.readTree(body).path(FIELD_ERROR).let { node ->
+                node.takeIf { it.isString }?.asString()
+            }
+        }.getOrElse { e ->
+            (e as? JacksonException) ?: throw e // JSON 파싱 외 예외는 삼키지 않는다
+            null
+        }
+
+    // cause 가 없으면(직접 분류 등) 분류 맥락을 잃지 않도록 합성 cause 를 만든다.
+    private fun toCause(cause: Throwable?): Throwable = cause ?: IllegalStateException("Google OAuth 응답을 분류할 수 없습니다.")
+}
+
+/** Google OAuth 호출 종류. 같은 status·바디라도 token vs userinfo 에서 의미가 달라 분기 신호로 쓴다. */
+enum class GoogleOAuthEndpoint {
+    TOKEN,
+    USER_INFO,
+}

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/kakao/KakaoOAuthClient.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/kakao/KakaoOAuthClient.kt
@@ -7,8 +7,11 @@ import com.depromeet.piki.auth.infrastructure.oauth.OAuthRestClient
 import com.depromeet.piki.auth.infrastructure.oauth.OAuthUserInfo
 import com.depromeet.piki.auth.infrastructure.oauth.kakao.dto.KakaoTokenResponse
 import com.depromeet.piki.auth.infrastructure.oauth.kakao.dto.KakaoUserInfoResponse
+import com.depromeet.piki.auth.infrastructure.oauth.logOAuthProviderError
+import org.slf4j.LoggerFactory
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
+import org.springframework.http.client.ClientHttpResponse
 import org.springframework.util.LinkedMultiValueMap
 import org.springframework.web.client.body
 import org.springframework.web.util.UriComponentsBuilder
@@ -17,6 +20,8 @@ class KakaoOAuthClient(
     private val kakaoProperties: KakaoProperties,
 ) : OAuthClient {
     override val provider = OAuthProvider.KAKAO
+
+    private val log = LoggerFactory.getLogger(javaClass)
 
     private val authClient = OAuthRestClient.create(AUTH_BASE_URL)
     private val apiClient = OAuthRestClient.create(API_BASE_URL)
@@ -72,7 +77,14 @@ class KakaoOAuthClient(
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                 .body(params)
                 .retrieve()
-                .body<KakaoTokenResponse>()
+                // token endpoint(error_code 문자열) 와 user API(정수 code) 는 바디 포맷이 달라
+                // classifier 의 분리된 분류 경로로 넘긴다. 4xx/5xx 를 시맨틱(400/401/502)으로 재매핑.
+                .onStatus({ it.isError }) { _, res ->
+                    val body = res.readBodyAsString()
+                    val exception = KakaoOAuthErrorClassifier.classifyTokenError(res.statusCode, body)
+                    logOAuthProviderError(log, "Kakao", "token", res.statusCode.value(), body, exception.category)
+                    throw exception
+                }.body<KakaoTokenResponse>()
                 ?: error("Kakao token response body is null")
         return response.accessToken
     }
@@ -83,8 +95,17 @@ class KakaoOAuthClient(
             .uri(USER_INFO_PATH)
             .header(HttpHeaders.AUTHORIZATION, "$BEARER_PREFIX$accessToken")
             .retrieve()
-            .body<KakaoUserInfoResponse>()
+            .onStatus({ it.isError }) { _, res ->
+                val body = res.readBodyAsString()
+                val exception = KakaoOAuthErrorClassifier.classifyUserApiError(res.statusCode, body)
+                logOAuthProviderError(log, "Kakao", "userApi", res.statusCode.value(), body, exception.category)
+                throw exception
+            }.body<KakaoUserInfoResponse>()
             ?: error("Kakao user info response body is null")
+
+    // 에러 응답 바디를 문자열로 읽어 classifier 에 넘긴다. classifier 는 정수 code 만으로 분기하므로
+    // 인코딩이 깨져도 분기 자체는 안전하다(미지 code → 502 fallback).
+    private fun ClientHttpResponse.readBodyAsString(): String = body.readBytes().toString(Charsets.UTF_8)
 
     companion object {
         private const val AUTH_BASE_URL = "https://kauth.kakao.com"

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/kakao/KakaoOAuthErrorClassifier.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/kakao/KakaoOAuthErrorClassifier.kt
@@ -1,0 +1,95 @@
+package com.depromeet.piki.auth.infrastructure.oauth.kakao
+
+import com.depromeet.piki.auth.infrastructure.oauth.OAuthException
+import org.springframework.http.HttpStatusCode
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.module.kotlin.jacksonObjectMapper
+
+// Kakao OAuth 에러 응답을 우리 시맨틱(400/401/502)으로 분류하는 순수 함수 모음.
+//
+// 견고함의 3원칙(PLAN.md):
+//   1. 메시지 문자열(error_description·msg)에 의존하지 않는다 — 안정 필드(KOE error_code · 정수 code)로만 분기.
+//   2. provider HTTP status 를 그대로 전달하지 않는다 — Kakao 는 장애(-1)도 HTTP 400 으로 주므로 시맨틱 재매핑.
+//   3. 미지의 코드는 502 로 fallback — 문서에 없는 코드가 와도 안 깨진다.
+//
+// token endpoint 와 user API 는 바디 포맷이 다르다(전자는 문자열 error_code, 후자는 정수 code)므로
+// endpoint 별로 분리된 분류 메서드를 둔다.
+object KakaoOAuthErrorClassifier {
+    // 파싱 실패·필드 누락에도 안 깨지게 readTree 로 방어적으로 읽는다.
+    private val objectMapper: ObjectMapper = jacksonObjectMapper()
+
+    // --- 안정 분기 신호 (provider 가 정해 보내는 고정값) ---
+    // token endpoint: 문자열 error_code(KOE...)
+    private const val INVALID_AUTH_CODE = "KOE320" // 인가코드 무효/만료/재사용 (클라) → 400
+    private val MISCONFIGURED_TOKEN_ERROR_CODES = setOf("KOE101", "KOE010", "KOE303", "KOE114", "KOE310") // 우리 설정 오류 → 502/SERVER_ERROR
+    private const val TRANSIENT_TOKEN_ERROR_CODE = "KOE003" // 카카오 OAuth 서버 일시 오류 → 502/RETRYABLE
+
+    // user API: 음수 정수 code
+    private const val INVALID_ACCESS_TOKEN_CODE = -401 // access_token 무효/만료 (클라) → 401
+    private val TRANSIENT_API_CODES = setOf(-1, -7, -9798) // provider 장애/점검 → 502/RETRYABLE
+    private val MISCONFIGURED_API_CODES = setOf(-2, -8) // 우리 요청 구성 버그(필수 인자 누락·헤더 오류) → 502/SERVER_ERROR
+
+    // JSON 안정 필드명
+    private const val FIELD_ERROR_CODE = "error_code"
+    private const val FIELD_CODE = "code"
+
+    // token endpoint 응답 바디는 { error, error_description, error_code(KOE...) } 형태.
+    fun classifyTokenError(
+        status: HttpStatusCode,
+        body: String,
+    ): OAuthException {
+        val errorCode = readErrorCode(body) ?: return OAuthException.providerError(cause(status, body))
+        return when (errorCode) {
+            // 인가코드 무효/만료/재사용 — 멀쩡한 클라가 정상 요청으로 도달 가능(계약) → 400.
+            INVALID_AUTH_CODE -> OAuthException.invalidGrant()
+            // 우리 설정 오류(REST 키·secret·redirect 불일치 등) → 502/SERVER_ERROR.
+            in MISCONFIGURED_TOKEN_ERROR_CODES -> OAuthException.misconfigured(cause(status, body))
+            // 카카오 OAuth 서버 일시 오류 → 502/RETRYABLE. (미지 KOE 도 아래 else 에서 동일하게 502 RETRYABLE)
+            TRANSIENT_TOKEN_ERROR_CODE -> OAuthException.providerError(cause(status, body))
+            // 그 외/미지 KOE — 보수적으로 502 로 fallback.
+            else -> OAuthException.providerError(cause(status, body))
+        }
+    }
+
+    // user API 응답 바디는 { msg, code(음수) } 형태. msg 는 가변이라 분기에 쓰지 않고 정수 code 로만 분기.
+    fun classifyUserApiError(
+        status: HttpStatusCode,
+        body: String,
+    ): OAuthException {
+        val code = readIntCode(body) ?: return OAuthException.providerError(cause(status, body))
+        return when (code) {
+            // access_token 무효/만료 — 클라가 정상 요청으로 도달 가능(계약) → 401.
+            INVALID_ACCESS_TOKEN_CODE -> OAuthException.invalidProviderToken()
+            // provider 장애(일시 오류·점검) → 502/RETRYABLE(재시도 대상).
+            in TRANSIENT_API_CODES -> OAuthException.providerError(cause(status, body))
+            // 우리 요청 구성 버그(필수 인자 누락·헤더 오류) → 502/SERVER_ERROR.
+            in MISCONFIGURED_API_CODES -> OAuthException.misconfigured(cause(status, body))
+            // 미지의 음수 code — 보수적으로 502 로 fallback.
+            else -> OAuthException.providerError(cause(status, body))
+        }
+    }
+
+    // KOE error_code(문자열)를 안전하게 추출. 없거나 파싱 실패 시 null.
+    private fun readErrorCode(body: String): String? {
+        val node = parse(body) ?: return null
+        val errorCode = node.get(FIELD_ERROR_CODE) ?: return null
+        return errorCode.asString().ifBlank { null }
+    }
+
+    // 정수 code 를 안전하게 추출. 정수가 아니거나 없으면 null.
+    private fun readIntCode(body: String): Int? {
+        val node = parse(body) ?: return null
+        val code = node.get(FIELD_CODE) ?: return null
+        return code.takeIf { it.canConvertToInt() }?.asInt()
+    }
+
+    private fun parse(body: String): JsonNode? =
+        runCatching { objectMapper.readTree(body) }.getOrNull()
+
+    // 원문 바디는 응답에 노출하지 않고 cause 로만 보존한다(내부 정보 비노출 컨벤션).
+    private fun cause(
+        status: HttpStatusCode,
+        body: String,
+    ): Throwable = IllegalStateException("Kakao OAuth error response (status=$status): $body")
+}

--- a/src/test/kotlin/com/depromeet/piki/auth/controller/OAuthLoginIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/controller/OAuthLoginIntegrationTest.kt
@@ -299,13 +299,16 @@ class OAuthLoginIntegrationTest : IntegrationTestSupport() {
 
     @Test
     fun `인가 정보 만료-무효 - invalidGrant 는 400 으로 매핑된다`() {
-        googleOAuthClient.fetchByAccessTokenStub = { throw OAuthException.invalidGrant() }
+        // invalidGrant 는 access token 실패가 아니라 인가코드(code) 교환 실패다 —
+        // v1 code+redirectUri 경로(fetchUserInfoByCode)로 실제 분기를 태워 검증한다.
+        googleOAuthClient.fetchByCodeStub = { _, _ -> throw OAuthException.invalidGrant() }
 
         mockMvc()
             .perform(
                 post("/api/v1/auth/login/google").contentType(MediaType.APPLICATION_JSON).content(
                     loginBody(
-                        "accessToken" to "t",
+                        "code" to "expired-code",
+                        "redirectUri" to "https://app/callback",
                     ),
                 ),
             ).andExpect(status().isBadRequest)

--- a/src/test/kotlin/com/depromeet/piki/auth/controller/OAuthLoginIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/controller/OAuthLoginIntegrationTest.kt
@@ -1,5 +1,6 @@
 package com.depromeet.piki.auth.controller
 
+import com.depromeet.piki.auth.infrastructure.oauth.OAuthException
 import com.depromeet.piki.auth.infrastructure.oauth.OAuthProvider
 import com.depromeet.piki.auth.infrastructure.oauth.OAuthUserInfo
 import com.depromeet.piki.support.IntegrationTestSupport
@@ -276,6 +277,59 @@ class OAuthLoginIntegrationTest : IntegrationTestSupport() {
                     ),
                 ),
             ).andExpect(status().isBadGateway)
+            .andExpect(jsonPath("$.detail").value("소셜 로그인 제공자 호출에 실패했습니다."))
+            .andExpect(jsonPath("$.data").value(nullValue()))
+    }
+
+    @Test
+    fun `provider access token 무효 - invalidProviderToken 은 401 로 매핑된다`() {
+        googleOAuthClient.fetchByAccessTokenStub = { throw OAuthException.invalidProviderToken() }
+
+        mockMvc()
+            .perform(
+                post("/api/v1/auth/login/google").contentType(MediaType.APPLICATION_JSON).content(
+                    loginBody(
+                        "accessToken" to "t",
+                    ),
+                ),
+            ).andExpect(status().isUnauthorized)
+            .andExpect(jsonPath("$.detail").value("소셜 로그인 토큰이 유효하지 않습니다. 다시 로그인해 주세요."))
+            .andExpect(jsonPath("$.data").value(nullValue()))
+    }
+
+    @Test
+    fun `인가 정보 만료-무효 - invalidGrant 는 400 으로 매핑된다`() {
+        googleOAuthClient.fetchByAccessTokenStub = { throw OAuthException.invalidGrant() }
+
+        mockMvc()
+            .perform(
+                post("/api/v1/auth/login/google").contentType(MediaType.APPLICATION_JSON).content(
+                    loginBody(
+                        "accessToken" to "t",
+                    ),
+                ),
+            ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.detail").value("소셜 로그인 인가 정보가 만료되었거나 유효하지 않습니다. 다시 시도해 주세요."))
+            .andExpect(jsonPath("$.data").value(nullValue()))
+    }
+
+    @Test
+    fun `OAuth 설정 오류 - misconfigured 는 502 로 매핑된다 (provider 장애 502 와 detail 로 구분)`() {
+        // 우리 OAuth 설정 오류(invalid_client 등)는 외부 호출 경계 실패라 502 + SERVER_ERROR 로 내려간다
+        // (GeminiApiException.clientError 와 같은 결). RETRYABLE 502(provider 장애)와는 detail 로 구분된다.
+        googleOAuthClient.fetchByAccessTokenStub =
+            { throw OAuthException.misconfigured(RuntimeException("client secret invalid")) }
+
+        mockMvc()
+            .perform(
+                post("/api/v1/auth/login/google").contentType(MediaType.APPLICATION_JSON).content(
+                    loginBody(
+                        "accessToken" to "t",
+                    ),
+                ),
+            ).andExpect(status().isBadGateway)
+            .andExpect(jsonPath("$.detail").value("소셜 로그인 설정 오류가 발생했습니다."))
+            .andExpect(jsonPath("$.data").value(nullValue()))
     }
 
     @Test

--- a/src/test/kotlin/com/depromeet/piki/auth/infrastructure/oauth/apple/AppleOAuthErrorClassifierTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/infrastructure/oauth/apple/AppleOAuthErrorClassifierTest.kt
@@ -1,0 +1,73 @@
+package com.depromeet.piki.auth.infrastructure.oauth.apple
+
+import com.depromeet.piki.common.exception.ErrorCategory
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatusCode
+import java.util.stream.Stream
+import kotlin.test.assertEquals
+
+// AppleOAuthErrorClassifier 의 분기를 망라하는 순수 단위 테스트 (Spring·DB 없음).
+// PLAN.md 의 실제 Apple ErrorResponse 샘플({"error":"..."} 단일 필드)을 픽스처로 쓴다.
+// 우리 설정 오류와 provider 장애는 둘 다 502 라 httpStatus 만으로 구분되지 않으므로
+// category(SERVER_ERROR vs RETRYABLE)까지 함께 단언한다 (GeminiApiException 과 같은 결).
+class AppleOAuthErrorClassifierTest {
+    @ParameterizedTest(name = "[{index}] {3} → {1}/{2}")
+    @MethodSource("cases")
+    fun `Apple token 에러 응답을 status·body 로 분류한다`(
+        status: HttpStatusCode,
+        expectedStatus: HttpStatus,
+        expectedCategory: ErrorCategory,
+        @Suppress("UNUSED_PARAMETER") description: String,
+        body: String,
+    ) {
+        val cause = RuntimeException("apple token exchange failed")
+
+        val exception = AppleOAuthErrorClassifier.classify(status, body, cause)
+
+        assertEquals(expectedStatus, exception.httpStatus)
+        assertEquals(expectedCategory, exception.category)
+    }
+
+    companion object {
+        @JvmStatic
+        fun cases(): Stream<Arguments> =
+            Stream.of(
+                // 400 INVALID_INPUT: code 만료(5분)/재사용 — 멀쩡한 클라가 정상 요청으로 도달 가능(계약). 보수 매핑.
+                Arguments.of(http(400), HttpStatus.BAD_REQUEST, ErrorCategory.INVALID_INPUT, "invalid_grant → 400", """{"error":"invalid_grant"}"""),
+                // 502 SERVER_ERROR: 우리 client_secret JWT·요청 구성 오류(우리 설정 버그). 외부 경계 실패라 502, 재시도 무의미라 SERVER_ERROR.
+                Arguments.of(http(400), HttpStatus.BAD_GATEWAY, ErrorCategory.SERVER_ERROR, "invalid_client → 502/SERVER_ERROR", """{"error":"invalid_client"}"""),
+                Arguments.of(http(400), HttpStatus.BAD_GATEWAY, ErrorCategory.SERVER_ERROR, "invalid_request → 502/SERVER_ERROR", """{"error":"invalid_request"}"""),
+                Arguments.of(http(400), HttpStatus.BAD_GATEWAY, ErrorCategory.SERVER_ERROR, "unauthorized_client → 502/SERVER_ERROR", """{"error":"unauthorized_client"}"""),
+                Arguments.of(
+                    http(400),
+                    HttpStatus.BAD_GATEWAY,
+                    ErrorCategory.SERVER_ERROR,
+                    "unsupported_grant_type → 502/SERVER_ERROR",
+                    """{"error":"unsupported_grant_type"}""",
+                ),
+                Arguments.of(http(400), HttpStatus.BAD_GATEWAY, ErrorCategory.SERVER_ERROR, "invalid_scope → 502/SERVER_ERROR", """{"error":"invalid_scope"}"""),
+                // error_description 이 동봉돼도 안정 필드인 error 코드로만 분류한다 (메시지 의존 금지).
+                Arguments.of(
+                    http(400),
+                    HttpStatus.BAD_REQUEST,
+                    ErrorCategory.INVALID_INPUT,
+                    "invalid_grant + error_description 동봉 → 400",
+                    """{"error":"invalid_grant","error_description":"code expired"}""",
+                ),
+                // 502 RETRYABLE fallback — 미지의 error 코드 / error 필드 부재 / 파싱 실패 / HTTP≠400(Apple outage).
+                Arguments.of(http(400), HttpStatus.BAD_GATEWAY, ErrorCategory.RETRYABLE, "미지의 error 코드 → 502/RETRYABLE", """{"error":"teapot"}"""),
+                Arguments.of(http(400), HttpStatus.BAD_GATEWAY, ErrorCategory.RETRYABLE, "error 필드 부재 → 502/RETRYABLE", """{"foo":"bar"}"""),
+                Arguments.of(http(400), HttpStatus.BAD_GATEWAY, ErrorCategory.RETRYABLE, "non-JSON 바디 → 502/RETRYABLE", "<html>Bad Request</html>"),
+                Arguments.of(http(400), HttpStatus.BAD_GATEWAY, ErrorCategory.RETRYABLE, "빈 바디 → 502/RETRYABLE", ""),
+                // HTTP≠400 — Apple outage·장애. 401 케이스는 Apple token endpoint 엔 없으나 방어적으로 502 매핑 확인.
+                Arguments.of(http(401), HttpStatus.BAD_GATEWAY, ErrorCategory.RETRYABLE, "HTTP 401 → 502/RETRYABLE", """{"error":"invalid_client"}"""),
+                Arguments.of(http(500), HttpStatus.BAD_GATEWAY, ErrorCategory.RETRYABLE, "HTTP 500 → 502/RETRYABLE", "Internal Server Error"),
+                Arguments.of(http(503), HttpStatus.BAD_GATEWAY, ErrorCategory.RETRYABLE, "HTTP 503 → 502/RETRYABLE", "Service Unavailable"),
+            )
+
+        private fun http(value: Int): HttpStatusCode = HttpStatusCode.valueOf(value)
+    }
+}

--- a/src/test/kotlin/com/depromeet/piki/auth/infrastructure/oauth/google/GoogleOAuthErrorClassifierTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/infrastructure/oauth/google/GoogleOAuthErrorClassifierTest.kt
@@ -1,0 +1,98 @@
+package com.depromeet.piki.auth.infrastructure.oauth.google
+
+import com.depromeet.piki.common.exception.ErrorCategory
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import org.springframework.http.HttpStatus
+import java.util.stream.Stream
+import kotlin.test.assertEquals
+
+// GoogleOAuthErrorClassifier 의 분기를 망라하는 순수 단위 테스트 (Spring·DB 없음).
+// TOKEN endpoint 는 안정 바디 필드(`error` 코드)로, USER_INFO endpoint 는 HTTP status 로 분기한다.
+// 우리 설정 오류(invalid_client 등)와 provider 장애는 둘 다 502 라서 httpStatus 만으로는 구분되지 않는다 —
+// GeminiApiException 과 같은 결로 category(SERVER_ERROR vs RETRYABLE)까지 함께 단언해 의도를 검증한다.
+class GoogleOAuthErrorClassifierTest {
+    // TOKEN: HTTP status 가 400/401 로 혼재 가능 → 안정 `error` 코드로만 분류한다. statusCode 는 무의미해 0 으로 고정.
+    @ParameterizedTest(name = "[{index}] {2} → {0}/{1}")
+    @MethodSource("tokenCases")
+    fun `Google token 에러 응답을 안정 error 코드로 분류한다`(
+        expectedStatus: HttpStatus,
+        expectedCategory: ErrorCategory,
+        @Suppress("UNUSED_PARAMETER") description: String,
+        body: String,
+    ) {
+        val cause = RuntimeException("google token exchange failed")
+
+        val exception = GoogleOAuthErrorClassifier.classify(GoogleOAuthEndpoint.TOKEN, statusCode = 0, body = body, cause = cause)
+
+        assertEquals(expectedStatus, exception.httpStatus)
+        assertEquals(expectedCategory, exception.category)
+    }
+
+    // USER_INFO: access_token 무효/만료는 HTTP 401 로 온다 — status 401 → 401, 그 외(403/5xx) → 502 fallback.
+    @ParameterizedTest(name = "[{index}] {2} → {0}/{1}")
+    @MethodSource("userInfoCases")
+    fun `Google userinfo 에러 응답을 HTTP status 로 분류한다`(
+        expectedStatus: HttpStatus,
+        expectedCategory: ErrorCategory,
+        @Suppress("UNUSED_PARAMETER") description: String,
+        statusCode: Int,
+    ) {
+        val cause = RuntimeException("google userinfo failed")
+
+        val exception = GoogleOAuthErrorClassifier.classify(GoogleOAuthEndpoint.USER_INFO, statusCode = statusCode, body = "", cause = cause)
+
+        assertEquals(expectedStatus, exception.httpStatus)
+        assertEquals(expectedCategory, exception.category)
+    }
+
+    companion object {
+        @JvmStatic
+        fun tokenCases(): Stream<Arguments> =
+            Stream.of(
+                // 400 INVALID_INPUT: 멀쩡한 클라가 정상 요청으로 도달 가능(계약). code 만료/재사용·요청 형식 오류.
+                Arguments.of(HttpStatus.BAD_REQUEST, ErrorCategory.INVALID_INPUT, "invalid_grant → 400", """{"error":"invalid_grant"}"""),
+                Arguments.of(HttpStatus.BAD_REQUEST, ErrorCategory.INVALID_INPUT, "invalid_request → 400", """{"error":"invalid_request"}"""),
+                // 502 SERVER_ERROR: 우리 OAuth 설정 오류(우리 버그). 외부 호출 경계 실패라 502, 재시도 무의미라 SERVER_ERROR.
+                // (GeminiApiException.clientError 와 동일 결.)
+                Arguments.of(HttpStatus.BAD_GATEWAY, ErrorCategory.SERVER_ERROR, "invalid_client → 502/SERVER_ERROR", """{"error":"invalid_client"}"""),
+                Arguments.of(
+                    HttpStatus.BAD_GATEWAY,
+                    ErrorCategory.SERVER_ERROR,
+                    "unauthorized_client → 502/SERVER_ERROR",
+                    """{"error":"unauthorized_client"}""",
+                ),
+                Arguments.of(
+                    HttpStatus.BAD_GATEWAY,
+                    ErrorCategory.SERVER_ERROR,
+                    "unsupported_grant_type → 502/SERVER_ERROR",
+                    """{"error":"unsupported_grant_type"}""",
+                ),
+                Arguments.of(HttpStatus.BAD_GATEWAY, ErrorCategory.SERVER_ERROR, "invalid_scope → 502/SERVER_ERROR", """{"error":"invalid_scope"}"""),
+                // error_description 이 동봉돼도 안정 필드인 error 코드로만 분류한다 (메시지 의존 금지).
+                Arguments.of(
+                    HttpStatus.BAD_REQUEST,
+                    ErrorCategory.INVALID_INPUT,
+                    "invalid_grant + error_description 동봉 → 400",
+                    """{"error":"invalid_grant","error_description":"Bad Request"}""",
+                ),
+                // 502 RETRYABLE fallback — 미지의 error 코드 / 파싱 실패. provider 장애로 보고 재시도 대상.
+                Arguments.of(HttpStatus.BAD_GATEWAY, ErrorCategory.RETRYABLE, "미지의 error 코드 → 502/RETRYABLE", """{"error":"teapot"}"""),
+                Arguments.of(HttpStatus.BAD_GATEWAY, ErrorCategory.RETRYABLE, "error 필드 부재 → 502/RETRYABLE", """{"foo":"bar"}"""),
+                Arguments.of(HttpStatus.BAD_GATEWAY, ErrorCategory.RETRYABLE, "non-JSON 바디 → 502/RETRYABLE", "<html>Bad Request</html>"),
+                Arguments.of(HttpStatus.BAD_GATEWAY, ErrorCategory.RETRYABLE, "빈 바디 → 502/RETRYABLE", ""),
+            )
+
+        @JvmStatic
+        fun userInfoCases(): Stream<Arguments> =
+            Stream.of(
+                // 401: access_token 무효/만료 — 클라가 정상 요청으로 도달 가능(계약).
+                Arguments.of(HttpStatus.UNAUTHORIZED, ErrorCategory.UNAUTHORIZED, "HTTP 401 → 401", 401),
+                // 502 RETRYABLE fallback — 그 외(403 scope 부족 판단은 별도 후속 / 5xx Google 장애).
+                Arguments.of(HttpStatus.BAD_GATEWAY, ErrorCategory.RETRYABLE, "HTTP 403 → 502/RETRYABLE", 403),
+                Arguments.of(HttpStatus.BAD_GATEWAY, ErrorCategory.RETRYABLE, "HTTP 500 → 502/RETRYABLE", 500),
+                Arguments.of(HttpStatus.BAD_GATEWAY, ErrorCategory.RETRYABLE, "HTTP 503 → 502/RETRYABLE", 503),
+            )
+    }
+}

--- a/src/test/kotlin/com/depromeet/piki/auth/infrastructure/oauth/google/GoogleOAuthErrorClassifierTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/infrastructure/oauth/google/GoogleOAuthErrorClassifierTest.kt
@@ -89,8 +89,8 @@ class GoogleOAuthErrorClassifierTest {
             Stream.of(
                 // 401: access_token 무효/만료 — 클라가 정상 요청으로 도달 가능(계약).
                 Arguments.of(HttpStatus.UNAUTHORIZED, ErrorCategory.UNAUTHORIZED, "HTTP 401 → 401", 401),
-                // 502 RETRYABLE fallback — 그 외(403 scope 부족 판단은 별도 후속 / 5xx Google 장애).
-                Arguments.of(HttpStatus.BAD_GATEWAY, ErrorCategory.RETRYABLE, "HTTP 403 → 502/RETRYABLE", 403),
+                // 403(scope 부족 등 우리 권한/설정 문제) → 502/SERVER_ERROR (재시도 무의미). 5xx 는 provider 장애 → RETRYABLE.
+                Arguments.of(HttpStatus.BAD_GATEWAY, ErrorCategory.SERVER_ERROR, "HTTP 403 → 502/SERVER_ERROR", 403),
                 Arguments.of(HttpStatus.BAD_GATEWAY, ErrorCategory.RETRYABLE, "HTTP 500 → 502/RETRYABLE", 500),
                 Arguments.of(HttpStatus.BAD_GATEWAY, ErrorCategory.RETRYABLE, "HTTP 503 → 502/RETRYABLE", 503),
             )

--- a/src/test/kotlin/com/depromeet/piki/auth/infrastructure/oauth/kakao/KakaoOAuthErrorClassifierTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/infrastructure/oauth/kakao/KakaoOAuthErrorClassifierTest.kt
@@ -1,0 +1,106 @@
+package com.depromeet.piki.auth.infrastructure.oauth.kakao
+
+import com.depromeet.piki.common.exception.ErrorCategory
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatusCode
+import java.util.stream.Stream
+import kotlin.test.assertEquals
+
+// KakaoOAuthErrorClassifier 의 분기를 망라하는 순수 단위 테스트 (Spring·DB 없음).
+// token endpoint 와 user API 는 바디 포맷·분기 필드가 다르므로(전자는 문자열 error_code, 후자는 정수 code)
+// 두 경로를 각각 별도 @ParameterizedTest 로 분리한다.
+// 우리 설정 오류와 provider 장애는 둘 다 502 라 httpStatus 만으로 구분되지 않으므로
+// category(SERVER_ERROR vs RETRYABLE)까지 함께 단언해 의도를 검증한다 (GeminiApiException 과 같은 결).
+class KakaoOAuthErrorClassifierTest {
+    // token endpoint: { error, error_description, error_code(KOE...) } — 문자열 error_code 로 분기.
+    @ParameterizedTest(name = "[{index}] {3} → {1}/{2}")
+    @MethodSource("tokenCases")
+    fun `Kakao token 에러 응답을 error_code 로 분류한다`(
+        status: HttpStatusCode,
+        expectedStatus: HttpStatus,
+        expectedCategory: ErrorCategory,
+        @Suppress("UNUSED_PARAMETER") description: String,
+        body: String,
+    ) {
+        val exception = KakaoOAuthErrorClassifier.classifyTokenError(status, body)
+
+        assertEquals(expectedStatus, exception.httpStatus)
+        assertEquals(expectedCategory, exception.category)
+    }
+
+    // user API: { msg, code(음수 정수) } — 정수 code 로 분기. msg 는 가변이라 분기에 쓰지 않는다.
+    @ParameterizedTest(name = "[{index}] {3} → {1}/{2}")
+    @MethodSource("userApiCases")
+    fun `Kakao user API 에러 응답을 정수 code 로 분류한다`(
+        status: HttpStatusCode,
+        expectedStatus: HttpStatus,
+        expectedCategory: ErrorCategory,
+        @Suppress("UNUSED_PARAMETER") description: String,
+        body: String,
+    ) {
+        val exception = KakaoOAuthErrorClassifier.classifyUserApiError(status, body)
+
+        assertEquals(expectedStatus, exception.httpStatus)
+        assertEquals(expectedCategory, exception.category)
+    }
+
+    companion object {
+        @JvmStatic
+        fun tokenCases(): Stream<Arguments> =
+            Stream.of(
+                // 400 INVALID_INPUT: KOE320 — 인가코드 무효/만료/재사용. 멀쩡한 클라가 정상 요청으로 도달 가능(계약).
+                Arguments.of(
+                    http(400),
+                    HttpStatus.BAD_REQUEST,
+                    ErrorCategory.INVALID_INPUT,
+                    "KOE320 (invalid_grant) → 400",
+                    """{"error":"invalid_grant","error_description":"authorization code not found","error_code":"KOE320"}""",
+                ),
+                // 502 SERVER_ERROR: 우리 설정 오류(REST 키·secret·redirect 불일치 등). 외부 경계 실패라 502, 재시도 무의미라 SERVER_ERROR.
+                Arguments.of(http(400), HttpStatus.BAD_GATEWAY, ErrorCategory.SERVER_ERROR, "KOE101 → 502/SERVER_ERROR", """{"error":"invalid_client","error_code":"KOE101"}"""),
+                Arguments.of(http(400), HttpStatus.BAD_GATEWAY, ErrorCategory.SERVER_ERROR, "KOE010 → 502/SERVER_ERROR", """{"error":"invalid_request","error_code":"KOE010"}"""),
+                Arguments.of(http(400), HttpStatus.BAD_GATEWAY, ErrorCategory.SERVER_ERROR, "KOE303 → 502/SERVER_ERROR", """{"error":"invalid_request","error_code":"KOE303"}"""),
+                Arguments.of(http(400), HttpStatus.BAD_GATEWAY, ErrorCategory.SERVER_ERROR, "KOE114 → 502/SERVER_ERROR", """{"error":"invalid_request","error_code":"KOE114"}"""),
+                Arguments.of(http(400), HttpStatus.BAD_GATEWAY, ErrorCategory.SERVER_ERROR, "KOE310 → 502/SERVER_ERROR", """{"error":"invalid_request","error_code":"KOE310"}"""),
+                // 502 RETRYABLE: KOE003 — 카카오 OAuth 서버 일시 오류(재시도 대상).
+                Arguments.of(http(400), HttpStatus.BAD_GATEWAY, ErrorCategory.RETRYABLE, "KOE003 → 502/RETRYABLE", """{"error":"server_error","error_code":"KOE003"}"""),
+                // 502 RETRYABLE fallback — 미지 KOE / error_code 부재 / blank / 파싱 실패.
+                Arguments.of(http(400), HttpStatus.BAD_GATEWAY, ErrorCategory.RETRYABLE, "미지의 KOE 코드 → 502/RETRYABLE", """{"error_code":"KOE999"}"""),
+                Arguments.of(http(400), HttpStatus.BAD_GATEWAY, ErrorCategory.RETRYABLE, "error_code 부재 → 502/RETRYABLE", """{"error":"x"}"""),
+                Arguments.of(http(400), HttpStatus.BAD_GATEWAY, ErrorCategory.RETRYABLE, "error_code 빈 문자열 → 502/RETRYABLE", """{"error_code":""}"""),
+                Arguments.of(http(400), HttpStatus.BAD_GATEWAY, ErrorCategory.RETRYABLE, "non-JSON 바디 → 502/RETRYABLE", "<html>Bad Request</html>"),
+                Arguments.of(http(400), HttpStatus.BAD_GATEWAY, ErrorCategory.RETRYABLE, "빈 바디 → 502/RETRYABLE", ""),
+            )
+
+        @JvmStatic
+        fun userApiCases(): Stream<Arguments> =
+            Stream.of(
+                // 401: -401 — access_token 무효/만료. 멀쩡한 클라가 정상 요청으로 도달 가능(계약).
+                Arguments.of(
+                    http(401),
+                    HttpStatus.UNAUTHORIZED,
+                    ErrorCategory.UNAUTHORIZED,
+                    "-401 (invalid token) → 401",
+                    """{"msg":"this access token does not exist","code":-401}""",
+                ),
+                // 502 RETRYABLE: provider 장애/점검(재시도 대상). 안정 필드 code 로만 분류(msg 의존 금지).
+                Arguments.of(http(400), HttpStatus.BAD_GATEWAY, ErrorCategory.RETRYABLE, "-1 → 502/RETRYABLE", """{"msg":"internal server error","code":-1}"""),
+                Arguments.of(http(400), HttpStatus.BAD_GATEWAY, ErrorCategory.RETRYABLE, "-7 → 502/RETRYABLE", """{"msg":"server unavailable","code":-7}"""),
+                Arguments.of(http(400), HttpStatus.BAD_GATEWAY, ErrorCategory.RETRYABLE, "-9798 → 502/RETRYABLE", """{"msg":"under maintenance","code":-9798}"""),
+                // 502 SERVER_ERROR: 우리 요청 구성 버그(필수 인자 누락·헤더 오류). 외부 경계 실패라 502, 재시도 무의미라 SERVER_ERROR.
+                Arguments.of(http(400), HttpStatus.BAD_GATEWAY, ErrorCategory.SERVER_ERROR, "-2 → 502/SERVER_ERROR", """{"msg":"invalid argument","code":-2}"""),
+                Arguments.of(http(400), HttpStatus.BAD_GATEWAY, ErrorCategory.SERVER_ERROR, "-8 → 502/SERVER_ERROR", """{"msg":"invalid header","code":-8}"""),
+                // 502 RETRYABLE fallback — 미지 음수 code / code 부재 / 정수 아님 / 파싱 실패.
+                Arguments.of(http(400), HttpStatus.BAD_GATEWAY, ErrorCategory.RETRYABLE, "미지의 음수 code → 502/RETRYABLE", """{"code":-12345}"""),
+                Arguments.of(http(400), HttpStatus.BAD_GATEWAY, ErrorCategory.RETRYABLE, "code 부재 → 502/RETRYABLE", """{"msg":"x"}"""),
+                Arguments.of(http(400), HttpStatus.BAD_GATEWAY, ErrorCategory.RETRYABLE, "정수 아닌 code → 502/RETRYABLE", """{"code":"-401"}"""),
+                Arguments.of(http(400), HttpStatus.BAD_GATEWAY, ErrorCategory.RETRYABLE, "non-JSON 바디 → 502/RETRYABLE", "Bad Request"),
+                Arguments.of(http(400), HttpStatus.BAD_GATEWAY, ErrorCategory.RETRYABLE, "빈 바디 → 502/RETRYABLE", ""),
+            )
+
+        private fun http(value: Int): HttpStatusCode = HttpStatusCode.valueOf(value)
+    }
+}

--- a/src/test/kotlin/com/depromeet/piki/common/controller/DocsAccessIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/common/controller/DocsAccessIntegrationTest.kt
@@ -84,4 +84,27 @@ class DocsAccessIntegrationTest : IntegrationTestSupport() {
             // 보호: operation 에 security 명시 없음 → 최상위 글로벌 Bearer 상속 (문서 UI 에 자물쇠 표시).
             .andExpect(jsonPath("$.paths['/api/v1/dev/users'].post.security").doesNotExist())
     }
+
+    @Test
+    fun `GET v3 api-docs - OAuth 로그인 선언 실패 응답에 example payload 가 부착된다 (회귀 가드)`() {
+        // OperationExamples.add 는 @ApiResponse 가 선언된 status 에만 example 을 붙인다(없으면 조용히 무시).
+        // #313 에서 OAuth 로그인 실패 응답을 400/401/502 로 정밀화하며 example 도 함께 붙였다 — 선언↔example
+        // 짝이 유지되는지 회귀 가드 (특히 500→502 로 바꾼 502: 우리 설정오류·provider 장애 두 example).
+        val mockMvc =
+            MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .apply<DefaultMockMvcBuilder>(springSecurity())
+                .build()
+
+        mockMvc
+            .perform(get("/v3/api-docs"))
+            .andExpect(status().isOk)
+            .andExpect(
+                jsonPath("$.paths['/api/v1/auth/login/{provider}'].post.responses['400'].content['application/json'].examples").exists(),
+            ).andExpect(
+                jsonPath("$.paths['/api/v1/auth/login/{provider}'].post.responses['401'].content['application/json'].examples").exists(),
+            ).andExpect(
+                jsonPath("$.paths['/api/v1/auth/login/{provider}'].post.responses['502'].content['application/json'].examples").exists(),
+            )
+    }
 }


### PR DESCRIPTION
## Situation
- 기존 `OAuthLoginService.runProvider` 가 provider 호출 실패를 전부 `providerError(502)` 한 가지로 뭉갰다. 그래서 클라가 보낸 토큰 만료·무효(userinfo 401)나 잘못된 code(token endpoint `invalid_grant`) 같은 "클라 잘못" 도 502 로 나가, 앱이 재로그인 대신 재시도만 반복해 사용자가 막혔다 (PR #307 에서 단순 502 매핑의 한계로 식별).
- 즉 클라가 "다시 로그인" 해야 하는지 "잠시 후 재시도" 하면 되는지를 status 로 구분할 수 없었다.

## Task
- provider 에러 응답을 파싱해 우리 커스텀 에러로 매핑하되, 클라가 행동을 결정할 수 있는 직관적 status 로 내린다: 클라 자격 오류는 400/401, provider 장애는 502.
- 단 100% 팀 컨벤션 안에서 한다. 핵심 결정 포인트가 둘 있었다 — (1) "우리 OAuth 설정 오류(`invalid_client` 등)" 를 어디로 보낼 것인가, (2) provider 가 문서에 없는 코드를 새로 추가하면 어떻게 되는가.

## Action

### 분류 설계 (provider별 안정 필드 기반 순수 함수)
- provider·엔드포인트마다 안정 신호가 다르다: Google token 은 `error` 문자열 / Google userinfo 는 HTTP status / Kakao token 은 `error_code`(KOE) / Kakao user API 는 정수 `code` / Apple 은 `error` 문자열. 각각에 맞춰 분류한다.
- 메시지 문자열(`error_description`·`msg`)에는 의존하지 않는다 (가변·스키마 미보장). 분류는 Spring·DB 없는 순수 함수(`*OAuthErrorClassifier`)로 빼 단위 테스트로 분기를 망라했다.
- 미지 코드·파싱 실패는 안전하게 502 RETRYABLE 로 fallback — 문서에 없는 코드가 와도 안 깨진다.

### 컨벤션 정합 — "우리 설정 오류" 를 500 이 아닌 502+SERVER_ERROR 로
- 초안에서는 `invalid_client` 류를 커스텀 `misconfigured()` 500 으로 두고 문서화까지 했으나, 이는 CLAUDE.md 의 "일반 500 은 `require`/`check`/`error`, 문서화 제외" 규칙과 충돌했다.
- 같은 상황(외부 API 경계에서 우리 잘못)을 팀이 이미 처리한 선례인 `GeminiApiException.clientError`(잘못된 키·요청 = 502 BAD_GATEWAY + SERVER_ERROR category)를 따라 502+SERVER_ERROR 로 정정했다. status 502 = 외부 호출 경계 실패, category SERVER_ERROR = 재시도 무의미한 우리 문제(알림 신호). 500 은 코드에서 완전히 제거했다.
- 결과적으로 문서화 응답은 200·400·401·502 로 정리됐다 (500 없음).

### open-set 대응 + 관측 (3사 공통)
- provider 에러코드는 닫힌 집합이 아니라 계속 추가되는 open set 이다. fallback 만 있으면 미지 코드가 502 로 조용히 묻혀 우리가 영영 알 수 없다 (`GlobalExceptionHandler` 는 고정 message 만 info 로 남기고 원본 body·cause 는 버린다).
- 각 client 에러 경로에 `logOAuthProviderError` 를 더해, 분류 결과 category 기준으로 provider 원본(status·body, 길이 제한)을 남긴다. 미지 코드는 502 RETRYABLE → WARN 으로 가시화되어 분류 set 에 추가할지 판단할 수 있다. 클라 자격 오류(400/401)는 info (서버 입장에선 정상 동작).

### 상수화 / 문서·테스트
- KOE 코드·정수 code·HTTP status 매직넘버·JSON 필드명을 named const/set 으로 추출했다. provider별 코드 집합은 의미가 달라(`invalid_request` 가 Google 은 400·Apple 은 502) 공유하지 않고 provider 별로 둔다.
- 분류기 단위 테스트는 `(httpStatus, category)` 쌍으로 단언해 502 안에서 SERVER_ERROR↔RETRYABLE 을 구분한다. `OAuthLoginIntegrationTest` 에 401/400/502 응답 contract 케이스를 더했다.
- `DocsAccessIntegrationTest` 에 OAuth 로그인 선언 실패응답(400·401·502)에 example payload 가 부착되는지 회귀 가드를 추가했다 (PR #360 의 패턴 차용).

### 검토 후 채택하지 않은 안
- 공식 에러코드를 enum 으로 모델링하는 안은 반려했다 — 외부 코드는 open set 이라 enum(closed) 과 안 맞고, 팀 코드에 외부 에러코드 enum 선례가 없으며(Gemini 도 status 로 분류), 우리는 코드를 식별하지 않고 3버킷으로 묶을 뿐이라 set 이 더 적합하다 (YAGNI).

## Result
- 클라가 "재로그인(400/401)" 과 "재시도(502)" 를 status 로 구분할 수 있게 됐다 — #307 에서 식별된 "502 라 재로그인 대신 재시도만" 문제 해소.
- 우리 설정 오류는 provider 장애로 오인되지 않고 SERVER_ERROR category 로 알림 가능, 미지 코드는 안전한 502 + WARN 관측으로 닫힌 루프가 됐다.
- 전체 테스트 620개 통과 (실패 0 · 스킵 2). classifier 단위(Google 15 · Kakao 23 · Apple 14) + OAuth 통합 contract + docs example 회귀 가드 포함.

---
## 연관 이슈

- close #313


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * OAuth 로그인 실패 시 더 명확한 에러 메시지 제공 (인증코드 만료, 제공자 토큰 무효, 설정 오류 등 구분)
  * OAuth 제공자 연동 오류에 대한 재시도 안내 개선

* **Documentation**
  * OAuth 로그인 API의 에러 응답 문서화 강화 (400, 401, 502 상태별 구체적 원인 설명)
  * API 문서에 OAuth 실패 케이스 예제 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->