### PR TITLE
pr 스킬 Status 조회 파싱 버그 수정

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -217,8 +217,10 @@ ISSUE_LABELS=$(gh issue view {번호} --json labels --jq '[.labels[].name] | joi
     gh pr edit --add-assignee @me ${ISSUE_LABELS:+--add-label "$ISSUE_LABELS"}
     ITEM_ID=$(gh project item-add 99 --owner depromeet --url {PR URL} --format json --jq '.id')
 
-    # Status + Start date 현재 값 동시 조회
-    read CURRENT_STATUS CURRENT_START < <(gh api graphql -F id="$ITEM_ID" -f query='
+    # Status + Start date 현재 값 동시 조회. @tsv 출력이라 IFS 를 탭으로 고정한다.
+    # 기본 IFS(공백 포함)면 "In review"·"In progress" 같은 공백 포함 단일 선택 값이 첫 단어에서
+    # 쪼개져 CURRENT_STATUS 가 "In" 으로 잘리고, In review 승격 분기가 조용히 어긋난다.
+    IFS=$'\t' read -r CURRENT_STATUS CURRENT_START < <(gh api graphql -F id="$ITEM_ID" -f query='
       query($id: ID!) {
         node(id: $id) {
           ... on ProjectV2Item {


### PR DESCRIPTION
## Situation

- /pr 스킬의 update 모드에는 Project 의 Status 와 Start date 를 한 번에 조회해 bash `read` 로 두 변수에 담는 메타데이터 보정 단계가 있다. gh 의 `@tsv` 출력을 받는다.
- 실제 다른 PR 을 보정하던 중 이 파싱이 깨지는 걸 발견했다. 조회 결과가 "In review" 인데 `read` 가 Status 를 "In" 으로 잘랐다.

## Task

- `@tsv` 는 필드를 탭으로 구분한다. 그런데 bash 의 기본 IFS 는 공백도 구분자로 친다. 그래서 "In review"·"In progress" 처럼 공백이 든 단일 선택 값이 첫 단어에서 쪼개진다.
- Status 가 "In" 으로 잘리면, 뒤이은 "Backlog·Ready·In progress 면 In review 로 승격" 분기를 통과하지 못한다.

## Action

- 조회 결과를 받는 `read` 의 구분자를 탭으로 고정했다 (`IFS=$'\t' read -r`). 공백이 든 값도 통째로 한 변수에 들어간다.
- 미래에 누가 IFS 를 지워 되돌리지 않도록, 왜 탭 고정이 필요한지 이유를 바로 위 주석에 박았다.

## Result

- "In progress" 상태의 PR 이 /pr update 를 거칠 때 In review 로 올라간다. 기존엔 "In" 으로 잘려 승격이 조용히 누락됐다.
- 그동안 안 드러난 이유: 가장 흔한 "In review" 는 잘려도 "유지" 분기와 우연히 일치해 결과가 맞았다. "In progress" 일 때만 실제로 어긋난다.
- 검증: 입력 "In review[탭]날짜" 로 파싱과 승격 분기를 전후 비교했다. 기본 IFS 면 "In progress" 승격 누락이 재현되고, 탭 고정 후 정상 승격됨을 확인했다.

---
## 연관 이슈

- 
