### PR TITLE
토너먼트 참가·아이템 추가 시 알림 자동 발송 연결

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentItemPersistenceService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentItemPersistenceService.kt
@@ -51,7 +51,7 @@ class TournamentItemPersistenceService(
                 ),
             ),
         ).first()
-        // 링크 1개 추가. 트랜잭션 안에서 발행 → AFTER_COMMIT 후 알림. 수신자는 참가자 - 본인(actor).
+        // 링크 1개 추가. 커밋된 뒤에만 구독자에게 전달되도록 트랜잭션 안에서 발행한다 (롤백 시 미발행).
         eventPublisher.publishEvent(TournamentItemAdded(tournamentId = tournamentId, actorId = userId))
         return PersistedTournamentItem(itemId = item.getId(), tournamentItemId = tournamentItem.getId())
     }
@@ -76,7 +76,7 @@ class TournamentItemPersistenceService(
                 )
             },
         )
-        // 이미지 N개를 한 번에 올려도 "추가됨" 알림은 1회. 수신자는 참가자 - 본인(actor).
+        // 이미지를 여러 장 한 번에 올려도 "아이템이 추가됐다"는 사실은 1건이라 이벤트도 1회만 발행한다.
         eventPublisher.publishEvent(TournamentItemAdded(tournamentId = tournamentId, actorId = userId))
         return items.zip(tournamentItems) { item, tournamentItem ->
             PersistedTournamentItem(itemId = item.getId(), tournamentItemId = tournamentItem.getId())

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentItemPersistenceService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentItemPersistenceService.kt
@@ -7,10 +7,12 @@ import com.depromeet.piki.item.repository.ItemRepository
 import com.depromeet.piki.item.repository.ItemSnapshotRepository
 import com.depromeet.piki.product.domain.ProductLink
 import com.depromeet.piki.tournament.domain.TournamentItem
+import com.depromeet.piki.tournament.event.TournamentItemAdded
 import com.depromeet.piki.tournament.repository.TournamentItemRepository
 import com.depromeet.piki.tournament.repository.TournamentRepository
 import com.depromeet.piki.tournament.repository.TournamentUserRepository
 import com.depromeet.piki.tournament.service.dto.PersistedTournamentItem
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
@@ -27,6 +29,7 @@ class TournamentItemPersistenceService(
     private val tournamentItemRepository: TournamentItemRepository,
     private val itemRepository: ItemRepository,
     private val itemSnapshotRepository: ItemSnapshotRepository,
+    private val eventPublisher: ApplicationEventPublisher,
 ) {
     @Transactional
     fun persistLinkItem(
@@ -48,6 +51,8 @@ class TournamentItemPersistenceService(
                 ),
             ),
         ).first()
+        // 링크 1개 추가. 트랜잭션 안에서 발행 → AFTER_COMMIT 후 알림. 수신자는 참가자 - 본인(actor).
+        eventPublisher.publishEvent(TournamentItemAdded(tournamentId = tournamentId, actorId = userId))
         return PersistedTournamentItem(itemId = item.getId(), tournamentItemId = tournamentItem.getId())
     }
 
@@ -71,6 +76,8 @@ class TournamentItemPersistenceService(
                 )
             },
         )
+        // 이미지 N개를 한 번에 올려도 "추가됨" 알림은 1회. 수신자는 참가자 - 본인(actor).
+        eventPublisher.publishEvent(TournamentItemAdded(tournamentId = tournamentId, actorId = userId))
         return items.zip(tournamentItems) { item, tournamentItem ->
             PersistedTournamentItem(itemId = item.getId(), tournamentItemId = tournamentItem.getId())
         }

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
@@ -9,6 +9,8 @@ import com.depromeet.piki.tournament.domain.TournamentHistory
 import com.depromeet.piki.tournament.domain.TournamentItem
 import com.depromeet.piki.tournament.domain.TournamentStatus
 import com.depromeet.piki.tournament.domain.TournamentUser
