### PR TITLE
FCM 발송 자가 테스트용 dev 엔드포인트

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/notification/fcm/controller/DevFcmApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/fcm/controller/DevFcmApi.kt
@@ -1,0 +1,57 @@
+package com.depromeet.piki.notification.fcm.controller
+
+import com.depromeet.piki.common.response.ApiResponseBody
+import com.depromeet.piki.notification.fcm.controller.dto.DevPushRequest
+import com.depromeet.piki.notification.fcm.controller.dto.DevPushResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.MediaType
+import java.util.UUID
+
+@Tag(name = "Dev", description = "개발·테스트 전용 API (운영 환경 비활성화)")
+interface DevFcmApi {
+    @Operation(
+        summary = "[DEV] FCM 즉시 발송 (토큰 직접 지정)",
+        description = """
+            본문의 FCM 토큰으로 즉시 푸시를 발송한다. FE 가 Xcode 에서 받은 토큰을 Postman 으로 던져
+            "우리 서버 → FCM → 내 기기" 도달을 자가 확인하는 개발 도구다. 등록(#244) 없이 토큰만으로 쏜다.
+            발송은 운영과 동일한 FirebaseMessageSender 를 태운다. @Profile("!prod") 라 운영에는 라우트가 없다.
+            인증: /api/v1/dev/** 는 GUEST 권한이 필요하다 (POST /api/v1/auth/guest 로 게스트 토큰 발급 후 Bearer).
+            응답 fcmEnabled=false 면 이 서버에 FIREBASE_SERVICE_ACCOUNT 가 없어 발송이 no-op,
+            staleTokenCount=1 이면 그 토큰이 무효/만료(앱 삭제 등)다.
+        """,
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "발송 위임 성공 (fcmEnabled·staleTokenCount 로 실제 발송 여부 확인)",
+                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청 (token 비어 있음 · 길이 초과)",
+                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "미인증 (JWT 토큰 없음 또는 유효하지 않음)",
+                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+            ),
+            ApiResponse(
+                responseCode = "403",
+                description = "GUEST 권한 없음 (/api/v1/dev/** 는 GUEST 권한 필요)",
+                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+            ),
+        ],
+    )
+    fun push(
+        @Parameter(hidden = true) userId: UUID,
+        request: DevPushRequest,
+    ): ApiResponseBody<DevPushResponse>
+}

--- a/src/main/kotlin/com/depromeet/piki/notification/fcm/controller/DevFcmApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/fcm/controller/DevFcmApiExamples.kt
@@ -1,0 +1,50 @@
+package com.depromeet.piki.notification.fcm.controller
+
+import com.depromeet.piki.common.exception.ErrorCategory
+import com.depromeet.piki.common.openapi.OpenApiObjectMapper
+import com.depromeet.piki.common.openapi.binds
+import com.depromeet.piki.common.openapi.examples
+import com.depromeet.piki.common.response.ApiResponseBody
+import com.depromeet.piki.notification.fcm.controller.dto.DevPushResponse
+import org.springdoc.core.customizers.OperationCustomizer
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+import org.springframework.http.HttpStatus
+
+@Profile("!prod")
+@Configuration
+class DevFcmApiExamples(
+    private val openApiObjectMapper: OpenApiObjectMapper,
+) {
+    @Bean
+    fun devFcmOpenApiExamples(): OperationCustomizer =
+        OperationCustomizer { operation, handlerMethod ->
+            if (handlerMethod.binds(DevFcmController::push)) {
+                operation.examples(openApiObjectMapper.delegate) {
+                    add(
+                        status = HttpStatus.OK,
+                        name = "발송 성공",
+                        payload = ApiResponseBody.ok(DevPushResponse(fcmEnabled = true, staleTokenCount = 0)),
+                    )
+                    add(
+                        status = HttpStatus.OK,
+                        name = "FCM 미설정 (no-op)",
+                        payload = ApiResponseBody.ok(DevPushResponse(fcmEnabled = false, staleTokenCount = 0)),
+                    )
+                    add(
+                        status = HttpStatus.BAD_REQUEST,
+                        name = "토큰 누락",
+                        payload =
+                            ApiResponseBody.fail<DevPushResponse>(
+                                category = ErrorCategory.INVALID_INPUT,
+                                detail = "FCM 토큰은 비어 있을 수 없습니다.",
+                            ),
+                    )
+                    unauthorized()
+                    forbidden(name = "GUEST 권한 없음")
+                }
+            }
+            operation
+        }
+}

