### PR TITLE
대시보드에 trace 목록 패널 추가

### DIFF
--- a/infra/grafana/dashboard.json
+++ b/infra/grafana/dashboard.json
@@ -3,7 +3,7 @@
     {
       "name": "DS_PROM",
       "label": "Prometheus",
-      "description": "PIKI 메트릭 (grafanacloud-piki-prom)",
+      "description": "PiKi 메트릭 (grafanacloud-piki-prom)",
       "type": "datasource",
       "pluginId": "prometheus",
       "pluginName": "Prometheus"
@@ -11,7 +11,7 @@
     {
       "name": "DS_LOKI",
       "label": "Loki",
-      "description": "PIKI 로그 (grafanacloud-piki-logs)",
+      "description": "PiKi 로그 (grafanacloud-piki-logs)",
       "type": "datasource",
       "pluginId": "loki",
       "pluginName": "Loki"
@@ -19,14 +19,14 @@
     {
       "name": "DS_TEMPO",
       "label": "Tempo",
-      "description": "PIKI 트레이스 (grafanacloud-piki-traces)",
+      "description": "PiKi 트레이스 (grafanacloud-piki-traces)",
       "type": "datasource",
       "pluginId": "tempo",
       "pluginName": "Tempo"
     }
   ],
   "__requires": [],
-  "title": "PIKI - 앱 + 호스트 개요",
+  "title": "PiKi - 앱 + 호스트 개요",
   "uid": "piki-app-overview",
   "tags": [
     "piki"

--- a/infra/grafana/dashboard.json
+++ b/infra/grafana/dashboard.json
@@ -15,389 +15,1428 @@
       "type": "datasource",
       "pluginId": "loki",
       "pluginName": "Loki"
+    },
+    {
+      "name": "DS_TEMPO",
+      "label": "Tempo",
+      "description": "PIKI 트레이스 (grafanacloud-piki-traces)",
+      "type": "datasource",
+      "pluginId": "tempo",
+      "pluginName": "Tempo"
     }
   ],
   "__requires": [],
   "title": "PIKI - 앱 + 호스트 개요",
   "uid": "piki-app-overview",
-  "tags": ["piki"],
+  "tags": [
+    "piki"
+  ],
   "timezone": "browser",
   "editable": true,
   "schemaVersion": 39,
   "version": 2,
   "refresh": "30s",
-  "time": { "from": "now-1h", "to": "now" },
-  "templating": { "list": [] },
-  "annotations": { "list": [] },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "traceFilter",
+        "type": "custom",
+        "label": "trace 필터",
+        "query": "전체 : { resource.service.name = \"PIKI\" },느린(>500ms) : { resource.service.name = \"PIKI\" && trace:duration > 500ms },에러 : { resource.service.name = \"PIKI\" && status = error }",
+        "current": {
+          "text": "전체",
+          "value": "{ resource.service.name = \"PIKI\" }",
+          "selected": true
+        },
+        "options": [
+          {
+            "text": "전체",
+            "value": "{ resource.service.name = \"PIKI\" }",
+            "selected": true
+          },
+          {
+            "text": "느린(>500ms)",
+            "value": "{ resource.service.name = \"PIKI\" && trace:duration > 500ms }",
+            "selected": false
+          },
+          {
+            "text": "에러",
+            "value": "{ resource.service.name = \"PIKI\" && status = error }",
+            "selected": false
+          }
+        ],
+        "includeAll": false,
+        "multi": false,
+        "hide": 0
+      }
+    ]
+  },
+  "annotations": {
+    "list": []
+  },
   "panels": [
+    {
+      "id": 107,
+      "type": "row",
+      "title": "트레이스",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      }
+    },
+    {
+      "id": 70,
+      "type": "table",
+      "title": "trace (필터: $traceFilter)",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "datasource": {
+        "type": "tempo",
+        "uid": "${DS_TEMPO}"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "tempo",
+            "uid": "${DS_TEMPO}"
+          },
+          "queryType": "traceql",
+          "query": "${traceFilter:raw}",
+          "tableType": "traces",
+          "limit": 20,
+          "filters": []
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Service"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "options": {}
+    },
     {
       "id": 100,
       "type": "row",
       "title": "한눈 건강 (위험하면 빨강)",
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 }
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      }
     },
     {
       "id": 1,
       "type": "stat",
       "title": "앱 상태 (up)",
-      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 1 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+      "gridPos": {
+        "h": 2,
+        "w": 4,
+        "x": 0,
+        "y": 10
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROM}"
+      },
       "fieldConfig": {
         "defaults": {
           "unit": "short",
           "mappings": [
-            { "type": "value", "options": { "0": { "text": "DOWN", "color": "red" }, "1": { "text": "UP", "color": "green" } } }
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "DOWN",
+                  "color": "red"
+                },
+                "1": {
+                  "text": "UP",
+                  "color": "green"
+                }
+              }
+            }
           ],
