### PR TITLE
dev 배포 OOM 으로 박스 다운 방지 (컨테이너 메모리 격리 + swappiness)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -361,11 +361,24 @@ jobs:
             # 앱 컨테이너는 bridge 네트워크라 컨테이너 안 localhost 가 --network host 인 Alloy 에 안 닿으므로,
             # --add-host=host.docker.internal:host-gateway 로 호스트 게이트웨이를 잡고 application.yml 의 OTLP
             # endpoint(host.docker.internal:4318)로 보낸다. 값 고정 평문이라 Secrets 불필요(로컬 미설정 → export off).
+            # --memory: 컨테이너 메모리 한도(cgroup). 906Mi 박스라 한도가 없으면 OOM 시 커널 전역
+            # OOM-killer 가 임의 프로세스를 죽이고 박스 전체가 thrash 로 무응답이 된다(2026-06-06 사고).
+            # 한도를 주면 초과 시 이 컨테이너만 cgroup-OOM 으로 죽고 --restart 로 재기동 — host·다른
+            # 컨테이너는 멀쩡. blue-green overlap 중 사고의 폭발 반경을 앱 한 개로 가둔다.
+            # --restart unless-stopped: redis/mysql/alloy 와 동일 정책. cgroup-OOM·박스 재부팅 후 자가 복구.
+            #   (teardown 은 docker stop + rm -f 라 정책과 충돌하지 않는다.)
+            # RAM 한도 400m: blue+green 이 동시에 떠도(overlap) 2×400=800 으로 RAM(906) 안에 들어가
+            #   swap 으로 안 넘치게 한다. 앱 hot working set 이 ~339 라 400 밑이라 라이브는 RAM 에서 빠르고,
+            #   식은 페이지만 swap 에 남는다. memory-swap 800m(= swap 400m 쿠션): 부팅 스파이크가 400 RAM 을
+            #   잠깐 넘어도 cgroup-OOM 대신 swap 으로 흘러 배포가 안 깨지게 하면서, 컨테이너 총량은 800 으로 묶는다.
+            #   값은 시작점 — 검증 배포에서 부팅 피크·overlap RAM 을 실측해 확정. ExitOnOutOfMemoryError: 힙 OOM 시 즉시 종료→재시작.
             docker run -d \
               --name "team3-$INACTIVE" \
+              --restart unless-stopped \
               -p "127.0.0.1:$INACTIVE_PORT:8080" \
               --add-host=host.docker.internal:host-gateway \
-              -e JAVA_TOOL_OPTIONS="-Xmx256m -Xms64m" \
+              --memory=400m --memory-swap=800m \
+              -e JAVA_TOOL_OPTIONS="-Xmx256m -Xms64m -XX:+ExitOnOutOfMemoryError" \
               -e LOG_STRUCTURED="ecs" \
               -e TRACING_OTLP_ENABLED="true" \
               -e SPRING_PROFILES_ACTIVE="$SPRING_PROFILES_ACTIVE" \

--- a/infra/scripts/provision-runtime.sh
+++ b/infra/scripts/provision-runtime.sh
@@ -18,6 +18,17 @@ else
   grep -q '/swapfile' /etc/fstab || echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab
 fi
 
+# 1b) swappiness — swap 은 비상 쿠션으로만 쓰고 라이브 JVM heap 은 RAM 에 유지한다. 기본 60 은
+# 너무 공격적이라 평시에도 JVM 이 swap 으로 밀려 GC 가 느려진다(실측 ~140Mi swap). 10 으로 낮춰
+# 커널이 anon(힙)보다 page cache 를 먼저 회수하게 한다. sysctl 드롭인으로 영속화 + 즉시 적용(멱등).
+if [ "$(cat /proc/sys/vm/swappiness)" = "10" ]; then
+  echo "[swappiness] 이미 10 — skip"
+else
+  echo "[swappiness] 60 → 10 설정"
+  echo 'vm.swappiness=10' | sudo tee /etc/sysctl.d/99-swappiness.conf
+  sudo sysctl -w vm.swappiness=10
+fi
+
 # 2) redis — RefreshToken 저장소(RedisRefreshTokenStore). 없을 때만 named 볼륨(team3-redis-data)으로 기동.
 #    기존 컨테이너(익명 볼륨 포함)는 보존한다 — 멱등 skip. 새 인스턴스에서만 named 볼륨으로 생성돼,
 #    이후 컨테이너 재생성에도 refresh token 이 유지된다.


