### PR TITLE
SSE 구독을 위한 nginx 프록시 설정 (스트리밍·HTTP/2)

### DIFF
--- a/infra/nginx/api.depromeet18team3.cloud.conf
+++ b/infra/nginx/api.depromeet18team3.cloud.conf
@@ -105,13 +105,31 @@ server {
         proxy_pass http://team3;
     }
 
+    # SSE 실시간 알림 구독 — text/event-stream 스트림이라 전용 설정이 필요하다(앱: GET /api/v1/notifications/subscribe).
+    # - proxy_http_version 1.1: nginx 가 백엔드에 붙는 기본값은 1.0 인데, 1.0 은 chunked 스트리밍이 안 돼
+    #   SSE 가 버퍼링되거나 끊긴다. 1.1 로 올린다. 다른 경로 동작을 안 건드리도록 server 전역이 아니라 이 location 한정으로 둔다.
+    # - proxy_buffering off: nginx 가 응답을 모았다 내보내면 실시간성이 깨진다. 이벤트를 받는 즉시 클라이언트로 흘려보낸다.
+    # 공통 proxy_set_header / proxy_read_timeout 90s 는 server 레벨에서 상속한다(앱 하트비트가 15s 라 90s read_timeout 은 안 끊긴다).
+    # 정확매칭(=)이라 catch-all(location /)보다 우선한다. 레이트리밋은 일반 그물(piki_general) 유지 — 구독은 오래 열린 1요청이라 카운트 1로 무해하다.
+    location = /api/v1/notifications/subscribe {
+        limit_req zone=piki_general burst=40 nodelay;
+        proxy_pass http://team3;
+        proxy_http_version 1.1;
+        proxy_buffering off;
+    }
+
     # 그 외 모든 경로 — 전역 느슨한 그물(piki_general). 정상 화면 로딩·무한스크롤은 무영향, 명백한 폭주만 429.
     location / {
         limit_req zone=piki_general burst=40 nodelay;
         proxy_pass http://team3;
     }
 
-    listen 443 ssl;
+    # http2: 브라우저는 origin 당 커넥션을 약 6개로 제한하는데, SSE 가 그 중 1개를 계속 점유한다.
+    # 멀티탭·요청 많은 화면에서 HTTP/2 의 스트림 multiplexing 이 이 제한을 풀어 SSE 가 다른 요청을 굶기지 않게 한다
+    # (백엔드 leg 와 무관한 클라이언트↔nginx leg 최적화). 단일 탭 해피케이스에선 이득이 작지만 켜는 비용도 0 에 가깝다.
+    # 형식 주의: nginx 1.25.1+ 는 `http2 on;` 지시어를 선호하나, 이 `listen ... http2` 파라미터 형식도 동작한다
+    # (신버전은 deprecation 경고만, nginx -t 는 통과). 운영 nginx 버전에 맞춰 추후 `http2 on;` 으로 바꿔도 된다.
+    listen 443 ssl http2;
     ssl_certificate /etc/letsencrypt/live/api.depromeet18team3.cloud/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/api.depromeet18team3.cloud/privkey.pem;
     include /etc/letsencrypt/options-ssl-nginx.conf;


### PR DESCRIPTION
## Situation
- SSE 알림 구독(이슈 #212, 앱 구현 PR #359)을 운영 nginx 뒤에서 제대로 흘리려면 nginx 설정이 선행돼야 한다. 기본 설정으로는 SSE 가 버퍼링되거나 끊긴다.
- nginx 는 **두 leg 를 따로** 다룬다 — 브라우저↔nginx, nginx↔백엔드. 각 leg 가 SSE 에 거는 제약이 달라서, 이 PR 은 그 둘을 분리해 처리한다.

## Task
- nginx↔백엔드 leg 의 스트리밍을 살려 SSE 가 실제로 동작하게 한다(필수).
- 브라우저↔nginx leg 의 커넥션 제한을 완화한다(권장).
- 다른 엔드포인트 동작에 영향을 주지 않도록 변경 범위를 최소화한다.

## Action
- **SSE 전용 location 추가** (`= /api/v1/notifications/subscribe`) — `proxy_http_version 1.1` + `proxy_buffering off`. nginx 가 백엔드에 붙는 기본값 1.0 과 기본 버퍼링은 chunked 스트리밍을 막아 SSE 가 끊기거나 모였다 나간다. **server 전역이 아니라 이 location 한정으로 스코프** 해 다른 경로의 업스트림 프로토콜·버퍼링은 안 건드린다.
- **`listen 443 ssl` → `listen 443 ssl http2`** — 브라우저는 origin당 커넥션을 약 6개로 제한하는데 SSE 가 그 1개를 계속 점유한다. HTTP/2 multiplexing 이 이 제한을 풀어 멀티탭·요청 많은 화면에서 SSE 가 다른 요청을 굶기지 않게 한다(클라이언트↔nginx leg, 백엔드 leg 와 무관). 단일 탭 해피케이스 이득은 작지만 켜는 비용도 0 에 가까워 기본값으로 켠다.
- read_timeout 은 기존 90s 유지 — 앱 하트비트가 15s 라 read 타이머가 계속 리셋돼 안 끊긴다(별도 상향 불필요).
- 검토 후 제외: upstream `keepalive` + `Connection ""`(백엔드 연결 재사용)은 server 전역 동작을 바꾸는 별개 최적화라, SSE 스코프인 이 PR 에 섞지 않았다.

## Result
- 로컬 docker `nginx -t`(더미 ssl·upstream 주입)로 문법 검증 통과. `listen ... http2` deprecation 경고는 nginx 1.25.1+ 에서만 나오고 `-t`(deploy.yml 게이트)는 통과한다 — 모든 버전에서 동작.
- 운영 nginx 가 1.25.1+ 면 추후 `http2 on;` 지시어로 바꿀 수 있다(동작 동일, 경고만 제거).
- 이 PR 머지·배포 후 SSE 앱 PR #359 의 실시간 push 가 운영에서 동작한다.

---
## 연관 이슈

- 연관(close 아님): SSE 앱 구현 PR #359 · 이슈 #212 의 운영 반영 선행 인프라. (#212 는 #359 가 닫으므로 여기선 close 키워드를 두지 않는다.)