+import com.depromeet.piki.tournament.event.TournamentItemAdded
+import com.depromeet.piki.tournament.event.TournamentJoined
 import com.depromeet.piki.tournament.repository.TournamentItemRepository
 import com.depromeet.piki.tournament.repository.TournamentRepository
 import com.depromeet.piki.tournament.repository.TournamentUserRepository
@@ -28,6 +30,7 @@ import com.depromeet.piki.tournament.service.dto.TournamentStartResult
 import com.depromeet.piki.tournament.service.dto.TournamentSummary
 import com.depromeet.piki.user.repository.UserRepository
 import com.depromeet.piki.wishlist.repository.WishRepository
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
@@ -42,6 +45,7 @@ class TournamentService(
     private val itemRepository: ItemRepository,
     private val itemSnapshotRepository: ItemSnapshotRepository,
     private val wishRepository: WishRepository,
+    private val eventPublisher: ApplicationEventPublisher,
 ) {
     @Transactional
     fun create(
@@ -87,6 +91,8 @@ class TournamentService(
             throw TournamentException.participantLimitExceeded()
         }
         tournamentUserRepository.save(TournamentUser(tournamentId = tournamentId, userId = userId))
+        // 트랜잭션 안에서 발행 → AFTER_COMMIT 리스너가 커밋 후에만 알림을 보낸다. 수신자는 참가자 - 본인(actor).
+        eventPublisher.publishEvent(TournamentJoined(tournamentId = tournamentId, actorId = userId))
     }
 
     @Transactional
@@ -126,7 +132,7 @@ class TournamentService(
             wishRepository
                 .findByItemIdsAndUserId(command.itemIds, userId)
                 .associate { it.itemId to it.snapshotId }
-        return tournamentItemRepository.saveAll(
+        val savedItemIds = tournamentItemRepository.saveAll(
             command.itemIds.map { itemId ->
                 val snapshotId =
                     snapshotIdByItemId[itemId]
@@ -139,6 +145,9 @@ class TournamentService(
                 )
             },
         ).map { it.getId() }
+        // 위시에서 N개를 한 번에 추가해도 "추가됨" 알림은 1회. 수신자는 참가자 - 본인(actor).
+        eventPublisher.publishEvent(TournamentItemAdded(tournamentId = command.tournamentId, actorId = userId))
+        return savedItemIds
     }
 
     @Transactional

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
@@ -91,7 +91,7 @@ class TournamentService(
             throw TournamentException.participantLimitExceeded()
         }
         tournamentUserRepository.save(TournamentUser(tournamentId = tournamentId, userId = userId))
-        // 트랜잭션 안에서 발행 → AFTER_COMMIT 리스너가 커밋 후에만 알림을 보낸다. 수신자는 참가자 - 본인(actor).
+        // 참여가 커밋된 뒤에만 구독자에게 전달되도록 트랜잭션 안에서 발행한다 (롤백 시 미발행).
         eventPublisher.publishEvent(TournamentJoined(tournamentId = tournamentId, actorId = userId))
     }
 
@@ -145,7 +145,7 @@ class TournamentService(
                 )
             },
         ).map { it.getId() }
-        // 위시에서 N개를 한 번에 추가해도 "추가됨" 알림은 1회. 수신자는 참가자 - 본인(actor).
+        // 여러 개를 한 번에 추가해도 "아이템이 추가됐다"는 사실은 1건이라 이벤트도 1회만 발행한다.
         eventPublisher.publishEvent(TournamentItemAdded(tournamentId = command.tournamentId, actorId = userId))
         return savedItemIds
     }

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentSocialPersistenceService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentSocialPersistenceService.kt
@@ -1,11 +1,13 @@
 package com.depromeet.piki.tournament.service
 
 import com.depromeet.piki.tournament.domain.TournamentUser
