### PR TITLE
wish·tournament 의 상품 참조를 snapshot 으로 이전 (상품 버저닝 3단계)

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/item/repository/ItemSnapshotJpaRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/item/repository/ItemSnapshotJpaRepository.kt
@@ -6,4 +6,10 @@ import org.springframework.data.jpa.repository.JpaRepository
 interface ItemSnapshotJpaRepository : JpaRepository<ItemSnapshot, Long> {
     // 한 item 의 살아있는(soft-delete 안 된) 최신 snapshot 1개 — id 역순 첫 행.
     fun findFirstByItemIdAndDeletedAtIsNullOrderByIdDesc(itemId: Long): ItemSnapshot?
+
+    // 살아있는 단건 조회. JpaRepository.findById(Optional) 와 충돌하지 않도록 deletedAt 조건을 붙여 이름을 구분한다.
+    fun findByIdAndDeletedAtIsNull(id: Long): ItemSnapshot?
+
+    // 살아있는 행만 id 목록으로 일괄 조회.
+    fun findByIdInAndDeletedAtIsNull(ids: Collection<Long>): List<ItemSnapshot>
 }

--- a/src/main/kotlin/com/depromeet/piki/item/repository/ItemSnapshotRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/item/repository/ItemSnapshotRepository.kt
@@ -10,4 +10,11 @@ interface ItemSnapshotRepository {
     // 한 item 의 최신 snapshot. 2단계는 item 당 snapshot 1행이라 사실상 그 행이며,
     // 상태 전이(markReady/markFailed/recover) 대상을 찾는 데 쓴다. 5단계 갱신에서 여러 버전이 쌓이면 "최신 버전" 의미가 된다.
     fun findLatestByItemId(itemId: Long): ItemSnapshot?
+
+    // 3단계(참조 이전): wish/tournament_item 이 가리키는 고정 snapshot 을 id 로 끌어온다.
+    // 단건 조회(위시 단건·토너먼트 아이템 단건)용. 삭제된 행은 제외, 없으면 null.
+    fun findById(id: Long): ItemSnapshot?
+
+    // 여러 snapshot 을 id 목록으로 한 번에 조회(목록·결과 조회의 메모리 조인용). 존재하는 것만 반환.
+    fun findByIds(ids: List<Long>): List<ItemSnapshot>
 }

