### PR TITLE
API 문서 태그 그룹을 도메인 흐름 순으로 정렬

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/common/config/OpenApiConfig.kt
+++ b/src/main/kotlin/com/depromeet/piki/common/config/OpenApiConfig.kt
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.models.info.License
 import io.swagger.v3.oas.models.security.SecurityRequirement
 import io.swagger.v3.oas.models.security.SecurityScheme
 import io.swagger.v3.oas.models.servers.Server
+import org.springdoc.core.customizers.OpenApiCustomizer
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -52,7 +53,41 @@ class OpenApiConfig {
             .addSecurityItem(SecurityRequirement().addList(SECURITY_SCHEME_NAME))
             .addServersItem(Server().url("/").description("Current host"))
 
+    // 문서 UI(Stoplight Elements)는 OpenAPI spec 의 tags[] 배열 순서를 사이드바 그룹 순서로 그대로
+    // 반영한다. springdoc 3.0.x 는 이 배열을 핸들러 스캔 순서(빈/핸들러 등록 순서에 의존해 사실상
+    // 비결정적)로 채워, OpenAPI 빈의 .tags() 로는 순서가 잡히지 않는다(실측). 그래서 문서 빌드가 끝난
+    // 뒤 OpenApiCustomizer 로 tags 를 도메인 흐름 순(TAG_ORDER)으로 재정렬한다. TAG_ORDER 에 없는
+    // 태그(새로 추가되고 등록을 빠뜨린 것)는 맨 뒤로 보내되 이름 알파벳으로 정렬한다 — 누락은
+    // OpenApiDocsIntegrationTest 의 순서 단언이 잡는다.
+    @Bean
+    fun sortTagsByDomainFlow(): OpenApiCustomizer =
+        OpenApiCustomizer { openApi ->
+            val tags = openApi.tags ?: return@OpenApiCustomizer
+            openApi.tags =
+                tags.sortedWith(
+                    compareBy(
+                        { TAG_ORDER.indexOf(it.name).let { idx -> if (idx < 0) Int.MAX_VALUE else idx } },
+                        { it.name },
+                    ),
+                )
+        }
+
     companion object {
         private const val SECURITY_SCHEME_NAME = "bearerAuth"
+
+        // 사이드바 그룹 순서: 인증·내 정보(진입) → 핵심 도메인(위시 → 토너먼트 → 토너먼트 아이템) →
+        // 알림(SSE·FCM) → 개발 전용. health-controller 는 @Tag 미선언 자동 태그라 spec 의 top-level
+        // tags[] 에 없어 여기 둘 필요가 없고, Stoplight Elements 가 사이드바 맨 뒤에 자동 배치한다.
+        private val TAG_ORDER =
+            listOf(
+                "Auth",
+                "User",
+                "Wishlist",
+                "Tournament",
+                "Tournament Item",
+                "Notification",
+                "FCM",
+                "Dev",
+            )
     }
 }

