### PR TITLE
배포 구버전 teardown hang 으로 성공한 배포가 실패 처리되던 문제 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -343,8 +343,10 @@ jobs:
             mkdir -p /var/log/team3
             docker logs "team3-$INACTIVE" > /var/log/team3/team3-$INACTIVE-$(date +%Y%m%d-%H%M%S).log 2>&1 || true
             find /var/log/team3 -name "team3-*.log" -mtime +7 -delete || true
-            docker stop "team3-$INACTIVE" || true
-            docker rm "team3-$INACTIVE" || true
+            # 직전 배포의 구버전 teardown 이 timeout 으로 끊겨 이 슬롯 컨테이너가 살아있을 수 있다.
+            # 아래 docker run 의 name/port 충돌을 막으려 force 로 지우고, 데몬 지연에 대비해 timeout 으로 상한을 건다.
+            timeout 40 docker stop -t 30 "team3-$INACTIVE" 2>/dev/null || true
+            timeout 30 docker rm -f "team3-$INACTIVE" 2>/dev/null || true
 
             # 새 버전 비활성 포트에 기동.
             # -p 를 127.0.0.1 에 바인딩해 호스트 공인 IP(EIP)로의 직접 접근을 막는다. nginx(호스트 프로세스)와
@@ -424,9 +426,12 @@ jobs:
                 echo "server localhost:$INACTIVE_PORT;" | sudo tee /etc/nginx/team3-upstream.conf
                 sudo nginx -s reload
                 echo "  SWITCHED : Nginx now → $INACTIVE (port $INACTIVE_PORT)"
-                # 구버전 종료 (team3-server 마이그레이션 포함)
-                docker stop "team3-$ACTIVE" team3-server 2>/dev/null || true
-                docker rm "team3-$ACTIVE" team3-server 2>/dev/null || true
+                # 구버전 종료 (team3-server 마이그레이션 포함) — switch 는 이미 끝났으므로 best-effort.
+                # blue+green 동시 기동 직후라 메모리 압박으로 Docker 데몬이 느려지면 docker stop 이 멈출 수 있다.
+                # 상한이 없으면 이미 성공한 switch 가 ssh-action 기본 command_timeout(10m)에 걸려 배포가 통째로 실패한다.
+                # timeout 으로 클라이언트 호출에 상한을 걸어, 데몬이 느려도 switch 성공을 막지 못하게 한다.
+                timeout 60 docker stop -t 30 "team3-$ACTIVE" team3-server 2>/dev/null || true
+                timeout 30 docker rm -f "team3-$ACTIVE" team3-server 2>/dev/null || true
                 echo "  STOPPED  : $ACTIVE (port $ACTIVE_PORT)"
                 echo "================================================"
                 exit 0
@@ -435,8 +440,9 @@ jobs:
               sleep 5
             done
             echo "Health check failed — rolling back"
-            docker stop "team3-$INACTIVE" || true
-            docker rm "team3-$INACTIVE" || true
+            # 실패 경로도 같은 데몬 지연에 멈출 수 있어 상한을 건다 (롤백이 10분 hang 뒤에야 보고되는 것 방지).
+            timeout 40 docker stop -t 30 "team3-$INACTIVE" 2>/dev/null || true
+            timeout 30 docker rm -f "team3-$INACTIVE" 2>/dev/null || true
             exit 1
 
       - name: Write deployment summary


### PR DESCRIPTION
## Situation

- dev 배포의 `Health check and switch` 단계가 실패(exit 1)로 끝났는데, 실제로는 헬스체크 통과와 nginx 의 green 슬롯 전환까지 모두 정상이었다.
- 로그상 `SWITCHED : Nginx now → green` 직후 와야 할 `STOPPED` 로그가 안 찍혔고, 약 9분 30초 뒤 `Run Command Timeout` 으로 step 이 떨어졌다.

## Task

- 전환(switch)이 끝나 이미 성공한 배포가, 그 뒤의 구버전 정리 한 줄 때문에 통째로 실패로 뒤집히는 구조를 끊는다.

## Action

### 진단

- 멈춘 지점은 switch 직후의 구버전 `docker stop`. appleboy/ssh-action 의 기본 `command_timeout` 이 10분이라, 여기서 hang 되면 그 시각에 step 이 강제 종료된다 (로그의 timeout 시각과 일치).
- 멈춘 이유는 blue+green 두 JVM 이 동시에 떠 있는 전환 직후의 메모리 압박으로 Docker 데몬이 느려진 것으로 추정. `docker stop` 은 기본 10초 뒤 SIGKILL 이라 데몬이 정상이면 멈출 수 없는데, 데몬 자체가 응답을 못 하면 클라이언트 호출이 통째로 hang 된다.

### 수정

- teardown 은 switch 가 끝난 뒤의 best-effort 라는 점에 맞춰, teardown 명령에 `timeout` 으로 상한을 건다. 데몬이 느려도 최대 약 90초 안에 반환되어 switch 성공을 막지 못한다.
- 적용 대상 3곳:

| 위치 | 변경 |
|------|------|
| 구버전 종료 (switch 직후) | `docker stop` 에 `timeout 60 ... -t 30`, `docker rm` 에 `timeout 30 ... -f` |
| 헬스체크 실패 롤백 | 동일 패턴 (실패 보고가 10분 hang 뒤로 밀리는 것 방지) |
| 다음 배포 슬롯 재기동 전 정리 | 동일 패턴, `docker rm -f` 로 강화 |

- 슬롯 정리를 `docker rm -f` 로 바꾼 이유: 직전 배포가 timeout 으로 구버전을 못 지우고 남겼을 때, 다음 배포의 `docker run` 이 같은 name/port 와 충돌해 실패하는 것을 막기 위해.

## Result

- 데몬 지연이 있어도 이미 전환된 배포가 timeout 으로 실패 처리되지 않는다. 정리하지 못한 컨테이너는 다음 배포 시작 시 force 제거되어 자가 회복된다.
- 검증 한계: CI 워크플로우라 최종 확정은 실제 배포 1회로만 가능하다 (로컬에서 데몬 지연을 재현할 수 없음). 로컬 검증은 YAML 파서 통과까지 마쳤고, `timeout` · `docker stop -t` · `docker rm -f` 는 EC2(coreutils + docker) 표준 동작이다.
- 후속 가능성: blue+green 동시 기동 시 메모리 압박은 EC2 capacity 관점의 별도 검토 대상.

---
## 연관 이슈

- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 배포 프로세스의 안정성 개선을 위해 Docker 작업 타임아웃 설정 추가. Blue-green 배포 단계에서 컨테이너 정리 작업의 무한 대기 문제를 완화하도록 시간 상한을 적용했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->