### PR TITLE
dev 배포 활성화 수정 (nginx SSL 헬퍼 + CORS dev origin)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -162,6 +162,17 @@ jobs:
                 --email depromeet18.3@gmail.com -d "$DOMAIN" \
                 --pre-hook "systemctl stop nginx" --post-hook "systemctl start nginx"
             fi
+            # nginx conf 가 include 하는 certbot 권장 SSL 파일은 certonly --standalone 로는 안 깔린다
+            # (certbot --nginx 설치 경로에서만 생성). 누락 시 nginx -t 가 깨지므로, certbot 패키지가
+            # 번들한 원본을 /etc/letsencrypt/ 로 복사한다(없을 때만 — prod 는 이미 있어 no-op, 동일 SSL 유지).
+            if [ ! -f /etc/letsencrypt/options-ssl-nginx.conf ]; then
+              SRC=$(find /usr -name options-ssl-nginx.conf 2>/dev/null | head -1)
+              [ -n "$SRC" ] && sudo cp "$SRC" /etc/letsencrypt/options-ssl-nginx.conf && echo "[certbot] options-ssl-nginx.conf 복사"
+            fi
+            if [ ! -f /etc/letsencrypt/ssl-dhparams.pem ]; then
+              SRC=$(find /usr -name ssl-dhparams.pem 2>/dev/null | head -1)
+              [ -n "$SRC" ] && sudo cp "$SRC" /etc/letsencrypt/ssl-dhparams.pem && echo "[certbot] ssl-dhparams.pem 복사"
+            fi
 
       - name: Apply nginx config
         id: nginx


### PR DESCRIPTION
## Situation
- dev/prod 분리 PR(#374)을 dev 에 머지한 뒤 **첫 dev 배포가 `Apply nginx config` 단계에서 실패**했다 (run 26940300722).
- 에러: `[emerg] open() "/etc/letsencrypt/options-ssl-nginx.conf" failed (No such file or directory) in .../dev.api.depromeet18team3.cloud:44` → `nginx -t` 실패 → 롤백·중단.
- resolve·guard·cert 발급·MySQL readiness 까지는 정상이었고, 딱 이 한 지점만 걸렸다.

## Task
- dev nginx conf 가 include 하는 certbot 권장 SSL 파일(`options-ssl-nginx.conf`, `ssl-dhparams.pem`)이 dev 박스에 존재하도록 보장해 `nginx -t` 를 통과시킨다.

## Action
- **근본 원인**: prod EC2 는 과거 **사람이 수동으로 `certbot --nginx`** 로 셋업해서 그 두 파일이 `/etc/letsencrypt/` 에 이미 생성돼 있었다. 이번 dev 는 cloud-init **자동 부트스트랩 + `certbot certonly --standalone`** 으로 발급하는데, **standalone 모드는 nginx installer 경로가 아니라 그 SSL 헬퍼 파일을 생성하지 않는다.** 두 환경의 conf 는 같은 include 를 쓰는데, 자동화 경로에서 이 의존 파일만 누락된 것.
- **수정**: `Ensure TLS cert` 단계에서 두 파일이 없으면 **certbot 패키지가 번들한 원본(`/usr` 하위)을 `find` 로 찾아 `/etc/letsencrypt/` 로 복사**한다. 없을 때만 복사하므로 prod 는 no-op(기존 파일 유지 = 동일 SSL 설정), dev 는 standalone 발급 후 채워진다.
- conf 에서 두 줄을 빼는 대안(의존 제거)도 있었으나, prod conf 와 동일한 SSL 하드닝을 유지하려고 "파일을 채우는" 쪽을 택했다.

## Result
- dev 첫 배포의 `nginx -t` 가 통과해 이후 단계(provision·blue-green·health)로 진행된다.
- prod 무영향(파일 이미 존재 → 복사 skip). dev/prod conf 가 동일한 SSL 설정을 공유.
- 머지 후 dev 재배포로 검증 예정.

---
## 연관 이슈

- close #376