--- a/src/main/kotlin/com/depromeet/piki/notification/fcm/controller/DevFcmController.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/fcm/controller/DevFcmController.kt
@@ -1,0 +1,38 @@
+package com.depromeet.piki.notification.fcm.controller
+
+import com.depromeet.piki.common.response.ApiResponseBody
+import com.depromeet.piki.notification.fcm.controller.dto.DevPushRequest
+import com.depromeet.piki.notification.fcm.controller.dto.DevPushResponse
+import com.depromeet.piki.notification.fcm.service.FcmMessageSender
+import jakarta.validation.Valid
+import org.springframework.beans.factory.ObjectProvider
+import org.springframework.context.annotation.Profile
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+// FE 가 Xcode 등에서 실시간으로 받은 FCM 토큰을 Postman 으로 우리 서버에 던져, 그 기기로 발송이 되는지
+// 자가 확인하는 개발 전용 컨트롤러. @Profile("!prod") 라 운영에는 라우트 자체가 없다.
+// 발송은 운영과 동일한 FcmMessageSender 를 그대로 태운다 — 이 API 로 본 동작이 곧 발송 경로의 동작이다.
+// (수신자 정책(#236) 없이 "이 토큰으로 바로" 쏘므로 user_devices·이벤트 경로는 거치지 않는다.)
+@Profile("!prod")
+@RestController
+@RequestMapping("/api/v1/dev/fcm")
+class DevFcmController(
+    private val fcmSenderProvider: ObjectProvider<FcmMessageSender>,
+) : DevFcmApi {
+    @PostMapping("/push")
+    override fun push(
+        @AuthenticationPrincipal userId: UUID,
+        @Valid @RequestBody request: DevPushRequest,
+    ): ApiResponseBody<DevPushResponse> {
+        val sender =
+            fcmSenderProvider.getIfAvailable()
+                ?: return ApiResponseBody.ok(DevPushResponse(fcmEnabled = false, staleTokenCount = 0))
+        val stale = sender.send(listOf(request.token.trim()), request.toNotification(userId))
+        return ApiResponseBody.ok(DevPushResponse(fcmEnabled = true, staleTokenCount = stale.size))
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/notification/fcm/controller/dto/DevPushRequest.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/fcm/controller/dto/DevPushRequest.kt
@@ -1,0 +1,45 @@
+package com.depromeet.piki.notification.fcm.controller.dto
+
+import com.depromeet.piki.notification.domain.Notification
+import com.depromeet.piki.notification.domain.NotificationType
+import com.depromeet.piki.notification.fcm.domain.UserDevice
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+import java.util.UUID
+
+@Schema(description = "[DEV] FCM 즉시 발송 요청 — 본문의 토큰으로 바로 푸시(등록 불필요). FE 가 Xcode 에서 받은 토큰을 붙여 발송 경로를 확인한다.")
+data class DevPushRequest(
+    @field:NotBlank
+    @field:Size(max = UserDevice.MAX_TOKEN_LENGTH)
+    @field:Schema(
+        description = "발송할 FCM 토큰 (Xcode 등에서 실시간으로 받은 값)",
+        example = "fGcServerTokenSample:APA91bF...",
+        requiredMode = Schema.RequiredMode.REQUIRED,
+    )
+    val token: String,
+    @field:Size(max = Notification.MAX_TEXT_LENGTH)
+    @field:Schema(description = "푸시 제목", example = DEFAULT_TITLE, defaultValue = DEFAULT_TITLE)
+    val title: String = DEFAULT_TITLE,
+    @field:Size(max = Notification.MAX_TEXT_LENGTH)
+    @field:Schema(description = "푸시 본문", example = DEFAULT_BODY, defaultValue = DEFAULT_BODY)
+    val body: String = DEFAULT_BODY,
+) {
+    // 받는 쪽(Notification)이 매핑을 책임진다. 테스트 발송은 딥링크 대상이 없어 더미 type·refId.
+    // userId 는 발송 메시지에 실리지 않고 throwaway Notification 구성에만 쓰여, 호출자(인증 유저)를 그대로 넣는다.
+    fun toNotification(userId: UUID): Notification =
+        Notification(
+            userId = userId,
+            type = NotificationType.ITEM_PARSING_COMPLETED,
+            title = title,
+            body = body,
+            refId = TEST_REF_ID,
+        )
+
+    companion object {
+        const val DEFAULT_TITLE = "PIKI 테스트 알림"
+        const val DEFAULT_BODY = "FCM 발송이 정상 동작하는지 확인하는 테스트 메시지입니다."
+
+        private const val TEST_REF_ID = 0L
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/notification/fcm/controller/dto/DevPushResponse.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/fcm/controller/dto/DevPushResponse.kt
@@ -1,0 +1,15 @@
+package com.depromeet.piki.notification.fcm.controller.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "[DEV] FCM 발송 결과 — 실제 배달 여부 디버깅용")
+data class DevPushResponse(
+    @field:Schema(
+        description = "FCM 활성 여부 — false 면 FIREBASE_SERVICE_ACCOUNT 미설정이라 발송이 no-op (이 서버에 키가 없음)",
+    )
+    val fcmEnabled: Boolean,
+    @field:Schema(
+        description = "FCM 이 무효(UNREGISTERED)로 응답해 정리 대상이 된 토큰 수 — 1 이면 그 토큰이 죽음/만료(앱 삭제 등)",
+    )
+    val staleTokenCount: Int,
+)

--- a/src/test/kotlin/com/depromeet/piki/notification/fcm/controller/DevFcmControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/notification/fcm/controller/DevFcmControllerIntegrationTest.kt
@@ -1,0 +1,76 @@
+package com.depromeet.piki.notification.fcm.controller
+
+import com.depromeet.piki.auth.infrastructure.jwt.JwtProvider
+import com.depromeet.piki.notification.fcm.controller.dto.DevPushRequest
+import com.depromeet.piki.support.IntegrationTestSupport
+import com.depromeet.piki.support.StubFcmMessageSender
+import com.depromeet.piki.user.domain.IdentityType
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.context.WebApplicationContext
+import tools.jackson.databind.ObjectMapper
+import java.util.UUID
+import kotlin.test.assertEquals
+
+// 개발 전용 발송 엔드포인트(@Profile("!prod")) contract. 테스트 프로파일은 prod 가 아니라 빈이 로드된다.
+// 외부 FCM 은 StubFcmMessageSender(@Primary)로 격리 — 본문 토큰이 그대로 sender 로 넘어가는지 확인한다.
+@Transactional
+class DevFcmControllerIntegrationTest : IntegrationTestSupport() {
+    @Autowired private lateinit var webApplicationContext: WebApplicationContext
+
+    @Autowired private lateinit var objectMapper: ObjectMapper
+
+    @Autowired private lateinit var jwtProvider: JwtProvider
+
+    @Autowired private lateinit var stubFcmMessageSender: StubFcmMessageSender
+
+    private fun guestToken(userId: UUID): String = jwtProvider.generateAccessToken(userId, IdentityType.GUEST)
+
+    private fun buildMockMvc(): MockMvc =
+        MockMvcBuilders
+            .webAppContextSetup(webApplicationContext)
+            .apply<DefaultMockMvcBuilder>(springSecurity())
+            .build()
+
+    @Test
+    fun `GUEST 가 토큰을 지정해 발송하면 200 과 함께 그 토큰으로 발송된다`() {
+        val userId = UUID.randomUUID()
+        var captured: List<String>? = null
+        stubFcmMessageSender.onSend = { tokens, _ ->
+            captured = tokens
+            emptyList()
+        }
+
+        buildMockMvc()
+            .perform(
+                post("/api/v1/dev/fcm/push")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer ${guestToken(userId)}")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(DevPushRequest(token = "live-token-from-xcode"))),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.fcmEnabled").value(true))
+            .andExpect(jsonPath("$.data.staleTokenCount").value(0))
+
+        assertEquals(listOf("live-token-from-xcode"), captured)
+    }
+
+    @Test
+    fun `미인증으로 발송 요청하면 401 이 내려간다`() {
+        buildMockMvc()
+            .perform(
+                post("/api/v1/dev/fcm/push")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(DevPushRequest(token = "t"))),
+            ).andExpect(status().isUnauthorized)
+    }
+}


### PR DESCRIPTION
## Situation
- #395 로 FCM 발송 인프라가 dev 에 머지됐다. 이제 FE 가 "우리 서버 → FCM → 내 기기" 도달을 직접 확인하고 싶어 한다.
- FE 는 Xcode 에서 dev 앱의 FCM 토큰을 실시간으로 얻는다. 그 토큰으로 우리 서버가 실제 발송하는지 Postman 으로 자가 테스트하려 한다.
- #395 에서 dev 발송 엔드포인트를 한 번 제거했었다(배포 아티팩트에 트리거를 안 두려고). 그런데 이 자가 테스트 요구는 Firebase 콘솔(우리 코드 경로를 안 거침)·env 게이트 로컬 테스트(백엔드가 직접 돌려야 함)로는 못 채워 재도입한다.

## Task
- FE 가 토큰만 있으면 우리 서버를 통해 발송을 직접 트리거할 수 있는 dev 전용 엔드포인트.
- 운영 오염 없이, 운영과 동일한 발송 코드로 검증되게.

## Action
- `POST /api/v1/dev/fcm/push { token, title?, body? }`: 본문 토큰으로 즉시 발송(등록 불필요). 운영과 동일한 `FirebaseMessageSender` 를 그대로 태운다. 이 API 로 본 동작이 곧 실제 발송 경로의 동작이다.
- `@Profile("!prod")` 로 운영에는 라우트 자체가 없다. `/api/v1/dev/**` 라 GUEST 권한(게스트 토큰)으로 호출한다.
- 응답 `fcmEnabled`(이 서버에 키가 설정됐는지)·`staleTokenCount`(토큰이 무효/만료인지)로 FE 가 도달 실패 원인을 구분한다.
- 검증 도구 역할 구분: Firebase 콘솔은 우리 코드를 안 거치고, env 게이트 테스트는 백엔드가 거쳐야 하며, 이 엔드포인트는 FE 자가 + 우리 코드 경로를 동시에 만족한다.
- contract 테스트: GUEST 가 토큰 지정 발송 시 200 이고 본문 토큰이 그대로 sender 로 전달되는지, 미인증 401.

## Result
- FE 가 Postman 으로 dev 서버에 Xcode 토큰을 던져 자기 기기 도달을 스스로 확인할 수 있다.
- `@Profile("!prod")` 라 prod 에는 배포되지 않는다.
- 발송 자체는 수신자 정책(#236) 없이 "이 토큰으로 바로" 쏘므로 user_devices·이벤트 경로는 거치지 않는다(순수 발송 경로 확인용).

---
## 연관 이슈

- close #397
