### PR TITLE
trace 계측 추가 (DB SQL · 외부 HTTP client span)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -83,6 +83,10 @@ dependencies {
     implementation("io.micrometer:micrometer-tracing-bridge-otel")
     implementation("io.opentelemetry:opentelemetry-exporter-otlp")
 
+    // JDBC 쿼리를 trace span 으로 계측 (DataSource proxy 자동 설정 → SQL 이 trace 의 한 구간으로 보인다).
+    // Spring Boot BOM 미관리라 버전 명시(Maven Central 최신 2.2.1). Boot 4 공식 호환 명시가 없어 부팅으로 검증한다.
+    implementation("net.ttddyy.observation:datasource-micrometer-spring-boot:2.2.1")
+
     // 크롭한 상품 이미지를 S3 에 업로드 (#144). 버전은 BOM 이 관리.
     implementation("software.amazon.awssdk:s3")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,7 +84,7 @@ dependencies {
     implementation("io.opentelemetry:opentelemetry-exporter-otlp")
 
     // JDBC 쿼리를 trace span 으로 계측 (DataSource proxy 자동 설정 → SQL 이 trace 의 한 구간으로 보인다).
-    // Spring Boot BOM 미관리라 버전 명시(Maven Central 최신 2.2.1). Boot 4 공식 호환 명시가 없어 부팅으로 검증한다.
+    // Spring Boot BOM 미관리라 버전 명시(2.2.1, 현재 최신). 2.x 가 Boot 4 대응 라인이나(이슈 #78) 릴리스 노트가 호환을 명시하진 않아 부팅으로 검증한다.
     implementation("net.ttddyy.observation:datasource-micrometer-spring-boot:2.2.1")
 
     // 크롭한 상품 이미지를 S3 에 업로드 (#144). 버전은 BOM 이 관리.

--- a/src/main/kotlin/com/depromeet/piki/product/service/gemini/GeminiHttpClient.kt
+++ b/src/main/kotlin/com/depromeet/piki/product/service/gemini/GeminiHttpClient.kt
@@ -1,5 +1,6 @@
 package com.depromeet.piki.product.service.gemini
 
+import io.micrometer.observation.ObservationRegistry
 import org.springframework.http.MediaType
 import org.springframework.http.client.SimpleClientHttpRequestFactory
 import org.springframework.stereotype.Component
@@ -23,7 +24,10 @@ import tools.jackson.databind.ObjectMapper
 class GeminiHttpClient(
     private val geminiProperties: GeminiProperties,
     private val objectMapper: ObjectMapper,
+    observationRegistry: ObservationRegistry,
 ) {
+    // ObservationRegistry 를 물려 Gemini 호출(최대 30s)이 trace 의 한 구간(HTTP client span)으로 잡히게 한다.
+    // 한 요청 trace 에서 LLM 호출 latency 가 막대로 또렷이 보인다.
     private val restClient =
         RestClient
             .builder()
@@ -33,7 +37,8 @@ class GeminiHttpClient(
                     setConnectTimeout(CONNECT_TIMEOUT_MS)
                     setReadTimeout(READ_TIMEOUT_MS)
                 },
-            ).build()
+            ).observationRegistry(observationRegistry)
+            .build()
 
     private val geminiRetry = GeminiRetry(geminiProperties.retry)
 

--- a/src/main/kotlin/com/depromeet/piki/product/service/http/HttpPageFetcher.kt
+++ b/src/main/kotlin/com/depromeet/piki/product/service/http/HttpPageFetcher.kt
@@ -3,6 +3,7 @@ package com.depromeet.piki.product.service.http
 import com.depromeet.piki.product.domain.ProductLink
 import com.depromeet.piki.product.service.PageContent
 import com.depromeet.piki.product.service.PageFetcher
+import io.micrometer.observation.ObservationRegistry
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpHeaders
 import org.springframework.http.client.SimpleClientHttpRequestFactory
@@ -14,7 +15,9 @@ import java.net.HttpURLConnection
 import java.net.InetAddress
 
 @Component
-class HttpPageFetcher : PageFetcher {
+class HttpPageFetcher(
+    observationRegistry: ObservationRegistry,
+) : PageFetcher {
     private val log = LoggerFactory.getLogger(javaClass)
 
     // 외부 페이지 fetch 라 redirect 를 따라가지 않는다. 따라가면 1차 host 검증을
@@ -40,6 +43,8 @@ class HttpPageFetcher : PageFetcher {
             .defaultHeader(HttpHeaders.USER_AGENT, USER_AGENT)
             .defaultHeader(HttpHeaders.ACCEPT, "text/html,application/xhtml+xml,*/*;q=0.8")
             .defaultHeader(HttpHeaders.ACCEPT_LANGUAGE, "ko,en;q=0.9")
+            // 상품 페이지 fetch 가 trace 의 한 구간(HTTP client span)으로 잡히게 한다.
+            .observationRegistry(observationRegistry)
             .build()
 
     override fun fetch(link: ProductLink): PageContent {

--- a/src/test/kotlin/com/depromeet/piki/common/config/DataSourceObservationIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/common/config/DataSourceObservationIntegrationTest.kt
@@ -1,0 +1,25 @@
+package com.depromeet.piki.common.config
+
+import com.depromeet.piki.support.IntegrationTestSupport
+import net.ttddyy.observation.boot.autoconfigure.DataSourceObservationBeanPostProcessor
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.ApplicationContext
+import kotlin.test.assertTrue
+
+// datasource-micrometer 가 Spring Boot 4 에서 autoconfig 되는지 검증한다. 부팅 성공만으론 autoconfig 가 조용히
+// skip 됐는지 알 수 없어(Boot 4 공식 호환 명시 없음), 핵심 빈(DataSourceObservationBeanPostProcessor) 등록을
+// 직접 단언해 negative control 로 둔다. 이 BeanPostProcessor 가 DataSource 를 observation proxy(JDK dynamic
+// proxy)로 감싸 JDBC 쿼리를 trace span 으로 잡는다(이 작업의 목적). 미등록이면 SQL span 이 안 생긴다.
+class DataSourceObservationIntegrationTest : IntegrationTestSupport() {
+    @Autowired
+    private lateinit var applicationContext: ApplicationContext
+
+    @Test
+    fun `datasource-micrometer autoconfig 가 적용돼 DataSource 를 observation proxy 로 감싼다`() {
+        assertTrue(
+            applicationContext.getBeanNamesForType(DataSourceObservationBeanPostProcessor::class.java).isNotEmpty(),
+            "datasource-micrometer 의 DataSourceObservationBeanPostProcessor 가 등록돼야 SQL 이 span 으로 잡힌다",
+        )
+    }
+}

--- a/src/test/kotlin/com/depromeet/piki/common/config/DataSourceObservationIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/common/config/DataSourceObservationIntegrationTest.kt
@@ -8,7 +8,7 @@ import org.springframework.context.ApplicationContext
 import kotlin.test.assertTrue
 
 // datasource-micrometer 가 Spring Boot 4 에서 autoconfig 되는지 검증한다. 부팅 성공만으론 autoconfig 가 조용히
-// skip 됐는지 알 수 없어(Boot 4 공식 호환 명시 없음), 핵심 빈(DataSourceObservationBeanPostProcessor) 등록을
+// skip 됐는지 알 수 없어(2.x 가 Boot 4 라인이나 릴리스 노트가 호환을 명시하진 않음), 핵심 빈(DataSourceObservationBeanPostProcessor) 등록을
 // 직접 단언해 negative control 로 둔다. 이 BeanPostProcessor 가 DataSource 를 observation proxy(JDK dynamic
 // proxy)로 감싸 JDBC 쿼리를 trace span 으로 잡는다(이 작업의 목적). 미등록이면 SQL span 이 안 생긴다.
 class DataSourceObservationIntegrationTest : IntegrationTestSupport() {

--- a/src/test/kotlin/com/depromeet/piki/product/service/ProductLinkExtractE2ETest.kt
+++ b/src/test/kotlin/com/depromeet/piki/product/service/ProductLinkExtractE2ETest.kt
@@ -5,6 +5,7 @@ import com.depromeet.piki.product.service.gemini.GeminiHttpClient
 import com.depromeet.piki.product.service.gemini.GeminiProductLinkExtractor
 import com.depromeet.piki.product.service.gemini.GeminiProperties
 import com.depromeet.piki.product.service.http.HttpPageFetcher
+import io.micrometer.observation.ObservationRegistry
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
@@ -19,14 +20,14 @@ import java.util.concurrent.TimeUnit
  */
 @Disabled("실제 Gemini API 호출 + 외부 쇼핑몰 fetch. 측정 필요 시 수동으로 enable 후 실행.")
 class ProductLinkExtractE2ETest {
-    private val pageFetcher = HttpPageFetcher()
+    private val pageFetcher = HttpPageFetcher(ObservationRegistry.NOOP)
     private val objectMapper = jacksonObjectMapper()
     private val properties =
         GeminiProperties(
             apiKey = System.getenv("GEMINI_API_KEY"),
             model = "gemini-3-flash-preview",
         )
-    private val httpClient = GeminiHttpClient(properties, objectMapper)
+    private val httpClient = GeminiHttpClient(properties, objectMapper, ObservationRegistry.NOOP)
     private val extractor =
         GeminiProductLinkExtractor(
             geminiHttpClient = httpClient,


### PR DESCRIPTION
## Situation
- #383, #385 로 분산 트레이싱(OTLP)을 도입해 trace 가 Tempo 에 쌓이지만, 자동 계측이 HTTP 요청·스케줄 작업 경계만 잡아 한 요청 trace 의 span 이 빈약했다(보통 1개). waterfall 이 단조로워 "이 요청의 어느 구간이 느린가"를 못 본다.

## Task
- 한 요청 trace 가 DB 쿼리·외부 호출 구간까지 쪼개진 waterfall 로 보이도록 계측을 추가한다.

## Action

### DB SQL span
- `datasource-micrometer-spring-boot` 2.2.1 을 추가했다. DataSource 를 observation proxy(JDK dynamic proxy)로 감싸 JDBC 쿼리가 span 으로 잡힌다. Spring Boot BOM 미관리라 버전을 명시했다(Maven Central 최신).

### 외부 HTTP client span
- `GeminiHttpClient`·`HttpPageFetcher` 의 `RestClient.builder()` 에 `ObservationRegistry` 를 주입했다. Gemini 호출(최대 30s)과 상품 페이지 fetch 가 HTTP client span 으로 잡힌다. 둘 다 builder 로 직접 생성하던 것이라 생성자로 registry 를 받게 했다.
- E2E 측정 테스트가 두 클라이언트를 직접 생성하므로 `ObservationRegistry.NOOP` 를 넘겨 컴파일을 맞췄다.

## Result
- (비자명한 검증) datasource-micrometer 는 2.x 가 Boot 4 대응 라인이지만(GitHub 이슈 #78) 릴리스 노트가 호환을 대놓고 명시하진 않는다. 부팅 성공은 autoconfig 의 조용한 skip 을 못 잡으므로, `DataSourceObservationBeanPostProcessor` 빈 등록을 통합테스트로 단언해 negative control 로 뒀다. 처음엔 proxy 클래스명이 `net.ttddyy` 일 거라 단언했다가 FAIL 났고, 실제로는 JDK 인터페이스 proxy 였어서(`jdk.proxy3.$Proxy`) 단언을 "빈 등록 확인"으로 정정했다.
- **배포 후 Tempo waterfall 에서 실제 DB·외부호출 span 이 보이는지 최종 실측**이 남아 있다.
- **OAuth RestClient(로그인 전용)는 이번에서 제외**했다. `object` 라 별도 리팩터가 필요하고, 메인 추출 플로우(fetch + Gemini + DB)와 별개 경로라 후속으로 분리한다.

## 연관 이슈
- 

## Updates

### Boot 4 호환 표현 정정 (2026-06-06)
- Result 의 "Spring Boot 4 공식 호환 명시가 없다" 를 정정했다. GitHub 이슈 #78(closed, milestone v2.0.0)에서 메인테이너가 "1.x 는 Boot 4 와 안 맞고 2.x 로 대응"이라 밝혀, 2.x 가 Boot 4 대응 라인임이 확인됐다. 다만 2.2.x 릴리스 노트엔 호환을 대놓고 명시한 문구가 없어 "2.x 가 Boot 4 라인이나 릴리스 노트가 호환을 명시하진 않는다" 로 다듬었다. 코드 주석(build.gradle.kts·테스트)도 같은 표현으로 함께 정정. (`dabdaa4`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * JDBC 쿼리, 외부 API 및 HTTP 요청에 대한 관측(Observation)/트레이싱 통합을 강화해 호출 구간이 더 명확히 추적됩니다.

* **Tests**
  * 관측 자동설정이 적용되는지 검증하는 통합 테스트를 추가하고, 관련 E2E 테스트를 관측 레지스트리 사용 방식으로 정리했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
