### PR TITLE
dev 프론트 CORS origin 허용

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/common/config/CorsConfig.kt
+++ b/src/main/kotlin/com/depromeet/piki/common/config/CorsConfig.kt
@@ -21,10 +21,15 @@ class CorsConfig {
                         "https://depromeet18team3.cloud",
                         "https://www.depromeet18team3.cloud",
                         "https://depromeet.vercel.app",
+                        // dev 프론트 — dev.api.depromeet18team3.cloud(dev 서버)를 호출하는 dev 프론트 origin.
+                        // (Apple 콜백이 www.dev 를 쓰는 등 호스트가 갈릴 수 있어 둘 다 허용)
+                        "https://dev.depromeet18team3.cloud",
+                        "https://www.dev.depromeet18team3.cloud",
                         // 우리 서버 자체 origin — Stoplight UI (/docs/index.html) 의 try-it 이
                         // 브라우저 fetch(mode=cors) 로 호출 시 same-origin 이어도 Origin 헤더가 박혀
-                        // CORS 검사를 거치므로 화이트리스트에 포함되어야 한다.
+                        // CORS 검사를 거치므로 화이트리스트에 포함되어야 한다. (prod·dev API 둘 다)
                         "https://api.depromeet18team3.cloud",
+                        "https://dev.api.depromeet18team3.cloud",
                         // 프론트엔드 로컬 개발 환경 (Next.js dev server) — 로컬에서 배포 서버 API 를
                         // 호출하며 통합 테스트할 때 Origin 헤더가 박혀 CORS 검사를 거치므로 허용한다.
                         // localhost 와 127.0.0.1 은 브라우저상 서로 다른 origin 이라 둘 다 명시한다.

--- a/src/test/kotlin/com/depromeet/piki/common/config/CorsIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/common/config/CorsIntegrationTest.kt
@@ -54,6 +54,26 @@ class CorsIntegrationTest : IntegrationTestSupport() {
     }
 
     @Test
+    fun `dev 프론트 origin 의 preflight 도 허용된다`() {
+        // dev/prod 분리로 dev 프론트(dev.depromeet18team3.cloud)가 dev API 를 호출한다. 화이트리스트
+        // 누락 시 dev 에서 모든 인증/JSON 요청이 CORS 로 막힌다. 회귀 가드.
+        val mockMvc =
+            MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .apply<DefaultMockMvcBuilder>(springSecurity())
+                .build()
+
+        mockMvc
+            .perform(
+                options("/api/v1/dev/users")
+                    .header(HttpHeaders.ORIGIN, "https://dev.depromeet18team3.cloud")
+                    .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "POST"),
+            ).andExpect(status().isOk)
+            .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "https://dev.depromeet18team3.cloud"))
+            .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS, "true"))
+    }
+
+    @Test
     fun `화이트리스트에 없는 origin 의 preflight 는 403 으로 거부된다`() {
         // 허용 목록 검증이 실제로 동작함을 함께 단언해 테스트가 vacuous 하지 않도록 한다.
         val mockMvc =


### PR DESCRIPTION
## Situation
- dev/prod 분리(#374) 후 dev 는 `dev.api.depromeet18team3.cloud` 에서 서비스되고, dev 프론트(`dev.depromeet18team3.cloud`)가 이 dev API 를 호출한다.
- 그런데 CORS 허용 origin 목록에 dev 프론트·dev API 가 없어, dev 에서 브라우저 인증/JSON 요청이 전부 CORS 로 막힌다.
- (#376 의 nginx 파트는 #375 로 이미 머지됐고, 이 PR 은 남은 CORS 파트.)

## Task
- dev 프론트·dev API self origin 을 CORS 화이트리스트에 추가해 dev 에서 API 호출이 통과하게 한다.

## Action
- `CorsConfig` 에 `https://dev.depromeet18team3.cloud`, `https://www.dev.depromeet18team3.cloud`(Apple 콜백이 www.dev 를 써서 대비), `https://dev.api.depromeet18team3.cloud`(Stoplight try-it self origin) 추가.
- `allowCredentials = true` 라 와일드카드(`*`)는 브라우저가 거부 → origin 명시.
- dev origin preflight 허용 회귀 가드 테스트 추가 (evil origin 403 거부 단언은 유지).

## Result
- dev 프론트에서 dev API 호출이 CORS 통과. prod origin/local 은 기존대로.
- 단위+통합 테스트 통과(로컬 BUILD SUCCESSFUL).

---
## 연관 이슈

- close #376


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 개발 환경 도메인에 대한 CORS 지원이 추가되었습니다.

* **Tests**
  * 개발 환경 도메인의 CORS preflight 요청을 검증하는 테스트 케이스가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->