--- a/src/main/kotlin/com/depromeet/piki/item/repository/ItemSnapshotRepositoryImpl.kt
+++ b/src/main/kotlin/com/depromeet/piki/item/repository/ItemSnapshotRepositoryImpl.kt
@@ -14,4 +14,9 @@ class ItemSnapshotRepositoryImpl(
 
     override fun findLatestByItemId(itemId: Long): ItemSnapshot? =
         itemSnapshotJpaRepository.findFirstByItemIdAndDeletedAtIsNullOrderByIdDesc(itemId)
+
+    override fun findById(id: Long): ItemSnapshot? = itemSnapshotJpaRepository.findByIdAndDeletedAtIsNull(id)
+
+    override fun findByIds(ids: List<Long>): List<ItemSnapshot> =
+        itemSnapshotJpaRepository.findByIdInAndDeletedAtIsNull(ids)
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/domain/TournamentItem.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/domain/TournamentItem.kt
@@ -18,6 +18,10 @@ class TournamentItem(
     val itemId: Long,
     @Column(name = "user_id", nullable = false, columnDefinition = "BINARY(16)")
     val userId: UUID,
+    // 출전 시점 고정 snapshot 참조. raw Long(FK 없음). 위시 갱신과 무관하게 고정돼 토너먼트 공정성을 지킨다.
+    // nullable — 3단계 전환기에 추가됐고, 신규 출전부터 채워진다.
+    @Column(name = "snapshot_id")
+    val snapshotId: Long? = null,
 ) : LongBaseEntity() {
     // 엔티티 불변식 — 0·음수는 존재할 수 없는 참조다. 정상 흐름에선 닿지 않고, 닿으면 코드 버그.
     init {

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentItemPersistenceService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentItemPersistenceService.kt
@@ -104,8 +104,15 @@ class TournamentItemPersistenceService(
             itemRepository.findById(tournamentItem.itemId)
                 ?: error("item 없음 — tournamentItemId=$tournamentItemId, itemId=${tournamentItem.itemId}")
         item.recover(name = name, currentPrice = price, imageUrl = imageUrl, currency = currency)
-        itemSnapshotRepository.findLatestByItemId(tournamentItem.itemId)
-            ?.recover(name = name, currentPrice = price, imageUrl = imageUrl, currency = currency)
+        // 토너먼트는 출전 시점 고정 snapshot 을 본다. 최신(findLatestByItemId)이 아니라 tournamentItem.snapshotId 를
+        // 갱신해야, 5단계 갱신으로 같은 item 에 snapshot 이 여러 개 생겨도 토너먼트가 고정한 버전만 보정돼 격리가 유지된다.
+        val snapshotId =
+            tournamentItem.snapshotId
+                ?: error("snapshot 없음 — tournamentItemId=$tournamentItemId, itemId=${tournamentItem.itemId}")
+        val snapshot =
+            itemSnapshotRepository.findById(snapshotId)
+                ?: error("snapshot 없음 — tournamentItemId=$tournamentItemId, snapshotId=$snapshotId")
+        snapshot.recover(name = name, currentPrice = price, imageUrl = imageUrl, currency = currency)
     }
 
     private fun validateAndCheckCapacity(

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentItemPersistenceService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentItemPersistenceService.kt
@@ -36,9 +36,17 @@ class TournamentItemPersistenceService(
     ): PersistedTournamentItem {
         validateAndCheckCapacity(userId, tournamentId, 1)
         val item = itemRepository.save(Item.processing(link))
-        itemSnapshotRepository.save(ItemSnapshot.forItem(item))
+        // 3단계: 저장한 snapshot 의 id 를 tournament_item 에 고정한다. 출전 시점 버전이 박혀 위시 갱신과 격리된다.
+        val snapshot = itemSnapshotRepository.save(ItemSnapshot.forItem(item))
         val tournamentItem = tournamentItemRepository.saveAll(
-            listOf(TournamentItem(tournamentId = tournamentId, itemId = item.getId(), userId = userId)),
+            listOf(
+                TournamentItem(
+                    tournamentId = tournamentId,
+                    itemId = item.getId(),
+                    userId = userId,
+                    snapshotId = snapshot.getId(),
+                ),
+            ),
         ).first()
         return PersistedTournamentItem(itemId = item.getId(), tournamentItemId = tournamentItem.getId())
     }
@@ -51,9 +59,17 @@ class TournamentItemPersistenceService(
     ): List<PersistedTournamentItem> {
         validateAndCheckCapacity(userId, tournamentId, count)
         val items = itemRepository.saveAll(List(count) { Item(status = ItemStatus.PROCESSING) })
-        itemSnapshotRepository.saveAll(items.map { ItemSnapshot.forItem(it) })
+        // saveAll 은 입력 순서를 보존하므로 items[i] 와 snapshots[i] 가 같은 상품이다. 각 tournament_item 에 그 snapshot 을 고정한다.
+        val snapshots = itemSnapshotRepository.saveAll(items.map { ItemSnapshot.forItem(it) })
         val tournamentItems = tournamentItemRepository.saveAll(
-            items.map { TournamentItem(tournamentId = tournamentId, itemId = it.getId(), userId = userId) },
+            items.zip(snapshots) { item, snapshot ->
+                TournamentItem(
+                    tournamentId = tournamentId,
+                    itemId = item.getId(),
+                    userId = userId,
+                    snapshotId = snapshot.getId(),
+                )
+            },
         )
         return items.zip(tournamentItems) { item, tournamentItem ->
             PersistedTournamentItem(itemId = item.getId(), tournamentItemId = tournamentItem.getId())

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
@@ -599,8 +599,13 @@ class TournamentService(
             val participant = ParticipantSummary(userId = user.id, nickname = user.nickname, profileImage = user.profileImage)
 
             for ((tournamentItemId, rank) in ranked) {
+                // tItem 누락은 삭제된 출전 아이템이 history 에 남은 정상 경우라 건너뛴다. 그러나 tItem 이 살아있으면
+                // snapshot 은 불변식상 반드시 있어야 한다 — 없으면 continue 로 삼키지 않고 fail-fast 로 터뜨려, 부분 집계된
+                // 랭킹이 200 으로 새어 나가는 것을 막는다.
                 val tItem = tItemById[tournamentItemId] ?: continue
-                val snapshot = tItem.snapshotId?.let { snapshotById[it] } ?: continue
+                val snapshot =
+                    tItem.snapshotId?.let { snapshotById[it] }
+                        ?: error("tournamentItem $tournamentItemId 의 snapshot ${tItem.snapshotId} 가 없다")
                 val key = RankKey(tItem.itemId, rank)
                 chosenByMap.getOrPut(key) { mutableListOf() }.add(participant)
                 if (t.getId() == rootId) {

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
@@ -1,7 +1,9 @@
 package com.depromeet.piki.tournament.service
 
 import com.depromeet.piki.item.domain.Item
+import com.depromeet.piki.item.domain.ItemSnapshot
 import com.depromeet.piki.item.repository.ItemRepository
+import com.depromeet.piki.item.repository.ItemSnapshotRepository
 import com.depromeet.piki.tournament.domain.Tournament
 import com.depromeet.piki.tournament.domain.TournamentHistory
 import com.depromeet.piki.tournament.domain.TournamentItem
@@ -38,6 +40,7 @@ class TournamentService(
     private val tournamentItemRepository: TournamentItemRepository,
     private val userRepository: UserRepository,
     private val itemRepository: ItemRepository,
+    private val itemSnapshotRepository: ItemSnapshotRepository,
     private val wishRepository: WishRepository,
 ) {
     @Transactional
@@ -118,9 +121,22 @@ class TournamentService(
         if (command.itemIds.any { it !in foundItemIds }) throw TournamentException.notFoundItems()
         // 비동기 파싱 중(PROCESSING)이거나 실패(FAILED)한 상품은 이름·가격이 비어 출전에 부적합하다. READY 만 허용.
         if (foundItems.any { !it.isReady() }) throw TournamentException.itemNotReady()
+        // 출전 시점에 위시의 활성 snapshot 을 tournament_item 에 고정한다 — 이후 위시 갱신과 무관하게 그 버전을 본다.
+        val snapshotIdByItemId =
+            wishRepository
+                .findByItemIdsAndUserId(command.itemIds, userId)
+                .associate { it.itemId to it.snapshotId }
         return tournamentItemRepository.saveAll(
             command.itemIds.map { itemId ->
-                TournamentItem(tournamentId = command.tournamentId, itemId = itemId, userId = userId)
+                val snapshotId =
+                    snapshotIdByItemId[itemId]
+                        ?: error("wish 의 활성 snapshot 없음 — itemId=$itemId, userId=$userId")
+                TournamentItem(
+                    tournamentId = command.tournamentId,
+                    itemId = itemId,
+                    userId = userId,
+                    snapshotId = snapshotId,
+                )
             },
         ).map { it.getId() }
     }
@@ -153,17 +169,19 @@ class TournamentService(
             if (!item.isReady()) throw TournamentException.itemNotReadyToStart()
             item.currentPrice ?: throw TournamentException.itemPriceRequired()
         }
+        // 검증은 item 으로 끝냈고, 표시값은 출전 시점 고정 snapshot 에서 읽는다.
+        val snapshotById = snapshotsOf(tournamentItems)
 
         tournament.start()
         return tournamentItems
             .map { tournamentItem ->
-                val item = itemById.getValue(tournamentItem.itemId)
+                val snapshot = tournamentItem.requireSnapshot(snapshotById)
                 TournamentStartResult(
                     tournamentItemId = tournamentItem.getId(),
-                    name = item.name,
-                    price = item.currentPrice,
-                    currency = item.currency,
-                    imageUrl = item.imageUrl,
+                    name = snapshot.name,
+                    price = snapshot.currentPrice,
+                    currency = snapshot.currency,
+                    imageUrl = snapshot.imageUrl,
                 )
             }
             .sortedWith(compareBy({ it.price }, { it.tournamentItemId }))
@@ -184,10 +202,7 @@ class TournamentService(
         return when (tournament.status) {
             TournamentStatus.PENDING -> {
                 val tournamentItems = tournamentItemRepository.findAllByTournamentId(tournamentId)
-                val itemById =
-                    itemRepository
-                        .findByIds(tournamentItems.map { it.itemId })
-                        .associate { it.getId() to it }
+                val snapshotById = snapshotsOf(tournamentItems)
                 val tournamentUsers = tournamentUserRepository.findByTournamentId(tournamentId)
                 val userById = userRepository
                     .findByIds(
@@ -201,7 +216,7 @@ class TournamentService(
                     name = tournament.name,
                     inviteCode = tournament.inviteCode,
                     inviteExpiresAt = tournament.inviteExpiresAt,
-                    items = tournamentItems.map { toItemDetail(it, itemById) },
+                    items = tournamentItems.map { toItemDetail(it, snapshotById) },
                     participants =
                         tournamentUsers.mapNotNull { tu ->
                             userById[tu.userId]?.let { user ->
@@ -236,11 +251,9 @@ class TournamentService(
                 val remainingTournamentItems = allTournamentItems.filter { item ->
                     item.getId() !in eliminatedItemIds && item.getId() !in foughtInCurrentRoundIds
                 }
-                val itemById = itemRepository
-                    .findByIds(remainingTournamentItems.map { it.itemId })
-                    .associate { it.getId() to it }
+                val snapshotById = snapshotsOf(remainingTournamentItems)
                 val remainingItems = remainingTournamentItems
-                    .map { toItemDetail(it, itemById) }
+                    .map { toItemDetail(it, snapshotById) }
                     .sortedWith(compareBy({ it.price }, { it.tournamentItemId }))
                 TournamentDetail.InProgress(
                     tournamentId = tournament.getId(),
@@ -272,17 +285,19 @@ class TournamentService(
         val tournamentItem = tournamentItemRepository.findById(tournamentItemId)
             ?: throw TournamentException.notFoundTournamentItem()
         if (tournamentItem.tournamentId != tournamentId) throw TournamentException.notFoundTournamentItem()
+        // sourceUrl(상품 링크)은 정체성이라 item 에서, 표시값은 고정 snapshot 에서 읽는다.
         val item = itemRepository.findById(tournamentItem.itemId)
             ?: throw TournamentException.notFoundTournamentItem()
+        val snapshot = tournamentItem.requireSnapshot(snapshotsOf(listOf(tournamentItem)))
         return TournamentItemDetail(
             tournamentItemId = tournamentItem.getId(),
             itemId = item.getId(),
             sourceUrl = item.link?.toString(),
-            name = item.name,
-            imageUrl = item.imageUrl,
-            price = item.currentPrice,
-            currency = item.currency,
-            status = item.status,
+            name = snapshot.name,
+            imageUrl = snapshot.imageUrl,
+            price = snapshot.currentPrice,
+            currency = snapshot.currency,
+            status = snapshot.status,
         )
     }
 
@@ -386,24 +401,21 @@ class TournamentService(
         val tournamentItemById = tournamentItemRepository
             .findByIds(rankedPairs.map { it.first })
             .associateBy { it.getId() }
-        val itemById = itemRepository
-            .findByIds(tournamentItemById.values.map { it.itemId })
-            .associate { it.getId() to it }
+        val snapshotById = snapshotsOf(tournamentItemById.values)
         return TournamentDetail.Completed(
             tournamentId = tournament.getId(),
             name = tournament.name,
             result = rankedPairs.map { (tournamentItemId, rank) ->
                 val tournamentItem = tournamentItemById.getValue(tournamentItemId)
-                val item = itemById[tournamentItem.itemId]
-                    ?: error("item 없음 — tournamentItemId=$tournamentItemId, itemId=${tournamentItem.itemId}")
+                val snapshot = tournamentItem.requireSnapshot(snapshotById)
                 RankedItem(
                     rank = rank,
                     tournamentItemId = tournamentItemId,
                     itemId = tournamentItem.itemId,
-                    name = item.name,
-                    price = item.currentPrice,
-                    currency = item.currency,
-                    imageUrl = item.imageUrl,
+                    name = snapshot.name,
+                    price = snapshot.currentPrice,
+                    currency = snapshot.currency,
+                    imageUrl = snapshot.imageUrl,
                 )
             },
             hasGroupResult = hasGroupResult,
@@ -519,8 +531,16 @@ class TournamentService(
         )
         newTournament.assignOwner(tournamentUser.getId())
 
+        // 플레이 링크 복제는 원본 브래킷을 그대로 옮기는 것이라, 원본 tournament_item 이 고정한 snapshot 도 같이 박는다.
         tournamentItemRepository.saveAll(
-            sourceItems.map { TournamentItem(tournamentId = newTournament.getId(), itemId = it.itemId, userId = userId) },
+            sourceItems.map {
+                TournamentItem(
+                    tournamentId = newTournament.getId(),
+                    itemId = it.itemId,
+                    userId = userId,
+                    snapshotId = it.snapshotId,
+                )
+            },
         )
         return newTournament.getId()
     }
@@ -570,7 +590,7 @@ class TournamentService(
             .mapValues { (_, histories) -> computeRanking(histories) }
         val allTournamentItemIds = rankedByTournamentId.values.flatten().map { it.first }
         val tItemById = tournamentItemRepository.findByIds(allTournamentItemIds).associateBy { it.getId() }
-        val itemById = itemRepository.findByIds(tItemById.values.map { it.itemId }).associate { it.getId() to it }
+        val snapshotById = snapshotsOf(tItemById.values)
 
         for (t in allRelated) {
             val ranked = rankedByTournamentId[t.getId()] ?: continue
@@ -580,7 +600,7 @@ class TournamentService(
 
             for ((tournamentItemId, rank) in ranked) {
                 val tItem = tItemById[tournamentItemId] ?: continue
-                val item = itemById[tItem.itemId] ?: continue
+                val snapshot = tItem.snapshotId?.let { snapshotById[it] } ?: continue
                 val key = RankKey(tItem.itemId, rank)
                 chosenByMap.getOrPut(key) { mutableListOf() }.add(participant)
                 if (t.getId() == rootId) {
@@ -588,10 +608,10 @@ class TournamentService(
                         rank = rank,
                         tournamentItemId = tournamentItemId,
                         itemId = tItem.itemId,
-                        name = item.name,
-                        price = item.currentPrice,
-                        currency = item.currency,
-                        imageUrl = item.imageUrl,
+                        name = snapshot.name,
+                        price = snapshot.currentPrice,
+                        currency = snapshot.currency,
+                        imageUrl = snapshot.imageUrl,
                     )
                 }
             }
@@ -644,20 +664,30 @@ class TournamentService(
 
     private fun toItemDetail(
         tournamentItem: TournamentItem,
-        itemById: Map<Long, Item>,
+        snapshotById: Map<Long, ItemSnapshot>,
     ): TournamentDetail.ItemDetail {
-        val item = itemById[tournamentItem.itemId]
-            ?: error("item 없음 — tournamentItemId=${tournamentItem.getId()}, itemId=${tournamentItem.itemId}")
+        val snapshot = tournamentItem.requireSnapshot(snapshotById)
         return TournamentDetail.ItemDetail(
             tournamentItemId = tournamentItem.getId(),
             itemId = tournamentItem.itemId,
-            name = item.name,
-            price = item.currentPrice,
-            currency = item.currency,
-            imageUrl = item.imageUrl,
-            status = item.status,
+            name = snapshot.name,
+            price = snapshot.currentPrice,
+            currency = snapshot.currency,
+            imageUrl = snapshot.imageUrl,
+            status = snapshot.status,
         )
     }
+
+    // tournament_item 들이 고정한 snapshot 을 한 번에 조회해 id→snapshot 맵으로. 표시값 조회의 메모리 조인 재료다.
+    private fun snapshotsOf(tournamentItems: Collection<TournamentItem>): Map<Long, ItemSnapshot> =
+        itemSnapshotRepository
+            .findByIds(tournamentItems.mapNotNull { it.snapshotId })
+            .associateBy { it.getId() }
+
+    // 고정 snapshot 은 출전 시점에 반드시 박힌다. 없으면 영속화 경로가 깨진 코드 버그다(전환 후 신규 출전부터 보장).
+    private fun TournamentItem.requireSnapshot(snapshotById: Map<Long, ItemSnapshot>): ItemSnapshot =
+        snapshotId?.let { snapshotById[it] }
+            ?: error("snapshot 없음 — tournamentItemId=${getId()}, snapshotId=$snapshotId")
 
     private fun computeRanking(histories: List<TournamentHistory>): List<Pair<Long, Int>> {
         val finalMatch = histories.find { it.currentRound == Tournament.FINAL_ROUND_SIZE }

--- a/src/main/kotlin/com/depromeet/piki/wishlist/controller/WishlistController.kt
+++ b/src/main/kotlin/com/depromeet/piki/wishlist/controller/WishlistController.kt
@@ -38,7 +38,7 @@ class WishlistController(
         @Valid @RequestBody request: WishlistRegisterRequest,
     ): ApiResponseBody<WishItemResponse> {
         val result = wishlistService.registerFromUrl(rawUrl = request.url, userId = userId)
-        return ApiResponseBody.created(WishItemResponse.from(result.wish, result.item))
+        return ApiResponseBody.created(WishItemResponse.from(result.wish, result.item, result.snapshot))
     }
 
     @PostMapping("/images", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
@@ -50,7 +50,7 @@ class WishlistController(
         // images 파트를 아예 안 보내면(0장) Spring 이 컨트롤러 진입 전 MissingServletRequestPartException 으로
         // 끊어 캐치올(500)로 떨어진다. required=false + orEmpty 로 항상 서비스 검증(invalidImageCount, 400)에 닿게 한다.
         val results = wishlistService.registerFromImages(images = images.orEmpty(), userId = userId)
-        return ApiResponseBody.created(results.map { WishItemResponse.from(it.wish, it.item) })
+        return ApiResponseBody.created(results.map { WishItemResponse.from(it.wish, it.item, it.snapshot) })
     }
 
     @GetMapping
@@ -60,7 +60,7 @@ class WishlistController(
         @RequestParam(required = false) size: Int?,
     ): ApiResponseBody<List<WishItemResponse>> {
         val page = wishlistService.getWishlist(userId = userId, rawCursor = cursor, rawSize = size)
-        val data = page.entries.map { WishItemResponse.from(it.wish, it.item) }
+        val data = page.entries.map { WishItemResponse.from(it.wish, it.item, it.snapshot) }
         return ApiResponseBody.ok(
             data = data,
             pageResponse = PageResponse(nextCursor = page.nextCursor, hasNext = page.hasNext),
@@ -73,7 +73,7 @@ class WishlistController(
         @PathVariable wishId: Long,
     ): ApiResponseBody<WishItemResponse> {
         val result = wishlistService.getWish(userId = userId, wishId = wishId)
-        return ApiResponseBody.ok(WishItemResponse.from(result.wish, result.item))
+        return ApiResponseBody.ok(WishItemResponse.from(result.wish, result.item, result.snapshot))
     }
 
     @PatchMapping("/{wishId}", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
@@ -92,7 +92,7 @@ class WishlistController(
                 currency = request.currency,
                 image = image,
             )
-        return ApiResponseBody.ok(WishItemResponse.from(result.wish, result.item))
+        return ApiResponseBody.ok(WishItemResponse.from(result.wish, result.item, result.snapshot))
     }
 
     @DeleteMapping("/{wishId}")

--- a/src/main/kotlin/com/depromeet/piki/wishlist/controller/dto/WishItemResponse.kt
+++ b/src/main/kotlin/com/depromeet/piki/wishlist/controller/dto/WishItemResponse.kt
@@ -1,6 +1,7 @@
 package com.depromeet.piki.wishlist.controller.dto
 
 import com.depromeet.piki.item.domain.Item
+import com.depromeet.piki.item.domain.ItemSnapshot
 import com.depromeet.piki.item.domain.ItemStatus
 import com.depromeet.piki.wishlist.domain.Wish
 import io.swagger.v3.oas.annotations.media.Schema
@@ -17,10 +18,11 @@ data class WishItemResponse(
         fun from(
             wish: Wish,
             item: Item,
+            snapshot: ItemSnapshot,
         ): WishItemResponse =
             WishItemResponse(
                 wish = WishView.from(wish),
-                item = ItemView.from(item),
+                item = ItemView.from(item, snapshot),
             )
     }
 
@@ -69,14 +71,19 @@ data class WishItemResponse(
         val sourceUrl: String?,
     ) {
         companion object {
-            fun from(item: Item): ItemView =
+            // 표시값(status·name·currentPrice·currency·imageUrl)은 활성 snapshot 에서,
+            // 정체성(id·sourceUrl=상품 링크)은 item 에서 읽는다. snapshot 은 5단계 갱신에서 새 버전으로 스왑된다.
+            fun from(
+                item: Item,
+                snapshot: ItemSnapshot,
+            ): ItemView =
                 ItemView(
                     id = item.getId(),
-                    status = item.status,
-                    name = item.name,
-                    currentPrice = item.currentPrice,
-                    currency = item.currency,
-                    imageUrl = item.imageUrl,
+                    status = snapshot.status,
+                    name = snapshot.name,
+                    currentPrice = snapshot.currentPrice,
+                    currency = snapshot.currency,
+                    imageUrl = snapshot.imageUrl,
                     sourceUrl = item.link?.toString(),
                 )
         }

--- a/src/main/kotlin/com/depromeet/piki/wishlist/domain/Wish.kt
+++ b/src/main/kotlin/com/depromeet/piki/wishlist/domain/Wish.kt
@@ -14,6 +14,10 @@ class Wish(
     val userId: UUID,
     @Column(name = "item_id", nullable = false)
     val itemId: Long,
+    // 활성 snapshot(현재 보여줄 버전) 참조. raw Long(FK 없음). 5단계 갱신에서 새 snapshot 으로 스왑된다.
+    // nullable — 3단계 전환기에 추가됐고 기존 dev 데이터는 비우고 가므로 신규 등록부터 채워진다.
+    @Column(name = "snapshot_id")
+    val snapshotId: Long? = null,
 ) : LongBaseEntity() {
     // 소유자가 아니면 거부. 도메인이 자기방어해 어느 통로로 호출되든 같은 결과를 낸다.
     fun verifyOwnedBy(userId: UUID) {

--- a/src/main/kotlin/com/depromeet/piki/wishlist/repository/WishJpaRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/wishlist/repository/WishJpaRepository.kt
@@ -30,4 +30,9 @@ interface WishJpaRepository : JpaRepository<Wish, Long> {
     fun findByIdAndDeletedAtIsNull(id: Long): Wish?
 
     fun findByIdInAndDeletedAtIsNull(ids: Collection<Long>): List<Wish>
+
+    fun findByItemIdInAndUserIdAndDeletedAtIsNull(
+        itemIds: Collection<Long>,
+        userId: UUID,
+    ): List<Wish>
 }

--- a/src/main/kotlin/com/depromeet/piki/wishlist/repository/WishRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/wishlist/repository/WishRepository.kt
@@ -30,4 +30,11 @@ interface WishRepository {
     // 삭제되지 않은 위시들을 id 목록으로 조회. 존재하는 것만 반환하므로(없는 id 는 빠진다)
     // 호출부가 반환 개수로 누락 여부를 판단한다.
     fun findAllByIds(ids: List<Long>): List<Wish>
+
+    // 한 유저의 위시를 itemId 목록으로 조회. 토너먼트로 출전시킬 때 각 위시의 활성 snapshotId 를
+    // 읽어 tournament_item 에 고정하는 데 쓴다. itemId 는 등록당 1건이라 유저 내에서 사실상 1:1.
+    fun findByItemIdsAndUserId(
+        itemIds: List<Long>,
+        userId: UUID,
+    ): List<Wish>
 }

--- a/src/main/kotlin/com/depromeet/piki/wishlist/repository/WishRepositoryImpl.kt
+++ b/src/main/kotlin/com/depromeet/piki/wishlist/repository/WishRepositoryImpl.kt
@@ -39,4 +39,9 @@ class WishRepositoryImpl(
     override fun findById(id: Long): Wish? = wishJpaRepository.findByIdAndDeletedAtIsNull(id)
 
     override fun findAllByIds(ids: List<Long>): List<Wish> = wishJpaRepository.findByIdInAndDeletedAtIsNull(ids)
+
+    override fun findByItemIdsAndUserId(
+        itemIds: List<Long>,
+        userId: UUID,
+    ): List<Wish> = wishJpaRepository.findByItemIdInAndUserIdAndDeletedAtIsNull(itemIds, userId)
 }

--- a/src/main/kotlin/com/depromeet/piki/wishlist/service/WishPersistenceService.kt
+++ b/src/main/kotlin/com/depromeet/piki/wishlist/service/WishPersistenceService.kt
@@ -32,9 +32,10 @@ class WishPersistenceService(
         item: Item,
     ): WishWithItem {
         val saved = itemRepository.save(item)
-        itemSnapshotRepository.save(ItemSnapshot.forItem(saved))
-        val wish = wishRepository.save(Wish(userId = userId, itemId = saved.getId()))
-        return WishWithItem(wish = wish, item = saved)
+        // 3단계: 저장한 snapshot 의 id 를 wish 의 활성 포인터(snapshotId)로 박는다. 5단계 갱신에서 새 버전으로 스왑된다.
+        val snapshot = itemSnapshotRepository.save(ItemSnapshot.forItem(saved))
+        val wish = wishRepository.save(Wish(userId = userId, itemId = saved.getId(), snapshotId = snapshot.getId()))
+        return WishWithItem(wish = wish, item = saved, snapshot = snapshot)
     }
 
     // 이미지 다건 등록용 — link 없는 PROCESSING item 을 count 만큼 배치 저장하고, 각각에 snapshot·wish 를 건다.
@@ -45,10 +46,11 @@ class WishPersistenceService(
         count: Int,
     ): List<WishWithItem> {
         val items = itemRepository.saveAll(List(count) { Item(status = ItemStatus.PROCESSING) })
-        itemSnapshotRepository.saveAll(items.map { ItemSnapshot.forItem(it) })
-        return items.map { item ->
-            val wish = wishRepository.save(Wish(userId = userId, itemId = item.getId()))
-            WishWithItem(wish = wish, item = item)
+        // saveAll 은 입력 순서를 보존하므로 items[i] 와 snapshots[i] 가 같은 상품을 가리킨다.
+        val snapshots = itemSnapshotRepository.saveAll(items.map { ItemSnapshot.forItem(it) })
+        return items.zip(snapshots) { item, snapshot ->
+            val wish = wishRepository.save(Wish(userId = userId, itemId = item.getId(), snapshotId = snapshot.getId()))
+            WishWithItem(wish = wish, item = item, snapshot = snapshot)
         }
     }
 

--- a/src/main/kotlin/com/depromeet/piki/wishlist/service/WishPersistenceService.kt
+++ b/src/main/kotlin/com/depromeet/piki/wishlist/service/WishPersistenceService.kt
@@ -46,9 +46,11 @@ class WishPersistenceService(
         count: Int,
     ): List<WishWithItem> {
         val items = itemRepository.saveAll(List(count) { Item(status = ItemStatus.PROCESSING) })
-        // saveAll 은 입력 순서를 보존하므로 items[i] 와 snapshots[i] 가 같은 상품을 가리킨다.
-        val snapshots = itemSnapshotRepository.saveAll(items.map { ItemSnapshot.forItem(it) })
-        return items.zip(snapshots) { item, snapshot ->
+        // snapshot 을 itemId 로 매핑해 saveAll 반환 순서에 의존하지 않는다(순서 보존은 공식 계약이 아니다).
+        val snapshotsByItemId =
+            itemSnapshotRepository.saveAll(items.map { ItemSnapshot.forItem(it) }).associateBy { it.itemId }
+        return items.map { item ->
+            val snapshot = snapshotsByItemId[item.getId()] ?: error("item ${item.getId()} 의 snapshot 이 없다")
             val wish = wishRepository.save(Wish(userId = userId, itemId = item.getId(), snapshotId = snapshot.getId()))
             WishWithItem(wish = wish, item = item, snapshot = snapshot)
         }

--- a/src/main/kotlin/com/depromeet/piki/wishlist/service/WishlistService.kt
+++ b/src/main/kotlin/com/depromeet/piki/wishlist/service/WishlistService.kt
@@ -4,6 +4,7 @@ import com.depromeet.piki.common.storage.ImageStorage
 import com.depromeet.piki.image.domain.ProductImage
 import com.depromeet.piki.item.domain.Item
 import com.depromeet.piki.item.repository.ItemRepository
+import com.depromeet.piki.item.repository.ItemSnapshotRepository
 import com.depromeet.piki.item.service.ImageParsingWorker
 import com.depromeet.piki.item.service.ItemParsingService
 import com.depromeet.piki.item.service.ItemParsingWorker
@@ -31,6 +32,7 @@ class WishlistService(
     private val imageStorage: ImageStorage,
     private val wishRepository: WishRepository,
     private val itemRepository: ItemRepository,
+    private val itemSnapshotRepository: ItemSnapshotRepository,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -93,11 +95,17 @@ class WishlistService(
         val pageWishes = fetched.take(size)
 
         val itemsById = itemRepository.findByIds(pageWishes.map { it.itemId }).associateBy { it.getId() }
+        // 표시값은 wish 의 활성 snapshot 에서 읽는다. snapshot 은 등록 시 함께 생기고 wish.snapshotId 로 고정된다.
+        val snapshotsById =
+            itemSnapshotRepository.findByIds(pageWishes.mapNotNull { it.snapshotId }).associateBy { it.getId() }
         val entries =
             pageWishes.map { wish ->
-                // item 은 wish 와 함께 영속화되며 별도 삭제 경로가 없다. 없으면 영속화 경로가 깨진 코드 버그다.
+                // item·snapshot 은 wish 와 함께 영속화되며 별도 삭제 경로가 없다. 없으면 영속화 경로가 깨진 코드 버그다.
                 val item = itemsById[wish.itemId] ?: error("wish ${wish.getId()} 의 item ${wish.itemId} 가 없다")
-                WishWithItem(wish = wish, item = item)
+                val snapshot =
+                    wish.snapshotId?.let { snapshotsById[it] }
+                        ?: error("wish ${wish.getId()} 의 snapshot ${wish.snapshotId} 가 없다")
+                WishWithItem(wish = wish, item = item, snapshot = snapshot)
             }
 
         val nextCursor =
@@ -118,9 +126,12 @@ class WishlistService(
     ): WishWithItem {
         val wish = wishRepository.findById(wishId) ?: throw WishException.notFound()
         wish.verifyOwnedBy(userId)
-        // wish 가 가리키는 item 은 반드시 존재한다. 없으면 영속화 경로가 깨진 코드 버그다.
+        // wish 가 가리키는 item·snapshot 은 반드시 존재한다. 없으면 영속화 경로가 깨진 코드 버그다.
         val item = itemRepository.findById(wish.itemId) ?: error("wish ${wish.getId()} 의 item ${wish.itemId} 가 없다")
-        return WishWithItem(wish = wish, item = item)
+        val snapshot =
+            wish.snapshotId?.let { itemSnapshotRepository.findById(it) }
+                ?: error("wish ${wish.getId()} 의 snapshot ${wish.snapshotId} 가 없다")
+        return WishWithItem(wish = wish, item = item, snapshot = snapshot)
     }
 
     // 추출 실패(FAILED) item 을 사용자가 직접 보정해 READY 로 복구한다. 이미지를 함께 주면 그대로 S3 에 올려
@@ -149,7 +160,11 @@ class WishlistService(
                 imageStorage.upload(it.bytes, "items/${UUID.randomUUID()}.${it.extension}", it.mimeType)
             }
         val recovered = wishPersistenceService.recoverItem(wish.itemId, name, currentPrice, imageUrl, currency)
-        return WishWithItem(wish = wish, item = recovered)
+        // recoverItem 이 같은 트랜잭션에서 활성 snapshot 도 보정해 두었다. 응답 표시값은 그 snapshot 에서 읽는다.
+        val snapshot =
+            wish.snapshotId?.let { itemSnapshotRepository.findById(it) }
+                ?: error("wish ${wish.getId()} 의 snapshot ${wish.snapshotId} 가 없다")
+        return WishWithItem(wish = wish, item = recovered, snapshot = snapshot)
     }
 
     // 멱등 삭제: 없거나 이미 삭제됐으면 "이미 목표 상태(없음)"이므로 성공으로 본다(no-op).

--- a/src/main/kotlin/com/depromeet/piki/wishlist/service/WishlistService.kt
+++ b/src/main/kotlin/com/depromeet/piki/wishlist/service/WishlistService.kt
@@ -105,6 +105,11 @@ class WishlistService(
                 val snapshot =
                     wish.snapshotId?.let { snapshotsById[it] }
                         ?: error("wish ${wish.getId()} 의 snapshot ${wish.snapshotId} 가 없다")
+                // snapshot_id 는 FK 없는 raw Long 이라 잘못 연결되면 item 은 A, 표시값은 B 인 섞인 응답이 나갈 수 있다.
+                // 서비스가 보장하는 정합성을 불변식으로 한 번 더 막는다(어긋나면 영속화 경로가 깨진 코드 버그).
+                require(snapshot.itemId == wish.itemId) {
+                    "wish ${wish.getId()} 의 snapshot(${snapshot.getId()}) 가 다른 item(${snapshot.itemId} != ${wish.itemId})을 가리킨다"
+                }
                 WishWithItem(wish = wish, item = item, snapshot = snapshot)
             }
 
@@ -131,6 +136,10 @@ class WishlistService(
         val snapshot =
             wish.snapshotId?.let { itemSnapshotRepository.findById(it) }
                 ?: error("wish ${wish.getId()} 의 snapshot ${wish.snapshotId} 가 없다")
+        // snapshot_id 는 FK 없는 raw Long 이라 잘못 연결되면 item 은 A, 표시값은 B 인 섞인 응답이 나갈 수 있다.
+        require(snapshot.itemId == wish.itemId) {
+            "wish ${wish.getId()} 의 snapshot(${snapshot.getId()}) 가 다른 item(${snapshot.itemId} != ${wish.itemId})을 가리킨다"
+        }
         return WishWithItem(wish = wish, item = item, snapshot = snapshot)
     }
 

--- a/src/main/kotlin/com/depromeet/piki/wishlist/service/dto/WishWithItem.kt
+++ b/src/main/kotlin/com/depromeet/piki/wishlist/service/dto/WishWithItem.kt
@@ -1,10 +1,13 @@
 package com.depromeet.piki.wishlist.service.dto
 
 import com.depromeet.piki.item.domain.Item
+import com.depromeet.piki.item.domain.ItemSnapshot
 import com.depromeet.piki.wishlist.domain.Wish
 
-// wish 기록과 그 wish 가 가리키는 item 스냅샷의 묶음. 등록 결과·조회 항목이 공유한다.
+// wish 기록과 그 wish 가 가리키는 상품의 정체성(item)·활성 버전(snapshot) 묶음. 등록 결과·조회 항목이 공유한다.
+// 표시값(name/price/image/status)은 snapshot 에서, 정체성(id·sourceUrl=link)은 item 에서 온다.
 data class WishWithItem(
     val wish: Wish,
     val item: Item,
+    val snapshot: ItemSnapshot,
 )

--- a/src/main/resources/db/migration/V20260604235808__add_snapshot_id_to_wishes_and_tournament_items.sql
+++ b/src/main/resources/db/migration/V20260604235808__add_snapshot_id_to_wishes_and_tournament_items.sql
@@ -1,0 +1,9 @@
+-- 상품 버저닝 3단계(참조 이전): wish/tournament_item 이 snapshot 을 참조하도록 snapshot_id 추가 (additive).
+-- nullable — 신규 등록·추출부터 채워진다(쓰기 연결). 기존 dev 데이터는 비우고 가므로 backfill 하지 않는다.
+-- FK 제약 없음(프로젝트 정책). item_id 컬럼은 조회 전환이 안정된 뒤 4단계에서 제거한다.
+ALTER TABLE wishes ADD COLUMN snapshot_id BIGINT NULL;
+ALTER TABLE tournament_items ADD COLUMN snapshot_id BIGINT NULL;
+
+-- 조회 시 snapshot 을 끌어오는 wish/tournament_item → snapshot 방향 조인용 인덱스.
+CREATE INDEX idx_wishes_snapshot_id ON wishes (snapshot_id);
+CREATE INDEX idx_tournament_items_snapshot_id ON tournament_items (snapshot_id);

--- a/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
@@ -1025,7 +1025,10 @@ class TournamentControllerTest : IntegrationTestSupport() {
         val mockMvc = buildMockMvc()
         val tournamentId = createTournament(mockMvc)
         val failedItem = itemJpaRepository.save(Item(status = ItemStatus.FAILED))
-        tournamentItemJpaRepository.save(TournamentItem(tournamentId = tournamentId, itemId = failedItem.getId(), userId = userId))
+        val snapshot = itemSnapshotJpaRepository.save(ItemSnapshot.forItem(failedItem))
+        tournamentItemJpaRepository.save(
+            TournamentItem(tournamentId = tournamentId, itemId = failedItem.getId(), userId = userId, snapshotId = snapshot.getId()),
+        )
         val tournamentItemId = tournamentItemJpaRepository.findAllByTournamentIdAndNotDeleted(tournamentId).first().getId()
 
         mockMvc
@@ -1116,7 +1119,10 @@ class TournamentControllerTest : IntegrationTestSupport() {
         val mockMvc = buildMockMvc()
         val tournamentId = createTournament(mockMvc)
         val failedItem = itemJpaRepository.save(Item(name = "기존 이름", status = ItemStatus.FAILED))
-        tournamentItemJpaRepository.save(TournamentItem(tournamentId = tournamentId, itemId = failedItem.getId(), userId = userId))
+        val snapshot = itemSnapshotJpaRepository.save(ItemSnapshot.forItem(failedItem))
+        tournamentItemJpaRepository.save(
+            TournamentItem(tournamentId = tournamentId, itemId = failedItem.getId(), userId = userId, snapshotId = snapshot.getId()),
+        )
         val tournamentItemId = tournamentItemJpaRepository.findAllByTournamentIdAndNotDeleted(tournamentId).first().getId()
 
         mockMvc

--- a/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
@@ -2,9 +2,11 @@ package com.depromeet.piki.tournament.controller
 
 import com.depromeet.piki.auth.infrastructure.jwt.JwtProvider
 import com.depromeet.piki.item.domain.Item
+import com.depromeet.piki.item.domain.ItemSnapshot
 import com.depromeet.piki.item.domain.ItemStatus
 import com.depromeet.piki.product.domain.ProductLink
 import com.depromeet.piki.item.repository.ItemJpaRepository
+import com.depromeet.piki.item.repository.ItemSnapshotJpaRepository
 import com.depromeet.piki.support.IntegrationTestSupport
 import com.depromeet.piki.support.StubImageParsingWorker
 import com.depromeet.piki.support.StubItemParsingWorker
@@ -61,6 +63,8 @@ class TournamentControllerTest : IntegrationTestSupport() {
     @Autowired private lateinit var userJpaRepository: UserJpaRepository
 
     @Autowired private lateinit var itemJpaRepository: ItemJpaRepository
+
+    @Autowired private lateinit var itemSnapshotJpaRepository: ItemSnapshotJpaRepository
 
     @Autowired private lateinit var jwtProvider: JwtProvider
 
@@ -839,8 +843,8 @@ class TournamentControllerTest : IntegrationTestSupport() {
     fun `GET tournaments-id 는 PENDING 상태에서 PROCESSING 아이템이 status=PROCESSING 으로 목록에 포함되고 name·price·imageUrl 은 없다`() {
         val mockMvc = buildMockMvc()
         val tournamentId = createTournament(mockMvc)
-        val processingItemId = itemJpaRepository.save(Item(status = ItemStatus.PROCESSING)).getId()
-        tournamentItemJpaRepository.save(TournamentItem(tournamentId = tournamentId, itemId = processingItemId, userId = userId))
+        val processingItem = itemJpaRepository.save(Item(status = ItemStatus.PROCESSING))
+        saveTournamentItemFor(tournamentId, processingItem)
 
         mockMvc
             .perform(
@@ -850,7 +854,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
             .andExpect(jsonPath("$.data.status").value("PENDING"))
             .andExpect(jsonPath("$.data.pending.items.length()").value(1))
             .andExpect(jsonPath("$.data.pending.items[0].status").value("PROCESSING"))
-            .andExpect(jsonPath("$.data.pending.items[0].itemId").value(processingItemId))
+            .andExpect(jsonPath("$.data.pending.items[0].itemId").value(processingItem.getId()))
             .andExpect(jsonPath("$.data.pending.items[0].name").doesNotExist())
             .andExpect(jsonPath("$.data.pending.items[0].price").doesNotExist())
             .andExpect(jsonPath("$.data.pending.items[0].imageUrl").doesNotExist())
@@ -1399,6 +1403,25 @@ class TournamentControllerTest : IntegrationTestSupport() {
     private fun saveItem(name: String = "테스트 아이템"): Long =
         itemJpaRepository.save(Item(name = name)).getId()
 
+    // 직접 저장하는 tournament_item 에 3단계 쓰기 계약(고정 snapshot)을 맞춰준다 — item 의 현재 상태를 미러링한
+    // snapshot 을 만들고 그 id 를 박아 저장한다. 조회 경로(getTournamentById·getTournamentItem)가 snapshot 을 읽기 때문이다.
+    // (서비스 경유 시딩 saveWishItem+addItemsToTournament 은 엔드포인트가 이미 snapshotId 를 채운다.)
+    private fun saveTournamentItemFor(
+        tournamentId: Long,
+        item: Item,
+        owner: UUID = userId,
+    ): TournamentItem {
+        val snapshot = itemSnapshotJpaRepository.save(ItemSnapshot.forItem(item))
+        return tournamentItemJpaRepository.save(
+            TournamentItem(
+                tournamentId = tournamentId,
+                itemId = item.getId(),
+                userId = owner,
+                snapshotId = snapshot.getId(),
+            ),
+        )
+    }
+
     // 위시리스트에도 등록된 READY 아이템 생성 — /items/wish 엔드포인트용
     private fun saveWishItem(owner: UUID = userId, name: String = "테스트 아이템", price: Int = 10_000): Long =
         wishPersistenceService.persist(owner, Item(name = name, currentPrice = price, currency = "KRW")).item.getId()
@@ -1439,7 +1462,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
                 currency = "KRW",
             ),
         )
-        tournamentItemJpaRepository.save(TournamentItem(tournamentId = tournamentId, itemId = linkItem.getId(), userId = userId))
+        saveTournamentItemFor(tournamentId, linkItem)
         val tournamentItemId = tournamentItemJpaRepository.findAllByTournamentIdAndNotDeleted(tournamentId).first().getId()
 
         mockMvc
@@ -1455,8 +1478,8 @@ class TournamentControllerTest : IntegrationTestSupport() {
     fun `GET tournaments-id-items-tournamentItemId 는 PROCESSING 아이템이면 name·price·imageUrl 이 응답에 없고 status 가 PROCESSING 이다`() {
         val mockMvc = buildMockMvc()
         val tournamentId = createTournament(mockMvc)
-        val processingItemId = itemJpaRepository.save(Item(status = ItemStatus.PROCESSING)).getId()
-        tournamentItemJpaRepository.save(TournamentItem(tournamentId = tournamentId, itemId = processingItemId, userId = userId))
+        val processingItem = itemJpaRepository.save(Item(status = ItemStatus.PROCESSING))
+        saveTournamentItemFor(tournamentId, processingItem)
         val tournamentItemId = tournamentItemJpaRepository.findAllByTournamentIdAndNotDeleted(tournamentId).first().getId()
 
         mockMvc

--- a/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentFromPlayLinkConcurrencyIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentFromPlayLinkConcurrencyIntegrationTest.kt
@@ -149,6 +149,22 @@ class TournamentFromPlayLinkConcurrencyIntegrationTest : IntegrationTestSupport(
         )
         assertEquals(1L, cloneCount, "복제본은 정확히 1개여야 한다")
 
+        // 복제 토너먼트가 원본의 고정 snapshot_id 를 그대로 가져왔는지 검증한다(복제본 개수만으로는 잘못된 snapshot 연결을 못 잡는다).
+        val sourcePairs = jdbcTemplate.queryForList(
+            "SELECT item_id, snapshot_id FROM tournament_items WHERE tournament_id = ? ORDER BY item_id",
+            sourceTournamentId,
+        )
+        val clonedPairs = jdbcTemplate.queryForList(
+            """SELECT ti.item_id, ti.snapshot_id
+               FROM tournament_items ti
+               JOIN tournaments t ON t.id = ti.tournament_id
+               JOIN tournament_users tu ON tu.tournament_id = t.id
+               WHERE t.source_tournament_id = ? AND tu.user_id = ? AND tu.deleted_at IS NULL
+               ORDER BY ti.item_id""",
+            sourceTournamentId, uuidToBytes(clonerId),
+        )
+        assertEquals(sourcePairs, clonedPairs, "복제 토너먼트는 원본 snapshot_id 를 그대로 가져야 한다")
+
         // 정리
         jdbcTemplate.update("DELETE FROM tournament_histories WHERE tournament_id = ?", sourceTournamentId)
         jdbcTemplate.update(

--- a/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentFromPlayLinkConcurrencyIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentFromPlayLinkConcurrencyIntegrationTest.kt
@@ -2,7 +2,9 @@ package com.depromeet.piki.tournament.controller
 
 import com.depromeet.piki.auth.infrastructure.jwt.JwtProvider
 import com.depromeet.piki.item.domain.Item
+import com.depromeet.piki.item.domain.ItemSnapshot
 import com.depromeet.piki.item.repository.ItemJpaRepository
+import com.depromeet.piki.item.repository.ItemSnapshotJpaRepository
 import com.depromeet.piki.support.IntegrationTestSupport
 import com.depromeet.piki.support.uuidToBytes
 import com.depromeet.piki.tournament.domain.TournamentItem
@@ -38,6 +40,7 @@ class TournamentFromPlayLinkConcurrencyIntegrationTest : IntegrationTestSupport(
     @Autowired private lateinit var jwtProvider: JwtProvider
     @Autowired private lateinit var userJpaRepository: UserJpaRepository
     @Autowired private lateinit var itemJpaRepository: ItemJpaRepository
+    @Autowired private lateinit var itemSnapshotJpaRepository: ItemSnapshotJpaRepository
     @Autowired private lateinit var tournamentItemJpaRepository: TournamentItemJpaRepository
     @Autowired private lateinit var tournamentJpaRepository: TournamentJpaRepository
     @Autowired private lateinit var tournamentUserJpaRepository: TournamentUserJpaRepository
@@ -68,10 +71,17 @@ class TournamentFromPlayLinkConcurrencyIntegrationTest : IntegrationTestSupport(
             ).andReturn()
             val tId = objectMapper.readTree(createResult.response.contentAsString)["data"]["tournamentId"].asLong()
 
-            val item1 = itemJpaRepository.save(Item(name = "race-item1", currentPrice = 10_000, currency = "KRW")).getId()
-            val item2 = itemJpaRepository.save(Item(name = "race-item2", currentPrice = 20_000, currency = "KRW")).getId()
-            tournamentItemJpaRepository.save(TournamentItem(tournamentId = tId, itemId = item1, userId = ownerId))
-            tournamentItemJpaRepository.save(TournamentItem(tournamentId = tId, itemId = item2, userId = ownerId))
+            // 3단계: tournament_item 은 고정 snapshot 을 참조한다. 조회·start 표시값이 snapshot 에서 오므로 함께 만들어 연결한다.
+            val item1 = itemJpaRepository.save(Item(name = "race-item1", currentPrice = 10_000, currency = "KRW"))
+            val item2 = itemJpaRepository.save(Item(name = "race-item2", currentPrice = 20_000, currency = "KRW"))
+            val snapshot1 = itemSnapshotJpaRepository.save(ItemSnapshot.forItem(item1))
+            val snapshot2 = itemSnapshotJpaRepository.save(ItemSnapshot.forItem(item2))
+            tournamentItemJpaRepository.save(
+                TournamentItem(tournamentId = tId, itemId = item1.getId(), userId = ownerId, snapshotId = snapshot1.getId()),
+            )
+            tournamentItemJpaRepository.save(
+                TournamentItem(tournamentId = tId, itemId = item2.getId(), userId = ownerId, snapshotId = snapshot2.getId()),
+            )
 
             mockMvc.perform(
                 post("/api/v1/tournaments/$tId/start")

--- a/src/test/kotlin/com/depromeet/piki/tournament/service/TournamentServiceTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/service/TournamentServiceTest.kt
@@ -2,8 +2,10 @@ package com.depromeet.piki.tournament.service
 
 import com.depromeet.piki.common.domain.LongBaseEntity
 import com.depromeet.piki.item.domain.Item
+import com.depromeet.piki.item.domain.ItemSnapshot
 import com.depromeet.piki.item.domain.ItemStatus
 import com.depromeet.piki.item.repository.ItemRepository
+import com.depromeet.piki.item.repository.ItemSnapshotRepository
 import com.depromeet.piki.tournament.domain.Tournament
 import com.depromeet.piki.tournament.domain.TournamentHistory
 import com.depromeet.piki.tournament.domain.TournamentItem
@@ -114,15 +116,35 @@ class TournamentServiceTest {
         }
     }
 
-    private class TestWishRepository : WishRepository {
-        // userId → itemIds 매핑. 위시에 등록된 것만 카운트된다.
-        val wishItemIdsByUser: MutableMap<UUID, MutableSet<Long>> = mutableMapOf()
+    // 위시 등록의 축약 — itemId 마다 활성 snapshot(READY·기본가)을 만들고 그것을 가리키는 wish 를 만든다.
+    // 실제 persist 흐름(item → snapshot → wish.snapshotId 연결)과 동형이라, addItemsFromWish 가 wish.snapshotId 를
+    // 읽어 tournament_item 에 고정하는 3단계 동작을 그대로 검증할 수 있다.
+    private class TestWishRepository(
+        private val snapshotRepository: TestItemSnapshotRepository,
+    ) : WishRepository {
+        val wishes = mutableListOf<Wish>()
+        private var idSeq = 1L
 
         fun addWish(
             userId: UUID,
             vararg itemIds: Long,
         ) {
-            wishItemIdsByUser.getOrPut(userId) { mutableSetOf() }.addAll(itemIds.toList())
+            itemIds.forEach { itemId ->
+                // 같은 (user, item) 중복은 무시한다(기존 Set 시맨틱 보존).
+                if (wishes.any { it.userId == userId && it.itemId == itemId }) return@forEach
+                val snapshot =
+                    snapshotRepository.save(
+                        ItemSnapshot(
+                            itemId = itemId,
+                            name = "상품$itemId",
+                            currentPrice = TestItemRepository.DEFAULT_PRICE,
+                            status = ItemStatus.READY,
+                        ),
+                    )
+                val wish = Wish(userId = userId, itemId = itemId, snapshotId = snapshot.getId())
+                setEntityId(wish, idSeq++)
+                wishes.add(wish)
+            }
         }
 
         override fun save(wish: Wish): Wish = wish
@@ -135,10 +157,7 @@ class TournamentServiceTest {
         override fun countByItemIdsAndUserId(
             itemIds: List<Long>,
             userId: UUID,
-        ): Long {
-            val owned = wishItemIdsByUser[userId] ?: emptySet()
-            return itemIds.count { it in owned }.toLong()
-        }
+        ): Long = wishes.count { it.userId == userId && it.itemId in itemIds }.toLong()
 
         override fun findPage(
             userId: UUID,
@@ -146,9 +165,52 @@ class TournamentServiceTest {
             limit: Int,
         ): List<Wish> = emptyList()
 
-        override fun findById(id: Long): Wish? = null
+        override fun findById(id: Long): Wish? = wishes.find { it.getId() == id }
 
-        override fun findAllByIds(ids: List<Long>): List<Wish> = emptyList()
+        override fun findAllByIds(ids: List<Long>): List<Wish> = wishes.filter { it.getId() in ids }
+
+        override fun findByItemIdsAndUserId(
+            itemIds: List<Long>,
+            userId: UUID,
+        ): List<Wish> = wishes.filter { it.userId == userId && it.itemId in itemIds }
+
+        private fun setEntityId(
+            entity: LongBaseEntity,
+            id: Long,
+        ) {
+            val field = LongBaseEntity::class.java.getDeclaredField("id")
+            field.isAccessible = true
+            field.set(entity, id)
+        }
+    }
+
+    // 고정/활성 snapshot 저장소. addWish 가 채운 snapshot 을 출전 후 조회 경로(getTournamentById 등)가 다시 읽는다.
+    private class TestItemSnapshotRepository : ItemSnapshotRepository {
+        val snapshots = mutableListOf<ItemSnapshot>()
+        private var idSeq = 1L
+
+        override fun save(snapshot: ItemSnapshot): ItemSnapshot {
+            setEntityId(snapshot, idSeq++)
+            snapshots.add(snapshot)
+            return snapshot
+        }
+
+        override fun saveAll(snapshots: List<ItemSnapshot>): List<ItemSnapshot> = snapshots.map { save(it) }
+
+        override fun findLatestByItemId(itemId: Long): ItemSnapshot? = snapshots.lastOrNull { it.itemId == itemId }
+
+        override fun findById(id: Long): ItemSnapshot? = snapshots.find { it.getId() == id }
+
+        override fun findByIds(ids: List<Long>): List<ItemSnapshot> = snapshots.filter { it.getId() in ids }
+
+        private fun setEntityId(
+            entity: LongBaseEntity,
+            id: Long,
+        ) {
+            val field = LongBaseEntity::class.java.getDeclaredField("id")
+            field.isAccessible = true
+            field.set(entity, id)
+        }
     }
 
     private class TestUserRepository : UserRepository {
@@ -295,7 +357,8 @@ class TournamentServiceTest {
     private val repository = TestTournamentRepository()
     private val testUserRepository = TestUserRepository()
     private val testItemRepository = TestItemRepository()
-    private val testWishRepository = TestWishRepository()
+    private val testItemSnapshotRepository = TestItemSnapshotRepository()
+    private val testWishRepository = TestWishRepository(testItemSnapshotRepository)
     private val service =
         TournamentService(
             tournamentUserRepository,
@@ -303,6 +366,7 @@ class TournamentServiceTest {
             tournamentItemRepository,
             testUserRepository,
             testItemRepository,
+            testItemSnapshotRepository,
             testWishRepository,
         )
     private val userId = UUID.randomUUID()


### PR DESCRIPTION
## Situation

- 지금은 위시리스트와 토너먼트가 같은 상품 행을 공유한다. 위시에서 상품 정보를 갱신하면 그 상품을 출전시킨 토너먼트의 이름·가격까지 같이 바뀌어 공정성이 깨지고, 과거 값이 덮어써져 가격 이력도 남지 않는다.
- 상품 버저닝 Epic(#362)은 이를 정체성(상품 링크)과 버전(추출 스냅샷)으로 나눠 푼다. 1·2단계에서 버전 테이블과 그것을 채우는 쓰기 이중화가 이미 들어갔다. 이번 3단계는 위시·토너먼트가 상품 본체 대신 그 버전을 참조·조회하도록 읽는 쪽과 연결을 옮긴다.

## Task

- 위시·토너먼트가 보여주는 상품 정보(이름·가격·통화·이미지·상태)를 상품 본체가 아니라 그 시점의 버전에서 읽게 한다. 위시는 나중에 갱신으로 바꿀 수 있는 활성 버전을, 토너먼트는 출전 당시로 박힌 고정 버전을 본다.
- 겉으로 보이는 응답은 한 글자도 달라지면 안 된다(평행 추적). 같은 필드, 같은 값이 나오는지가 합격 기준이다.
- 착수하며 정할 디테일: 전환 이전 데이터(버전 포인터가 빈 행)를 조회에서 어떻게 다룰지.

## Action

### 설계 결정

- 전환 이전 데이터는 fallback 없이 간다. 조회는 항상 버전을 읽고, 없으면 코드 버그로 보고 에러를 낸다. dev 기존 데이터는 수동으로 비우기로 해 파괴적 마이그레이션을 두지 않았다. 검토했으나 버린 대안은 "상품 값으로 fallback": 상품 본체 읽기 경로를 살려둬 전환이 흐려지고 4단계 정리 부담이 커진다.
- 출전 가능 검증(READY 인지, 가격이 있는지)은 이번엔 상품 본체에 그대로 둔다. 이슈 스코프가 표시값 전환이라, 검증 이전은 상품 값 컬럼을 실제로 지우는 4단계와 함께 하는 것이 안전하다.

### 쓰기 연결

- 상품을 저장·생성하는 모든 길에서, 같이 만든 버전의 id 를 위시(활성)와 토너먼트 출전 항목(고정)에 박는다.
- 위시에서 토너먼트로 담을 때는 위시가 보고 있던 활성 버전을 그대로 고정한다.
- 플레이 링크 복제는 원본 출전 항목이 박아둔 버전을 그대로 복제한다. 누락하기 쉬운 지점이라 함께 정정했다.

### 조회 전환

표시값은 버전에서, 정체성(상품 id, 원본 링크)은 상품 본체에서 읽도록 갈랐다.

| 조회 화면 | 표시값(이름·가격·통화·이미지·상태) | id, 원본 링크 |
|---|---|---|
| 위시 목록·단건·보정 | 활성 버전 | 상품 본체 |
| 토너먼트 시작·상세·단건·완료·그룹결과 | 고정 버전 | 상품 본체 |

### 구현

- 참조 컬럼·인덱스 추가 마이그레이션과 두 엔티티의 snapshot_id 필드(이전 커밋).
- 버전 조회용 메서드 신설: 단건·일괄 버전 조회, 그리고 출전 시 위시의 활성 버전을 itemId 로 역조회하는 메서드.
- 표시값을 채우던 서비스 코드를 버전 조회로 교체. 응답 DTO 모양은 그대로 두어 외부 계약을 건드리지 않았다.

## Result

- 위시 단건 갱신(5단계)이 새 버전으로 스왑돼도 토너먼트는 출전 당시 고정 버전을 그대로 보게 돼, 토너먼트 격리와 가격 이력 보존의 토대가 섰다.
- 검증에서 비자명한 부분: 데이터를 직접 심는 테스트 다섯 곳(대기 목록, 단건 조회 2종, 플레이 링크 복제 동시성)은 버전을 연결하지 않으면 조회가 실패하도록 바뀌어, 버전 필수 규칙이 실제로 강제됨을 반대 방향으로 확인했다. 응답 동일성 회귀 테스트로 필드·값이 그대로 나옴을 확인한다.
- 후속: 상품 값 컬럼과 검증 게이트 이전 제거는 4단계, 위시 단건 갱신(버전 스왑)은 5단계(#358)에서 이어간다.

## Updates

### dev 머지 충돌 해결 (2026-06-05)

- 머지 게이트("up to date before merging")가 걸려 최신 dev 를 머지했다. dev 의 알림 수신자 도출(#371)이 위시 레포지토리와 토너먼트 테스트 더블을 함께 건드려 세 곳에서 충돌이 났다. (`90d559c`)
- 레포지토리 인터페이스·구현은 양쪽 메서드를 나란히 살렸다. 3단계가 더한 활성 버전 역조회와 #371 이 더한 "위시에 담은 유저" 역조회는 서로 독립이라 단순 병합이다.
- 토너먼트 테스트 더블은 판단이 필요했다. 3단계는 이 더블을 버전 저장소를 끼운 위시 리스트 기반으로 새로 짰고, #371 은 같은 더블에 유저별 아이템 맵을 두고 조회를 더했다. 두 구조 중 3단계의 리스트 기반을 남기고, #371 의 조회를 그 리스트에서 뽑도록(같은 아이템을 담은 위시의 유저들, 중복 제거) 옮겨 의미를 보존했다.

### CodeRabbit 리뷰 대응 (2026-06-05)

CodeRabbit 리뷰 5건(Major 4, nitpick 1)을 전부 반영했다. 핵심은 토너먼트 격리를 정면으로 건드리던 recover 였다.

- 토너먼트 recover 가 상품의 최신 버전이 아니라 출전 시점 고정 버전을 갱신하게 바꿨다. 기존엔 5단계 갱신으로 같은 상품에 버전이 여러 개 생기면 토너먼트가 고정한 버전이 아닌 최신을 수정해 격리가 깨졌다. 버전 누락 시 즉시 실패. (`0c63eaf`)
- 위시 조회에 버전-상품 정합성 검증을 더했다. 버전 참조가 FK 없는 raw id 라 잘못 연결되면 정체성은 A, 표시값은 B 인 섞인 응답이 나갈 수 있어 불변식으로 한 번 더 막는다. (`0c63eaf`)
- 그룹 결과에서 버전 누락을 건너뛰지 않고 즉시 실패시킨다. 건너뛰면 부분 집계된 랭킹이 정상 응답으로 새어나간다. 단 바로 위 출전 아이템 누락은 삭제분이 history 에 남은 정상 경우라 건너뛰기를 유지했다. (`0c63eaf`)
- 배치 저장의 반환 순서 의존을 제거하고 상품 id 로 매핑했다. 순서 보존은 공식 계약이 아니다. (`0c63eaf`)
- 플레이 링크 동시성 테스트에 원본과 복제의 버전 id 일치 단언을 더했다. 복제본 개수만으로는 잘못된 버전 연결을 못 잡는다. recover 성공 테스트의 시딩이 버전을 안 박던 누락도 함께 정정했다. (`124390b`)

---
## 연관 이슈

- close #384


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 위시와 토너먼트 항목이 등록/출전 시점의 스냅샷 기준으로 고정되어 이름·가격·이미지·상태 등이 일관되게 표시됩니다.
  * 위시/토너먼트 조회·복구 응답에 스냅샷 정보가 포함되어 결과가 예측 가능해졌습니다.

* **Database**
  * wishes 및 tournament_items 테이블에 snapshot_id 컬럼과 인덱스가 추가되었습니다.

* **Tests**
  * 관련 테스트 시나리오 및 시드 데이터가 스냅샷 기반으로 갱신되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

