### PR TITLE
Alloy trace exporter 를 HTTP OTLP gateway 로 교체

### DIFF
--- a/infra/alloy/config.alloy
+++ b/infra/alloy/config.alloy
@@ -176,19 +176,21 @@ otelcol.receiver.otlp "app" {
 // 작은 박스라 span 을 모아 한 번에 보내 네트워크·CPU 를 아낀다.
 otelcol.processor.batch "traces" {
   output {
-    traces = [otelcol.exporter.otlp.grafana_cloud.input]
+    traces = [otelcol.exporter.otlphttp.grafana_cloud.input]
   }
 }
 
-// GC Tempo 로 OTLP export. endpoint·instance ID 는 secret, token 은 메트릭·로그와 공유(GRAFANA_CLOUD_TOKEN).
-// GRAFANA_TRACES_URL 미설정(traces secret 미등록) 시 더미로 fallback 해 Alloy 부팅을 살린다 — 메트릭·로그는 계속
-// 수집되고 trace export 만 연결 실패 로그를 남긴다(skip 가드는 GRAFANA_METRICS_URL 기준이라 traces 만 비면 여기 닿는다).
-// 더미는 receiver(4317/4318)와 안 겹쳐 self-loop 가 없다. secret 등록 후 다음 배포에 정상화된다.
-// dev/prod 구분(메트릭 external_labels·로그 static_labels 의 environment)은 trace 엔 아직 안 붙인다 — trace 는
+// GC 로 OTLP export. GC 는 통합 OTLP gateway(HTTP/protobuf, https://otlp-gateway-...grafana.net/otlp)를
+// 제공하므로 gRPC(otelcol.exporter.otlp)가 아니라 otlphttp 로 보낸다. otlphttp 는 endpoint 뒤에 /v1/traces 를
+// 붙여 전송한다. endpoint·instance ID(basic auth username)는 secret, token 은 메트릭·로그와 공유
+// (GRAFANA_CLOUD_TOKEN, traces:write scope 포함).
+// GRAFANA_TRACES_URL 미설정(traces secret 미등록) 시 더미로 fallback 해 Alloy 부팅을 살린다(메트릭·로그는 계속
+// 수집되고 trace export 만 연결 실패 로그를 남긴다. skip 가드는 GRAFANA_METRICS_URL 기준이라 traces 만 비면 여기 닿는다).
+// dev/prod 구분(메트릭 external_labels·로그 static_labels 의 environment)은 trace 엔 아직 안 붙인다. trace 는
 // traceId 단건 조회·service.name(piki)으로 우선 식별하고, 환경 필터가 필요하면 후속에 resource attribute 로 추가한다.
-otelcol.exporter.otlp "grafana_cloud" {
+otelcol.exporter.otlphttp "grafana_cloud" {
   client {
-    endpoint = coalesce(sys.env("GRAFANA_TRACES_URL"), "tempo-unset.invalid:443")
+    endpoint = coalesce(sys.env("GRAFANA_TRACES_URL"), "https://otlp-unset.invalid/otlp")
     auth     = otelcol.auth.basic.grafana_cloud.handler
   }
 }


### PR DESCRIPTION
## Situation
- #383 으로 Grafana Cloud Traces 도입을 머지했으나, Alloy 의 trace exporter 를 gRPC(`otelcol.exporter.otlp`)로 두고 GC Tempo 가 gRPC native endpoint(`tempo-...:443`)로 받는다고 가정했다.
- 실제 GC 콘솔이 발급한 ingest 경로는 통합 OTLP gateway(HTTP/protobuf, `https://otlp-gateway-...grafana.net/otlp`)였다. gRPC exporter 로는 그 endpoint 와 자격증명이 맞지 않아 trace 가 GC 로 올라가지 않는다.

## Task
- Alloy 의 trace export 를 GC 가 실제 제공하는 HTTP OTLP gateway 에 맞춘다.

## Action
- `config.alloy` 의 `otelcol.exporter.otlp`(gRPC)를 `otelcol.exporter.otlphttp`(HTTP)로 교체하고, batch output 의 exporter 참조도 함께 갱신했다.
- otlphttp 는 endpoint 뒤에 `/v1/traces` 를 붙여 전송한다. instance ID(basic auth username)와 token 은 그대로 `GRAFANA_TRACES_USER`, `GRAFANA_CLOUD_TOKEN` 을 쓴다.
- traces secret 미등록 시 부팅 fallback 의도를 유지하려고 coalesce 더미를 `tempo-unset.invalid:443` 에서 `https://otlp-unset.invalid/otlp` 로 바꿨다. 메트릭과 로그는 계속 수집되고 Alloy 도 죽지 않는다.
- 앱 코드는 건드리지 않았다. 앱에서 Alloy 로 보내는 구간은 그대로 OTLP 이고, Alloy 에서 GC 로 내보내는 구간만 HTTP 로 바꿨다.

## Result
- alloy v1.16.1 로 config validate 통과(otlphttp 와 coalesce 문법 확인).
- 머지 후 배포되면 #383 의 secret(`GRAFANA_TRACES_URL` 은 OTLP gateway endpoint, `GRAFANA_TRACES_USER` 는 instance ID, token 은 traces:write 포함) 등록을 전제로 trace 가 GC Tempo 로 올라간다.

## 연관 이슈
- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Trace 내보내기 프로토콜을 gRPC 기반에서 HTTP 기반으로 변경하여 전송 방식을 개선했습니다.
  * 환경 변수 설정 미흡 시 메트릭과 로그는 계속 수집하면서 trace 내보내기만 안정적으로 처리하도록 폴백 로직을 추가하고 관련 설정 문서를 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->