### PR TITLE
POST /tournaments/{id}/join/guest 응답 토큰 쿠키 누락 수정

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
@@ -330,15 +330,17 @@ interface TournamentApi {
             닉네임을 입력해 게스트 계정을 생성하고 토너먼트에 참여한다. 인증 불필요.
             - 링크 직접 접근: inviteCode 생략 가능. 만료 여부만 확인.
             - 코드 입력 경로: inviteCode 전달 시 코드 일치 여부도 검증.
-            성공 시 JWT 토큰 쌍(accessToken·refreshToken)과 생성된 사용자 정보가 반환된다.
-            이후 요청에서는 발급받은 accessToken 을 사용한다.
+            성공 시 JWT 토큰 쌍과 생성된 사용자 정보가 반환된다.
+            토큰 전달 방식은 클라이언트 타입에 따라 다르다 (X-Client-Type 헤더):
+            - WEB(기본·미설정): accessToken·refreshToken 은 HttpOnly 쿠키로 전달, body 값은 null.
+            - APP(app 명시): accessToken·refreshToken 을 body 로 전달, 쿠키 없음.
         """,
     )
     @ApiResponses(
         value = [
             ApiResponse(
                 responseCode = "201",
-                description = "게스트 계정 생성 및 참여 성공 (accessToken·refreshToken·userId·nickname·profileImage 포함)",
+                description = "게스트 계정 생성 및 참여 성공 (WEB=쿠키 전달·body null / APP=body 전달)",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApiExamples.kt
@@ -4,6 +4,7 @@ import com.depromeet.piki.common.exception.ErrorCategory
 import com.depromeet.piki.common.openapi.OpenApiObjectMapper
 import com.depromeet.piki.common.openapi.binds
 import com.depromeet.piki.common.openapi.examples
+import com.depromeet.piki.auth.service.dto.TokenPair
 import com.depromeet.piki.common.response.ApiResponseBody
 import com.depromeet.piki.item.domain.ItemStatus
 import com.depromeet.piki.tournament.controller.dto.CreateTournamentResponse
@@ -88,12 +89,14 @@ class TournamentApiExamples(
                     operation.examples(openApiObjectMapper.delegate) {
                         add(
                             status = HttpStatus.CREATED,
-                            name = "게스트 참여 성공",
+                            name = "게스트 참여 성공 (APP — body 토큰)",
                             payload =
                                 ApiResponseBody.created(
                                     JoinTournamentAsGuestResponse(
-                                        accessToken = "eyJhbGciOiJIUzI1NiJ9.example",
-                                        refreshToken = "eyJhbGciOiJIUzI1NiJ9.refresh",
+                                        tokenPair = TokenPair(
+                                            accessToken = "eyJhbGciOiJIUzI1NiJ9.example",
+                                            refreshToken = "eyJhbGciOiJIUzI1NiJ9.refresh",
+                                        ),
                                         userId = UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"),
                                         nickname = "멋진친구",
                                         profileImage = "https://api.dicebear.com/9.x/bottts/svg?seed=aaaaaaaa",

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/dto/JoinTournamentAsGuestResponse.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/dto/JoinTournamentAsGuestResponse.kt
@@ -1,21 +1,34 @@
 package com.depromeet.piki.tournament.controller.dto
 
+import com.depromeet.piki.auth.service.dto.TokenPair
+import com.depromeet.piki.auth.web.TokenCarrying
 import com.depromeet.piki.tournament.service.dto.JoinTournamentAsGuestResult
+import com.fasterxml.jackson.annotation.JsonIgnore
+import io.swagger.v3.oas.annotations.media.Schema
 import java.util.UUID
 
 data class JoinTournamentAsGuestResponse(
-    val accessToken: String,
-    val refreshToken: String,
     val userId: UUID,
     val nickname: String,
     val profileImage: String,
     val tournamentId: Long,
-) {
+    @get:JsonIgnore
+    override val tokenPair: TokenPair,
+    @get:JsonIgnore
+    val bodyTokensIncluded: Boolean = true,
+) : TokenCarrying {
+    @get:Schema(description = "액세스 토큰 (APP=값 / WEB=null, 쿠키로 전달)", nullable = true, example = "eyJhbGciOiJIUzI1NiJ9...")
+    val accessToken: String? get() = tokenPair.accessToken.takeIf { bodyTokensIncluded }
+
+    @get:Schema(description = "리프레시 토큰 (APP=값 / WEB=null, 쿠키로 전달)", nullable = true, example = "eyJhbGciOiJIUzI1NiJ9...")
+    val refreshToken: String? get() = tokenPair.refreshToken.takeIf { bodyTokensIncluded }
+
+    override fun withoutBodyTokens(): TokenCarrying = copy(bodyTokensIncluded = false)
+
     companion object {
         fun from(result: JoinTournamentAsGuestResult): JoinTournamentAsGuestResponse =
             JoinTournamentAsGuestResponse(
-                accessToken = result.tokenPair.accessToken,
-                refreshToken = result.tokenPair.refreshToken,
+                tokenPair = result.tokenPair,
                 userId = result.user.id,
                 nickname = result.user.nickname,
                 profileImage = result.user.profileImage,

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/dto/JoinTournamentAsGuestResponse.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/dto/JoinTournamentAsGuestResponse.kt
@@ -14,16 +14,12 @@ data class JoinTournamentAsGuestResponse(
     val tournamentId: Long,
     @get:JsonIgnore
     override val tokenPair: TokenPair,
-    @get:JsonIgnore
-    val bodyTokensIncluded: Boolean = true,
-) : TokenCarrying {
     @get:Schema(description = "액세스 토큰 (APP=값 / WEB=null, 쿠키로 전달)", nullable = true, example = "eyJhbGciOiJIUzI1NiJ9...")
-    val accessToken: String? get() = tokenPair.accessToken.takeIf { bodyTokensIncluded }
-
+    val accessToken: String? = tokenPair.accessToken,
     @get:Schema(description = "리프레시 토큰 (APP=값 / WEB=null, 쿠키로 전달)", nullable = true, example = "eyJhbGciOiJIUzI1NiJ9...")
-    val refreshToken: String? get() = tokenPair.refreshToken.takeIf { bodyTokensIncluded }
-
-    override fun withoutBodyTokens(): TokenCarrying = copy(bodyTokensIncluded = false)
+    val refreshToken: String? = tokenPair.refreshToken,
+) : TokenCarrying {
+    override fun withoutBodyTokens(): TokenCarrying = copy(accessToken = null, refreshToken = null)
 
     companion object {
         fun from(result: JoinTournamentAsGuestResult): JoinTournamentAsGuestResponse =

--- a/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
@@ -42,6 +42,8 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.hamcrest.Matchers.nullValue
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
@@ -207,8 +209,12 @@ class TournamentControllerTest : IntegrationTestSupport() {
                     .contentType(MediaType.APPLICATION_JSON)
                     .content("""{"inviteCode":"$inviteCode","nickname":"새친구"}"""),
             ).andExpect(status().isCreated)
-            .andExpect(jsonPath("$.data.accessToken").isString)
-            .andExpect(jsonPath("$.data.refreshToken").isString)
+            .andExpect(cookie().exists("access_token"))
+            .andExpect(cookie().httpOnly("access_token", true))
+            .andExpect(cookie().exists("refresh_token"))
+            .andExpect(cookie().httpOnly("refresh_token", true))
+            .andExpect(jsonPath("$.data.accessToken").value(nullValue()))
+            .andExpect(jsonPath("$.data.refreshToken").value(nullValue()))
             .andExpect(jsonPath("$.data.userId").isString)
             .andExpect(jsonPath("$.data.nickname").value("새친구"))
             .andExpect(jsonPath("$.data.tournamentId").value(tournamentId))


### PR DESCRIPTION
## Situation

- 초대 링크로 토너먼트에 참여하는 비회원(게스트) 흐름에서, 참여 응답에 Set-Cookie 헤더가 없었다.
- 응답 body 에 accessToken/refreshToken 이 있었음에도 쿠키가 없어서, 후속 요청(GET /tournaments/{id} 등)이 모두 401로 떨어졌다.
- `/auth/guest`(게스트 계정만 생성)는 정상 동작하는데 `/tournaments/{id}/join/guest`(참여 포함)만 누락된 상태였다.

## Task

- 두 엔드포인트의 응답 처리 방식 차이를 파악하고 동일하게 맞추는 것이 목표였다.
- 핵심 판단 지점: 쿠키를 직접 심는 코드가 없는데 어디서 차이가 발생하는지 추적.

## Action

### 원인 분석

- `TokenCookieResponseAdvice`(ResponseBodyAdvice)가 응답 body 의 `data` 타입이 `TokenCarrying`인지 보고 쿠키를 심는다.
- `GuestCreateResponse`는 `TokenCarrying`을 구현 중이었으나, `JoinTournamentAsGuestResponse`는 미구현 상태였다. Advice 입장에서 `else` 분기로 떨어져 쿠키 세팅 자체가 일어나지 않았다.

### 수정

- `JoinTournamentAsGuestResponse`를 `GuestCreateResponse`와 동일한 패턴으로 `TokenCarrying` 구현.
  - `accessToken: String`/`refreshToken: String` 고정 필드를 제거하고, `tokenPair: TokenPair`를 `@JsonIgnore`로 들고 `bodyTokensIncluded` 플래그로 노출 여부를 제어.
  - `accessToken`/`refreshToken`은 computed property로: WEB(기본)=null(쿠키 전달), APP(X-Client-Type: app)=값.
  - `withoutBodyTokens()`를 구현해 Advice가 쿠키 세팅 후 body 토큰을 비울 수 있게 함.
- `TournamentApiExamples`: DTO 생성자 변경에 맞춰 `tokenPair` 인자 방식으로 전환, 예시명에 `(APP - body 토큰)` 추가.
- `TournamentApi`: Operation description과 201 응답 설명을 WEB/APP 분기 동작 기준으로 수정.

### 테스트

- 기존 통합 테스트가 `accessToken`이 String인지만 확인했는데, 이는 쿠키 누락 버그를 잡지 못하는 단언이었다.
- WEB(기본) 흐름 기준으로 쿠키 존재 및 HttpOnly 확인, body 토큰이 null인지 검증으로 교체.
- `doesNotExist()` 대신 `value(nullValue())` 사용: 필드가 absent가 아니라 null로 직렬화되기 때문.

## Result

- 비회원이 초대 링크로 참여할 때 Set-Cookie 헤더가 정상 응답에 포함된다.
- `GuestCreateResponse`와 완전히 동일한 WEB/APP 분기 동작을 갖게 되었다.

---
## 연관 이슈

- close #433