-          "thresholds": { "mode": "absolute", "steps": [ { "color": "red", "value": null }, { "color": "green", "value": 1 } ] }
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
         },
         "overrides": []
       },
-      "options": { "colorMode": "background", "graphMode": "none", "textMode": "auto", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "textMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
       "targets": [
-        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "max(up{job=\"prometheus.scrape.app\"})" }
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROM}"
+          },
+          "expr": "max(up{job=\"prometheus.scrape.app\"})"
+        }
       ]
     },
     {
       "id": 2,
       "type": "stat",
       "title": "5xx 에러율",
-      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 1 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+      "gridPos": {
+        "h": 2,
+        "w": 4,
+        "x": 4,
+        "y": 10
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROM}"
+      },
       "fieldConfig": {
         "defaults": {
           "unit": "percent",
-          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 1 }, { "color": "red", "value": 5 } ] }
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          }
         },
         "overrides": []
       },
-      "options": { "colorMode": "background", "graphMode": "area", "textMode": "auto", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "textMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
       "targets": [
-        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "sum(rate(http_server_requests_seconds_count{application=\"PIKI\", status=~\"5..\"}[$__rate_interval])) / clamp_min(sum(rate(http_server_requests_seconds_count{application=\"PIKI\"}[$__rate_interval])), 0.001) * 100" }
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROM}"
+          },
+          "expr": "sum(rate(http_server_requests_seconds_count{application=\"PIKI\", status=~\"5..\"}[$__rate_interval])) / clamp_min(sum(rate(http_server_requests_seconds_count{application=\"PIKI\"}[$__rate_interval])), 0.001) * 100"
+        }
       ]
     },
     {
       "id": 3,
       "type": "stat",
       "title": "HTTP p99 지연",
-      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 1 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+      "gridPos": {
+        "h": 2,
+        "w": 4,
+        "x": 8,
+        "y": 10
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROM}"
+      },
       "fieldConfig": {
         "defaults": {
           "unit": "s",
-          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 1 }, { "color": "red", "value": 5 } ] }
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          }
         },
         "overrides": []
       },
-      "options": { "colorMode": "background", "graphMode": "area", "textMode": "auto", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "textMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
       "targets": [
-        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "histogram_quantile(0.99, sum by (le) (rate(http_server_requests_seconds_bucket{application=\"PIKI\"}[$__rate_interval])))" }
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROM}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(http_server_requests_seconds_bucket{application=\"PIKI\"}[$__rate_interval])))"
+        }
       ]
     },
     {
       "id": 4,
       "type": "stat",
       "title": "JVM Heap 사용률",
-      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 1 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+      "gridPos": {
+        "h": 2,
+        "w": 4,
+        "x": 12,
+        "y": 10
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROM}"
+      },
       "fieldConfig": {
         "defaults": {
           "unit": "percent",
-          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 70 }, { "color": "red", "value": 85 } ] }
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          }
         },
         "overrides": []
       },