### PR DESCRIPTION
## Situation

- 2026-06-06 dev 배포가 blue-green overlap 중 1GB(906Mi) EC2 의 메모리를 고갈시켜, 커널 전역 OOM-killer 가 컨테이너 java 를 죽이고 박스 전체가 약 90분 무응답이 됐다 (콘솔 재부팅으로 복구).
- 직전 PR(#402)이 switch 후 teardown hang 은 막았지만, 그 한 단계 위 원인인 "overlap 메모리 스파이크"는 그대로 남아 있었다.

## Task

- 인스턴스 스케일 업 없이, blue-green 무중단 구조를 유지한 채 OOM 재발을 막는다.
- 핵심 결정: overlap 을 없애지 않고(무중단 유지), 메모리를 OS/컨테이너 레벨로 다스린다.

## Action

### 컨테이너 격리 (박스 보호)
- 앱 컨테이너에 메모리 한도(`--memory=400m --memory-swap=800m`)를 줘, 초과 시 전역 OOM 이 아니라 cgroup-OOM 으로 그 컨테이너만 죽게 격리한다. host·다른 컨테이너는 멀쩡.
- RAM 한도 400m 은 "blue+green 이 동시에 떠도 2×400=800 으로 RAM(906) 안에 들어간다"는 기준으로 잡았다 (overlap 이 swap 으로 안 넘침). hot working set 이 ~339 라 라이브는 RAM 에서 빠르고, swap 400m 은 부팅 스파이크가 cgroup-OOM 대신 흘러가는 쿠션.
- 앱에 `--restart unless-stopped` 추가 (redis/mysql/alloy 는 이미 있는데 앱만 빠져 있었다). cgroup-OOM·박스 재부팅 후 자가 복구된다. 오늘 재부팅 뒤 앱이 안 떠 있던 문제도 같이 해결.

### swap 정상화
- `vm.swappiness 60 → 10` (provisioning sysctl 로 영속화). 실측상 라이브 JVM heap 이 평시에도 약 140Mi 가 swap 으로 밀려 있었다. 낮춰서 힙은 RAM 에 두고 swap 은 overlap 순간의 비상 쿠션으로만 쓰게 한다.

### 의도적으로 안 한 것
- GC 변경: 이미 SerialGC(906Mi<2GB 라 ergonomic 기본)라 무의미 — 컨테이너에서 직접 확인.
- metaspace/codecache/ActiveProcessorCount 미세튜닝: 효과 작고 리스크 커 제외. `-XX:+ExitOnOutOfMemoryError` 만 추가(힙 OOM 시 즉시 종료 후 재시작).
- swap 증설·`-Xmx` 인하: 지금은 보류. 검증에서 부족하면 그때 적용.

## Result

- 메모리 사고의 폭발 반경이 "박스 전체 90분 다운"에서 "앱 컨테이너만 재시작"으로 줄어든다.
- deploy.yml·provisioning 은 dev/prod 공용이라 prod(같은 1GB 박스)에도 자동 적용된다.
- 검증 한계: `--memory` 값(400m/800m)은 시작점이다. 머지 후 배포를 `vmstat`/`free` 로 지켜보며 green 부팅 피크가 캡(400) 안에서 false-OOM 없이 뜨고, 라이브 앱의 hot working set 이 400 밑에 들어와 steady-state thrash 가 없는지 실측해 확정할 예정. (실제 배포로만 검증 가능한 영역)

---
## 연관 이슈

- 
