### PR TITLE
초대 코드 단독 조회 API 추가 및 completed 응답 보완

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/auth/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/config/SecurityConfig.kt
@@ -89,7 +89,10 @@ class SecurityConfig(
                     // 소셜 토너먼트 게스트 합류: 계정 없이 초대 코드 + 닉네임으로 가입과 동시에 참여
                     .requestMatchers(HttpMethod.POST, "/api/v1/tournaments/*/join/guest")
                     .permitAll()
-                    // 초대 코드 미리보기: 미인증 상태에서 6자리 코드만으로 토너먼트 정보 확인
+                    // 링크 접근 미리보기: 미인증 상태에서 tournamentId 로 참여 전 정보 확인
+                    .requestMatchers(HttpMethod.GET, "/api/v1/tournaments/*/invite-preview")
+                    .permitAll()
+                    // 코드 입력 미리보기: 미인증 상태에서 6자리 코드만으로 토너먼트 정보 확인
                     .requestMatchers(HttpMethod.GET, "/api/v1/tournaments/by-invite-code")
                     .permitAll()
                     // 플레이 링크 정보 조회: 미인증 상태에서 링크 진입 시 토너먼트 정보 확인

--- a/src/main/kotlin/com/depromeet/piki/auth/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/config/SecurityConfig.kt
@@ -89,8 +89,8 @@ class SecurityConfig(
                     // 소셜 토너먼트 게스트 합류: 계정 없이 초대 코드 + 닉네임으로 가입과 동시에 참여
                     .requestMatchers(HttpMethod.POST, "/api/v1/tournaments/*/join/guest")
                     .permitAll()
-                    // 초대 코드 검증 미리보기: 미인증 상태에서 토너먼트 참여 전 정보 확인
-                    .requestMatchers(HttpMethod.GET, "/api/v1/tournaments/*/invite-preview")
+                    // 초대 코드 미리보기: 미인증 상태에서 6자리 코드만으로 토너먼트 정보 확인
+                    .requestMatchers(HttpMethod.GET, "/api/v1/tournaments/by-invite-code")
                     .permitAll()
                     // 플레이 링크 정보 조회: 미인증 상태에서 링크 진입 시 토너먼트 정보 확인
                     .requestMatchers(HttpMethod.GET, "/api/v1/tournaments/*/play-link-info")

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
@@ -526,44 +526,6 @@ interface TournamentApi {
     ): ApiResponseBody<Unit>
 
     @Operation(
-        summary = "토너먼트 참여 전 미리보기",
-        description = """
-            토너먼트 기본 정보(이름, 아이템 수, 참여자 수)를 반환한다. 인증 불필요.
-            - 링크 직접 접근: inviteCode 생략 가능. 만료 여부만 확인.
-            - 코드 입력 경로: inviteCode 전달 시 코드 일치 여부도 함께 검증.
-            비회원은 이 정보를 보고 닉네임 설정 후 /join/guest, 회원은 /join을 호출한다.
-        """,
-    )
-    @ApiResponses(
-        value = [
-            ApiResponse(
-                responseCode = "200",
-                description = "조회 성공 (토너먼트 이름·아이템 수·참여자 수 반환)",
-                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
-            ),
-            ApiResponse(
-                responseCode = "400",
-                description = "잘못된 요청 (초대 코드 불일치 — inviteCode 전달 시에만 발생)",
-                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
-            ),
-            ApiResponse(
-                responseCode = "404",
-                description = "토너먼트를 찾을 수 없음",
-                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
-            ),
-            ApiResponse(
-                responseCode = "409",
-                description = "상태 충돌 (PENDING이 아닌 토너먼트 · 초대 링크 만료)",
-                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
-            ),
-        ],
-    )
-    fun getInvitePreview(
-        @Parameter(description = "토너먼트 ID", example = "1") tournamentId: Long,
-        @Parameter(description = "초대 코드 (영어 대문자 3자리 + 숫자 3자리, 코드 입력 경로에서만 전달)", example = "ABC123") inviteCode: String?,
-    ): ApiResponseBody<TournamentInvitePreviewResponse>
-
-    @Operation(
         summary = "초대 코드로 토너먼트 미리보기",
         description = """
             홈 다이얼로그에서 6자리 코드만 입력하는 경로 전용 — tournamentId 없이 코드만으로 조회한다.

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
@@ -526,6 +526,33 @@ interface TournamentApi {
     ): ApiResponseBody<Unit>
 
     @Operation(
+        summary = "링크 접근 경로 — 토너먼트 참여 전 미리보기",
+        description = "초대 링크 직접 접근 시 tournamentId 만으로 토너먼트 정보(이름·아이템 수·참여자 수)를 반환한다. 인증 불필요.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "조회 성공 (토너먼트 이름·아이템 수·참여자 수 반환)",
+                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "토너먼트를 찾을 수 없음",
+                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+            ),
+            ApiResponse(
+                responseCode = "409",
+                description = "상태 충돌 (PENDING이 아닌 토너먼트 · 초대 링크 만료)",
+                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+            ),
+        ],
+    )
+    fun getInvitePreview(
+        @Parameter(description = "토너먼트 ID", example = "1") tournamentId: Long,
+    ): ApiResponseBody<TournamentInvitePreviewResponse>
+
+    @Operation(
         summary = "초대 코드로 토너먼트 미리보기",
         description = """
             홈 다이얼로그에서 6자리 코드만 입력하는 경로 전용 — tournamentId 없이 코드만으로 조회한다.

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
@@ -564,6 +564,37 @@ interface TournamentApi {
     ): ApiResponseBody<TournamentInvitePreviewResponse>
 
     @Operation(
+        summary = "초대 코드로 토너먼트 미리보기",
+        description = """
+            홈 다이얼로그에서 6자리 코드만 입력하는 경로 전용 — tournamentId 없이 코드만으로 조회한다.
+            코드가 유효하면 tournamentId·이름·아이템 수·참여자 수를 반환한다.
+            이후 /join 또는 /join/guest 호출 시 응답의 tournamentId를 사용하면 된다.
+        """,
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "조회 성공 (tournamentId·토너먼트 이름·아이템 수·참여자 수 반환)",
+                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청 (코드에 해당하는 토너먼트 없음)",
+                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+            ),
+            ApiResponse(
+                responseCode = "409",
+                description = "상태 충돌 (PENDING이 아닌 토너먼트 · 초대 링크 만료)",
+                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+            ),
+        ],
+    )
+    fun getInvitePreviewByCode(
+        @Parameter(description = "초대 코드 (영어 대문자 3자리 + 숫자 3자리)", example = "ABC123") code: String,
+    ): ApiResponseBody<TournamentInvitePreviewResponse>
+
+    @Operation(
         summary = "플레이 링크 생성",
         description = """
             완료된 토너먼트의 플레이 링크를 생성한다. 토너먼트 소유자만 호출 가능.

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApiExamples.kt
@@ -496,6 +496,22 @@ class TournamentApiExamples(
                         )
                     }
 
+                handlerMethod.binds(TournamentController::getInvitePreview) ->
+                    operation.examples(openApiObjectMapper.delegate) {
+                        add(
+                            status = HttpStatus.OK,
+                            name = "링크 접근 미리보기 성공",
+                            payload = ApiResponseBody.ok(
+                                TournamentInvitePreviewResponse(
+                                    tournamentId = 1,
+                                    tournamentName = "내 토너먼트",
+                                    itemCount = 8,
+                                    participantCount = 2,
+                                ),
+                            ),
+                        )
+                    }
+
                 handlerMethod.binds(TournamentController::getInvitePreviewByCode) ->
                     operation.examples(openApiObjectMapper.delegate) {
                         add(

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApiExamples.kt
@@ -238,6 +238,7 @@ class TournamentApiExamples(
                                         ),
                                     ),
                                     hasGroupResult = true,
+                                    playLinkExpiresAt = java.time.LocalDateTime.of(2026, 6, 20, 22, 0, 0),
                                 ),
                             ),
                         )
@@ -432,6 +433,7 @@ class TournamentApiExamples(
                                                         ),
                                                     ),
                                                 hasGroupResult = true,
+                                                playLinkExpiresAt = java.time.LocalDateTime.of(2026, 6, 20, 22, 0, 0),
                                             ),
                                     ),
                                 ),
@@ -506,6 +508,38 @@ class TournamentApiExamples(
                                     itemCount = 8,
                                     participantCount = 2,
                                 ),
+                            ),
+                        )
+                    }
+
+                handlerMethod.binds(TournamentController::getInvitePreviewByCode) ->
+                    operation.examples(openApiObjectMapper.delegate) {
+                        add(
+                            status = HttpStatus.OK,
+                            name = "코드 조회 성공",
+                            payload = ApiResponseBody.ok(
+                                TournamentInvitePreviewResponse(
+                                    tournamentId = 1,
+                                    tournamentName = "내 토너먼트",
+                                    itemCount = 8,
+                                    participantCount = 2,
+                                ),
+                            ),
+                        )
+                        add(
+                            status = HttpStatus.BAD_REQUEST,
+                            name = "코드에 해당하는 토너먼트 없음",
+                            payload = ApiResponseBody.fail<Unit>(
+                                category = ErrorCategory.INVALID_INPUT,
+                                detail = "초대 코드가 올바르지 않습니다.",
+                            ),
+                        )
+                        add(
+                            status = HttpStatus.CONFLICT,
+                            name = "초대 링크 만료",
+                            payload = ApiResponseBody.fail<Unit>(
+                                category = ErrorCategory.CONFLICT,
+                                detail = "초대 링크가 만료되었습니다.",
                             ),
                         )
                     }

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApiExamples.kt
@@ -496,22 +496,6 @@ class TournamentApiExamples(
                         )
                     }
 
-                handlerMethod.binds(TournamentController::getInvitePreview) ->
-                    operation.examples(openApiObjectMapper.delegate) {
-                        add(
-                            status = HttpStatus.OK,
-                            name = "초대 코드 검증 성공",
-                            payload = ApiResponseBody.ok(
-                                TournamentInvitePreviewResponse(
-                                    tournamentId = 1,
-                                    tournamentName = "내 토너먼트",
-                                    itemCount = 8,
-                                    participantCount = 2,
-                                ),
-                            ),
-                        )
-                    }
-
                 handlerMethod.binds(TournamentController::getInvitePreviewByCode) ->
                     operation.examples(openApiObjectMapper.delegate) {
                         add(

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentController.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentController.kt
@@ -116,15 +116,6 @@ class TournamentController(
         return ApiResponseBody.ok()
     }
 
-    @GetMapping("/{tournamentId}/invite-preview")
-    override fun getInvitePreview(
-        @PathVariable tournamentId: Long,
-        @RequestParam(required = false) inviteCode: String?,
-    ): ApiResponseBody<TournamentInvitePreviewResponse> {
-        val preview = tournamentService.getInvitePreview(tournamentId, inviteCode)
-        return ApiResponseBody.ok(TournamentInvitePreviewResponse.from(preview))
-    }
-
     @GetMapping("/by-invite-code")
     override fun getInvitePreviewByCode(
         @RequestParam code: String,

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentController.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentController.kt
@@ -116,6 +116,14 @@ class TournamentController(
         return ApiResponseBody.ok()
     }
 
+    @GetMapping("/{tournamentId}/invite-preview")
+    override fun getInvitePreview(
+        @PathVariable tournamentId: Long,
+    ): ApiResponseBody<TournamentInvitePreviewResponse> {
+        val preview = tournamentService.getInvitePreview(tournamentId)
+        return ApiResponseBody.ok(TournamentInvitePreviewResponse.from(preview))
+    }
+
     @GetMapping("/by-invite-code")
     override fun getInvitePreviewByCode(
         @RequestParam code: String,

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentController.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentController.kt
@@ -125,6 +125,14 @@ class TournamentController(
         return ApiResponseBody.ok(TournamentInvitePreviewResponse.from(preview))
     }
 
+    @GetMapping("/by-invite-code")
+    override fun getInvitePreviewByCode(
+        @RequestParam code: String,
+    ): ApiResponseBody<TournamentInvitePreviewResponse> {
+        val preview = tournamentService.getInvitePreviewByCode(code)
+        return ApiResponseBody.ok(TournamentInvitePreviewResponse.from(preview))
+    }
+
     @PostMapping("/{tournamentId}/play-link")
     override fun createPlayLink(
         @AuthenticationPrincipal userId: UUID,

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/dto/TournamentDetailResponse.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/dto/TournamentDetailResponse.kt
@@ -77,12 +77,14 @@ data class TournamentDetailResponse(
     data class CompletedData(
         val result: List<RankedItemResponse>,
         val hasGroupResult: Boolean,
+        val playLinkExpiresAt: LocalDateTime?,
     ) {
         companion object {
             fun from(completed: TournamentDetail.Completed): CompletedData =
                 CompletedData(
                     result = completed.result.map { RankedItemResponse.from(it) },
                     hasGroupResult = completed.hasGroupResult,
+                    playLinkExpiresAt = completed.playLinkExpiresAt,
                 )
         }
     }

--- a/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentJpaRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentJpaRepository.kt
@@ -22,4 +22,6 @@ interface TournamentJpaRepository : JpaRepository<Tournament, Long> {
     fun findByIdInAndDeletedAtIsNullOrderByCreatedAtDesc(ids: List<Long>): List<Tournament>
 
     fun findBySourceTournamentIdAndDeletedAtIsNull(sourceTournamentId: Long): List<Tournament>
+
+    fun findByInviteCodeAndDeletedAtIsNull(inviteCode: String): Tournament?
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentJpaRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentJpaRepository.kt
@@ -23,5 +23,10 @@ interface TournamentJpaRepository : JpaRepository<Tournament, Long> {
 
     fun findBySourceTournamentIdAndDeletedAtIsNull(sourceTournamentId: Long): List<Tournament>
 
-    fun findByInviteCodeAndDeletedAtIsNull(inviteCode: String): Tournament?
+    // findBy 는 결과가 2개 이상이면 IncorrectResultSizeDataAccessException → 500 이므로
+    // findFirst 로 방어한다. uk_tournaments_active_invite_code 가 정상이면 활성 코드 중복은 없지만
+    // 마이그레이션 이전 레거시 데이터 등 예외 상황에서도 안전하게 동작한다.
+    fun findFirstByInviteCodeAndDeletedAtIsNull(inviteCode: String): Tournament?
+
+    fun existsByInviteCodeAndDeletedAtIsNull(inviteCode: String): Boolean
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentRepository.kt
@@ -25,4 +25,6 @@ interface TournamentRepository {
     fun softDeleteHistoriesByTournamentId(tournamentId: Long)
 
     fun findBySourceTournamentId(sourceTournamentId: Long): List<Tournament>
+
+    fun findTournamentByInviteCode(code: String): Tournament?
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentRepository.kt
@@ -27,4 +27,6 @@ interface TournamentRepository {
     fun findBySourceTournamentId(sourceTournamentId: Long): List<Tournament>
 
     fun findTournamentByInviteCode(code: String): Tournament?
+
+    fun existsTournamentByInviteCode(code: String): Boolean
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentRepositoryImpl.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentRepositoryImpl.kt
@@ -47,4 +47,7 @@ class TournamentRepositoryImpl(
 
     override fun findBySourceTournamentId(sourceTournamentId: Long): List<Tournament> =
         tournamentJpaRepository.findBySourceTournamentIdAndDeletedAtIsNull(sourceTournamentId)
+
+    override fun findTournamentByInviteCode(code: String): Tournament? =
+        tournamentJpaRepository.findByInviteCodeAndDeletedAtIsNull(code)
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentRepositoryImpl.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/repository/TournamentRepositoryImpl.kt
@@ -49,5 +49,8 @@ class TournamentRepositoryImpl(
         tournamentJpaRepository.findBySourceTournamentIdAndDeletedAtIsNull(sourceTournamentId)
 
     override fun findTournamentByInviteCode(code: String): Tournament? =
-        tournamentJpaRepository.findByInviteCodeAndDeletedAtIsNull(code)
+        tournamentJpaRepository.findFirstByInviteCodeAndDeletedAtIsNull(code)
+
+    override fun existsTournamentByInviteCode(code: String): Boolean =
+        tournamentJpaRepository.existsByInviteCodeAndDeletedAtIsNull(code)
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentConstants.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentConstants.kt
@@ -10,3 +10,6 @@ internal const val PLAY_LINK_DURATION_DAYS = 14L
 
 // 소유자 1명 + 친구 최대 8명
 internal const val TOURNAMENT_MAX_PARTICIPANT_COUNT = 9
+
+// invite_code 충돌 시 재시도 최대 횟수 (17,576,000 가지 조합 → 충돌 극히 드물어 5회면 충분)
+internal const val INVITE_CODE_MAX_ATTEMPTS = 5

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
@@ -444,6 +444,22 @@ class TournamentService(
     }
 
     @Transactional(readOnly = true)
+    fun getInvitePreview(tournamentId: Long): TournamentInvitePreview {
+        val tournament =
+            tournamentRepository.findTournamentById(tournamentId)
+                ?: throw TournamentException.notFoundTournament()
+        tournament.checkJoinable(null)
+        val itemCount = tournamentItemRepository.countByTournamentId(tournamentId)
+        val participantCount = tournamentUserRepository.countByTournamentId(tournamentId)
+        return TournamentInvitePreview(
+            tournamentId = tournamentId,
+            tournamentName = tournament.name,
+            itemCount = itemCount,
+            participantCount = participantCount,
+        )
+    }
+
+    @Transactional(readOnly = true)
     fun getInvitePreviewByCode(code: String): TournamentInvitePreview {
         val tournament =
             tournamentRepository.findTournamentByInviteCode(code)

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
@@ -444,25 +444,6 @@ class TournamentService(
     }
 
     @Transactional(readOnly = true)
-    fun getInvitePreview(
-        tournamentId: Long,
-        inviteCode: String?,
-    ): TournamentInvitePreview {
-        val tournament =
-            tournamentRepository.findTournamentById(tournamentId)
-                ?: throw TournamentException.notFoundTournament()
-        tournament.checkJoinable(inviteCode)
-        val itemCount = tournamentItemRepository.countByTournamentId(tournamentId)
-        val participantCount = tournamentUserRepository.countByTournamentId(tournamentId)
-        return TournamentInvitePreview(
-            tournamentId = tournamentId,
-            tournamentName = tournament.name,
-            itemCount = itemCount,
-            participantCount = participantCount,
-        )
-    }
-
-    @Transactional(readOnly = true)
     fun getInvitePreviewByCode(code: String): TournamentInvitePreview {
         val tournament =
             tournamentRepository.findTournamentByInviteCode(code)

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
@@ -420,6 +420,7 @@ class TournamentService(
             },
             hasGroupResult = hasGroupResult,
             isOwner = isOwner,
+            playLinkExpiresAt = tournament.playLinkExpiresAt,
         )
     }
 
@@ -455,6 +456,22 @@ class TournamentService(
         val participantCount = tournamentUserRepository.countByTournamentId(tournamentId)
         return TournamentInvitePreview(
             tournamentId = tournamentId,
+            tournamentName = tournament.name,
+            itemCount = itemCount,
+            participantCount = participantCount,
+        )
+    }
+
+    @Transactional(readOnly = true)
+    fun getInvitePreviewByCode(code: String): TournamentInvitePreview {
+        val tournament =
+            tournamentRepository.findTournamentByInviteCode(code)
+                ?: throw TournamentException.invalidInviteCode()
+        tournament.checkJoinable(null)
+        val itemCount = tournamentItemRepository.countByTournamentId(tournament.getId())
+        val participantCount = tournamentUserRepository.countByTournamentId(tournament.getId())
+        return TournamentInvitePreview(
+            tournamentId = tournament.getId(),
             tournamentName = tournament.name,
             itemCount = itemCount,
             participantCount = participantCount,

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
@@ -48,7 +48,7 @@ class TournamentService(
         userId: UUID,
         command: CreateTournament,
     ): CreateTournamentResult {
-        val inviteCode = Tournament.generateInviteCode()
+        val inviteCode = generateUniqueInviteCode()
         val inviteExpiresAt = LocalDateTime.now().plusMinutes(command.inviteDurationMinutes)
         val tournament =
             tournamentRepository.saveTournament(
@@ -530,7 +530,7 @@ class TournamentService(
         val sourceItems = tournamentItemRepository.findAllByTournamentId(sourceTournamentId)
         require(sourceItems.isNotEmpty()) { "플레이 링크 복제 시 원본 아이템 없음 — sourceTournamentId=$sourceTournamentId" }
 
-        val inviteCode = Tournament.generateInviteCode()
+        val inviteCode = generateUniqueInviteCode()
         val newTournament = tournamentRepository.saveTournament(
             Tournament(
                 ownerTournamentUserId = 0L,
@@ -758,6 +758,16 @@ class TournamentService(
         }
         // 모든 라운드가 완료됐는데 isInProgress() 인 상태 — tournament.complete() 누락 버그
         error("모든 라운드가 완료됐는데 IN_PROGRESS 상태임 tournamentId=${histories.firstOrNull()?.tournamentId}")
+    }
+
+    // invite_code 는 랜덤 생성이라 충돌 가능성이 낮지만 0이 아니다. 활성 코드 중복을 사전 확인하고
+    // 충돌 시 재시도한다. DB 레벨 unique constraint(uk_tournaments_active_invite_code)가 최후 보루.
+    private fun generateUniqueInviteCode(): String {
+        repeat(INVITE_CODE_MAX_ATTEMPTS) {
+            val code = Tournament.generateInviteCode()
+            if (!tournamentRepository.existsTournamentByInviteCode(code)) return code
+        }
+        error("invite_code $INVITE_CODE_MAX_ATTEMPTS 회 생성 실패 — DB 포화 또는 keyspace 고갈 가능성")
     }
 }
 

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/dto/TournamentDetail.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/dto/TournamentDetail.kt
@@ -30,6 +30,7 @@ sealed class TournamentDetail {
         val result: List<RankedItem>,
         val hasGroupResult: Boolean,
         val isOwner: Boolean,
+        val playLinkExpiresAt: java.time.LocalDateTime?,
     ) : TournamentDetail()
 
     data class ItemDetail(

--- a/src/main/resources/db/migration/V20260607003923__add_unique_active_invite_code_to_tournaments.sql
+++ b/src/main/resources/db/migration/V20260607003923__add_unique_active_invite_code_to_tournaments.sql
@@ -1,0 +1,7 @@
+-- invite_code 는 랜덤 생성이라 낮은 확률로 충돌이 발생할 수 있다.
+-- MySQL 은 partial unique index 를 지원하지 않으므로, generated column 으로 흉내낸다.
+-- 활성 토너먼트(deleted_at IS NULL): active_invite_code = invite_code → 중복 차단
+-- 삭제 토너먼트(deleted_at IS NOT NULL): active_invite_code = NULL → MySQL unique 는 NULL 여러 개 허용
+ALTER TABLE tournaments
+    ADD COLUMN active_invite_code VARCHAR(6) GENERATED ALWAYS AS (IF(deleted_at IS NULL, invite_code, NULL)) STORED,
+    ADD UNIQUE KEY uk_tournaments_active_invite_code (active_invite_code);

--- a/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
@@ -11,6 +11,7 @@ import com.depromeet.piki.support.IntegrationTestSupport
 import com.depromeet.piki.support.StubImageParsingWorker
 import com.depromeet.piki.support.StubItemParsingWorker
 import com.depromeet.piki.support.StubRefreshTokenStore
+import com.depromeet.piki.tournament.domain.Tournament
 import com.depromeet.piki.tournament.domain.TournamentItem
 import com.depromeet.piki.tournament.domain.TournamentUser
 import com.depromeet.piki.tournament.repository.TournamentItemJpaRepository
@@ -1669,6 +1670,39 @@ class TournamentControllerTest : IntegrationTestSupport() {
         mockMvc
             .perform(get("/api/v1/tournaments/by-invite-code").param("code", "ZZZ999"))
             .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `GET by-invite-code 는 초대 링크가 만료된 토너먼트이면 409 를 반환한다`() {
+        val mockMvc = buildMockMvc()
+        val expiredCode = "EXP001"
+        tournamentJpaRepository.save(
+            Tournament(
+                ownerTournamentUserId = 0L,
+                name = "만료 토너먼트",
+                inviteCode = expiredCode,
+                inviteExpiresAt = java.time.LocalDateTime.now().minusMinutes(1),
+            ),
+        )
+
+        mockMvc
+            .perform(get("/api/v1/tournaments/by-invite-code").param("code", expiredCode))
+            .andExpect(status().isConflict)
+    }
+
+    @Test
+    fun `GET by-invite-code 는 PENDING 이 아닌 토너먼트이면 409 를 반환한다`() {
+        val mockMvc = buildMockMvc()
+        val (tournamentId, inviteCode) = createTournamentWithInviteCode(mockMvc)
+        addItemsToTournament(mockMvc, tournamentId, userId, saveWishItem(name = "아이템1"), saveWishItem(name = "아이템2"))
+        mockMvc.perform(
+            post("/api/v1/tournaments/$tournamentId/start")
+                .header(HttpHeaders.AUTHORIZATION, authHeader(userId)),
+        )
+
+        mockMvc
+            .perform(get("/api/v1/tournaments/by-invite-code").param("code", inviteCode))
+            .andExpect(status().isConflict)
     }
 
     // ── 플레이 링크 ──────────────────────────────────────────────────

--- a/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
@@ -1614,48 +1614,6 @@ class TournamentControllerTest : IntegrationTestSupport() {
             ).andExpect(status().isNotFound)
     }
 
-    // ── 초대 미리보기 ──────────────────────────────────────────────────
-
-    @Test
-    fun `GET invite-preview 는 유효한 초대 코드로 토너먼트 정보를 반환한다`() {
-        val mockMvc = buildMockMvc()
-        val (tournamentId, inviteCode) = createTournamentWithInviteCode(mockMvc)
-
-        mockMvc
-            .perform(
-                get("/api/v1/tournaments/$tournamentId/invite-preview")
-                    .param("inviteCode", inviteCode),
-            ).andExpect(status().isOk)
-            .andExpect(jsonPath("$.data.tournamentId").value(tournamentId))
-            .andExpect(jsonPath("$.data.tournamentName").isString)
-            .andExpect(jsonPath("$.data.itemCount").value(0))
-            .andExpect(jsonPath("$.data.participantCount").value(1))
-    }
-
-    @Test
-    fun `GET invite-preview 는 JWT 없이도 호출 가능하다`() {
-        val mockMvc = buildMockMvc()
-        val (tournamentId, inviteCode) = createTournamentWithInviteCode(mockMvc)
-
-        mockMvc
-            .perform(
-                get("/api/v1/tournaments/$tournamentId/invite-preview")
-                    .param("inviteCode", inviteCode),
-            ).andExpect(status().isOk)
-    }
-
-    @Test
-    fun `GET invite-preview 는 초대 코드가 불일치하면 400 을 반환한다`() {
-        val mockMvc = buildMockMvc()
-        val (tournamentId, _) = createTournamentWithInviteCode(mockMvc)
-
-        mockMvc
-            .perform(
-                get("/api/v1/tournaments/$tournamentId/invite-preview")
-                    .param("inviteCode", "ZZZ999"),
-            ).andExpect(status().isBadRequest)
-    }
-
     // ── 플레이 링크 ──────────────────────────────────────────────────
 
     @Test

--- a/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
@@ -1614,6 +1614,63 @@ class TournamentControllerTest : IntegrationTestSupport() {
             ).andExpect(status().isNotFound)
     }
 
+    // ── 초대 미리보기 ──────────────────────────────────────────────────
+
+    @Test
+    fun `GET invite-preview 는 tournamentId 만으로 토너먼트 정보를 반환한다`() {
+        val mockMvc = buildMockMvc()
+        val (tournamentId, _) = createTournamentWithInviteCode(mockMvc)
+
+        mockMvc
+            .perform(get("/api/v1/tournaments/$tournamentId/invite-preview"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.tournamentId").value(tournamentId))
+            .andExpect(jsonPath("$.data.tournamentName").isString)
+            .andExpect(jsonPath("$.data.itemCount").value(0))
+            .andExpect(jsonPath("$.data.participantCount").value(1))
+    }
+
+    @Test
+    fun `GET invite-preview 는 JWT 없이도 호출 가능하다`() {
+        val mockMvc = buildMockMvc()
+        val (tournamentId, _) = createTournamentWithInviteCode(mockMvc)
+
+        mockMvc
+            .perform(get("/api/v1/tournaments/$tournamentId/invite-preview"))
+            .andExpect(status().isOk)
+    }
+
+    @Test
+    fun `GET by-invite-code 는 유효한 코드로 tournamentId 를 포함한 토너먼트 정보를 반환한다`() {
+        val mockMvc = buildMockMvc()
+        val (tournamentId, inviteCode) = createTournamentWithInviteCode(mockMvc)
+
+        mockMvc
+            .perform(get("/api/v1/tournaments/by-invite-code").param("code", inviteCode))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.tournamentId").value(tournamentId))
+            .andExpect(jsonPath("$.data.tournamentName").isString)
+    }
+
+    @Test
+    fun `GET by-invite-code 는 JWT 없이도 호출 가능하다`() {
+        val mockMvc = buildMockMvc()
+        val (_, inviteCode) = createTournamentWithInviteCode(mockMvc)
+
+        mockMvc
+            .perform(get("/api/v1/tournaments/by-invite-code").param("code", inviteCode))
+            .andExpect(status().isOk)
+    }
+
+    @Test
+    fun `GET by-invite-code 는 존재하지 않는 코드이면 400 을 반환한다`() {
+        val mockMvc = buildMockMvc()
+
+        mockMvc
+            .perform(get("/api/v1/tournaments/by-invite-code").param("code", "ZZZ999"))
+            .andExpect(status().isBadRequest)
+    }
+
     // ── 플레이 링크 ──────────────────────────────────────────────────
 
     @Test

--- a/src/test/kotlin/com/depromeet/piki/tournament/service/TournamentServiceTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/service/TournamentServiceTest.kt
@@ -355,6 +355,9 @@ class TournamentServiceTest {
         override fun findTournamentByInviteCode(code: String): Tournament? =
             tournaments.values.firstOrNull { it.inviteCode == code && (it.deletedAt?.let { false } ?: true) }
 
+        override fun existsTournamentByInviteCode(code: String): Boolean =
+            tournaments.values.any { it.inviteCode == code && (it.deletedAt?.let { false } ?: true) }
+
         private fun setEntityId(
             entity: LongBaseEntity,
             id: Long,

--- a/src/test/kotlin/com/depromeet/piki/tournament/service/TournamentServiceTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/service/TournamentServiceTest.kt
@@ -352,6 +352,9 @@ class TournamentServiceTest {
         override fun findBySourceTournamentId(sourceTournamentId: Long): List<Tournament> =
             tournaments.values.filter { it.sourceTournamentId == sourceTournamentId && (it.deletedAt?.let { false } ?: true) }
 
+        override fun findTournamentByInviteCode(code: String): Tournament? =
+            tournaments.values.firstOrNull { it.inviteCode == code && (it.deletedAt?.let { false } ?: true) }
+
         private fun setEntityId(
             entity: LongBaseEntity,
             id: Long,


### PR DESCRIPTION
## Situation

- 프론트엔드에서 홈 다이얼로그에 6자리 코드만 입력해 토너먼트에 참여하는 경로가 완전히 막혀 있었다.
- 기존 `/{tournamentId}/invite-preview`는 코드 검증과 링크 직접 접근 두 경로를 한 엔드포인트에 혼합했고, 두 경로 모두 `tournamentId`를 path에 필수로 요구했다.
- 코드만 아는 사용자는 `tournamentId`를 알 방법이 없어 `invite-preview`도, `join`도 호출 불가 상태였다.
- 또한 `completed` 응답에 `playLinkExpiresAt`이 없어 클라이언트가 만료 시각을 today+14일로 추정해야 했다. 플레이링크가 이미 생성된 토너먼트에 재진입할 때 실제 만료 시각을 표시할 수 없었다.

## Task

- 코드 입력 경로와 링크 직접 접근 경로를 각자의 엔드포인트로 명확히 분리한다.
- `completed` 응답에 `playLinkExpiresAt`을 추가해 프론트가 실제 만료 시각을 표시할 수 있게 한다.

## Action

### 엔드포인트 분리

- `GET /tournaments/by-invite-code?code=ABC123` 신규 추가: 코드만으로 `tournamentId` 조회. DB에서 코드로 토너먼트를 찾은 뒤 PENDING 여부와 초대 만료를 검증해 tournamentId, 이름, 인원, 아이템 수를 반환한다. 이후 `/join` 또는 `/join/guest` 호출 시 응답의 tournamentId를 사용한다.
- `GET /tournaments/{tournamentId}/invite-preview` 시그니처 변경: `inviteCode` 파라미터 제거. 링크 직접 접근 경로는 tournamentId만으로 PENDING + 만료 여부를 확인하면 충분하며, 코드 검증은 `by-invite-code`가 담당한다.
- SecurityConfig에 `by-invite-code` permitAll 추가.

| 경로 | 엔드포인트 | 필요 정보 |
|---|---|---|
| 링크 직접 접근 | `/{tournamentId}/invite-preview` | tournamentId (URL에 포함) |
| 코드 입력 | `/by-invite-code?code=` | 6자리 코드만 |

### completed 응답 보완

- `TournamentDetail.Completed`, `CompletedData` DTO에 `playLinkExpiresAt: LocalDateTime?` 추가.
- 플레이링크 미생성이면 `null`, 생성 후면 실제 만료 시각 반환.

### 테스트

- 기존 `invite-preview` 테스트(코드 파라미터 전달 방식)를 새 동작에 맞게 교체.
- `invite-preview` (tournamentId만, JWT 없이 호출 가능), `by-invite-code` (코드 조회 성공, JWT 없이 호출 가능, 잘못된 코드 400) 통합 테스트 추가.

## Result

- 코드 입력 경로가 `by-invite-code` 단 한 번의 호출로 unblock 된다.
- 링크 접근과 코드 입력이 엔드포인트 레벨에서 분리되어 각 경로의 역할이 명확해진다.
- `completed.playLinkExpiresAt`으로 플레이링크 재진입 시 실제 만료 시각 표시가 가능해진다.

---
## 연관 이슈

- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 초대 코드를 입력하여 토너먼트 미리보기를 확인할 수 있는 기능 추가
  * 로그인 없이 초대 코드로 토너먼트 정보 조회 가능

* **Enhancements**
  * 토너먼트 미리보기 기능을 링크 직접 접근과 초대 코드 입력 방식으로 분리
  * 완료된 토너먼트에 재생 링크 만료 시간 표시 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Updates

### 코드리뷰 대응 — invite_code 중복 500 방지 (`764edcb`)

- `GET /by-invite-code`는 코드를 단건 조회하는데, 활성 토너먼트 중 동일 `invite_code`가 2개 이상이면 `IncorrectResultSizeDataAccessException` → 500 발생 가능
- DB에 unique constraint가 없어 충돌 가능성이 열려 있었고, 생성 시 재시도 로직도 없었음

세 가지 계층에서 수정:
1. **DB**: `active_invite_code` generated column + unique key 추가 (MySQL partial index 미지원 우회 — 소프트딜리트 시 NULL이 되어 재사용 허용)
2. **Repository**: `findFirstByInviteCode`로 변경 (DB 이상 상황에서도 500 방지)
3. **Service**: `create()`, `createFromPlayLink()` 양쪽에 코드 사전 확인 + 최대 5회 재시도 추가