-      "options": { "colorMode": "background", "graphMode": "area", "textMode": "auto", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "textMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
       "targets": [
-        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "sum(jvm_memory_used_bytes{application=\"PIKI\", area=\"heap\"}) / sum(jvm_memory_max_bytes{application=\"PIKI\", area=\"heap\"}) * 100" }
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROM}"
+          },
+          "expr": "sum(jvm_memory_used_bytes{application=\"PIKI\", area=\"heap\"}) / sum(jvm_memory_max_bytes{application=\"PIKI\", area=\"heap\"}) * 100"
+        }
       ]
     },
     {
       "id": 5,
       "type": "stat",
       "title": "호스트 메모리 사용률",
-      "gridPos": { "h": 4, "w": 4, "x": 16, "y": 1 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+      "gridPos": {
+        "h": 2,
+        "w": 4,
+        "x": 16,
+        "y": 10
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROM}"
+      },
       "fieldConfig": {
         "defaults": {
           "unit": "percent",
-          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 80 }, { "color": "red", "value": 90 } ] }
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 80
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          }
         },
         "overrides": []
       },
-      "options": { "colorMode": "background", "graphMode": "area", "textMode": "auto", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "textMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
       "targets": [
-        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "(1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes) * 100" }
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROM}"
+          },
+          "expr": "(1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes) * 100"
+        }
       ]
     },
     {
       "id": 6,
       "type": "stat",
       "title": "Swap 사용량",
-      "gridPos": { "h": 4, "w": 4, "x": 20, "y": 1 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+      "gridPos": {
+        "h": 2,
+        "w": 4,
+        "x": 20,
+        "y": 10
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROM}"
+      },
       "fieldConfig": {
         "defaults": {
           "unit": "bytes",
-          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 1 }, { "color": "red", "value": 268435456 } ] }
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 268435456
+              }
+            ]
+          }
         },
         "overrides": []
       },
