### PR TITLE
nginx read-timeout 정상화와 SSE 하트비트 주기 조정

### DIFF
--- a/infra/nginx/api.depromeet18team3.cloud.conf
+++ b/infra/nginx/api.depromeet18team3.cloud.conf
@@ -53,11 +53,12 @@ server {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
 
-    # OCR 등 LLM 호출 엔드포인트는 앱이 Gemini read-timeout(30s) + 재시도까지 최악 약 60s 를 쓸 수 있다.
-    # nginx 기본 60s 로는 앱이 502 + 실패 사유를 내려보내기 직전에 잘려 504(사유 없음)가 클라이언트로 나간다.
-    # 앱 최악치보다 여유 있게 두어, 느린 호출도 앱이 끝까지 응답해 사유를 전달하게 한다.
-    # (근본 단축은 앱 측 read-timeout/재시도 조정 — 별도 작업)
-    proxy_read_timeout 90s;
+    # nginx 기본값(60s)을 의도적으로 명시한다. 과거엔 상품 추출(외부 fetch + Gemini)이 요청 스레드에서
+    # 동기로 돌아 최악 60s 가까이 걸렸고, 504(사유 없음)를 피하려 90s 로 늘렸었다. 이후 추출이 전부
+    # @Async 워커로 빠져(요청 스레드는 PROCESSING item 저장 후 즉시 응답, 결과는 SSE 알림으로 전달)
+    # 요청 스레드를 길게 잡는 동기 외부 호출은 사라졌다. 남은 최대 동기 외부 호출은 OAuth 로그인(read 10s)
+    # 과 recover 의 S3 이미지 1장 업로드(수초)뿐이라 60s 로 충분하다.
+    proxy_read_timeout 60s;
 
     # actuator 엔드포인트는 외부에 노출하지 않는다. 메트릭(/actuator/prometheus)·health 는
     # EC2 내부의 Grafana Alloy 가 localhost 컨테이너 포트로 직접 scrape 하므로 nginx 를 거치지 않는다.
@@ -87,7 +88,7 @@ server {
     # burst=20 nodelay: 순간 연타·모바일 CGNAT(여러 사용자가 한 공인 IP 뒤에 묶임)는 흡수하되,
     # 지속적인 폭주만 429 로 막는다. nodelay 라 burst 분은 지연 없이 즉시 통과한다.
     #
-    # 토너먼트 아이템 추가 — /{tournamentId}/items/link(링크 추출) · /items/images(이미지 OCR). 둘 다 POST 전용 경로.
+    # 토너먼트 아이템 추가 — /{tournamentId}/items/link(링크 추출) · /items/images(이미지 추출). 둘 다 POST 전용 경로.
     # /?$ : trailing slash 변형(.../link/)도 같은 비싼 경로로 묶어 piki_llm 우회를 막는다.
     location ~ ^/api/v1/tournaments/[^/]+/items/(link|images)/?$ {
         limit_req zone=piki_llm burst=20 nodelay;
@@ -99,7 +100,7 @@ server {
         limit_req zone=piki_llm burst=20 nodelay;
         proxy_pass http://team3;
     }
-    # 위시 이미지 등록(POST = 이미지 OCR).
+    # 위시 이미지 등록(POST = 이미지 추출).
     location ~ ^/api/v1/wishlists/images/?$ {
         limit_req zone=piki_llm burst=20 nodelay;
         proxy_pass http://team3;
@@ -109,7 +110,7 @@ server {
     # - proxy_http_version 1.1: nginx 가 백엔드에 붙는 기본값은 1.0 인데, 1.0 은 chunked 스트리밍이 안 돼
     #   SSE 가 버퍼링되거나 끊긴다. 1.1 로 올린다. 다른 경로 동작을 안 건드리도록 server 전역이 아니라 이 location 한정으로 둔다.
     # - proxy_buffering off: nginx 가 응답을 모았다 내보내면 실시간성이 깨진다. 이벤트를 받는 즉시 클라이언트로 흘려보낸다.
-    # 공통 proxy_set_header / proxy_read_timeout 90s 는 server 레벨에서 상속한다(앱 하트비트가 15s 라 90s read_timeout 은 안 끊긴다).
+    # 공통 proxy_set_header / proxy_read_timeout 60s 는 server 레벨에서 상속한다(앱 하트비트가 30s 라 60s read_timeout 은 안 끊긴다).
     # 정확매칭(=)이라 catch-all(location /)보다 우선한다. 레이트리밋은 일반 그물(piki_general) 유지 — 구독은 오래 열린 1요청이라 카운트 1로 무해하다.
     location = /api/v1/notifications/subscribe {
         limit_req zone=piki_general burst=40 nodelay;

--- a/infra/nginx/dev.api.depromeet18team3.cloud.conf
+++ b/infra/nginx/dev.api.depromeet18team3.cloud.conf
@@ -35,7 +35,8 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_read_timeout 90s;
+        # nginx 기본값(60s). 추출이 @Async 워커로 빠져 요청 스레드를 길게 잡는 동기 외부 호출이 없어 60s 로 충분하다 (prod conf 와 동일 근거).
+        proxy_read_timeout 60s;
     }
 
     listen 443 ssl;

--- a/src/main/kotlin/com/depromeet/piki/notification/controller/NotificationSseApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/controller/NotificationSseApi.kt
@@ -22,7 +22,7 @@ interface NotificationSseApi {
             응답은 ApiResponseBody JSON 래퍼가 아니라 text/event-stream 스트림이며, 다음 이벤트가 흘러온다.
             - connect: 구독 직후 1회. data="connected". 연결 성립 신호.
             - notification: 알림 1건. data 는 NotificationSsePayload JSON (200 응답 스키마 참고). type+refId 로 딥링크를 분기한다.
-            - (주석 ping): 약 15초 간격 하트비트. 연결 유지용이며 data 이벤트가 아니다.
+            - (주석 ping): 약 30초 간격 하트비트. 연결 유지용이며 data 이벤트가 아니다.
             토너먼트 알림은 해당 토너먼트 참여자에게만 fan-out 되므로, 자기 스트림 1개만 구독하면 토너먼트·개인 알림이 모두 도착한다.
             연결은 30분 후 타임아웃되며, 클라이언트는 끊기면 재연결한다.
         """,

--- a/src/main/kotlin/com/depromeet/piki/notification/sse/SseHeartbeatScheduler.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/sse/SseHeartbeatScheduler.kt
@@ -5,8 +5,11 @@ import org.springframework.stereotype.Component
 
 // 주기적으로 모든 SSE 연결에 ping 을 흘려 연결을 살아있게 유지하고, 끊긴 연결을 정리한다(write 는 LocalSseDelivery).
 //
-// 운영 nginx 의 proxy_read_timeout(90s)보다 짧은 주기여야 프록시가 idle SSE 연결을 끊지 않는다 —
-// HEARTBEAT_INTERVAL_MS=15s 로 충분한 여유를 둔다.
+// 운영 nginx 의 proxy_read_timeout(60s)보다 짧은 주기여야 프록시가 idle SSE 연결을 끊지 않는다.
+// 다만 진짜 제약은 nginx 한 구간이 아니라 경로상 가장 빡빡한 idle timeout 이다 — 모바일 캐리어 NAT 등
+// 클라이언트 쪽 중간 장비까지 고려해, 업계 SSE 하트비트의 표준 범위(25~30초)인 30s 로 둔다. nginx 60s
+// 대비 절반이라 keep-alive 여유가 있고, 더 늘리면(45s+) 단일 스케줄러 스레드 지연 시 60s 에 근접할 수
+// 있어 30s 에서 멈춘다. (ping 은 수 바이트라 주기를 줄여도 대역폭 이득은 미미하다.)
 //
 // 단일 인스턴스 기준이지만, 멀티 인스턴스로 확장돼도 각 인스턴스가 "자기 메모리의 연결만" ping 하므로 중복
 // 실행 방지(ShedLock 등)가 필요 없다 — SseEmitter 는 자기 소켓에 묶인 인스턴스-로컬 객체라, @Scheduled 가
@@ -21,7 +24,7 @@ class SseHeartbeatScheduler(
     }
 
     companion object {
-        // nginx proxy_read_timeout(90s) 아래로 둔다.
-        const val HEARTBEAT_INTERVAL_MS = 15_000L
+        // nginx proxy_read_timeout(60s) 아래로 두되, 모바일 NAT idle timeout 까지 고려한 30s.
+        const val HEARTBEAT_INTERVAL_MS = 30_000L
     }
 }


### PR DESCRIPTION
## Situation
- 과거 상품 추출(외부 fetch + Gemini)이 요청 스레드에서 동기로 돌아 최악 60초 가까이 걸렸고, nginx 가 그 사이 504(사유 없음)를 내는 걸 막으려 proxy_read_timeout 을 기본값 60s 에서 90s 로 늘렸었다.
- 이후 추출이 전부 @Async 워커로 빠지면서(요청 스레드는 PROCESSING item 을 저장하고 즉시 응답, 결과는 SSE 알림으로 전달) 요청 스레드를 길게 잡는 동기 외부 호출이 사라졌다. 90s 의 근거가 무효가 됐는데 값과 주석은 그대로 남아 있었다.

## Task
- nginx read-timeout 을 현실에 맞게 정상화하고, 그 값을 정당화하던 죽은 주석을 갱신한다.
- read-timeout 변화에 맞춰 SSE 하트비트 주기도 재검토한다. 하트비트는 nginx 가 idle 연결을 끊지 않게 하는 keep-alive 라 read-timeout 과 직접 엮인다.

## Action
### nginx read-timeout
- proxy_read_timeout 을 90s 에서 기본값 60s 로 낮췄다. 요청 스레드에 남은 최대 동기 외부 호출을 추적한 결과 OAuth 로그인(read 10s)과 recover 의 S3 이미지 1장 업로드(수초)뿐이라 60s 로 충분하다.
- "OCR 등 LLM 호출이 동기로 최악 60s" 라는 죽은 전제 주석을 제거하고, 추출이 비동기로 빠진 현재 구조를 반영했다.

### SSE 하트비트
- 하트비트 주기를 15s 에서 30s 로 늘렸다. nginx 60s 대비 절반 여유라 keep-alive 가 안전하고, 모바일 캐리어 NAT 의 idle timeout 까지 고려한 업계 표준 범위(약 25-30s)다.
- 더 늘리지 않은 이유: 단일 스케줄러 스레드와 nginx 60s 조합에서 45s 이상은 스케줄러 지연 시 60s 에 근접할 위험이 있다.
- "ping 이 너무 자주 나가 낭비" 라는 관점은 부차적이었다. ping 은 수 바이트라 대역폭 이득은 미미하고, 실질 이득은 단일 스케줄러 스레드의 순회 빈도가 절반으로 주는 것이다.

### 곁다리 정리
- 레이트리밋 경로 주석의 "이미지 OCR" 을 "이미지 추출" 로 바꿨다. 코드에서 OCR 은 Gemini Vision 으로 대체돼 더 이상 존재하지 않는다.
- OpenAPI 문서(NotificationSseApi)의 하트비트 간격 "약 15초" 를 "약 30초" 로 갱신했다.

## Result
- 30분 emitter timeout 은 의도적으로 유지했다. nginx idle 끊김과 무관하고(하트비트가 막는다) 자원 회수와 좀비 연결 청소의 백스톱 역할이라 이번 변경과 독립적이다.
- nginx conf 는 PR CI(assemble + test)가 문법을 검증하지 않으므로, SSL 과 upstream 을 더미로 우회한 로컬 docker nginx -t 로 문법을 확인했다. 배포 시 deploy.yml 이 EC2 의 실제 인증서로 다시 nginx -t 후 reload 한다.

---
## 연관 이슈

- 


---
## Updates

### dev conf 누락 보정
- prod conf 만 60s 로 낮추고 빠뜨렸던 dev nginx conf 의 proxy_read_timeout 도 90s 에서 60s 로 정상화했다. dev 서버도 같은 앱(추출 비동기)이라 90s 근거가 동일하게 무효다. (`33877e7`)
- branch protection 의 up-to-date 요구로 최신 dev 를 브랜치에 머지했다 (trace 계측·대시보드 변경, nginx 와 무관). (`76b47ec`)
