### PR TITLE
spring.jackson yml 바인딩 오류 수정 (앱 부팅 실패 hotfix)

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,12 +1,6 @@
 spring:
   application:
     name: PIKI
-  jackson:
-    serialization:
-      # LocalDateTime 을 ISO-8601 문자열로 직렬화한다 (숫자 타임스탬프 대신).
-      # Z(UTC) suffix 보장은 LocalDateTime → Instant/OffsetDateTime 타입 마이그레이션이 필요하며,
-      # 이 PR 범위를 넘어 별도 이슈로 추적한다. time-zone 설정은 LocalDateTime 에 효과 없어 제거.
-      write-dates-as-timestamps: false
   config:
     # .env 다음에 .env.local 을 읽어 로컬 개인 override 를 덮어쓴다(뒤가 우선). 둘 다 optional·gitignore.
     import:


### PR DESCRIPTION
## Situation

- PR #426(소셜 토너먼트 버그 수정) 배포 후 dev 헬스체크가 120초 동안 `status=000`으로 실패하여 롤백됐다.
- `docker run`으로 실패 이미지를 직접 구동해 보니 `APPLICATION FAILED TO START` 오류가 발생했고, 원인은 `JacksonProperties` 바인딩 실패였다.

## Task

- `spring.jackson.serialization.write-dates-as-timestamps: false` 설정이 Spring Boot 4 / Jackson 3 환경에서 바인딩 오류를 일으켜 앱이 시작되지 않는 문제를 제거한다.

## Action

- `application.yml`의 `spring.jackson.serialization.write-dates-as-timestamps: false` 블록 6줄 제거.
- PR #426에서 함께 추가된 `JacksonConfig`의 `LocalDateTimeUtcSerializer`가 이미 `LocalDateTime` 직렬화를 처리하므로 yml 설정은 중복이었고, 오히려 앱 시작을 막는 원인이었다.

## Result

- `JacksonProperties` 바인딩 오류가 제거되어 앱이 정상 기동된다.
- `LocalDateTime` ISO-8601 직렬화는 `JacksonConfig` 커스텀 시리얼라이저가 그대로 담당하므로 응답 형식 변화 없음.

---
## 연관 이슈

- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Spring Jackson 날짜 직렬화 설정이 제거되었습니다. 이로 인해 API 응답에서 날짜-시간 값의 형식이 변경될 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->