### PR TITLE
운영 로그 구조화(ECS JSON)와 Loki structured metadata 로 trace 분리

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -232,10 +232,14 @@ jobs:
             # 외부에서 직접 scrape 되는 우회 경로를 구조적으로 차단한다 (nginx /actuator 차단의 보강).
             # 주의: 별도 PR 의 Grafana Alloy 는 같은 호스트의 컨테이너이므로 --network host 로 띄워 localhost 를 scrape 해야 한다
             #       (redis 가 쓰는 172.17.0.1 bridge 바인딩 방식으로는 127.0.0.1 바인딩 포트에 닿지 못한다).
+            # LOG_STRUCTURED=ecs: 운영 로그를 ECS JSON 으로 출력해 Alloy 가 trace 를 Loki structured
+            # metadata 로 승격하게 한다(#364). 값 고정 평문이라 Secrets 불필요. 로컬은 이 변수 미설정이라
+            # application.yml 의 평문 콘솔 패턴(#361)을 그대로 쓴다.
             docker run -d \
               --name "team3-$INACTIVE" \
               -p "127.0.0.1:$INACTIVE_PORT:8080" \
               -e JAVA_TOOL_OPTIONS="-Xmx256m -Xms64m" \
+              -e LOG_STRUCTURED="ecs" \
               -e GEMINI_API_KEY="$GEMINI_API_KEY" \
               -e DB_HOST="$DB_HOST" \
               -e DB_PORT="$DB_PORT" \