+import com.depromeet.piki.tournament.event.TournamentJoined
 import com.depromeet.piki.tournament.repository.TournamentRepository
 import com.depromeet.piki.tournament.repository.TournamentUserRepository
 import com.depromeet.piki.user.domain.User
 import com.depromeet.piki.user.service.UserService
 import java.util.UUID
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -17,6 +19,7 @@ class TournamentSocialPersistenceService(
     private val tournamentRepository: TournamentRepository,
     private val tournamentUserRepository: TournamentUserRepository,
     private val userService: UserService,
+    private val eventPublisher: ApplicationEventPublisher,
 ) {
     @Transactional
     fun createGuestAndJoin(
@@ -33,6 +36,8 @@ class TournamentSocialPersistenceService(
         }
         val user = userService.createGuestWithNickname(nickname)
         tournamentUserRepository.save(TournamentUser(tournamentId = tournamentId, userId = user.id))
+        // 게스트 합류. 트랜잭션 안에서 발행 → AFTER_COMMIT 후 알림. 수신자는 기존 참가자 - 본인(actor=새 게스트).
+        eventPublisher.publishEvent(TournamentJoined(tournamentId = tournamentId, actorId = user.id))
         return user
     }
 

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentSocialPersistenceService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentSocialPersistenceService.kt
@@ -36,7 +36,7 @@ class TournamentSocialPersistenceService(
         }
         val user = userService.createGuestWithNickname(nickname)
         tournamentUserRepository.save(TournamentUser(tournamentId = tournamentId, userId = user.id))
-        // 게스트 합류. 트랜잭션 안에서 발행 → AFTER_COMMIT 후 알림. 수신자는 기존 참가자 - 본인(actor=새 게스트).
+        // 게스트 합류도 일반 참여와 같은 사실이라 같은 이벤트를 발행한다. 커밋된 뒤에만 전달되도록 트랜잭션 안에서 (롤백 시 미발행).
         eventPublisher.publishEvent(TournamentJoined(tournamentId = tournamentId, actorId = user.id))
         return user
     }

--- a/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
@@ -13,6 +13,8 @@ import com.depromeet.piki.support.StubItemParsingWorker
 import com.depromeet.piki.support.StubRefreshTokenStore
 import com.depromeet.piki.tournament.domain.TournamentItem
 import com.depromeet.piki.tournament.domain.TournamentUser
+import com.depromeet.piki.tournament.event.TournamentItemAdded
+import com.depromeet.piki.tournament.event.TournamentJoined
 import com.depromeet.piki.tournament.repository.TournamentItemJpaRepository
 import com.depromeet.piki.tournament.repository.TournamentJpaRepository
 import com.depromeet.piki.tournament.repository.TournamentUserJpaRepository
@@ -29,6 +31,8 @@ import org.springframework.http.HttpMethod
 import org.springframework.http.MediaType
 import org.springframework.mock.web.MockMultipartFile
 import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