-      "options": { "colorMode": "background", "graphMode": "area", "textMode": "auto", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "textMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
       "targets": [
-        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "node_memory_SwapTotal_bytes - node_memory_SwapFree_bytes" }
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROM}"
+          },
+          "expr": "node_memory_SwapTotal_bytes - node_memory_SwapFree_bytes"
+        }
       ]
     },
     {
       "id": 101,
       "type": "row",
       "title": "트래픽 (RED: 요청률 · 에러 · 지연)",
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 }
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 12
+      }
     },
     {
       "id": 10,
       "type": "timeseries",
       "title": "HTTP 요청률 (status별)",
-      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 6 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
-      "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never" } }, "overrides": [] },
-      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 0,
+        "y": 13
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROM}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "targets": [
-        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "sum by (status) (rate(http_server_requests_seconds_count{application=\"PIKI\"}[$__rate_interval]))", "legendFormat": "{{status}}" }
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROM}"
+          },
+          "expr": "sum by (status) (rate(http_server_requests_seconds_count{application=\"PIKI\"}[$__rate_interval]))",
+          "legendFormat": "{{status}}"
+        }
       ]
     },
     {
       "id": 11,
       "type": "timeseries",
       "title": "5xx 요청률 (uri별)",
-      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 6 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
-      "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "fillOpacity": 20, "showPoints": "never" } }, "overrides": [] },
-      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 8,
+        "y": 13
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROM}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "targets": [
-        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "sum by (uri, status) (rate(http_server_requests_seconds_count{application=\"PIKI\", status=~\"5..\"}[$__rate_interval]))", "legendFormat": "{{status}} {{uri}}" }
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROM}"
+          },
+          "expr": "sum by (uri, status) (rate(http_server_requests_seconds_count{application=\"PIKI\", status=~\"5..\"}[$__rate_interval]))",
+          "legendFormat": "{{status}} {{uri}}"
+        }
       ]
     },
     {
       "id": 12,
       "type": "timeseries",
       "title": "HTTP 지연 (p50 / p95 / p99)",
-      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 6 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
-      "fieldConfig": { "defaults": { "unit": "s", "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never" } }, "overrides": [] },
-      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 13
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROM}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "targets": [
-        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "histogram_quantile(0.50, sum by (le) (rate(http_server_requests_seconds_bucket{application=\"PIKI\"}[$__rate_interval])))", "legendFormat": "p50" },
-        { "refId": "B", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_requests_seconds_bucket{application=\"PIKI\"}[$__rate_interval])))", "legendFormat": "p95" },
-        { "refId": "C", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "histogram_quantile(0.99, sum by (le) (rate(http_server_requests_seconds_bucket{application=\"PIKI\"}[$__rate_interval])))", "legendFormat": "p99" }
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROM}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(http_server_requests_seconds_bucket{application=\"PIKI\"}[$__rate_interval])))",
+          "legendFormat": "p50"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROM}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_requests_seconds_bucket{application=\"PIKI\"}[$__rate_interval])))",
+          "legendFormat": "p95"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROM}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(http_server_requests_seconds_bucket{application=\"PIKI\"}[$__rate_interval])))",
+          "legendFormat": "p99"
+        }
       ]
     },
     {
       "id": 102,
       "type": "row",
       "title": "JVM 메모리 · GC (1순위 리스크)",
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 14 }
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      }
     },
     {
       "id": 20,
       "type": "timeseries",
       "title": "JVM Heap (used / max)",
-      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 15 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
-      "fieldConfig": { "defaults": { "unit": "bytes", "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never" } }, "overrides": [] },
-      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 0,
+        "y": 18
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROM}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
       "targets": [
-        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "sum by (instance) (jvm_memory_used_bytes{application=\"PIKI\", area=\"heap\"})", "legendFormat": "used {{instance}}" },
-        { "refId": "B", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "sum by (instance) (jvm_memory_max_bytes{application=\"PIKI\", area=\"heap\"})", "legendFormat": "max {{instance}}" }
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROM}"
+          },
+          "expr": "sum by (instance) (jvm_memory_used_bytes{application=\"PIKI\", area=\"heap\"})",
+          "legendFormat": "used {{instance}}"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROM}"
+          },
+          "expr": "sum by (instance) (jvm_memory_max_bytes{application=\"PIKI\", area=\"heap\"})",
+          "legendFormat": "max {{instance}}"
+        }
       ]
     },
     {
       "id": 21,
       "type": "timeseries",
       "title": "JVM NonHeap (used)",
-      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 15 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
-      "fieldConfig": { "defaults": { "unit": "bytes", "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never" } }, "overrides": [] },
-      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 8,
+        "y": 18
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROM}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
       "targets": [
-        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "sum by (instance) (jvm_memory_used_bytes{application=\"PIKI\", area=\"nonheap\"})", "legendFormat": "nonheap {{instance}}" }
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROM}"
+          },
+          "expr": "sum by (instance) (jvm_memory_used_bytes{application=\"PIKI\", area=\"nonheap\"})",
+          "legendFormat": "nonheap {{instance}}"
+        }
       ]
     },
     {
       "id": 22,
       "type": "timeseries",
       "title": "GC pause (p99) · GC 빈도",
-      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 15 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 18
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROM}"
+      },
       "fieldConfig": {
-        "defaults": { "unit": "s", "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never" } },
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
         "overrides": [
-          { "matcher": { "id": "byName", "options": "gc/s" }, "properties": [ { "id": "unit", "value": "ops" } ] }
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "gc/s"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "ops"
+              }
+            ]
+          }
         ]
       },
