### PR TITLE
친구 초대 마감 시각 수정 API 추가

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
@@ -5,8 +5,8 @@ import com.depromeet.piki.tournament.controller.dto.CreateTournamentRequest
 import com.depromeet.piki.tournament.controller.dto.CreateTournamentResponse
 import com.depromeet.piki.tournament.controller.dto.GroupResultResponse
 import com.depromeet.piki.tournament.controller.dto.JoinTournamentAsGuestRequest
-import com.depromeet.piki.tournament.controller.dto.UpdateInviteDurationRequest
 import com.depromeet.piki.tournament.controller.dto.JoinTournamentAsGuestResponse
+import com.depromeet.piki.tournament.controller.dto.UpdateInviteDurationRequest
 import com.depromeet.piki.tournament.controller.dto.JoinTournamentRequest
 import com.depromeet.piki.tournament.controller.dto.PlayLinkInfoResponse
 import com.depromeet.piki.tournament.controller.dto.RecordMatchRequest
@@ -525,7 +525,6 @@ interface TournamentApi {
         @Parameter(hidden = true) userId: UUID,
         @Parameter(description = "토너먼트 ID", example = "1") tournamentId: Long,
     ): ApiResponseBody<Unit>
-
 
     @Operation(
         summary = "친구 초대 마감 시각 수정",

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
@@ -5,6 +5,7 @@ import com.depromeet.piki.tournament.controller.dto.CreateTournamentRequest
 import com.depromeet.piki.tournament.controller.dto.CreateTournamentResponse
 import com.depromeet.piki.tournament.controller.dto.GroupResultResponse
 import com.depromeet.piki.tournament.controller.dto.JoinTournamentAsGuestRequest
+import com.depromeet.piki.tournament.controller.dto.UpdateInviteDurationRequest
 import com.depromeet.piki.tournament.controller.dto.JoinTournamentAsGuestResponse
 import com.depromeet.piki.tournament.controller.dto.JoinTournamentRequest
 import com.depromeet.piki.tournament.controller.dto.PlayLinkInfoResponse
@@ -524,6 +525,51 @@ interface TournamentApi {
         @Parameter(hidden = true) userId: UUID,
         @Parameter(description = "토너먼트 ID", example = "1") tournamentId: Long,
     ): ApiResponseBody<Unit>
+
+
+    @Operation(
+        summary = "친구 초대 마감 시각 수정",
+        description = "PENDING 상태 토너먼트의 초대 마감 시각을 지금으로부터 N분 후로 재설정한다. 주최자만 가능. 최소 1분, 최대 1440분(24시간).",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "수정 성공 (새 inviteExpiresAt 반환)",
+                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청 (inviteDurationMinutes 1 미만 또는 1440 초과)",
+                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "미인증 (JWT 토큰 없음 또는 유효하지 않음)",
+                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+            ),
+            ApiResponse(
+                responseCode = "403",
+                description = "권한 없음 (토너먼트 참여자가 아님 · 소유자가 아님)",
+                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "토너먼트를 찾을 수 없음",
+                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+            ),
+            ApiResponse(
+                responseCode = "409",
+                description = "상태 충돌 (PENDING이 아닌 토너먼트)",
+                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+            ),
+        ],
+    )
+    fun updateInviteExpiry(
+        @Parameter(hidden = true) userId: UUID,
+        @Parameter(description = "토너먼트 ID", example = "1") tournamentId: Long,
+        request: UpdateInviteDurationRequest,
+    ): ApiResponseBody<LocalDateTime>
 
     @Operation(
         summary = "링크 접근 경로 — 토너먼트 참여 전 미리보기",

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApiExamples.kt
@@ -9,8 +9,8 @@ import com.depromeet.piki.item.domain.ItemStatus
 import com.depromeet.piki.tournament.controller.dto.CreateTournamentResponse
 import com.depromeet.piki.tournament.controller.dto.GroupResultResponse
 import com.depromeet.piki.tournament.controller.dto.JoinTournamentAsGuestRequest
-import com.depromeet.piki.tournament.controller.dto.UpdateInviteDurationRequest
 import com.depromeet.piki.tournament.controller.dto.JoinTournamentAsGuestResponse
+import com.depromeet.piki.tournament.controller.dto.UpdateInviteDurationRequest
 import com.depromeet.piki.tournament.controller.dto.PlayLinkInfoResponse
 import com.depromeet.piki.tournament.controller.dto.RankedItemResponse
 import com.depromeet.piki.tournament.controller.dto.TournamentDetailResponse

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApiExamples.kt
@@ -9,6 +9,7 @@ import com.depromeet.piki.item.domain.ItemStatus
 import com.depromeet.piki.tournament.controller.dto.CreateTournamentResponse
 import com.depromeet.piki.tournament.controller.dto.GroupResultResponse
 import com.depromeet.piki.tournament.controller.dto.JoinTournamentAsGuestRequest
+import com.depromeet.piki.tournament.controller.dto.UpdateInviteDurationRequest
 import com.depromeet.piki.tournament.controller.dto.JoinTournamentAsGuestResponse
 import com.depromeet.piki.tournament.controller.dto.PlayLinkInfoResponse
 import com.depromeet.piki.tournament.controller.dto.RankedItemResponse
@@ -402,6 +403,28 @@ class TournamentApiExamples(
                         add(TournamentException.forbiddenTournament(), name = "토너먼트 권한 없음")
                         add(TournamentException.notFoundTournament(), name = "토너먼트를 찾을 수 없음")
                         add(TournamentException.inProgressTournamentCannotBeDeleted(), name = "진행 중 토너먼트 삭제 불가")
+                    }
+
+                handlerMethod.binds(TournamentController::updateInviteExpiry) ->
+                    operation.examples(openApiObjectMapper.delegate) {
+                        add(
+                            status = HttpStatus.OK,
+                            name = "초대 마감 시각 수정 성공",
+                            payload = ApiResponseBody.ok(LocalDateTime.of(2026, 6, 7, 11, 0, 0)),
+                        )
+                        add(
+                            status = HttpStatus.BAD_REQUEST,
+                            name = "유효 시간 범위 초과",
+                            payload =
+                                ApiResponseBody.fail<Unit>(
+                                    category = ErrorCategory.INVALID_INPUT,
+                                    detail = "inviteDurationMinutes: ${UpdateInviteDurationRequest.INVITE_DURATION_MAX_MESSAGE}",
+                                ),
+                        )
+                        unauthorized()
+                        add(TournamentException.forbiddenTournament(), name = "권한 없음 (소유자 아님)")
+                        add(TournamentException.notFoundTournament(), name = "토너먼트를 찾을 수 없음")
+                        add(TournamentException.notPendingTournament(), name = "PENDING이 아닌 토너먼트")
                     }
 
                 handlerMethod.binds(TournamentController::getInvitePreview) ->

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentController.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentController.kt
@@ -5,8 +5,8 @@ import com.depromeet.piki.tournament.controller.dto.CreateTournamentRequest
 import com.depromeet.piki.tournament.controller.dto.CreateTournamentResponse
 import com.depromeet.piki.tournament.controller.dto.GroupResultResponse
 import com.depromeet.piki.tournament.controller.dto.JoinTournamentAsGuestRequest
-import com.depromeet.piki.tournament.controller.dto.UpdateInviteDurationRequest
 import com.depromeet.piki.tournament.controller.dto.JoinTournamentAsGuestResponse
+import com.depromeet.piki.tournament.controller.dto.UpdateInviteDurationRequest
 import com.depromeet.piki.tournament.controller.dto.JoinTournamentRequest
 import com.depromeet.piki.tournament.controller.dto.PlayLinkInfoResponse
 import com.depromeet.piki.tournament.controller.dto.RecordMatchRequest
@@ -23,8 +23,8 @@ import org.springframework.http.HttpStatus
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentController.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentController.kt
@@ -5,6 +5,7 @@ import com.depromeet.piki.tournament.controller.dto.CreateTournamentRequest
 import com.depromeet.piki.tournament.controller.dto.CreateTournamentResponse
 import com.depromeet.piki.tournament.controller.dto.GroupResultResponse
 import com.depromeet.piki.tournament.controller.dto.JoinTournamentAsGuestRequest
+import com.depromeet.piki.tournament.controller.dto.UpdateInviteDurationRequest
 import com.depromeet.piki.tournament.controller.dto.JoinTournamentAsGuestResponse
 import com.depromeet.piki.tournament.controller.dto.JoinTournamentRequest
 import com.depromeet.piki.tournament.controller.dto.PlayLinkInfoResponse
@@ -23,6 +24,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -114,6 +116,16 @@ class TournamentController(
     ): ApiResponseBody<Unit> {
         tournamentService.deleteTournament(userId, tournamentId)
         return ApiResponseBody.ok()
+    }
+
+    @PatchMapping("/{tournamentId}/invite")
+    override fun updateInviteExpiry(
+        @AuthenticationPrincipal userId: UUID,
+        @PathVariable tournamentId: Long,
+        @Valid @RequestBody request: UpdateInviteDurationRequest,
+    ): ApiResponseBody<LocalDateTime> {
+        val newExpiresAt = tournamentService.updateInviteExpiry(userId, tournamentId, request.inviteDurationMinutes)
+        return ApiResponseBody.ok(newExpiresAt)
     }
 
     @GetMapping("/{tournamentId}/invite-preview")

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/dto/UpdateInviteDurationRequest.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/dto/UpdateInviteDurationRequest.kt
@@ -1,0 +1,17 @@
+package com.depromeet.piki.tournament.controller.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+
+data class UpdateInviteDurationRequest(
+    @field:Schema(description = "새 초대 마감까지 남은 시간 (분 단위, 1-1440)", example = "60")
+    @field:Min(value = 1, message = INVITE_DURATION_MIN_MESSAGE)
+    @field:Max(value = 1440, message = INVITE_DURATION_MAX_MESSAGE)
+    val inviteDurationMinutes: Long,
+) {
+    companion object {
+        const val INVITE_DURATION_MIN_MESSAGE = "초대 유효 시간은 1분 이상이어야 합니다."
+        const val INVITE_DURATION_MAX_MESSAGE = "초대 유효 시간은 1440분(24시간) 이하이어야 합니다."
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/tournament/domain/Tournament.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/domain/Tournament.kt
@@ -72,6 +72,7 @@ class Tournament(
     }
 
     fun updateInviteExpiry(newExpiresAt: LocalDateTime) {
+        check(isPending()) { "updateInviteExpiry는 PENDING 상태에서만 호출 가능" }
         _inviteExpiresAt = newExpiresAt
     }
 

--- a/src/main/kotlin/com/depromeet/piki/tournament/domain/Tournament.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/domain/Tournament.kt
@@ -17,8 +17,8 @@ class Tournament(
     val name: String,
     @Column(name = "invite_code", nullable = false, length = 6)
     val inviteCode: String,
-    @Column(name = "invite_expires_at", nullable = false)
-    val inviteExpiresAt: LocalDateTime,
+    inviteExpiresAt: LocalDateTime,
+
     @Enumerated(value = EnumType.STRING)
     @Column(columnDefinition = "varchar(50)")
     var status: TournamentStatus = TournamentStatus.PENDING,
@@ -31,6 +31,11 @@ class Tournament(
     private var _ownerTournamentUserId: Long = ownerTournamentUserId
 
     val ownerTournamentUserId: Long get() = _ownerTournamentUserId
+
+    @Column(name = "invite_expires_at", nullable = false)
+    private var _inviteExpiresAt: LocalDateTime = inviteExpiresAt
+
+    val inviteExpiresAt: LocalDateTime get() = _inviteExpiresAt
 
     @Column(name = "play_link_expires_at")
     var playLinkExpiresAt: LocalDateTime? = null
@@ -66,9 +71,19 @@ class Tournament(
         deletedAt = java.time.LocalDateTime.now()
     }
 
-    fun isInviteValid(): Boolean = LocalDateTime.now().isBefore(inviteExpiresAt)
+    fun updateInviteExpiry(newExpiresAt: LocalDateTime) {
+        _inviteExpiresAt = newExpiresAt
+    }
 
-    fun isPlayLinkValid(): Boolean = playLinkExpiresAt?.let { LocalDateTime.now().isBefore(it) } ?: false
+    fun isInviteValid(): Boolean = LocalDateTime
+        .now()
+        .isBefore(inviteExpiresAt)
+
+    fun isPlayLinkValid(): Boolean = playLinkExpiresAt?.let {
+        LocalDateTime
+            .now()
+            .isBefore(it)
+    } ?: false
 
     companion object {
         internal const val FINAL_ROUND_SIZE = 2
@@ -76,8 +91,12 @@ class Tournament(
         private val DIGITS = ('0'..'9').toList()
 
         fun generateInviteCode(): String {
-            val letters = (1..3).map { LETTERS[Random.nextInt(LETTERS.size)] }.joinToString("")
-            val digits = (1..3).map { DIGITS[Random.nextInt(DIGITS.size)] }.joinToString("")
+            val letters = (1..3)
+                .map { LETTERS[Random.nextInt(LETTERS.size)] }
+                .joinToString("")
+            val digits = (1..3)
+                .map { DIGITS[Random.nextInt(DIGITS.size)] }
+                .joinToString("")
             return letters + digits
         }
     }

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
@@ -1,6 +1,5 @@
 package com.depromeet.piki.tournament.service
 
-import com.depromeet.piki.item.domain.Item
 import com.depromeet.piki.item.domain.ItemSnapshot
 import com.depromeet.piki.item.repository.ItemRepository
 import com.depromeet.piki.item.repository.ItemSnapshotRepository
@@ -53,7 +52,9 @@ class TournamentService(
         command: CreateTournament,
     ): CreateTournamentResult {
         val inviteCode = generateUniqueInviteCode()
-        val inviteExpiresAt = LocalDateTime.now().plusMinutes(command.inviteDurationMinutes)
+        val inviteExpiresAt = LocalDateTime
+            .now()
+            .plusMinutes(command.inviteDurationMinutes)
         val tournament =
             tournamentRepository.saveTournament(
                 Tournament(
@@ -85,7 +86,8 @@ class TournamentService(
             tournamentRepository.findTournamentByIdForUpdate(tournamentId)
                 ?: throw TournamentException.notFoundTournament()
         tournament.checkJoinable(inviteCode)
-        tournamentUserRepository.findByTournamentIdAndUserId(tournamentId, userId)
+        tournamentUserRepository
+            .findByTournamentIdAndUserId(tournamentId, userId)
             ?.let { throw TournamentException.alreadyParticipant() }
         if (tournamentUserRepository.countByTournamentId(tournamentId) >= TOURNAMENT_MAX_PARTICIPANT_COUNT) {
             throw TournamentException.participantLimitExceeded()
@@ -135,19 +137,21 @@ class TournamentService(
         if (activeSnapshots.size != command.itemIds.size || activeSnapshots.any { !it.isReady() }) {
             throw TournamentException.itemNotReady()
         }
-        val savedItemIds = tournamentItemRepository.saveAll(
-            command.itemIds.map { itemId ->
-                val snapshotId =
-                    snapshotIdByItemId[itemId]
-                        ?: error("wish 의 활성 snapshot 없음 — itemId=$itemId, userId=$userId")
-                TournamentItem(
-                    tournamentId = command.tournamentId,
-                    itemId = itemId,
-                    userId = userId,
-                    snapshotId = snapshotId,
-                )
-            },
-        ).map { it.getId() }
+        val savedItemIds = tournamentItemRepository
+            .saveAll(
+                command.itemIds.map { itemId ->
+                    val snapshotId =
+                        snapshotIdByItemId[itemId]
+                            ?: error("wish 의 활성 snapshot 없음 — itemId=$itemId, userId=$userId")
+                    TournamentItem(
+                        tournamentId = command.tournamentId,
+                        itemId = itemId,
+                        userId = userId,
+                        snapshotId = snapshotId,
+                    )
+                },
+            )
+            .map { it.getId() }
         // 여러 개를 한 번에 추가해도 "아이템이 추가됐다"는 사실은 1건이라 이벤트도 1회만 발행한다.
         eventPublisher.publishEvent(TournamentItemAdded(tournamentId = command.tournamentId, actorId = userId))
         return savedItemIds
@@ -247,7 +251,9 @@ class TournamentService(
             TournamentStatus.IN_PROGRESS -> {
                 val histories = tournamentRepository.findTournamentHistoriesByTournamentId(tournamentId)
                 // 히스토리는 currentRound ASC, id ASC 정렬이라 lastOrNull()은 라운드가 바뀌면 틀림 — ID 최대값이 가장 최근 매치
-                val lastHistory = histories.maxByOrNull { it.getId() }?.let { TournamentDetail.HistoryEntry.from(it) }
+                val lastHistory = histories
+                    .maxByOrNull { it.getId() }
+                    ?.let { TournamentDetail.HistoryEntry.from(it) }
                 val allTournamentItems = tournamentItemRepository.findAllByTournamentId(tournamentId)
                 val currentRound = computeExpectedRound(allTournamentItems.size, allTournamentItems.size / 2, histories)
                 // 단일 패스: 탈락 아이템 + 현재 라운드 대결 완료 아이템 동시 수집
@@ -362,7 +368,9 @@ class TournamentService(
             throw TournamentException.invalidWinner()
         }
 
-        val tournamentItemIds = tournamentItemRepository.findIdsByTournamentId(command.tournamentId).toSet()
+        val tournamentItemIds = tournamentItemRepository
+            .findIdsByTournamentId(command.tournamentId)
+            .toSet()
         if (command.firstTournamentItemId !in tournamentItemIds ||
             command.secondTournamentItemId !in tournamentItemIds
         ) {
@@ -370,7 +378,9 @@ class TournamentService(
         }
 
         val histories = tournamentRepository.findTournamentHistoriesByTournamentId(command.tournamentId)
-        val eliminatedItemIds = histories.map { it.loser() }.toSet()
+        val eliminatedItemIds = histories
+            .map { it.loser() }
+            .toSet()
         if (command.firstTournamentItemId in eliminatedItemIds || command.secondTournamentItemId in eliminatedItemIds) {
             throw TournamentException.eliminatedTournamentItem()
         }
@@ -398,9 +408,13 @@ class TournamentService(
 
     private fun computeHasGroupResult(tournament: Tournament): Boolean {
         val rootId = tournament.sourceTournamentId ?: tournament.getId()
-        val completedClones = tournamentRepository.findBySourceTournamentId(rootId).count { it.isCompleted() }
+        val completedClones = tournamentRepository
+            .findBySourceTournamentId(rootId)
+            .count { it.isCompleted() }
         tournament.sourceTournamentId ?: return completedClones >= 1
-        val rootCompleted = tournamentRepository.findTournamentById(rootId)?.isCompleted() == true
+        val rootCompleted = tournamentRepository
+            .findTournamentById(rootId)
+            ?.isCompleted() == true
         return rootCompleted || completedClones >= 2
     }
 
@@ -456,6 +470,27 @@ class TournamentService(
         tournament.softDelete()
     }
 
+    @Transactional
+    fun updateInviteExpiry(
+        userId: UUID,
+        tournamentId: Long,
+        inviteDurationMinutes: Long,
+    ): LocalDateTime {
+        val tournament =
+            tournamentRepository.findTournamentByIdForUpdate(tournamentId)
+                ?: throw TournamentException.notFoundTournament()
+        val tournamentUser =
+            tournamentUserRepository.findByTournamentIdAndUserId(tournamentId, userId)
+                ?: throw TournamentException.forbiddenTournament()
+        if (tournamentUser.getId() != tournament.ownerTournamentUserId) throw TournamentException.forbiddenTournament()
+        if (!tournament.isPending()) throw TournamentException.notPendingTournament()
+        val newExpiresAt = LocalDateTime
+            .now()
+            .plusMinutes(inviteDurationMinutes)
+        tournament.updateInviteExpiry(newExpiresAt)
+        return newExpiresAt
+    }
+
     @Transactional(readOnly = true)
     fun getInvitePreview(tournamentId: Long): TournamentInvitePreview {
         val tournament =
@@ -503,7 +538,9 @@ class TournamentService(
         if (tournamentUser.getId() != tournament.ownerTournamentUserId) throw TournamentException.forbiddenTournament()
         tournament.sourceTournamentId?.let { throw TournamentException.clonedTournamentCannotSharePlayLink() }
         tournament.playLinkExpiresAt?.let { throw TournamentException.playLinkAlreadyCreated() }
-        val expiresAt = LocalDateTime.now().plusDays(PLAY_LINK_DURATION_DAYS)
+        val expiresAt = LocalDateTime
+            .now()
+            .plusDays(PLAY_LINK_DURATION_DAYS)
         tournament.createPlayLink(expiresAt)
         return expiresAt
     }
@@ -535,8 +572,11 @@ class TournamentService(
         sourceTournament.playLinkExpiresAt ?: throw TournamentException.playLinkNotCreated()
         if (!sourceTournament.isPlayLinkValid()) throw TournamentException.playLinkExpired()
 
-        val existingTournamentIds = tournamentUserRepository.findTournamentIdsByUserId(userId).toSet()
-        val alreadyCloned = tournamentRepository.findBySourceTournamentId(sourceTournamentId)
+        val existingTournamentIds = tournamentUserRepository
+            .findTournamentIdsByUserId(userId)
+            .toSet()
+        val alreadyCloned = tournamentRepository
+            .findBySourceTournamentId(sourceTournamentId)
             .any { it.getId() in existingTournamentIds }
         if (alreadyCloned) throw TournamentException.alreadyCloned()
 
@@ -549,7 +589,9 @@ class TournamentService(
                 ownerTournamentUserId = 0L,
                 name = sourceTournament.name,
                 inviteCode = inviteCode,
-                inviteExpiresAt = LocalDateTime.now().plusMinutes(TOURNAMENT_INVITE_DEFAULT_DURATION_MINUTES),
+                inviteExpiresAt = LocalDateTime
+                    .now()
+                    .plusMinutes(TOURNAMENT_INVITE_DEFAULT_DURATION_MINUTES),
                 sourceTournamentId = sourceTournamentId,
             ),
         )
@@ -587,13 +629,19 @@ class TournamentService(
         val rootId = tournament.sourceTournamentId ?: tournamentId
         val allRelated = buildList {
             tournament.sourceTournamentId
-                ?.let { tournamentRepository.findTournamentById(rootId)?.let { root -> add(root) } }
+                ?.let {
+                    tournamentRepository
+                        .findTournamentById(rootId)
+                        ?.let { root -> add(root) }
+                }
                 ?: add(tournament)
             addAll(tournamentRepository.findBySourceTournamentId(rootId))
         }.filter { it.isCompleted() }
 
         val ownerByTournamentId: Map<Long, UUID> = run {
-            val ownerTuIds = allRelated.map { it.ownerTournamentUserId }.toSet()
+            val ownerTuIds = allRelated
+                .map { it.ownerTournamentUserId }
+                .toSet()
             tournamentUserRepository
                 .findByTournamentIds(allRelated.map { it.getId() })
                 .filter { it.getId() in ownerTuIds }
@@ -605,25 +653,32 @@ class TournamentService(
 
         // 각 토너먼트의 결과를 itemId + rank 로 집계
         data class RankKey(val itemId: Long, val rank: Int)
+
         val chosenByMap = mutableMapOf<RankKey, MutableList<ParticipantSummary>>()
 
         // 원본 토너먼트의 아이템 정보를 기준으로 결과 표시
         val referenceItemsById: MutableMap<Long, RankedItem> = mutableMapOf()
 
         val allRelatedIds = allRelated.map { it.getId() }
-        val historiesByTournamentId = tournamentRepository.findHistoriesByTournamentIds(allRelatedIds)
+        val historiesByTournamentId = tournamentRepository
+            .findHistoriesByTournamentIds(allRelatedIds)
             .groupBy { it.tournamentId }
         val rankedByTournamentId = historiesByTournamentId
             .mapValues { (_, histories) -> computeRanking(histories) }
-        val allTournamentItemIds = rankedByTournamentId.values.flatten().map { it.first }
-        val tItemById = tournamentItemRepository.findByIds(allTournamentItemIds).associateBy { it.getId() }
+        val allTournamentItemIds = rankedByTournamentId.values
+            .flatten()
+            .map { it.first }
+        val tItemById = tournamentItemRepository
+            .findByIds(allTournamentItemIds)
+            .associateBy { it.getId() }
         val snapshotById = snapshotsOf(tItemById.values)
 
         for (t in allRelated) {
             val ranked = rankedByTournamentId[t.getId()] ?: continue
             val ownerUserId = ownerByTournamentId[t.getId()] ?: continue
             val user = userById[ownerUserId] ?: continue
-            val participant = ParticipantSummary(userId = user.id, nickname = user.nickname, profileImage = user.profileImage)
+            val participant =
+                ParticipantSummary(userId = user.id, nickname = user.nickname, profileImage = user.profileImage)
 
             for ((tournamentItemId, rank) in ranked) {
                 // tItem 누락은 삭제된 출전 아이템이 history 에 남은 정상 경우라 건너뛴다. 그러나 tItem 이 살아있으면
@@ -634,7 +689,9 @@ class TournamentService(
                     tItem.snapshotId?.let { snapshotById[it] }
                         ?: error("tournamentItem $tournamentItemId 의 snapshot ${tItem.snapshotId} 가 없다")
                 val key = RankKey(tItem.itemId, rank)
-                chosenByMap.getOrPut(key) { mutableListOf() }.add(participant)
+                chosenByMap
+                    .getOrPut(key) { mutableListOf() }
+                    .add(participant)
                 if (t.getId() == rootId) {
                     referenceItemsById[tItem.itemId] = RankedItem(
                         rank = rank,
@@ -728,7 +785,12 @@ class TournamentService(
             .filter { it.currentRound > Tournament.FINAL_ROUND_SIZE }
             .minByOrNull { it.currentRound }?.currentRound
         val semiLosers = semiRound
-            ?.let { round -> histories.filter { it.currentRound == round }.map { it.loser() }.sorted() }
+            ?.let { round ->
+                histories
+                    .filter { it.currentRound == round }
+                    .map { it.loser() }
+                    .sorted()
+            }
             ?: emptyList()
         return buildList {
             add(finalMatch.selectedTournamentItemId to 1)

--- a/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
@@ -1750,6 +1750,87 @@ class TournamentControllerTest : IntegrationTestSupport() {
             ).andExpect(status().isNotFound)
     }
 
+    // ── 초대 기한 수정 ──────────────────────────────────────────────────
+
+    @Test
+    fun `PATCH tournaments-id-invite 는 주최자가 200 과 함께 새 inviteExpiresAt 을 반환한다`() {
+        val mockMvc = buildMockMvc()
+        val tournamentId = createTournament(mockMvc)
+        val before = LocalDateTime.now()
+
+        val result = mockMvc
+            .perform(
+                patch("/api/v1/tournaments/$tournamentId/invite")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(userId))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"inviteDurationMinutes":60}"""),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.data").isString)
+            .andReturn()
+
+        val expiresAtStr = objectMapper.readTree(result.response.contentAsString)["data"].asText()
+        val expiresAt = java.time.OffsetDateTime.parse(expiresAtStr, DateTimeFormatter.ISO_OFFSET_DATE_TIME).toLocalDateTime()
+        val expectedMin = before.plusMinutes(60)
+        val expectedMax = LocalDateTime.now().plusMinutes(60)
+        assertTrue(expiresAt >= expectedMin && expiresAt <= expectedMax)
+    }
+
+    @Test
+    fun `PATCH tournaments-id-invite 에서 inviteDurationMinutes 가 0 이면 400 을 반환한다`() {
+        val mockMvc = buildMockMvc()
+        val tournamentId = createTournament(mockMvc)
+
+        mockMvc
+            .perform(
+                patch("/api/v1/tournaments/$tournamentId/invite")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(userId))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"inviteDurationMinutes":0}"""),
+            ).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `PATCH tournaments-id-invite 에서 참여자이지만 주최자가 아니면 403 을 반환한다`() {
+        val mockMvc = buildMockMvc()
+        val tournamentId = createTournament(mockMvc)
+        tournamentUserJpaRepository.save(TournamentUser(tournamentId = tournamentId, userId = otherUserId))
+
+        mockMvc
+            .perform(
+                patch("/api/v1/tournaments/$tournamentId/invite")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(otherUserId))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"inviteDurationMinutes":60}"""),
+            ).andExpect(status().isForbidden)
+    }
+
+    @Test
+    fun `PATCH tournaments-id-invite 에서 존재하지 않는 토너먼트이면 404 를 반환한다`() {
+        val mockMvc = buildMockMvc()
+
+        mockMvc
+            .perform(
+                patch("/api/v1/tournaments/999999/invite")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(userId))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"inviteDurationMinutes":60}"""),
+            ).andExpect(status().isNotFound)
+    }
+
+    @Test
+    fun `PATCH tournaments-id-invite 에서 PENDING 이 아닌 토너먼트이면 409 를 반환한다`() {
+        val mockMvc = buildMockMvc()
+        val (tournamentId) = startTournamentWith2Items(mockMvc)
+
+        mockMvc
+            .perform(
+                patch("/api/v1/tournaments/$tournamentId/invite")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(userId))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"inviteDurationMinutes":60}"""),
+            ).andExpect(status().isConflict)
+    }
+
     // ── 초대 미리보기 ──────────────────────────────────────────────────
 
     @Test

--- a/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
@@ -1753,7 +1753,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
     // ── 초대 기한 수정 ──────────────────────────────────────────────────
 
     @Test
-    fun `PATCH tournaments-id-invite 는 주최자가 200 과 함께 새 inviteExpiresAt 을 반환한다`() {
+    fun `PATCH tournaments-id-invite 는 주최자가 200 과 함께 새 inviteExpiresAt 을 반환하고 DB 에도 반영된다`() {
         val mockMvc = buildMockMvc()
         val tournamentId = createTournament(mockMvc)
         val before = LocalDateTime.now()
@@ -1773,6 +1773,10 @@ class TournamentControllerTest : IntegrationTestSupport() {
         val expectedMin = before.plusMinutes(60)
         val expectedMax = LocalDateTime.now().plusMinutes(60)
         assertTrue(expiresAt >= expectedMin && expiresAt <= expectedMax)
+
+        // 응답뿐 아니라 엔티티에 실제로 반영됐는지 확인 — backing field dirty-check가 깨져도 응답은 통과하므로
+        val saved = tournamentJpaRepository.findByIdAndDeletedAtIsNull(tournamentId)!!
+        assertTrue(saved.inviteExpiresAt >= expectedMin && saved.inviteExpiresAt <= expectedMax)
     }
 
     @Test


### PR DESCRIPTION
## Situation

- PENDING 상태 토너먼트를 만들면 초대 링크에 만료 시각이 고정된다. 그런데 만료 전에 주최자가 기한을 늘리거나 재설정할 수 있어야 한다는 요구사항이 있었다.
- 기존에는 초대 기한을 바꾸는 API가 없어서 한 번 만든 링크를 연장하거나 단축할 수 없었다.

## Task

- 주최자가 PENDING 상태 토너먼트의 초대 마감 시각을 "지금으로부터 N분 후"로 재설정할 수 있는 API 추가
- 1분 이상 1440분(24시간) 이하, PENDING 상태, 주최자 권한 조건을 강제

## Action

### API 설계

- `PATCH /api/v1/tournaments/{tournamentId}/invite` 엔드포인트 추가
- 요청 바디: `{ "inviteDurationMinutes": 60 }` — `Long`으로 받아 `@Min(1)` / `@Max(1440)` 으로 Bean Validation
- 응답: 새로 설정된 `inviteExpiresAt` (`LocalDateTime`) 반환
- 유효성 검증 메시지 상수를 `UpdateInviteDurationRequest.companion object` 에 두고 `@field`와 example 양쪽에서 같은 상수 참조

### 도메인 변경

- `Tournament.inviteExpiresAt` 을 `val` 에서 backing field 패턴(`private var _inviteExpiresAt`)으로 변경 — JPA `open class` 제약상 `private set` 을 쓸 수 없어 외부 변경 차단이 불가했던 것을 backing field로 해결
- `Tournament.updateInviteExpiry(newExpiresAt)` 도메인 메서드 추가. `check(isPending())` 으로 불변식 guard 추가 — `TournamentException` 이 `service` 패키지에 있어 도메인에서 커스텀 예외를 던질 수 없는 구조적 한계 때문에 `check` (500)로 처리. 409 PENDING 체크는 서비스 레이어에서 커스텀 예외로 별도 처리

### 서비스·컨트롤러

- `TournamentService.updateInviteExpiry`: 토너먼트 존재(404) → 참여자 확인(403) → 주최자 확인(403) → PENDING 확인(409) 순으로 guard 배치
- `findTournamentByIdForUpdate` (pessimistic lock) 사용 — 다른 수정 메서드와 동일 패턴
- OpenAPI 문서: 200/400/401/403/404/409 전 응답 문서화 + example 등록

### 통합 테스트

- 5건 추가: 200 성공(inviteExpiresAt 범위 실측), 400(inviteDurationMinutes=0), 403(참여자이지만 주최자 아닌 경우), 404(없는 토너먼트), 409(IN_PROGRESS 상태)

## Result

- 주최자가 PENDING 토너먼트에서 초대 기한을 자유롭게 재설정할 수 있다.
- `TournamentException` 이 `service` 패키지에 있어 도메인 자기방어가 완전하지 않다. `check()`로 불변식은 보호하지만, 409 응답은 서비스에서만 나온다. 근본 해결은 `TournamentException` 을 `domain` 패키지로 이동하는 별도 작업.
- `TournamentService.kt` 에 기존 코드의 포매팅 변경(메서드 체인 멀티라인)이 함께 포함되어 diff가 커졌다. 기능과 무관한 변경이므로 리뷰 시 참고.

---
## 연관 이슈

- close #427

## Updates

### DB 반영 검증 보강

- 200 성공 테스트가 응답값만 검증해 backing field dirty-check 실패가 눈에 안 띄는 점을 발견. 서비스가 계산값을 직접 반환하므로 DB 저장이 깨져도 응답은 정상으로 나온다. (`bcb0453`)
- `tournamentJpaRepository`로 재조회해 `inviteExpiresAt`이 실제 DB에 저장됐는지 검증 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 토너먼트 주최자가 보류 중인 토너먼트의 초대 기한을 재설정할 수 있습니다. 1~1,440분(1일) 범위 내에서 초대 만료 시각을 동적으로 조정할 수 있으며, 성공 시 새로운 초대 만료 시각이 반환됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