+import org.springframework.test.context.event.ApplicationEvents
+import org.springframework.test.context.event.RecordApplicationEvents
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
@@ -48,6 +52,7 @@ import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
+@RecordApplicationEvents
 @Transactional
 class TournamentControllerTest : IntegrationTestSupport() {
     @Autowired private lateinit var webApplicationContext: WebApplicationContext
@@ -77,6 +82,10 @@ class TournamentControllerTest : IntegrationTestSupport() {
     @Autowired private lateinit var stubImageParsingWorker: StubImageParsingWorker
 
     @Autowired private lateinit var stubRefreshTokenStore: StubRefreshTokenStore
+
+    // 발행 검증용 — 같은 스레드(MockMvc 컨트롤러 실행)에서 publish 된 도메인 이벤트를 기록한다.
+    // AFTER_COMMIT 리스너 발화(별도 스레드, 트랜잭션 롤백 무관) 여부와 독립적으로 "서비스가 이벤트를 쐈는가" 만 본다.
+    @Autowired private lateinit var applicationEvents: ApplicationEvents
 
     private val userId: UUID = UUID.fromString("11111111-2222-3333-4444-555555555555")
     private val otherUserId: UUID = UUID.fromString("99999999-8888-7777-6666-555555555555")
@@ -1245,6 +1254,73 @@ class TournamentControllerTest : IntegrationTestSupport() {
                 .andExpect(jsonPath("$.data.tournamentItemIds.length()").value(2))
 
             assertEquals(2, tournamentItemJpaRepository.findAllByTournamentIdAndNotDeleted(tournamentId).size)
+        } finally {
+            stubImageParsingWorker.enabled = true
+        }
+    }
+
+    @Test
+    fun `게스트 합류 시 TournamentJoined 이벤트가 발행된다`() {
+        val mockMvc = buildMockMvc()
+        val (tournamentId, inviteCode) = createTournamentWithInviteCode(mockMvc)
+
+        mockMvc
+            .perform(
+                post("/api/v1/tournaments/$tournamentId/join/guest")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"inviteCode":"$inviteCode","nickname":"새친구"}"""),
+            ).andExpect(status().isCreated)
+
+        val joined = applicationEvents.stream(TournamentJoined::class.java).toList()
+        assertEquals(1, joined.size)
+        assertEquals(tournamentId, joined.first().tournamentId)
+    }
+
+    @Test
+    fun `링크 아이템 추가 시 TournamentItemAdded 이벤트가 발행된다`() {
+        stubItemParsingWorker.enabled = false
+        try {
+            val mockMvc = buildMockMvc()
+            val tournamentId = createTournament(mockMvc)
+
+            mockMvc
+                .perform(
+                    post("/api/v1/tournaments/$tournamentId/items/link")
+                        .header(HttpHeaders.AUTHORIZATION, authHeader(userId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""{"url":"https://example.com/product"}"""),
+                ).andExpect(status().isOk)
+
+            val added = applicationEvents.stream(TournamentItemAdded::class.java).toList()
+            assertEquals(1, added.size)
+            assertEquals(tournamentId, added.first().tournamentId)
+            assertEquals(userId, added.first().actorId)
+        } finally {
+            stubItemParsingWorker.enabled = true
+        }
+    }
+
+    @Test
+    fun `이미지 아이템 추가는 여러 장이어도 TournamentItemAdded 를 한 번만 발행한다`() {
+        stubImageParsingWorker.enabled = false
+        try {
+            val mockMvc = buildMockMvc()
+            val tournamentId = createTournament(mockMvc)
+            val image1 = MockMultipartFile("images", "img1.jpg", "image/jpeg", ByteArray(100) { 1 })
+            val image2 = MockMultipartFile("images", "img2.jpg", "image/jpeg", ByteArray(100) { 2 })
+
+            mockMvc
+                .perform(
+                    multipart("/api/v1/tournaments/$tournamentId/items/images")
+                        .file(image1)
+                        .file(image2)
+                        .header(HttpHeaders.AUTHORIZATION, authHeader(userId)),
+                ).andExpect(status().isOk)
+
+            val added = applicationEvents.stream(TournamentItemAdded::class.java).toList()
+            assertEquals(1, added.size)
+            assertEquals(tournamentId, added.first().tournamentId)
+            assertEquals(userId, added.first().actorId)
         } finally {
             stubImageParsingWorker.enabled = true
         }

--- a/src/test/kotlin/com/depromeet/piki/tournament/service/TournamentServiceTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/service/TournamentServiceTest.kt
@@ -11,6 +11,8 @@ import com.depromeet.piki.tournament.domain.TournamentHistory
 import com.depromeet.piki.tournament.domain.TournamentItem
 import com.depromeet.piki.tournament.domain.TournamentStatus
 import com.depromeet.piki.tournament.domain.TournamentUser
+import com.depromeet.piki.tournament.event.TournamentItemAdded
+import com.depromeet.piki.tournament.event.TournamentJoined
 import com.depromeet.piki.tournament.repository.TournamentItemRepository
 import com.depromeet.piki.tournament.repository.TournamentRepository
 import com.depromeet.piki.tournament.repository.TournamentUserRepository
@@ -25,6 +27,7 @@ import com.depromeet.piki.wishlist.domain.Wish
 import com.depromeet.piki.wishlist.domain.WishCursor
 import com.depromeet.piki.wishlist.repository.WishRepository
 import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.http.HttpStatus
 import java.util.UUID
 import kotlin.test.assertEquals
@@ -369,6 +372,8 @@ class TournamentServiceTest {
     private val testItemRepository = TestItemRepository()
     private val testItemSnapshotRepository = TestItemSnapshotRepository()
     private val testWishRepository = TestWishRepository(testItemSnapshotRepository)
+    // 발행된 도메인 이벤트를 그대로 모으는 capturing publisher — 발행 단언에 쓴다.
+    private val publishedEvents = mutableListOf<Any>()
     private val service =
         TournamentService(
             tournamentUserRepository,
@@ -378,6 +383,7 @@ class TournamentServiceTest {
             testItemRepository,
             testItemSnapshotRepository,
             testWishRepository,
+            ApplicationEventPublisher { publishedEvents += it },
         )
     private val userId = UUID.randomUUID()
     private val otherUserId = UUID.randomUUID()
@@ -401,6 +407,25 @@ class TournamentServiceTest {
         assertEquals(1L, id)
         assertTrue(result.inviteCode.matches(Regex("[A-Z]{3}\\d{3}")))
         assertEquals(TournamentStatus.PENDING, repository.tournaments[id]!!.status)
+    }
+
+    @Test
+    fun `join 은 참여 후 TournamentJoined 이벤트를 발행한다`() {
+        val created = service.create(userId, CreateTournament("내 토너먼트"))
+
+        service.join(otherUserId, created.tournamentId, created.inviteCode)
+
+        assertEquals(listOf<Any>(TournamentJoined(created.tournamentId, otherUserId)), publishedEvents)
+    }
+
+    @Test
+    fun `addItemsFromWish 는 여러 개를 추가해도 TournamentItemAdded 를 한 번만 발행한다`() {
+        val tournamentId = service.create(userId, CreateTournament("내 토너먼트")).tournamentId
+        testWishRepository.addWish(userId, *(1L..3L).toList().toLongArray())
+
+        service.addItemsFromWish(userId, AddTournamentItemsFromWish(tournamentId, (1L..3L).toList()))
+
+        assertEquals(listOf<Any>(TournamentItemAdded(tournamentId, userId)), publishedEvents)
     }
 
     @Test


### PR DESCRIPTION
## Situation

- 알림 backbone(수신자 도출, AFTER_COMMIT 리스너, dispatcher, SSE·FCM 채널)은 이미 구축돼 있었다. 그런데 토너먼트 쪽 도메인 이벤트를 아무도 발행하지 않아, 토너먼트 참가·아이템 추가 알림이 실제로는 누구에게도 나가지 않았다.
- 아이템 파싱 완료·실패 알림은 이미 발행이 연결돼 정상 동작 중이었다. 토너먼트 두 종류만 "받을 사람은 정해져 있는데 보낼 사건이 안 터지는" 상태였다.

## Task

- 토너먼트 참가·아이템 추가 비즈니스 로직에 이벤트 발행을 연결해, 기존 알림 인프라가 자동으로 알림을 내보내게 한다.
- 참가·추가 경로가 여러 갈래라(일반 참가, 게스트 합류, 위시·링크·이미지 추가) 어느 자리에, 몇 번, 어떤 순서로 발행할지 정한다.

## Action

발행 지점과 수신자:

| 사건 | 이벤트 | 수신자 |
|---|---|---|
| 토너먼트 참가 (일반·게스트 합류) | TournamentJoined | 그 토너먼트 참가자에서 본인을 뺀 전원 |
| 아이템 추가 (위시·링크·이미지) | TournamentItemAdded | 그 토너먼트 참가자에서 추가한 본인을 뺀 전원 |

### 발행 위치
- 참가는 일반 참가와 게스트 합류 두 경로에 각각 발행한다. 게스트 합류는 트랜잭션 경계가 별도라(게스트 계정 생성과 참여를 한 트랜잭션으로 묶는 빈) 그 안에서 발행한다.
- 추가는 위시·링크·이미지 세 경로에 발행한다. 링크·이미지는 비동기 파싱이라 추가 시점엔 아직 상품 정보가 비어 있지만, 추가 즉시 발행한다. 다른 참가자가 "누가 무언가를 올렸다"로 화면을 갱신하는 게 설계 의도이고, 파싱 완료·실패 알림은 올린 본인에게만 따로 간다.

### 정책 결정
- 여러 개를 한 번에 올려도(위시 N개, 이미지 N장) 추가 이벤트는 한 번만 발행한다. 이벤트가 토너먼트 식별자만 담아 "추가됨" 한 번이 자연스럽고 알림 폭주를 막는다.
- 토너먼트 생성 시 방장이 자동으로 첫 참가자가 되는 경로는 발행하지 않는다. 수신자가 본인뿐이라 "본인 제외" 규칙상 받을 사람이 0명이다.
- 발행은 모두 트랜잭션 안 + 저장 이후에 둔다. 커밋이 성공해야(AFTER_COMMIT) 알림이 나가고, 롤백되면 안 나간다.

### 검증
- 단위: 발행 이벤트를 그대로 모으는 publisher 로 일반 참가·위시 추가의 발행을 단언한다. 다건 추가가 한 번만 발행하는지도 확인한다.
- 통합: 실제 빈 흐름(컨트롤러 진입)에서 게스트 합류·링크·이미지 추가가 이벤트를 발행하는지 `@RecordApplicationEvents` 로 확인한다. 비동기 리스너 발화(별도 스레드, 트랜잭션 롤백 무관)와 독립적으로 발행 자체만 본다.

## Result

- 토너먼트 참가·아이템 추가 시 참가자에게 알림이 자동으로 나간다. SSE 는 항상, FCM 푸시는 서버에 Firebase 키가 설정된 환경에서 함께 발송된다.
- 이 발행 연결이 알림 Epic 의 마지막 자동 발송 블로커였다. 토너먼트 알림이 이제 end-to-end 로 동작한다.

---
## 연관 이슈

- close #247

## Updates

### 발행부 주석 정리 (`1353cc7`)
- 발행부 주석이 "수신자는 참가자 - 본인" 처럼 알림 도메인의 수신자 규칙·리스너 종류를 적고 있어, 도메인에서 알림으로의 단방향 결합 원칙이 주석 레벨에서 새던 것을 정리한다. 코드는 알림 패키지를 import 하지 않아 실제 결합은 없으나, 주석이 "이 이벤트는 알림 전용"이라는 오해를 부르고 미래의 다른 구독자(통계 등)와 충돌한다.
- 도메인 사실 관점만 남긴다: 트랜잭션 안 발행 이유(커밋된 뒤에만 구독자에게 전달, 롤백 시 미발행)와 1회 발행 이유(여러 개를 올려도 "추가됐다"는 사실은 1건). 수신자 규칙은 resolveRecipients 의 책임이라 그 주석에 위임한다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 토너먼트 참여 및 아이템 추가 시 도메인 이벤트 발행 기능 추가. 복수 아이템 추가 시에도 이벤트는 1회만 발행되어 효율적인 이벤트 처리 구현.

* **테스트**
  * 토너먼트 참여, 링크 아이템 추가, 이미지 아이템 추가 등 주요 작업에서 도메인 이벤트 발행 검증 테스트 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->