### PR TITLE
dev nginx 를 prod 와 정합 (SSE·레이트리밋·http2 누락 보정)

### DIFF
--- a/infra/nginx/dev.api.depromeet18team3.cloud.conf
+++ b/infra/nginx/dev.api.depromeet18team3.cloud.conf
@@ -3,7 +3,10 @@
 # 이 파일이 배포 시 EC2 /etc/nginx/sites-available/dev.api.depromeet18team3.cloud 로 복사되고,
 # nginx -t 검증을 통과해야 reload 된다 (.github/workflows/deploy.yml).
 #
-# piki.day 도메인으로 전환 시 server_name 과 ssl_certificate 경로의 도메인 문자열만 교체하면 된다.
+# prod conf(api.depromeet18team3.cloud.conf)와 동일 구조를 유지한다 — 별도 파일이라 한쪽에만 설정이
+# 빠지는 드리프트가 생기기 쉽다. dev 가 prod 의 상위집합이 되도록(prod 에 있는 건 dev 에도 있게) 맞춘다.
+# 환경 고유 차이는 server_name 과 ssl_certificate 경로의 도메인 문자열뿐이다.
+# piki.day 도메인으로 전환 시 그 도메인 문자열만 교체하면 된다.
 #
 # 동적·서버 의존 요소는 이 레포가 관리하지 않고 경로로 참조만 한다:
 #   - /etc/nginx/team3-upstream.conf : deploy.yml 이 blue/green 전환 때 런타임에 생성하는 상태 파일
@@ -16,6 +19,36 @@
 upstream team3 {
     include /etc/nginx/team3-upstream.conf;
 }
