### PR TITLE
웹 Apple OAuth 콜백을 query 모드로 통일

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/apple/AppleOAuthClient.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/apple/AppleOAuthClient.kt
@@ -45,8 +45,11 @@ class AppleOAuthClient(
             .queryParam(OAuthParams.CLIENT_ID, props.clientId)
             .queryParam(OAuthParams.REDIRECT_URI, redirectUri ?: props.redirectUri)
             .queryParam(OAuthParams.RESPONSE_TYPE, OAuthParams.RESPONSE_TYPE_CODE)
-            .queryParam("response_mode", "form_post")
-            .queryParam(OAuthParams.SCOPE, "email name")
+            // Apple 은 scope 에 email/name 이 있으면 response_mode 를 form_post 로 강제해 콜백이 POST 로 온다.
+            // 우리는 email/name 을 수집·저장하지 않고 id_token 의 sub(socialId)만 쓰므로 scope 를 요청하지 않는다.
+            // 그 결과 response_mode=query 가 허용되어 Kakao·Google 과 동일하게 GET 쿼리(code·state)로 콜백받는다.
+            // (scope 에 email/name 을 다시 넣으면 Apple 이 form_post 를 강제하므로 함께 되돌리면 안 된다.)
+            .queryParam("response_mode", "query")
             .queryParam(OAuthParams.STATE, state)
             .build()
             .encode()

--- a/src/test/kotlin/com/depromeet/piki/auth/infrastructure/oauth/apple/AppleOAuthClientTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/infrastructure/oauth/apple/AppleOAuthClientTest.kt
@@ -45,6 +45,44 @@ class AppleOAuthClientTest {
     )
 
     @Nested
+    inner class BuildAuthUrl {
+        @Test
+        fun `response_mode 는 query 이고 scope 는 요청하지 않는다 - Kakao Google 과 동일한 GET 쿼리 콜백`() {
+            val client = AppleOAuthClient(props())
+
+            val url = client.buildAuthUrl(state = "STATE_TOKEN", redirectUri = null)
+
+            // Apple 은 scope 에 email/name 이 있으면 response_mode 를 form_post 로 강제 → POST 콜백.
+            // scope 를 빼서 query 콜백(GET code·state)으로 통일한다.
+            assertTrue("response_mode=query" in url, "response_mode 는 query 여야 한다: $url")
+            assertFalse("form_post" in url, "form_post 가 남아 있으면 안 된다: $url")
+            assertFalse("scope=" in url, "scope 를 요청하면 Apple 이 form_post 를 강제한다: $url")
+        }
+
+        @Test
+        fun `필수 인가 파라미터와 state redirectUri 를 포함한다`() {
+            val client = AppleOAuthClient(props(clientId = "com.test.service"))
+
+            val url = client.buildAuthUrl(state = "STATE_TOKEN", redirectUri = "https://piki.day/auth/callback/apple")
+
+            assertTrue("response_type=code" in url, "response_type=code 가 있어야 한다: $url")
+            assertTrue("client_id=com.test.service" in url, "client_id 가 있어야 한다: $url")
+            assertTrue("state=STATE_TOKEN" in url, "state 가 있어야 한다: $url")
+            // 인자 redirectUri 가 props 기본값보다 우선한다 (URL 인코딩된 형태로 포함)
+            assertTrue("piki.day" in url, "인자로 받은 redirectUri 가 반영돼야 한다: $url")
+        }
+
+        @Test
+        fun `redirectUri 가 null 이면 props 기본값을 쓴다`() {
+            val client = AppleOAuthClient(props(redirectUri = "https://example.com/callback"))
+
+            val url = client.buildAuthUrl(state = "STATE_TOKEN", redirectUri = null)
+
+            assertTrue("example.com" in url, "redirectUri 가 null 이면 props.redirectUri 를 써야 한다: $url")
+        }
+    }
+
+    @Nested
     inner class PropertiesToString {
         @Test
         fun `toString 은 privateKey 를 마스킹한다 - 부팅 로그·BindException 으로 누출 방지`() {


### PR DESCRIPTION
## Situation

- 웹에서 Apple 로그인을 하면 로그인 페이지로 계속 튕기는 문제가 제보됐다.
- 원인은 Apple 콜백이 POST(form_post)로 오는데, 프론트는 콜백 경로에서 GET 쿼리(code, state)만 읽는 구조라 값을 못 받는 것이었다.
- Kakao, Google 은 GET 쿼리 콜백이라 정상 동작했고, Apple 만 콜백 방식이 어긋나 있었다.

## Task

- Apple 도 Kakao, Google 과 동일하게 GET 쿼리로 콜백받도록 서버에서 통일한다.
- 핵심 제약: Apple 은 scope 에 email 이나 name 이 있으면 response_mode 를 form_post 로 강제한다. 그래서 response_mode 만 query 로 바꿔선 안 되고, scope 도 함께 빼야 한다.
- 결정 포인트는 "scope 의 email/name 을 빼도 되는가", 즉 우리가 그 값을 실제로 쓰는가였다.

## Action

- 인가 URL 생성에서 response_mode 를 query 로 바꾸고 scope 요청을 제거했다.
- 빼도 되는지 코드로 확인했다. 우리는 Apple 의 email/name 을 수집도 저장도 하지 않는다. provider 사용자 정보 객체에 email 필드가 없고, id_token 에서는 식별자(sub)만 꺼내 쓰며, 프로필 이미지는 항상 null 로 둔다. 즉 scope 로 받던 값은 받아만 놓고 버리던 상태라 제거해도 잃는 게 없다.
- 같은 실수가 재발하지 않도록, scope 에 email/name 을 다시 넣으면 Apple 이 form_post 를 강제한다는 점을 코드 주석으로 남겼다.
- 회귀 방지용 단위 테스트를 추가했다: query 모드와 scope 미요청 단언, 필수 인가 파라미터와 state, 인자 redirectUri 우선, redirectUri null 시 기본값 사용.

#### 구현

- 변경 지점은 `AppleOAuthClient.buildAuthUrl` 한 곳. provider 별 `buildAuthUrl` 은 각 클라이언트가 따로 구현하므로 Kakao, Google 코드는 건드리지 않았다.

## Result

- Apple 콜백이 GET 쿼리(code, state)로 통일되어 프론트의 기존 콜백 핸들러가 그대로 동작한다.
- 영향 범위는 웹 v1(code) 흐름 한정이다. iOS v2(identityToken 직접 검증)는 인가 URL 을 타지 않아 무관하다.
- 부수 효과로, 실제로 안 쓰던 개인정보(email, name) 동의 요청이 사라져 최소수집에 가까워졌다.
- 후속 메모: 회원 탈퇴 에픽(#415)의 "user_details 의 email PII 를 격리" 전제가 현재 코드와 맞지 않는다. 지금 email 은 어디에도 보관하지 않으므로, 그 작업에 들어갈 때 격리 대상을 식별자와 provider 기준으로 재정의해야 한다.

---
## 연관 이슈

- close #430
