### PR TITLE
dev 박스 swap 2GB 추가 (배포 overlap 시 swap 100% 도달 완화)

### DIFF
--- a/infra/scripts/provision-runtime.sh
+++ b/infra/scripts/provision-runtime.sh
@@ -32,16 +32,18 @@ fi
 # 1c) swap 추가 증설 — overlap(blue+green) 때 1G swap 이 100% 꽉 차는 게 실측됐다(#420 검증 배포). 2G 를
 # 별도 파일로 더해 총 3G 로 만든다. 기존 /swapfile 을 리사이즈(swapoff)하지 않는 이유: swap 사용량이
 # free RAM 보다 클 때 swapoff 는 페이지를 RAM 으로 못 옮겨 OOM 위험이 있다(라이브 박스). 추가 파일은 안전·멱등.
+# swapon 활성 체크는 생성·활성화만 가르고, fstab 영속화는 활성 여부와 무관하게 항상 보장한다 —
+# "활성이지만 fstab 누락" 상태면 재부팅에 swap2 가 사라져 완화가 무력화되기 때문.
 if sudo swapon --show | grep -q '/swapfile2'; then
-  echo "[swap2] 이미 활성 — skip"
+  echo "[swap2] 이미 활성"
 else
   echo "[swap2] /swapfile2 2G 추가 (총 3G)"
   sudo fallocate -l 2G /swapfile2 || sudo dd if=/dev/zero of=/swapfile2 bs=1M count=2048
   sudo chmod 600 /swapfile2
   sudo mkswap /swapfile2
   sudo swapon /swapfile2
-  grep -q '/swapfile2' /etc/fstab || echo '/swapfile2 none swap sw 0 0' | sudo tee -a /etc/fstab
 fi
+grep -q '^/swapfile2[[:space:]]' /etc/fstab || echo '/swapfile2 none swap sw 0 0' | sudo tee -a /etc/fstab
 
 # 2) redis — RefreshToken 저장소(RedisRefreshTokenStore). 없을 때만 named 볼륨(team3-redis-data)으로 기동.
 #    기존 컨테이너(익명 볼륨 포함)는 보존한다 — 멱등 skip. 새 인스턴스에서만 named 볼륨으로 생성돼,

--- a/infra/scripts/provision-runtime.sh
+++ b/infra/scripts/provision-runtime.sh
@@ -29,6 +29,20 @@ else
   sudo sysctl -w vm.swappiness=10
 fi
 
+# 1c) swap 추가 증설 — overlap(blue+green) 때 1G swap 이 100% 꽉 차는 게 실측됐다(#420 검증 배포). 2G 를
+# 별도 파일로 더해 총 3G 로 만든다. 기존 /swapfile 을 리사이즈(swapoff)하지 않는 이유: swap 사용량이
+# free RAM 보다 클 때 swapoff 는 페이지를 RAM 으로 못 옮겨 OOM 위험이 있다(라이브 박스). 추가 파일은 안전·멱등.
+if sudo swapon --show | grep -q '/swapfile2'; then
+  echo "[swap2] 이미 활성 — skip"
+else
+  echo "[swap2] /swapfile2 2G 추가 (총 3G)"
+  sudo fallocate -l 2G /swapfile2 || sudo dd if=/dev/zero of=/swapfile2 bs=1M count=2048
+  sudo chmod 600 /swapfile2
+  sudo mkswap /swapfile2
+  sudo swapon /swapfile2
+  grep -q '/swapfile2' /etc/fstab || echo '/swapfile2 none swap sw 0 0' | sudo tee -a /etc/fstab
+fi
+
 # 2) redis — RefreshToken 저장소(RedisRefreshTokenStore). 없을 때만 named 볼륨(team3-redis-data)으로 기동.
 #    기존 컨테이너(익명 볼륨 포함)는 보존한다 — 멱등 skip. 새 인스턴스에서만 named 볼륨으로 생성돼,
 #    이후 컨테이너 재생성에도 refresh token 이 유지된다.


### PR DESCRIPTION
## Situation

- #410 검증 배포를 `vmstat`/`free` 로 실측한 결과, blue-green overlap(약 67초) 동안 **swap 이 1024/1024(100%)까지 꽉 차는 것**이 확인됐다 (green 부팅 피크 394MiB / 400 캡, 여유 약 6MiB). 박스는 살아남고 배포는 성공했지만 swap 여유가 0 이었다.

## Task

- 1GB(906MiB) 박스에서 overlap 의 binding constraint 였던 swap 에 여유를 줘, OOM tip-over 위험을 없앤다.

## Action

- provisioning 에 2G swapfile(`/swapfile2`)을 추가해 총 3G 로 만든다.
- **리사이즈(`swapoff`) 대신 별도 파일 추가** 방식: swap 사용량이 free RAM 보다 큰 라이브 박스에서 `swapoff` 는 swap 페이지를 RAM 으로 못 옮겨 OOM 을 유발할 수 있다. 추가 파일은 그 위험이 없고 멱등하다.
- 컨테이너 캡(400)·swappiness(10)은 유지한다: green 부팅이 394 로 캡에 거의 맞아, 캡을 올리면 overlap 수요만 더 커진다. 실측이 가리킨 손볼 자원은 swap 하나다.

## Result

- overlap 의 swap 압박(1G 한계)에 2G 여유가 생겨, 부팅이 더 무겁거나 overlap 이 길어져도 tip-over 하지 않는다.
- 적용은 다음 배포의 provisioning step 에서 일어난다 (`/swapfile2` 생성·swapon·fstab 등록).
- 근본 한계는 남는다: 1GB 박스는 blue-green overlap(2 JVM)을 RAM 만으로 담지 못해 swap 에 의존한다. 인스턴스 증설·footprint 축소·비오버랩 배포가 근본책이며, 이슈 #420 본문에 기록했다. prod(같은 1GB)도 동일 위험.

---
## 연관 이슈

- close #420


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 시스템 스왑 메모리 용량이 증대되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
## Updates

### CodeRabbit 리뷰 대응
- swap2 의 fstab 영속화가 `else`(미활성) 블록 안이라 "이미 활성이지만 fstab 누락" 상태면 재부팅에 swap2 가 사라질 수 있던 지적을 반영. 활성화 로직과 fstab 영속화를 분리해 fstab 을 활성 여부와 무관하게 항상 보장, grep 도 anchored 로 정확 매칭. (`a3cdde1`)