+
+# --- 레이트리밋(1/2): 비싼 Gemini 호출(링크 추출·이미지 OCR)을 IP별로 타이트하게 제한한다 ---
+# 목적은 Gemini 호출 폭주로 인한 비용·자원(톰캣 스레드·DB 커넥션) 고갈 방어다. (일반 경로의 느슨한 전역 그물은 2/2 참고.)
+#
+# 이건 거친 1차 그물이다 — 일부러 느슨하게 둬서 정상 유저 오탐(CGNAT·공유망)을 0 으로 하고 명백한 flood 만 막는다.
+# 정밀한 비용·공정성 제어(인증 사용자별 "하루 N회" quota)는 앱 레이어 후속 작업(userId + Redis)이 맡는다.
+# 둘은 대체가 아니라 보완이다: IP 는 미인증·flood 1차 차단, userId 는 인증 후 정밀 quota.
+#
+# POST 만 카운트 키에 담는다 — 비싼 경로는 전부 POST 이고, 같은 경로의 GET(위시 목록 조회)·기타 메서드는
+# 빈 키가 되어 limit_req 가 카운트에서 제외한다(nginx 는 키가 빈 문자열인 요청을 세지 않는다).
+# 그래서 location 을 메서드별로 쪼개지 않고도 POST 만 정확히 잡는다.
+#
+# $binary_remote_addr 을 키로 쓴다 — EIP 직결(앞단에 ALB/CloudFront 없음)이라 이게 진짜 클라이언트 IP 다.
+# 단일 노드(blue/green 도 한 박스)라 shared memory zone 카운터가 IP 별로 정확하다.
+# (앞단 LB 를 도입하면 $remote_addr 이 LB IP 로 바뀌어 전 요청이 한 버킷에 묶이므로, 그때 real_ip 모듈 +
+#  X-Forwarded-For 로 키를 바꿔야 한다.)
+map $request_method $piki_llm_limit_key {
+    POST    $binary_remote_addr;
+    default "";
+}
+limit_req_zone $piki_llm_limit_key zone=piki_llm:10m rate=30r/m;   # 분당 30회 / IP(느슨), zone 10m ≈ IP 16만 개 추적
+
+# --- 레이트리밋(2/2): 전역 — 모든 경로(메서드 무관)에 아주 느슨한 IP별 그물 ---
+# 일반 조회·CRUD 도 무제한이면 스크래핑·flood 에 노출된다. 다만 일반 경로는 정상 트래픽이 비싼 경로보다
+# 훨씬 잦아(화면 1개에 GET 여럿 동시 호출·무한스크롤) 같은 강도면 정상 사용자가 막힌다. 그래서 1/2 보다
+# 훨씬 느슨하게 둬 명백한 폭주만 컷한다. 키는 raw $binary_remote_addr(메서드·경로 무관 전부 카운트).
+# 비싼 경로는 piki_llm(초당 0.5)이 이보다 훨씬 타이트해 지배하므로, 그쪽 location 엔 이 zone 을 겹치지 않는다.
+limit_req_zone $binary_remote_addr zone=piki_general:10m rate=20r/s;   # 초당 20회 / IP(아주 느슨)
+
+limit_req_status 429;                                              # 초과 시 기본 503 대신 429 Too Many Requests (두 zone 공통)
 
 server {
     server_name dev.api.depromeet18team3.cloud;
@@ -30,6 +63,11 @@ server {
     # nginx 기본값(60s). 추출이 @Async 워커로 빠져 요청 스레드를 길게 잡는 동기 외부 호출이 없어 60s 로 충분하다 (prod conf 와 동일 근거).
     proxy_read_timeout 60s;
 
+    # actuator 엔드포인트는 외부에 노출하지 않는다. 메트릭(/actuator/prometheus)·health 는
+    # EC2 내부의 Grafana Alloy 가 localhost 컨테이너 포트로 직접 scrape 하므로 nginx 를 거치지 않는다.
+    # ^~ 접두어 매칭이 아래 정규/일반 `location /` 보다 우선해, /actuator/* 외부 요청은 앱까지 가지 않고 여기서 끊긴다.
+    # `^~ /actuator/` 는 슬래시로 끝나는 prefix 라 슬래시 없는 부모 경로 `/actuator`(actuator 인덱스)는
+    # 안 잡혀 location / 로 새어 나간다. `= /actuator` 정확 매칭을 따로 둬 그 구멍을 막는다.
     location = /actuator {
         return 403;
     }
@@ -37,23 +75,65 @@ server {
         return 403;
     }
 
+    # 레이트리밋 초과(429)를 ApiResponseBody 모양 JSON 으로 내린다 (위 limit_req_status 429 와 짝).
+    # nginx 가 앱 앞에서 끊어 GlobalExceptionHandler 를 못 거치므로, 클라이언트가 "모든 응답=ApiResponseBody"
+    # 로 파싱해도 깨지지 않게 같은 스키마({data, detail, pageResponse})를 고정 JSON 으로 흉내낸다.
+    # 주의: ApiResponseBody 필드가 바뀌면 이 JSON 도 손으로 맞춰야 한다(컴파일러가 못 잡는 drift).
+    # 완전한 해법은 후속 userId 앱 레이어 레이트리밋(GlobalExceptionHandler 가 진짜 ApiResponseBody 를 만든다).
+    error_page 429 = @rate_limited;
+    location @rate_limited {
+        default_type application/json;
+        add_header Retry-After 1 always;
+        return 429 '{"data":null,"detail":"요청이 너무 잦습니다. 잠시 후 다시 시도해 주세요.","pageResponse":{"nextCursor":null,"hasNext":false}}';
+    }
+
+    # --- 비싼 Gemini 경로: IP별 레이트리밋 적용 ---
+    # burst=20 nodelay: 순간 연타·모바일 CGNAT(여러 사용자가 한 공인 IP 뒤에 묶임)는 흡수하되,
+    # 지속적인 폭주만 429 로 막는다. nodelay 라 burst 분은 지연 없이 즉시 통과한다.
+    #
+    # 토너먼트 아이템 추가 — /{tournamentId}/items/link(링크 추출) · /items/images(이미지 추출). 둘 다 POST 전용 경로.
+    # /?$ : trailing slash 변형(.../link/)도 같은 비싼 경로로 묶어 piki_llm 우회를 막는다.
+    location ~ ^/api/v1/tournaments/[^/]+/items/(link|images)/?$ {
+        limit_req zone=piki_llm burst=20 nodelay;
+        proxy_pass http://team3;
+    }
+    # 위시 등록(POST = 링크 추출). 같은 경로의 GET(목록 조회)은 map 의 빈 키로 제한에서 제외된다.
+    # /?$ : trailing slash 변형(/api/v1/wishlists/)도 같은 경로로 묶어 piki_llm 우회를 막는다.
+    location ~ ^/api/v1/wishlists/?$ {
+        limit_req zone=piki_llm burst=20 nodelay;
+        proxy_pass http://team3;
+    }
+    # 위시 이미지 등록(POST = 이미지 추출).
+    location ~ ^/api/v1/wishlists/images/?$ {
+        limit_req zone=piki_llm burst=20 nodelay;
+        proxy_pass http://team3;
+    }
+
     # SSE 실시간 알림 구독 — text/event-stream 스트림이라 전용 설정이 필요하다(앱: GET /api/v1/notifications/subscribe).
     # - proxy_http_version 1.1: nginx 가 백엔드에 붙는 기본값은 1.0 인데, 1.0 은 chunked 스트리밍이 안 돼
     #   SSE 가 버퍼링되거나 끊긴다. 1.1 로 올린다. 다른 경로 동작을 안 건드리도록 server 전역이 아니라 이 location 한정으로 둔다.
     # - proxy_buffering off: nginx 가 응답을 모았다 내보내면 실시간성이 깨진다. 이벤트를 받는 즉시 클라이언트로 흘려보낸다.
     # 공통 proxy_set_header / proxy_read_timeout 60s 는 server 레벨에서 상속한다(앱 하트비트가 30s 라 60s read_timeout 은 안 끊긴다).
-    # 정확매칭(=)이라 catch-all(location /)보다 우선한다. (dev 는 레이트리밋 미적용이라 prod 와 달리 limit_req 가 없다.)
+    # 정확매칭(=)이라 catch-all(location /)보다 우선한다. 레이트리밋은 일반 그물(piki_general) 유지 — 구독은 오래 열린 1요청이라 카운트 1로 무해하다.
     location = /api/v1/notifications/subscribe {
+        limit_req zone=piki_general burst=40 nodelay;
         proxy_pass http://team3;
         proxy_http_version 1.1;
         proxy_buffering off;
     }
 
+    # 그 외 모든 경로 — 전역 느슨한 그물(piki_general). 정상 화면 로딩·무한스크롤은 무영향, 명백한 폭주만 429.
     location / {
+        limit_req zone=piki_general burst=40 nodelay;
         proxy_pass http://team3;
     }
 
-    listen 443 ssl;
+    # http2: 브라우저는 origin 당 커넥션을 약 6개로 제한하는데, SSE 가 그 중 1개를 계속 점유한다.
+    # 멀티탭·요청 많은 화면에서 HTTP/2 의 스트림 multiplexing 이 이 제한을 풀어 SSE 가 다른 요청을 굶기지 않게 한다
+    # (백엔드 leg 와 무관한 클라이언트↔nginx leg 최적화). 단일 탭 해피케이스에선 이득이 작지만 켜는 비용도 0 에 가깝다.
+    # 형식 주의: nginx 1.25.1+ 는 `http2 on;` 지시어를 선호하나, 이 `listen ... http2` 파라미터 형식도 동작한다
+    # (신버전은 deprecation 경고만, nginx -t 는 통과). 운영 nginx 버전에 맞춰 추후 `http2 on;` 으로 바꿔도 된다.
+    listen 443 ssl http2;
     ssl_certificate /etc/letsencrypt/live/dev.api.depromeet18team3.cloud/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/dev.api.depromeet18team3.cloud/privkey.pem;
     include /etc/letsencrypt/options-ssl-nginx.conf;

--- a/infra/nginx/dev.api.depromeet18team3.cloud.conf
+++ b/infra/nginx/dev.api.depromeet18team3.cloud.conf
@@ -22,6 +22,14 @@ server {
 
     client_max_body_size 25M;
 
+    # 공통 proxy 설정 — 아래 proxy_pass location 들이 상속한다(actuator 403 location 은 프록시하지 않아 무관).
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    # nginx 기본값(60s). 추출이 @Async 워커로 빠져 요청 스레드를 길게 잡는 동기 외부 호출이 없어 60s 로 충분하다 (prod conf 와 동일 근거).
+    proxy_read_timeout 60s;
+
     location = /actuator {
         return 403;
     }
@@ -29,14 +37,20 @@ server {
         return 403;
     }
 
+    # SSE 실시간 알림 구독 — text/event-stream 스트림이라 전용 설정이 필요하다(앱: GET /api/v1/notifications/subscribe).
+    # - proxy_http_version 1.1: nginx 가 백엔드에 붙는 기본값은 1.0 인데, 1.0 은 chunked 스트리밍이 안 돼
+    #   SSE 가 버퍼링되거나 끊긴다. 1.1 로 올린다. 다른 경로 동작을 안 건드리도록 server 전역이 아니라 이 location 한정으로 둔다.
+    # - proxy_buffering off: nginx 가 응답을 모았다 내보내면 실시간성이 깨진다. 이벤트를 받는 즉시 클라이언트로 흘려보낸다.
+    # 공통 proxy_set_header / proxy_read_timeout 60s 는 server 레벨에서 상속한다(앱 하트비트가 30s 라 60s read_timeout 은 안 끊긴다).
+    # 정확매칭(=)이라 catch-all(location /)보다 우선한다. (dev 는 레이트리밋 미적용이라 prod 와 달리 limit_req 가 없다.)
+    location = /api/v1/notifications/subscribe {
+        proxy_pass http://team3;
+        proxy_http_version 1.1;
+        proxy_buffering off;
+    }
+
     location / {
         proxy_pass http://team3;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        # nginx 기본값(60s). 추출이 @Async 워커로 빠져 요청 스레드를 길게 잡는 동기 외부 호출이 없어 60s 로 충분하다 (prod conf 와 동일 근거).
-        proxy_read_timeout 60s;
     }
 
     listen 443 ssl;


### PR DESCRIPTION
## Situation
- dev 서버에서 실시간 알림(SSE) 구독이 전혀 동작하지 않았다. 아이템을 추가해도 알림은 물론, 연결 직후 오는 connect 이벤트와 하트비트(ping)조차 클라이언트에 도착하지 않았다.
- connect 와 하트비트는 비즈니스 로직과 무관하게 무조건 나가는 신호다. 둘 다 안 온다는 건 알림 수신자 규칙(올린 본인 제외 등)의 문제가 아니라, 연결 자체 또는 스트림 전송 경로가 막힌 것이다.

## Task
- 처음엔 토너먼트 알림 이벤트 발행이 빠진 것으로 의심했으나, 로컬 dev 가 origin/dev 보다 10커밋 뒤처진 stale 상태였다. 발행은 이미 머지(#406)되어 dev 에 배포돼 있었고, 진단 기준을 origin/dev 로 바로잡으니 애플리케이션 코드는 정상이었다.
- 진짜 원인은 nginx 였다. prod conf 에는 SSE 전용 location 이 있는데 dev conf 에는 통째로 없어, 구독 요청이 catch-all location / 로 빠져 nginx 기본값으로 처리되고 있었다.

## Action

### 수정
- dev conf 에 prod 와 동일한 SSE 전용 location 을 추가했다. 핵심은 두 가지다.
  - proxy_buffering off: 켜져 있으면(기본값) nginx 가 응답을 모았다 내보내, connect·하트비트·알림이 버퍼에 갇혀 클라이언트까지 흐르지 않는다.
  - proxy_http_version 1.1: 백엔드 연결 기본값 1.0 은 chunked 스트리밍이 안 돼 SSE 가 버퍼링되거나 끊긴다.
- 공통 proxy_set_header 4개와 proxy_read_timeout 60s 를 location / 안에서 server 레벨로 추출해, 새 SSE location 도 상속받게 했다. prod conf 구조와 일치하며 location / 동작은 그대로다.

### 누락 경위
- prod conf 의 SSE 설정(#367)은 dev/prod 분리(#374)보다 하루 먼저 단일 conf 에 들어갔다. 분리 때 dev conf 를 축약본으로 새로 쓰면서 그 블록을 빠뜨렸다.
- 같은 종류의 분리 누락을 #399 가 한 번(read_timeout) 보정했으나 SSE location 은 남아 있었다.

### 검증
- 로컬 docker 로 nginx -t 를 돌려 dev·prod conf 둘 다 문법 통과를 확인했다 (ssl 인증서·upstream 은 더미로 우회). dhparam 더미를 1024 로 두면 OpenSSL 3.x 가 "too small" 로 거부해 dhparam 로드 단계에서 멈추므로, 2048 로 재생성해 최종 통과를 확정했다.

## Result
- dev 서버에서도 SSE 스트림(connect·하트비트·알림)이 클라이언트까지 정상적으로 흐른다.
- 점검 중 같은 분리 누락으로 dev 에 빠진 설정이 더 있음을 확인했다: 레이트리밋 전체(#332)와 listen 443 의 http2. 둘 다 동작 변화가 있어 이 핫픽스에는 넣지 않고 별도로 다룬다.

---
## 연관 이슈

- 


## Updates

### 레이트리밋·http2 정합 (dev/prod 드리프트 전수 점검)
- 위 Result 에서 "별도로 다룬다"고 했던 항목을, 점검 후 이 PR 에 함께 합쳤다. dev conf 를 한 번에 prod 와 완전 정합한다.
- 드리프트 전수 점검: dev/prod 로 별도 파일이 갈린 설정은 nginx conf 한 쌍뿐이다. deploy.yml·application.yml·provision-runtime.sh·config.alloy 는 단일 파일이 environment 로 분기해, 한쪽에만 빠지는 드리프트가 구조적으로 생기지 않는다. `@Profile("!prod")` 빈·dev MySQL·prod release 는 prod 에 없고 dev 에 있는 의도된 분기라 대상이 아니다.
- 그 한 쌍에서 dev 에 빠졌던 레이트리밋(#332: 비싼 Gemini 경로 piki_llm + 전역 piki_general + 429 를 ApiResponseBody JSON 으로 내리는 처리)과 listen 443 의 http2 를 prod 와 동일하게 추가했다. 레이트리밋은 dev 에서도 429 가 발생하는 동작 변화가 있으나, 드리프트를 남기면 회귀를 prod 에서만 처음 겪으므로 정합을 택했다. (`43a63c4`)
- 정합 후 dev conf 는 prod 와 nginx 지시어가 100% 동일하다. server_name·ssl_certificate 경로의 도메인 문자열만 환경별로 다르고, 나머지 차이는 주석뿐이다. 검증: 로컬 docker nginx -t 통과, dev 를 prod 도메인으로 정규화해 diff 하면 지시어 차이 0.