-      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
       "targets": [
-        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "histogram_quantile(0.99, sum by (le) (rate(jvm_gc_pause_seconds_bucket{application=\"PIKI\"}[$__rate_interval])))", "legendFormat": "pause p99" },
-        { "refId": "B", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "sum(rate(jvm_gc_pause_seconds_count{application=\"PIKI\"}[$__rate_interval]))", "legendFormat": "gc/s" }
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROM}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(jvm_gc_pause_seconds_bucket{application=\"PIKI\"}[$__rate_interval])))",
+          "legendFormat": "pause p99"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROM}"
+          },
+          "expr": "sum(rate(jvm_gc_pause_seconds_count{application=\"PIKI\"}[$__rate_interval]))",
+          "legendFormat": "gc/s"
+        }
       ]
     },
     {
       "id": 103,
       "type": "row",
       "title": "호스트 (메모리 · swap · 디스크)",
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 23 }
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 22
+      }
     },
     {
       "id": 30,
       "type": "timeseries",
       "title": "호스트 메모리 (used / total)",
-      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 24 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
-      "fieldConfig": { "defaults": { "unit": "bytes", "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never" } }, "overrides": [] },
-      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 0,
+        "y": 23
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROM}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
       "targets": [
-        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes", "legendFormat": "used" },
-        { "refId": "B", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "node_memory_MemTotal_bytes", "legendFormat": "total" }
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROM}"
+          },
+          "expr": "node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes",
+          "legendFormat": "used"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROM}"
+          },
+          "expr": "node_memory_MemTotal_bytes",
+          "legendFormat": "total"
+        }
       ]
     },
     {
       "id": 31,
       "type": "timeseries",
       "title": "Swap (used / total)",
-      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 24 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
-      "fieldConfig": { "defaults": { "unit": "bytes", "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never" } }, "overrides": [] },
-      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 8,
+        "y": 23
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROM}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
       "targets": [
-        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "node_memory_SwapTotal_bytes - node_memory_SwapFree_bytes", "legendFormat": "used" },
-        { "refId": "B", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "node_memory_SwapTotal_bytes", "legendFormat": "total" }
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROM}"
+          },
+          "expr": "node_memory_SwapTotal_bytes - node_memory_SwapFree_bytes",
+          "legendFormat": "used"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROM}"
+          },
+          "expr": "node_memory_SwapTotal_bytes",
+          "legendFormat": "total"
+        }
       ]
     },
     {
       "id": 32,
       "type": "timeseries",
       "title": "디스크 여유 (mountpoint별)",
-      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 24 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
-      "fieldConfig": { "defaults": { "unit": "bytes", "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never" } }, "overrides": [] },
-      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 23
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROM}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
       "targets": [
-        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "node_filesystem_avail_bytes{fstype!~\"tmpfs|overlay|squashfs\"}", "legendFormat": "{{mountpoint}}" }
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROM}"
+          },
+          "expr": "node_filesystem_avail_bytes{fstype!~\"tmpfs|overlay|squashfs\"}",
+          "legendFormat": "{{mountpoint}}"
+        }
       ]
     },
     {
       "id": 104,
       "type": "row",
       "title": "의존성 (외부 호출 · 풀 · 비동기)",
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 32 }
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 27
+      }
     },
     {
       "id": 40,
       "type": "timeseries",
       "title": "502 (Gemini 등 외부 의존성 실패)",
-      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 33 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
-      "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "fillOpacity": 20, "showPoints": "never" } }, "overrides": [] },
-      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 0,
+        "y": 28
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROM}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
       "targets": [
-        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "sum by (uri) (rate(http_server_requests_seconds_count{application=\"PIKI\", status=\"502\"}[$__rate_interval]))", "legendFormat": "{{uri}}" }
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROM}"
+          },
+          "expr": "sum by (uri) (rate(http_server_requests_seconds_count{application=\"PIKI\", status=\"502\"}[$__rate_interval]))",
+          "legendFormat": "{{uri}}"
+        }
       ]
     },
     {
       "id": 41,
       "type": "timeseries",
       "title": "Executor 스레드풀 (active / queued)",
-      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 33 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
-      "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never" } }, "overrides": [] },
-      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 8,
+        "y": 28
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROM}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
       "targets": [
-        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "executor_active_threads{application=\"PIKI\"}", "legendFormat": "active {{name}}" },
-        { "refId": "B", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "executor_queued_tasks{application=\"PIKI\"}", "legendFormat": "queued {{name}}" }
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROM}"
+          },
+          "expr": "executor_active_threads{application=\"PIKI\"}",
+          "legendFormat": "active {{name}}"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROM}"
+          },
+          "expr": "executor_queued_tasks{application=\"PIKI\"}",
+          "legendFormat": "queued {{name}}"
+        }
       ]
     },
     {
       "id": 42,
       "type": "timeseries",
       "title": "HikariCP 커넥션풀 (active / idle / pending)",
-      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 33 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
-      "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never" } }, "overrides": [] },
-      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 28
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROM}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
       "targets": [
-        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "hikaricp_connections_active{application=\"PIKI\"}", "legendFormat": "active {{pool}}" },
-        { "refId": "B", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "hikaricp_connections_idle{application=\"PIKI\"}", "legendFormat": "idle {{pool}}" },
-        { "refId": "C", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "hikaricp_connections_pending{application=\"PIKI\"}", "legendFormat": "pending {{pool}}" }
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROM}"
+          },
+          "expr": "hikaricp_connections_active{application=\"PIKI\"}",
+          "legendFormat": "active {{pool}}"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROM}"
+          },
+          "expr": "hikaricp_connections_idle{application=\"PIKI\"}",
+          "legendFormat": "idle {{pool}}"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROM}"
+          },
+          "expr": "hikaricp_connections_pending{application=\"PIKI\"}",
+          "legendFormat": "pending {{pool}}"
+        }
       ]
     },
     {
       "id": 105,
       "type": "row",
       "title": "리소스 (CPU · 스레드)",
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 41 }
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 32
+      }
     },
     {
       "id": 50,
       "type": "timeseries",
       "title": "앱 CPU (process / system)",
-      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 42 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
-      "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0, "max": 1, "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never" } }, "overrides": [] },
-      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 0,
+        "y": 33
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROM}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
       "targets": [
-        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "process_cpu_usage{application=\"PIKI\"}", "legendFormat": "process {{instance}}" },
-        { "refId": "B", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "system_cpu_usage{application=\"PIKI\"}", "legendFormat": "system {{instance}}" }
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROM}"
+          },
+          "expr": "process_cpu_usage{application=\"PIKI\"}",
+          "legendFormat": "process {{instance}}"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROM}"
+          },
+          "expr": "system_cpu_usage{application=\"PIKI\"}",
+          "legendFormat": "system {{instance}}"
+        }
       ]
     },
     {
       "id": 51,
       "type": "timeseries",
       "title": "JVM 라이브 스레드",
-      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 42 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
-      "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never" } }, "overrides": [] },
-      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 8,
+        "y": 33
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROM}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
       "targets": [
-        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "jvm_threads_live_threads{application=\"PIKI\"}", "legendFormat": "{{instance}}" }
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROM}"
+          },
+          "expr": "jvm_threads_live_threads{application=\"PIKI\"}",
+          "legendFormat": "{{instance}}"
+        }
       ]
     },
     {
       "id": 52,
       "type": "timeseries",
       "title": "호스트 CPU 사용률",
-      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 42 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROM}" },
-      "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0, "max": 1, "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never" } }, "overrides": [] },
-      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 33
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROM}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
       "targets": [
-        { "refId": "A", "datasource": { "type": "prometheus", "uid": "${DS_PROM}" }, "expr": "1 - avg(rate(node_cpu_seconds_total{mode=\"idle\"}[$__rate_interval]))", "legendFormat": "busy" }
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROM}"
+          },
+          "expr": "1 - avg(rate(node_cpu_seconds_total{mode=\"idle\"}[$__rate_interval]))",
+          "legendFormat": "busy"
+        }
       ]
     },
     {
       "id": 106,
       "type": "row",
       "title": "로그 (team3-blue / team3-green)",
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 50 }
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 37
+      }
     },
     {
       "id": 60,
       "type": "logs",
       "title": "에러/경고 로그",
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 51 },
-      "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
-      "options": { "showTime": true, "showLabels": false, "wrapLogMessage": true, "enableLogDetails": true, "dedupStrategy": "none", "sortOrder": "Descending" },
+      "gridPos": {
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 38
+      },
+      "datasource": {
+        "type": "loki",
+        "uid": "${DS_LOKI}"
+      },
+      "options": {
+        "showTime": true,
+        "showLabels": false,
+        "wrapLogMessage": true,
+        "enableLogDetails": true,
+        "dedupStrategy": "none",
+        "sortOrder": "Descending"
+      },
       "targets": [
-        { "refId": "A", "datasource": { "type": "loki", "uid": "${DS_LOKI}" }, "expr": "{container=~\"team3-(blue|green)\"} |~ \"(?i)(error|exception|warn|fail)\"" }
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "${DS_LOKI}"
+          },
+          "expr": "{container=~\"team3-(blue|green)\"} |~ \"(?i)(error|exception|warn|fail)\""
+        }
       ]
     },
     {
       "id": 61,
       "type": "logs",
       "title": "전체 로그",
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 59 },
-      "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
-      "options": { "showTime": true, "showLabels": false, "wrapLogMessage": true, "enableLogDetails": true, "dedupStrategy": "none", "sortOrder": "Descending" },
+      "gridPos": {
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 42
+      },
+      "datasource": {
+        "type": "loki",
+        "uid": "${DS_LOKI}"
+      },
+      "options": {
+        "showTime": true,
+        "showLabels": false,
+        "wrapLogMessage": true,
+        "enableLogDetails": true,
+        "dedupStrategy": "none",
+        "sortOrder": "Descending"
+      },
       "targets": [
-        { "refId": "A", "datasource": { "type": "loki", "uid": "${DS_LOKI}" }, "expr": "{container=~\"team3-(blue|green)\"}" }
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "${DS_LOKI}"
+          },
+          "expr": "{container=~\"team3-(blue|green)\"}"
+        }
       ]
     }
   ]


