### PR TITLE
소셜 토너먼트 버그 수정

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/auth/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/config/SecurityConfig.kt
@@ -107,8 +107,11 @@ class SecurityConfig(
                     // FCM 토큰 등록/해제 — 인증 유저가 자기 기기 토큰을 등록한다 (GUEST 포함, 토너먼트 푸시 대상).
                     .requestMatchers("/api/v1/fcm/**")
                     .authenticated()
-                    // /users/me 와 /users/nickname/check 는 게스트도 호출 가능 (닉네임 확정/수정 흐름)
-                    .requestMatchers(HttpMethod.GET, "/api/v1/users/me", "/api/v1/users/nickname/check")
+                    // 닉네임 중복 체크: 게스트 참여 화면에서 JWT 없는 상태로 호출하므로 인증 불필요
+                    .requestMatchers(HttpMethod.GET, "/api/v1/users/nickname/check")
+                    .permitAll()
+                    // /users/me 는 자기 프로필 조회/수정 — 게스트 포함 인증 필요
+                    .requestMatchers(HttpMethod.GET, "/api/v1/users/me")
                     .authenticated()
                     .requestMatchers(HttpMethod.PATCH, "/api/v1/users/me")
                     .authenticated()

--- a/src/main/kotlin/com/depromeet/piki/common/config/JacksonConfig.kt
+++ b/src/main/kotlin/com/depromeet/piki/common/config/JacksonConfig.kt
@@ -18,6 +18,10 @@ class JacksonConfig {
             // LocalDateTime 은 타임존 정보가 없는 타입이라 그대로 직렬화하면 Z(UTC) suffix 가 붙지 않는다.
             // 서버는 serverTimezone=UTC 기준으로 모든 시각을 UTC 로 다루므로,
             // OffsetDateTime(UTC) 로 변환 후 ISO-8601 with offset 형태로 직렬화한다.
+            //
+            // 주의: 현재 코드베이스에는 request body 로 LocalDateTime 을 직접 받는 필드가 없다.
+            // 추후 request DTO 에 LocalDateTime 필드를 추가하는 경우, 클라이언트가 +00:00 suffix 를
+            // 붙여 보내면 기본 역직렬화가 실패한다. 그 시점에 custom deserializer 도 함께 추가해야 한다.
             addSerializer(LocalDateTime::class.java, LocalDateTimeUtcSerializer)
         }
 

--- a/src/main/kotlin/com/depromeet/piki/common/config/JacksonConfig.kt
+++ b/src/main/kotlin/com/depromeet/piki/common/config/JacksonConfig.kt
@@ -1,0 +1,31 @@
+package com.depromeet.piki.common.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import tools.jackson.core.JsonGenerator
+import tools.jackson.databind.SerializationContext
+import tools.jackson.databind.ValueSerializer
+import tools.jackson.databind.module.SimpleModule
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+
+@Configuration
+class JacksonConfig {
+    @Bean
+    fun localDateTimeModule(): SimpleModule =
+        SimpleModule().apply {
+            // LocalDateTime 은 타임존 정보가 없는 타입이라 그대로 직렬화하면 Z(UTC) suffix 가 붙지 않는다.
+            // 서버는 serverTimezone=UTC 기준으로 모든 시각을 UTC 로 다루므로,
+            // OffsetDateTime(UTC) 로 변환 후 ISO-8601 with offset 형태로 직렬화한다.
+            addSerializer(LocalDateTime::class.java, LocalDateTimeUtcSerializer)
+        }
+
+    private object LocalDateTimeUtcSerializer : ValueSerializer<LocalDateTime>() {
+        private val formatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME
+
+        override fun serialize(value: LocalDateTime, gen: JsonGenerator, ctxt: SerializationContext) {
+            gen.writeString(value.atOffset(ZoneOffset.UTC).format(formatter))
+        }
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/user/controller/UserApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/user/controller/UserApi.kt
@@ -255,7 +255,7 @@ interface UserApi {
         ],
     )
     fun checkNickname(
-        @Parameter(hidden = true) userId: UUID,
+        @Parameter(hidden = true) userId: UUID?,
         request: NicknameCheckRequest,
     ): ApiResponseBody<NicknameCheckResponse>
 }

--- a/src/main/kotlin/com/depromeet/piki/user/controller/UserController.kt
+++ b/src/main/kotlin/com/depromeet/piki/user/controller/UserController.kt
@@ -60,7 +60,7 @@ class UserController(
 
     @GetMapping("/nickname/check")
     override fun checkNickname(
-        @AuthenticationPrincipal userId: UUID,
+        @AuthenticationPrincipal userId: UUID?,
         @Valid request: NicknameCheckRequest,
     ): ApiResponseBody<NicknameCheckResponse> =
         ApiResponseBody.ok(

--- a/src/main/kotlin/com/depromeet/piki/user/service/UserService.kt
+++ b/src/main/kotlin/com/depromeet/piki/user/service/UserService.kt
@@ -158,8 +158,11 @@ class UserService(
     @Transactional(readOnly = true)
     fun isNicknameAvailable(
         nickname: String,
-        userId: UUID,
-    ): Boolean = !userRepository.existsByNicknameAndIdNot(nickname, userId)
+        userId: UUID?,
+    ): Boolean =
+        userId
+            ?.let { !userRepository.existsByNicknameAndIdNot(nickname, it) }
+            ?: !userRepository.existsByNickname(nickname)
 
     @Transactional
     fun updateNickname(

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,10 @@
 spring:
   application:
     name: PIKI
+  jackson:
+    serialization:
+      write-dates-as-timestamps: false
+    time-zone: UTC
   config:
     # .env 다음에 .env.local 을 읽어 로컬 개인 override 를 덮어쓴다(뒤가 우선). 둘 다 optional·gitignore.
     import:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,8 +3,10 @@ spring:
     name: PIKI
   jackson:
     serialization:
+      # LocalDateTime 을 ISO-8601 문자열로 직렬화한다 (숫자 타임스탬프 대신).
+      # Z(UTC) suffix 보장은 LocalDateTime → Instant/OffsetDateTime 타입 마이그레이션이 필요하며,
+      # 이 PR 범위를 넘어 별도 이슈로 추적한다. time-zone 설정은 LocalDateTime 에 효과 없어 제거.
       write-dates-as-timestamps: false
-    time-zone: UTC
   config:
     # .env 다음에 .env.local 을 읽어 로컬 개인 override 를 덮어쓴다(뒤가 우선). 둘 다 optional·gitignore.
     import:

--- a/src/test/kotlin/com/depromeet/piki/auth/config/AuthorizationBoundaryIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/config/AuthorizationBoundaryIntegrationTest.kt
@@ -81,7 +81,7 @@ class AuthorizationBoundaryIntegrationTest : IntegrationTestSupport() {
                 arguments(HttpMethod.GET, "/api/v1/tournaments/1"),
                 arguments(HttpMethod.GET, "/api/v1/users/me"),
                 arguments(HttpMethod.PATCH, "/api/v1/users/me"),
-                arguments(HttpMethod.GET, "/api/v1/users/nickname/check"),
+                // nickname/check 는 비회원 게스트 참여 화면에서 JWT 없이 호출하므로 permitAll — 이 목록에서 제외
             )
     }
 }

--- a/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
@@ -130,7 +130,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
             .andReturn()
 
         val expiresAtStr = objectMapper.readTree(result.response.contentAsString)["data"]["inviteExpiresAt"].asText()
-        val expiresAt = LocalDateTime.parse(expiresAtStr, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+        val expiresAt = java.time.OffsetDateTime.parse(expiresAtStr, DateTimeFormatter.ISO_OFFSET_DATE_TIME).toLocalDateTime()
         val expectedMin = before.plusMinutes(60)
         val expectedMax = LocalDateTime.now().plusMinutes(60)
         assertTrue(expiresAt >= expectedMin && expiresAt <= expectedMax)

--- a/src/test/kotlin/com/depromeet/piki/user/controller/UserControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/user/controller/UserControllerIntegrationTest.kt
@@ -225,6 +225,22 @@ class UserControllerIntegrationTest : IntegrationTestSupport() {
     }
 
     @Test
+    fun `GET users nickname check - JWT 없이도 200 을 반환한다`() {
+        val mockMvc =
+            MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .apply<DefaultMockMvcBuilder>(springSecurity())
+                .build()
+
+        mockMvc
+            .perform(
+                get("/api/v1/users/nickname/check")
+                    .param("nickname", "안쓰는닉네임"),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.available").value(true))
+    }
+
+    @Test
     fun `PATCH users me - 본인이 자기 닉네임 그대로 보내면 200 으로 통과한다`() {
         val mockMvc =
             MockMvcBuilders


### PR DESCRIPTION
## Situation

- 비회원 게스트가 초대 링크로 참여하는 화면에서 두 가지 버그가 발견됐다.
- 첫째, 닉네임 입력 시 자동으로 중복 체크가 호출되는데 이 엔드포인트가 인증 필수로 막혀 있어 JWT 없는 상태에서 401이 반환됐다. 게스트 참여 자체가 불가한 상태였다.
- 둘째, 응답의 datetime 필드(`inviteExpiresAt`, `playLinkExpiresAt` 등)에 timezone 정보가 없어 클라이언트가 서버 로컬 시간으로 잘못 해석하고 있었다. 예: `"2026-06-06T19:03:51"` 로 내려와 사용자 기기 시간대 기준으로 파싱됨.

## Task

- `GET /users/nickname/check`를 인증 없이 호출 가능하도록 수정한다.
- 모든 datetime 응답에 timezone suffix(`Z`)를 포함시킨다.

## Action

- `SecurityConfig`: `nickname/check`를 `authenticated()`에서 `permitAll()`로 변경. 게스트 참여 화면은 JWT 발급 전 단계라 인증이 없는 상태가 정상이다.
- `application.yml`: Jackson 설정 두 줄 추가. `write-dates-as-timestamps: false` + `time-zone: UTC`로 `LocalDateTime`이 ISO-8601 UTC 형식으로 직렬화된다.
- `AuthorizationBoundaryIntegrationTest`: `nickname/check`를 보호 엔드포인트 목록에서 제거하고 변경 이유를 주석으로 명시.

## Result

- 비회원이 닉네임 중복 체크를 인증 없이 호출 가능해져 게스트 참여 흐름이 정상 작동한다.
- 모든 datetime 응답이 `"2026-06-06T19:03:51.308252Z"` 형태로 내려간다. 클라이언트가 UTC 기준으로 정확히 파싱 가능하다.

---
## 연관 이슈

- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * API 접근 제어를 재정렬하여 닉네임 중복 확인 엔드포인트는 로그인 없이 호출 가능하도록 변경
  * 시스템 전체 날짜/시간 설정을 ISO 8601 형식 및 UTC 기준으로 통일

* **Tests**
  * API 인증 테스트 범위 조정

<!-- end of auto-generated comment: release notes by coderabbit.ai -->