--- a/infra/alloy/config.alloy
+++ b/infra/alloy/config.alloy
@@ -58,6 +58,54 @@ discovery.relabel "team3" {
 loki.source.docker "containers" {
   host       = "unix:///var/run/docker.sock"
   targets    = discovery.relabel.team3.output
+  forward_to = [loki.process.app_logs.receiver]
+}
+
+// ── ECS JSON 파싱: trace 를 structured metadata 로 승격, 본문은 message 만 (#364) ──
+// 앱이 LOG_STRUCTURED=ecs 로 내보내는 ECS JSON 한 줄(예:
+//   {"@timestamp":...,"log":{"level":"INFO","logger":"...EntryPoint"},"message":"GET / ...",
+//    "traceId":"6a1f...","spanId":"2ca4...","ecs":{"version":"8.11"}})
+// 을 받아 다음을 한다:
+//  - traceId·spanId·logger 를 structured metadata 층으로 올린다. label 이 아니라 metadata 라
+//    traceId 의 고카디널리티가 스트림을 쪼개지 않으면서 Grafana 에서 필드로 필터·표시된다.
+//  - 라인 본문을 message 로 교체해 Loki 에서 줄에 메시지만 깔끔히 남게 한다(가독성, 이 이슈의 목적).
+// 키는 로컬 ecs 부팅 실측(2026-06-03)으로 확정: Spring Boot ECS formatter 는 micrometer MDC 키를
+// 그대로 top-level 로 둔다 → traceId·spanId(camelCase). log.level·log.logger 는 nested 라 점 경로.
+loki.process "app_logs" {
+  // 비-JSON 라인(구버전 컨테이너의 평문 셧다운 로그 등)은 stage.json 이 조용히 무시하고 라인을 보존한다.
+  stage.json {
+    expressions = {
+      msg      = "message",
+      trace_id = "traceId",
+      span_id  = "spanId",
+      logger   = "log.logger",
+      level    = "log.level",
+    }
+  }
+
+  // 고카디널리티(trace_id)·중카디널리티(logger)는 인덱스 없는 structured metadata 로.
+  // 빈 문자열 = 위 stage.json 이 추출한 동명 변수를 그대로 쓴다.
+  stage.structured_metadata {
+    values = {
+      trace_id = "",
+      span_id  = "",
+      logger   = "",
+    }
+  }
+
+  // level 은 저카디널리티(INFO/WARN/ERROR 등)라 label 로 — Grafana Explore 의 레벨 필터·색상이 동작한다.
+  // 라인을 message 로 줄이면 본문에 레벨 문자열이 없어 Loki 자동 detect 가 놓치므로 명시적으로 올린다.
+  stage.labels {
+    values = {
+      level = "",
+    }
+  }
+
+  // 저장 라인 본문을 message 로 교체 — 줄에 메시지만 남는다.
+  stage.output {
+    source = "msg"
+  }
+
   forward_to = [loki.write.grafana_cloud.receiver]
 }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -118,7 +118,16 @@ management:
       probability: 1.0
 
 logging:
+  structured:
+    format:
+      # 운영은 Grafana(Loki)로 로그를 보낸다. ECS JSON 으로 출력하면 Alloy 가 trace.id·log.level·message 등
+      # 필드를 파싱해 trace 를 Loki structured metadata 로 승격하고 본문은 message 만 남길 수 있다(#364).
+      # 값이 있으면(ecs) 구조화 JSON 출력이 켜지고 아래 pattern.console(평문)은 무시된다.
+      # 로컬은 LOG_STRUCTURED 미설정(빈값)이라 구조화 off → pattern.console 평문 패턴이 적용된다.
+      # (운영 docker run 에만 -e LOG_STRUCTURED=ecs 를 준다. env override 패턴은 ADMIN_ENABLED 와 동일.)
+      console: ${LOG_STRUCTURED:}
   pattern:
+    # 아래 평문 패턴은 구조화 off(로컬)일 때만 적용된다 — LOG_STRUCTURED=ecs 면 위 구조화 출력이 우선한다.
     # 운영 로그는 Grafana(Loki)에서 본다. Grafana 가 줄 앞에 수집시각(KST)+레벨을 자동으로 붙이므로,
     # Spring Boot 기본 콘솔 패턴의 시각·레벨과 겹쳐 한 줄에 시각·레벨이 두 번씩 나온다. 게다가 운영 컨테이너
     # JVM 은 UTC 라 Spring 시각이 Grafana 의 KST 표시와 9시간 어긋나 더 헷갈린다.


### PR DESCRIPTION
## Situation
- #361 로 콘솔 로그 패턴을 KST·노이즈 제거로 정리했으나, Grafana(Loki) 로그 뷰에서 thread·traceId·spanId 메타가 메시지 앞을 길게 차지했다. 특히 traceId 32자 + spanId 16자가 줄 앞을 먹어, 정작 읽고 싶은 메시지가 오른쪽으로 밀려 가독성이 떨어졌다.
- 처음엔 메타를 줄 끝으로 재배치하는 가벼운 안을 검토했으나, trace 를 로그 라인 텍스트에서 아예 빼 Loki 의 structured metadata 층으로 옮기는 근본 해결을 택했다. trace 는 의미가 있으니 버리는 게 아니라 본문에서 메타데이터 층으로 옮기는 것.

## Task
- 운영 로그를 ECS JSON 으로 구조화하고, Alloy 파이프라인에서 traceId/spanId 를 Loki structured metadata 로 승격해 라인 본문에는 message 만 남긴다.
- 로컬 개발 콘솔 가독성은 평문으로 유지(환경 분기).

## Action
### 앱 — 구조화 토글
- `application.yml` 에 `logging.structured.format.console=${LOG_STRUCTURED:}` 추가. 값이 `ecs` 면 JSON 구조화 출력(`pattern.console` 무시), 빈값이면 기존 평문 패턴(#361). 운영만 JSON, 로컬은 평문.
- 포맷은 Spring Boot 4 내장 ECS 를 택함 (`trace.id`·`log.level`·`service.name` 표준 필드, OTel/Grafana 생태계 호환, Alloy 파싱 용이).
- 환경 분기는 `@Profile` 미사용 철학과 일관된 환경변수 토글. 전부 JSON 은 로컬 IDE 콘솔 가독성을 희생하므로 배제.

### 인프라 — Alloy 파이프라인
- `config.alloy` 에 `loki.process` 신설: 기존 `loki.source.docker → loki.write`(raw forward) 사이에 끼움. `stage.json` 으로 ECS JSON 파싱 → `traceId`/`spanId`/`logger` 를 structured metadata 로 승격 → `level` 은 label → 본문은 `message` 로 교체.
- 고카디널리티(traceId)·중카디널리티(logger)는 label 대신 metadata 로 — traceId 를 label 로 두면 스트림이 폭발하므로 metadata 가 정답.
- `deploy.yml` docker run 에 `-e LOG_STRUCTURED="ecs"` 주입. 값 고정 평문이라 Secrets 불필요.

### 검증 — 실측으로 확정
- trace 키: 로컬 ecs 부팅 실측으로 `traceId`/`spanId` 가 top-level(camelCase)임을 확정. Spring Boot ECS formatter 는 micrometer MDC 키를 ECS 표준 `trace.id` 로 매핑하지 않고 그대로 둔다 (`log.level`·`log.logger` 는 nested). 이 키로 `stage.json` 의 추출 경로를 박았다.
- 토글 양방향: `LOG_STRUCTURED=ecs` → ECS JSON, 빈값 → 평문(#361) 둘 다 로컬 부팅으로 확인.
- Alloy 문법: 운영과 동일한 `grafana/alloy:v1.16.1 validate` 통과.
- 회귀: `./gradlew test` 전체 통과 (application.yml 변경이 통합 테스트 컨텍스트 부팅을 깨지 않음).

## Result
- 운영 Grafana(Loki)에서 로그 라인은 message 만 깔끔히 남고, traceId/spanId/logger 는 클릭 가능한 metadata 필드로 분리돼 한 요청의 전 로그를 traceId 로 묶어 추적할 수 있다.
- 앱 동작·API·다른 팀원 코드에는 영향 없음 — 로그 관측 방식(평문→ECS JSON + metadata 분리)만 바뀐다.
- **후속 확인 필요**: Alloy 의 실제 파싱·승격은 로컬 Loki 가 없어 이 PR 에서 검증하지 못했다. 배포 후 Grafana 에서 (1) 라인이 message 만 남는지, (2) traceId/spanId 가 metadata 필드로 떨어지는지, (3) level label·detected level 이 동작하는지 최종 확인한다.

---
## 연관 이슈
- close #364