### PR DESCRIPTION
## Situation
- 분산 트레이싱 도입(#383, #385) 후 trace 가 Tempo 에 쌓이지만 **Explore 에서만** 볼 수 있어 불편했다. 대시보드에서 trace 를 목록으로 보고, 다른 메트릭과 한 화면에서 함께 보고 싶다는 요구.

## Task
- trace 를 대시보드 패널로 올려 Explore 를 안 거치고 모니터링하게 한다.

## Action
- 맨 위 **트레이스 섹션**에 Tempo Table 패널 **1개 + `traceFilter` 드롭다운**(전체 · 느린 · 에러)을 뒀다. 행을 클릭하면 waterfall 로 펼쳐진다. 처음엔 최근·느린·에러를 3패널 가로로 뒀는데, Table 이 좁아 가독성이 나빠서 1패널 + 필터 드롭다운으로 통일했다.
- 필터는 대시보드 custom 변수로 구현했다. 값을 완전한 TraceQL 쿼리로 두고 패널은 `${traceFilter:raw}` 로 치환한다. 처음엔 "조건 조각 + 빈 값" 방식이었는데 전체·느린 필터가 안 떠서(빈 값·부등호 이스케이프 문제), 완전 쿼리 + raw 치환으로 바꿨다. 느린은 span 단위 `duration` 이 아니라 trace 전체 `trace:duration > 500ms` 다.
- 기존 30패널 height 를 반으로(stat 4→2, timeseries 8→4, logs 8→4) 줄이고 트레이스 섹션 아래로 재배치했다. `Service`(전부 PIKI) 컬럼은 override 로 숨겼다.

## Result
- **검증**: GC import 후 세 필터(전체·느린·에러)가 다 동작하는 것을 화면으로 확인했다. dashboard.json 은 GC 수동 import 산출물이라 JSON diff 가 아니라 import 후 화면이 리뷰 기준이다.
- diff 가 큰 것은 대부분 **json 포맷 정규화**(기존 손작성 compact 를 표준 indent 로) 때문이고, 실질 변경은 trace 패널 1개 + 필터 변수, 기존 패널 height 반·재배치, DS_TEMPO 추가다.

## 연관 이슈
- 

## Updates

### 브랜드 표기 PiKi 정정 (2026-06-06)
- 대시보드 제목을 "PiKi - 앱 + 호스트 개요" 로, datasource 설명(메트릭·로그·트레이스)을 PiKi 로 정정했다. 서비스 브랜드 표기가 PiKi(P·K 대문자, i 소문자)로 확정돼 맞췄다. (`688c2b3`)
- 쿼리의 PIKI 는 그대로 뒀다. 메트릭 라벨 `application="PIKI"`, trace `resource.service.name = "PIKI"` 는 telemetry service.name 이라, 표기를 바꾸면 기존 메트릭/trace 시계열이 끊긴다. service.name 은 내부 식별자(사람이 직접 안 봄)라, 표기 통일 이득보다 시계열 단절 비용이 커서 브랜드 표기(사용자 대면)만 PiKi 로 하고 telemetry 는 PIKI 로 유지했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 신규 기능
* 분산 트레이싱 기능 추가로 요청 추적 가능
* 트레이스 필터링 옵션 제공(전체/느린 요청(>500ms)/에러)
* 트레이스 데이터를 통한 새로운 모니터링 테이블 제공

## 개선사항
* 대시보드 레이아웃 및 패널 배치 최적화
* 메트릭, 로그, 트레이싱 섹션 간 시각적 일관성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
