### PR TITLE
PR CI 에 nginx conf 문법 검증 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,3 +76,37 @@ jobs:
           path: build/test-results/**/*.xml
           reporter: java-junit
           fail-on-error: false
+
+  # nginx conf 문법 검증 — 깨진 conf 가 dev 에 머지된 뒤 배포(deploy.yml)에서야 nginx -t 로
+  # 걸려 롤백되던 걸, PR 단계에서 미리 막는다. infra/nginx 변경이 없는 PR 도 수초면 통과하므로
+  # path filter 없이 항상 돌려 required check 로 걸어도 skip 함정이 없게 한다.
+  nginx-validate:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      # conf 는 http{} 안에서 include 되는 partial 이고, SSL 인증서·upstream include 가 런타임
+      # 의존이라 그대로는 단독 검증이 안 된다. 우회: http 컨텍스트 래퍼로 감싸고, SSL·letsencrypt
+      # 라인을 제거(listen 443 ssl[...] → 평문 8443: prod 는 http2, dev 는 없는 형식 둘 다 커버),
+      # upstream include 는 더미로 마운트한다. 실제 인증서 검증은 배포 시 deploy.yml 이 EC2 에서 한다.
+      - name: Validate nginx configs
+        run: |
+          set -e
+          for conf in infra/nginx/*.conf; do
+            echo "::group::validate $conf"
+            work=$(mktemp -d)
+            sed -e 's/listen 443 ssl[^;]*;/listen 8443;/' \
+                -e '/ssl_certificate/d' -e '/ssl_dhparam/d' -e '/include \/etc\/letsencrypt/d' \
+                "$conf" > "$work/site.conf"
+            echo 'server 127.0.0.1:8080;' > "$work/team3-upstream.conf"
+            printf 'events {}\nhttp {\n  include /work/site.conf;\n}\n' > "$work/nginx.conf"
+            docker run --rm \
+              -v "$work/nginx.conf:/work/nginx.conf:ro" \
+              -v "$work/site.conf:/work/site.conf:ro" \
+              -v "$work/team3-upstream.conf:/etc/nginx/team3-upstream.conf:ro" \
+              nginx:alpine nginx -t -c /work/nginx.conf
+            echo "::endgroup::"
+          done


### PR DESCRIPTION
## Situation
- nginx conf 문법 검증이 배포(deploy.yml)가 EC2 에서 nginx -t 를 돌릴 때만 일어났다. 깨진 conf 가 dev 에 머지된 뒤 배포 단계에서야 발견돼 롤백되고 배포가 중단된다. PR 단계에선 아무도 막지 않았다.
- 이번 세션의 nginx read-timeout 정상화 작업(PR #399) 중, PR CI(assemble + test)가 conf 문법을 전혀 검증하지 않는다는 걸 확인하고 후속으로 분리한 작업이다.

## Task
- nginx conf 문법 오류를 PR 단계에서 잡아, 깨진 채로 dev 에 머지되는 걸 막는다.

## Action
- ci.yml 에 nginx-validate job 을 추가했다. docker nginx:alpine 로 infra/nginx 의 prod·dev conf 를 전부 nginx -t 한다.
- conf 는 http{} 안에서 include 되는 partial 이고 SSL 인증서와 upstream include 가 런타임 의존이라 단독으로는 검증되지 않는다. http 컨텍스트 래퍼로 감싸고, SSL·letsencrypt 라인을 제거하고, upstream include 를 더미로 마운트해 우회했다. 실제 인증서 검증은 지금처럼 배포 시 EC2 가 담당한다.
- path filter 없이 항상 실행한다. 검증이 수초라 부담이 적고, path filter 와 required check 를 함께 쓸 때의 skip 함정(nginx 를 안 바꾼 PR 이 job skip 으로 영영 머지 대기에 걸리는 것)을 피하기 위해서다.
- prod conf 는 listen 443 ssl http2, dev conf 는 listen 443 ssl 로 형식이 다르다. sed 패턴 listen 443 ssl[^;]*; 로 둘 다 평문 listen 으로 치환해 커버했다.

## Result
- 깨진 nginx conf 는 이제 PR 에서 빨간불로 걸려 머지 전에 막힌다. required check 로 등록하면 강제할 수 있고(레포 설정이라 별도), 항상 실행이라 skip 함정이 없다.
- 검증 방식: actionlint 로 ci.yml 문법과 nginx-validate 셸 스크립트(shellcheck)를 확인했고, 같은 스크립트를 로컬에서 재현해 prod·dev conf 둘 다 nginx -t 를 통과하는 걸 확인했다.

---
## 연관 이슈

- 