--- a/src/test/kotlin/com/depromeet/piki/common/config/OpenApiDocsIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/common/config/OpenApiDocsIntegrationTest.kt
@@ -1,0 +1,69 @@
+package com.depromeet.piki.common.config
+
+import com.depromeet.piki.support.IntegrationTestSupport
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.web.context.WebApplicationContext
+import tools.jackson.databind.ObjectMapper
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class OpenApiDocsIntegrationTest : IntegrationTestSupport() {
+    @Autowired
+    private lateinit var webApplicationContext: WebApplicationContext
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    private fun mockMvc() =
+        MockMvcBuilders
+            .webAppContextSetup(webApplicationContext)
+            .apply<DefaultMockMvcBuilder>(springSecurity())
+            .build()
+
+    @Test
+    fun `api-docs 의 태그 그룹은 도메인 흐름 순서대로 노출된다`() {
+        // 문서 UI(Stoplight Elements)의 그룹 순서는 spec 의 tags[] 배열 순서를 따른다. springdoc 기본은
+        // 핸들러 스캔 순서(비결정적)라, OpenApiConfig.sortTagsByDomainFlow() 가 이를 도메인 흐름 순으로
+        // 재정렬한다. health-controller 는 @Tag 미선언 자동 태그라 top-level tags[] 에 없고(Elements 가
+        // 사이드바 맨 뒤에 자동 배치) 여기 단언 대상이 아니다. 이 순서를 회귀 가드로 고정한다(새 태그가
+        // 늘면 단언이 깨져 TAG_ORDER 갱신을 강제).
+        val expected =
+            listOf(
+                "Auth",
+                "User",
+                "Wishlist",
+                "Tournament",
+                "Tournament Item",
+                "Notification",
+                "FCM",
+                "Dev",
+            )
+
+        val response =
+            mockMvc()
+                .perform(get("/v3/api-docs"))
+                .andExpect(status().isOk)
+                .andReturn()
+                .response
+                .contentAsString
+
+        val tags = objectMapper.readTree(response).get("tags")
+        val actual = (0 until tags.size()).map { i -> tags.get(i).get("name").asText() }
+        assertEquals(expected, actual)
+
+        // 각 그룹에 설명이 채워져 있어야 한다(빈 description 회귀 방지).
+        (0 until tags.size()).forEach { i ->
+            val tag = tags.get(i)
+            assertTrue(
+                tag.get("description").asText().isNotBlank(),
+                "${tag.get("name").asText()} 태그에 description 이 비어 있다",
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Situation
- API 문서 UI(Stoplight Elements)의 좌측 그룹이 도메인과 무관한 순서로 나왔다. 토너먼트 아이템이 맨 위로 오는 식이라, 문서를 훑을 때 인증, 핵심 기능, 부가 기능으로 이어지는 흐름이 보이지 않았다.
- 원인은 springdoc 이 문서의 태그 배열을 컨트롤러 핸들러 스캔 순서로 채우는 데 있다. 이 순서는 빈 등록 순서에 의존해 알파벳도 선언순도 아니고, 컨트롤러가 늘면 또 바뀌는 사실상 비결정적 순서다.

## Task
- 문서 그룹 순서를 도메인 흐름대로 읽히게 고정한다. 인증과 내 정보로 시작해 핵심 도메인(위시, 토너먼트, 토너먼트 아이템), 알림, 개발·운영용을 뒤로 둔다.

## Action

### 원인 규명 (세 가지 시도가 모두 무효였다)
- `@Tag` 선언 순서로는 안 된다. springdoc 이 스캔 순서로 덮는다.
- OpenAPI 빈에 순서를 직접 박아도(`.tags()`) 무효였다. springdoc 3.0.3 이 태그를 Set 으로 모아, 명시한 순서가 뒤섞였다(빈으로 정렬을 강제하려다 실측으로 확인).
- `springdoc.swagger-ui.tags-sorter` 도 무효다. 이 프로젝트 문서 UI 는 Swagger UI 가 아니라 Stoplight Elements 라, 그 설정을 아예 읽지 않는다.

### 구현
- 문서가 다 만들어진 뒤 한 번 더 손대는 방식으로 전환했다. springdoc 표준 후처리 훅(`OpenApiCustomizer`)으로 태그 배열을 도메인 흐름 순(`TAG_ORDER`)으로 재정렬한다.
- 목록에 없는 태그는 맨 뒤로 보내되 이름 알파벳으로 둔다. health 체크처럼 `@Tag` 를 안 단 자동 태그는 애초에 이 배열에 안 잡히고, Elements 가 사이드바 맨 뒤에 알아서 배치한다.

### 안전망
- 문서의 태그 순서를 단언하는 통합 테스트를 추가했다. 새 컨트롤러 태그가 생기면 이 단언이 깨져, 순서 목록 갱신을 강제한다(조용히 맨 뒤로 묻히지 않게).

## Result
- 최종 그룹 순서: Auth, User, Wishlist, Tournament, Tournament Item, Notification, FCM, Dev (health 는 맨 뒤 자동 배치).
- 순서가 코드의 상수 하나(`TAG_ORDER`)에만 의존한다. 새 태그를 더하면 가드 테스트가 갱신을 요구한다.

---
## 연관 이슈

- 
