### PR TITLE
TournamentApi, TournamentItemApi 문서 정비

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
@@ -135,6 +135,133 @@ interface TournamentApi {
     ): ApiResponseBody<TournamentDetailResponse>
 
     @Operation(
+        summary = "링크 접근 경로 — 토너먼트 참여 전 미리보기",
+        description = "초대 링크 직접 접근 시 tournamentId 만으로 토너먼트 정보(이름·아이템 수·참여자 수)를 반환한다. 인증 불필요.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "조회 성공 (토너먼트 이름·아이템 수·참여자 수 반환)",
+                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "토너먼트를 찾을 수 없음",
+                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+            ),
+            ApiResponse(
+                responseCode = "409",
+                description = "상태 충돌 (PENDING이 아닌 토너먼트 · 초대 링크 만료)",
+                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+            ),
+        ],
+    )
+    fun getInvitePreview(
+        @Parameter(description = "토너먼트 ID", example = "1") tournamentId: Long,
+    ): ApiResponseBody<TournamentInvitePreviewResponse>
+
+    @Operation(
+        summary = "초대 코드로 토너먼트 미리보기",
+        description = """
+            홈 다이얼로그에서 6자리 코드만 입력하는 경로 전용 — tournamentId 없이 코드만으로 조회한다.
+            코드가 유효하면 tournamentId·이름·아이템 수·참여자 수를 반환한다.
+            이후 /join 또는 /join/guest 호출 시 응답의 tournamentId를 사용하면 된다.
+        """,
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "조회 성공 (tournamentId·토너먼트 이름·아이템 수·참여자 수 반환)",
+                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청 (코드에 해당하는 토너먼트 없음)",
+                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+            ),
+            ApiResponse(
+                responseCode = "409",
+                description = "상태 충돌 (PENDING이 아닌 토너먼트 · 초대 링크 만료)",
+                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+            ),
+        ],
+    )
+    fun getInvitePreviewByCode(
+        @Parameter(description = "초대 코드 (영어 대문자 3자리 + 숫자 3자리)", example = "ABC123") code: String,
+    ): ApiResponseBody<TournamentInvitePreviewResponse>
+
+    @Operation(
+        summary = "플레이 링크 정보 조회",
+        description = "플레이 링크가 유효한 토너먼트의 정보(이름, 아이템 수, 만료 시간)를 반환한다. 인증 불필요.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "조회 성공",
+                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "토너먼트를 찾을 수 없음 · 플레이 링크가 생성되지 않은 토너먼트",
+                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+            ),
+            ApiResponse(
+                responseCode = "409",
+                description = "플레이 링크 만료",
+                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+            ),
+        ],
+    )
+    fun getPlayLinkInfo(
+        @Parameter(description = "원본 토너먼트 ID", example = "1") tournamentId: Long,
+    ): ApiResponseBody<PlayLinkInfoResponse>
+
+    @Operation(
+        summary = "그룹 결과 조회",
+        description = """
+            완료된 토너먼트의 그룹 결과를 조회한다.
+            원본 토너먼트와 플레이 링크로 복제된 모든 토너먼트의 결과를 비교해,
+            각 순위의 아이템마다 동일한 결과를 선택한 참여자 정보를 반환한다.
+        """,
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "그룹 결과 조회 성공",
+                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "미인증 (JWT 토큰 없음 또는 유효하지 않음)",
+                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+            ),
+            ApiResponse(
+                responseCode = "403",
+                description = "권한 없음 (토너먼트 참여자가 아님)",
+                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "토너먼트를 찾을 수 없음",
+                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+            ),
+            ApiResponse(
+                responseCode = "409",
+                description = "상태 충돌 (COMPLETED가 아닌 토너먼트)",
+                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+            ),
+        ],
+    )
+    fun getGroupResult(
+        @Parameter(hidden = true) userId: UUID,
+        @Parameter(description = "토너먼트 ID", example = "1") tournamentId: Long,
+    ): ApiResponseBody<GroupResultResponse>
+
+    @Operation(
         summary = "토너먼트 생성",
         description = """
             이름으로 PENDING 상태의 토너먼트를 생성한다.
@@ -466,6 +593,129 @@ interface TournamentApi {
     ): ApiResponseBody<TournamentDetailResponse.CompletedData?>
 
     @Operation(
+        summary = "플레이 링크 생성",
+        description = """
+            완료된 토너먼트의 플레이 링크를 생성한다. 토너먼트 소유자만 호출 가능.
+            플레이 링크를 통해 친구들이 동일한 아이템 구성으로 토너먼트를 진행할 수 있다.
+            만료 기간은 생성 시점 + 14일로 고정이며 변경 불가.
+            이미 링크가 있으면 만료 시간이 갱신된다.
+        """,
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "플레이 링크 생성 성공 (playLinkExpiresAt 반환)",
+                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "미인증 (JWT 토큰 없음 또는 유효하지 않음)",
+                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+            ),
+            ApiResponse(
+                responseCode = "403",
+                description = "권한 없음 (토너먼트 참여자가 아님 · 소유자가 아님 · 플레이 링크로 참여한 토너먼트는 플레이 링크 생성 불가)",
+                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "토너먼트를 찾을 수 없음",
+                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+            ),
+            ApiResponse(
+                responseCode = "409",
+                description = "상태 충돌 (COMPLETED가 아닌 토너먼트 · 플레이 링크가 이미 생성됨)",
+                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+            ),
+        ],
+    )
+    fun createPlayLink(
+        @Parameter(hidden = true) userId: UUID,
+        @Parameter(description = "토너먼트 ID", example = "1") tournamentId: Long,
+    ): ApiResponseBody<LocalDateTime>
+
+    @Operation(
+        summary = "플레이 링크로 토너먼트 복제 생성",
+        description = """
+            플레이 링크가 유효한 토너먼트와 동일한 아이템 구성으로 새 토너먼트를 생성한다.
+            생성된 토너먼트는 PENDING 상태이며 아이템이 미리 복사되어 있어 바로 시작할 수 있다.
+        """,
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "201",
+                description = "복제 토너먼트 생성 성공 (tournamentId 반환)",
+                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "미인증 (JWT 토큰 없음 또는 유효하지 않음)",
+                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "토너먼트를 찾을 수 없음 · 플레이 링크가 생성되지 않은 토너먼트",
+                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+            ),
+            ApiResponse(
+                responseCode = "409",
+                description = "상태 충돌 (플레이 링크 만료 · 이미 해당 플레이 링크로 토너먼트를 생성한 경우)",
+                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+            ),
+        ],
+    )
+    fun createFromPlayLink(
+        @Parameter(hidden = true) userId: UUID,
+        @Parameter(description = "원본 토너먼트 ID", example = "1") sourceTournamentId: Long,
+    ): ApiResponseBody<Long>
+
+    @Operation(
+        summary = "친구 초대 마감 시각 수정",
+        description = "PENDING 상태 토너먼트의 초대 마감 시각을 지금으로부터 N분 후로 재설정한다. 주최자만 가능. 최소 1분, 최대 1440분(24시간).",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "수정 성공 (새 inviteExpiresAt 반환)",
+                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청 (inviteDurationMinutes 1 미만 또는 1440 초과)",
+                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "미인증 (JWT 토큰 없음 또는 유효하지 않음)",
+                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+            ),
+            ApiResponse(
+                responseCode = "403",
+                description = "권한 없음 (토너먼트 참여자가 아님 · 소유자가 아님)",
+                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "토너먼트를 찾을 수 없음",
+                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+            ),
+            ApiResponse(
+                responseCode = "409",
+                description = "상태 충돌 (PENDING이 아닌 토너먼트)",
+                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
+            ),
+        ],
+    )
+    fun updateInviteExpiry(
+        @Parameter(hidden = true) userId: UUID,
+        @Parameter(description = "토너먼트 ID", example = "1") tournamentId: Long,
+        request: UpdateInviteDurationRequest,
+    ): ApiResponseBody<LocalDateTime>
+
+    @Operation(
         summary = "토너먼트 삭제",
         description = "PENDING 또는 COMPLETED 상태의 토너먼트를 삭제한다. 토너먼트 소유자만 삭제할 수 있으며, IN_PROGRESS 상태에서는 삭제할 수 없다.",
     )
@@ -527,254 +777,4 @@ interface TournamentApi {
         @Parameter(hidden = true) userId: UUID,
         @Parameter(description = "토너먼트 ID", example = "1") tournamentId: Long,
     ): ApiResponseBody<Unit>
-
-    @Operation(
-        summary = "친구 초대 마감 시각 수정",
-        description = "PENDING 상태 토너먼트의 초대 마감 시각을 지금으로부터 N분 후로 재설정한다. 주최자만 가능. 최소 1분, 최대 1440분(24시간).",
-    )
-    @ApiResponses(
-        value = [
-            ApiResponse(
-                responseCode = "200",
-                description = "수정 성공 (새 inviteExpiresAt 반환)",
-                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
-            ),
-            ApiResponse(
-                responseCode = "400",
-                description = "잘못된 요청 (inviteDurationMinutes 1 미만 또는 1440 초과)",
-                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
-            ),
-            ApiResponse(
-                responseCode = "401",
-                description = "미인증 (JWT 토큰 없음 또는 유효하지 않음)",
-                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
-            ),
-            ApiResponse(
-                responseCode = "403",
-                description = "권한 없음 (토너먼트 참여자가 아님 · 소유자가 아님)",
-                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
-            ),
-            ApiResponse(
-                responseCode = "404",
-                description = "토너먼트를 찾을 수 없음",
-                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
-            ),
-            ApiResponse(
-                responseCode = "409",
-                description = "상태 충돌 (PENDING이 아닌 토너먼트)",
-                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
-            ),
-        ],
-    )
-    fun updateInviteExpiry(
-        @Parameter(hidden = true) userId: UUID,
-        @Parameter(description = "토너먼트 ID", example = "1") tournamentId: Long,
-        request: UpdateInviteDurationRequest,
-    ): ApiResponseBody<LocalDateTime>
-
-    @Operation(
-        summary = "링크 접근 경로 — 토너먼트 참여 전 미리보기",
-        description = "초대 링크 직접 접근 시 tournamentId 만으로 토너먼트 정보(이름·아이템 수·참여자 수)를 반환한다. 인증 불필요.",
-    )
-    @ApiResponses(
-        value = [
-            ApiResponse(
-                responseCode = "200",
-                description = "조회 성공 (토너먼트 이름·아이템 수·참여자 수 반환)",
-                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
-            ),
-            ApiResponse(
-                responseCode = "404",
-                description = "토너먼트를 찾을 수 없음",
-                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
-            ),
-            ApiResponse(
-                responseCode = "409",
-                description = "상태 충돌 (PENDING이 아닌 토너먼트 · 초대 링크 만료)",
-                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
-            ),
-        ],
-    )
-    fun getInvitePreview(
-        @Parameter(description = "토너먼트 ID", example = "1") tournamentId: Long,
-    ): ApiResponseBody<TournamentInvitePreviewResponse>
-
-    @Operation(
-        summary = "초대 코드로 토너먼트 미리보기",
-        description = """
-            홈 다이얼로그에서 6자리 코드만 입력하는 경로 전용 — tournamentId 없이 코드만으로 조회한다.
-            코드가 유효하면 tournamentId·이름·아이템 수·참여자 수를 반환한다.
-            이후 /join 또는 /join/guest 호출 시 응답의 tournamentId를 사용하면 된다.
-        """,
-    )
-    @ApiResponses(
-        value = [
-            ApiResponse(
-                responseCode = "200",
-                description = "조회 성공 (tournamentId·토너먼트 이름·아이템 수·참여자 수 반환)",
-                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
-            ),
-            ApiResponse(
-                responseCode = "400",
-                description = "잘못된 요청 (코드에 해당하는 토너먼트 없음)",
-                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
-            ),
-            ApiResponse(
-                responseCode = "409",
-                description = "상태 충돌 (PENDING이 아닌 토너먼트 · 초대 링크 만료)",
-                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
-            ),
-        ],
-    )
-    fun getInvitePreviewByCode(
-        @Parameter(description = "초대 코드 (영어 대문자 3자리 + 숫자 3자리)", example = "ABC123") code: String,
-    ): ApiResponseBody<TournamentInvitePreviewResponse>
-
-    @Operation(
-        summary = "플레이 링크 생성",
-        description = """
-            완료된 토너먼트의 플레이 링크를 생성한다. 토너먼트 소유자만 호출 가능.
-            플레이 링크를 통해 친구들이 동일한 아이템 구성으로 토너먼트를 진행할 수 있다.
-            만료 기간은 생성 시점 + 14일로 고정이며 변경 불가.
-            이미 링크가 있으면 만료 시간이 갱신된다.
-        """,
-    )
-    @ApiResponses(
-        value = [
-            ApiResponse(
-                responseCode = "200",
-                description = "플레이 링크 생성 성공 (playLinkExpiresAt 반환)",
-                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
-            ),
-            ApiResponse(
-                responseCode = "401",
-                description = "미인증 (JWT 토큰 없음 또는 유효하지 않음)",
-                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
-            ),
-            ApiResponse(
-                responseCode = "403",
-                description = "권한 없음 (토너먼트 참여자가 아님 · 소유자가 아님 · 플레이 링크로 참여한 토너먼트는 플레이 링크 생성 불가)",
-                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
-            ),
-            ApiResponse(
-                responseCode = "404",
-                description = "토너먼트를 찾을 수 없음",
-                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
-            ),
-            ApiResponse(
-                responseCode = "409",
-                description = "상태 충돌 (COMPLETED가 아닌 토너먼트 · 플레이 링크가 이미 생성됨)",
-                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
-            ),
-        ],
-    )
-    fun createPlayLink(
-        @Parameter(hidden = true) userId: UUID,
-        @Parameter(description = "토너먼트 ID", example = "1") tournamentId: Long,
-    ): ApiResponseBody<LocalDateTime>
-
-    @Operation(
-        summary = "플레이 링크 정보 조회",
-        description = "플레이 링크가 유효한 토너먼트의 정보(이름, 아이템 수, 만료 시간)를 반환한다. 인증 불필요.",
-    )
-    @ApiResponses(
-        value = [
-            ApiResponse(
-                responseCode = "200",
-                description = "조회 성공",
-                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
-            ),
-            ApiResponse(
-                responseCode = "404",
-                description = "토너먼트를 찾을 수 없음 · 플레이 링크가 생성되지 않은 토너먼트",
-                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
-            ),
-            ApiResponse(
-                responseCode = "409",
-                description = "플레이 링크 만료",
-                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
-            ),
-        ],
-    )
-    fun getPlayLinkInfo(
-        @Parameter(description = "원본 토너먼트 ID", example = "1") tournamentId: Long,
-    ): ApiResponseBody<PlayLinkInfoResponse>
-
-    @Operation(
-        summary = "플레이 링크로 토너먼트 복제 생성",
-        description = """
-            플레이 링크가 유효한 토너먼트와 동일한 아이템 구성으로 새 토너먼트를 생성한다.
-            생성된 토너먼트는 PENDING 상태이며 아이템이 미리 복사되어 있어 바로 시작할 수 있다.
-        """,
-    )
-    @ApiResponses(
-        value = [
-            ApiResponse(
-                responseCode = "201",
-                description = "복제 토너먼트 생성 성공 (tournamentId 반환)",
-                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
-            ),
-            ApiResponse(
-                responseCode = "401",
-                description = "미인증 (JWT 토큰 없음 또는 유효하지 않음)",
-                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
-            ),
-            ApiResponse(
-                responseCode = "404",
-                description = "토너먼트를 찾을 수 없음 · 플레이 링크가 생성되지 않은 토너먼트",
-                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
-            ),
-            ApiResponse(
-                responseCode = "409",
-                description = "상태 충돌 (플레이 링크 만료 · 이미 해당 플레이 링크로 토너먼트를 생성한 경우)",
-                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
-            ),
-        ],
-    )
-    fun createFromPlayLink(
-        @Parameter(hidden = true) userId: UUID,
-        @Parameter(description = "원본 토너먼트 ID", example = "1") sourceTournamentId: Long,
-    ): ApiResponseBody<Long>
-
-    @Operation(
-        summary = "그룹 결과 조회",
-        description = """
-            완료된 토너먼트의 그룹 결과를 조회한다.
-            원본 토너먼트와 플레이 링크로 복제된 모든 토너먼트의 결과를 비교해,
-            각 순위의 아이템마다 동일한 결과를 선택한 참여자 정보를 반환한다.
-        """,
-    )
-    @ApiResponses(
-        value = [
-            ApiResponse(
-                responseCode = "200",
-                description = "그룹 결과 조회 성공",
-                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
-            ),
-            ApiResponse(
-                responseCode = "401",
-                description = "미인증 (JWT 토큰 없음 또는 유효하지 않음)",
-                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
-            ),
-            ApiResponse(
-                responseCode = "403",
-                description = "권한 없음 (토너먼트 참여자가 아님)",
-                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
-            ),
-            ApiResponse(
-                responseCode = "404",
-                description = "토너먼트를 찾을 수 없음",
-                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
-            ),
-            ApiResponse(
-                responseCode = "409",
-                description = "상태 충돌 (COMPLETED가 아닌 토너먼트)",
-                content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
-            ),
-        ],
-    )
-    fun getGroupResult(
-        @Parameter(hidden = true) userId: UUID,
-        @Parameter(description = "토너먼트 ID", example = "1") tournamentId: Long,
-    ): ApiResponseBody<GroupResultResponse>
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
@@ -135,7 +135,7 @@ interface TournamentApi {
     ): ApiResponseBody<TournamentDetailResponse>
 
     @Operation(
-        summary = "링크 접근 경로 — 토너먼트 참여 전 미리보기",
+        summary = "초대 링크로 참여 화면 진입",
         description = "초대 링크 직접 접근 시 tournamentId 만으로 토너먼트 정보(이름·아이템 수·참여자 수)를 반환한다. 인증 불필요.",
     )
     @ApiResponses(
@@ -162,7 +162,7 @@ interface TournamentApi {
     ): ApiResponseBody<TournamentInvitePreviewResponse>
 
     @Operation(
-        summary = "초대 코드로 토너먼트 미리보기",
+        summary = "초대 코드로 참여 화면 진입",
         description = """
             홈 다이얼로그에서 6자리 코드만 입력하는 경로 전용 — tournamentId 없이 코드만으로 조회한다.
             코드가 유효하면 tournamentId·이름·아이템 수·참여자 수를 반환한다.
@@ -193,7 +193,7 @@ interface TournamentApi {
     ): ApiResponseBody<TournamentInvitePreviewResponse>
 
     @Operation(
-        summary = "플레이 링크 정보 조회",
+        summary = "플레이 링크로 참여 화면 진입",
         description = "플레이 링크가 유효한 토너먼트의 정보(이름, 아이템 수, 만료 시간)를 반환한다. 인증 불필요.",
     )
     @ApiResponses(
@@ -636,7 +636,7 @@ interface TournamentApi {
     ): ApiResponseBody<LocalDateTime>
 
     @Operation(
-        summary = "플레이 링크로 토너먼트 복제 생성",
+        summary = "플레이 링크로 토너먼트 진행",
         description = """
             플레이 링크가 유효한 토너먼트와 동일한 아이템 구성으로 새 토너먼트를 생성한다.
             생성된 토너먼트는 PENDING 상태이며 아이템이 미리 복사되어 있어 바로 시작할 수 있다.

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentItemApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentItemApi.kt
@@ -21,6 +21,70 @@ import java.util.UUID
 
 @Tag(name = "Tournament Item", description = "토너먼트 아이템 API")
 interface TournamentItemApi {
+
+    @Operation(
+        summary = "토너먼트 아이템 단건 조회",
+        description = """
+            토너먼트 아이템의 상세 정보와 파싱 상태를 조회한다.
+            링크·이미지로 아이템을 추가하면 비동기 파싱이 진행되므로,
+            클라이언트가 status 필드를 폴링해 PROCESSING → READY/FAILED 전환을 감지할 수 있다.
+            - PROCESSING: 파싱 진행 중 (name·price·imageUrl 은 null)
+            - READY: 파싱 완료 (모든 필드 채워짐)
+            - FAILED: 파싱 실패 (상품 페이지 아님 또는 추출 불가)
+            sourceUrl: 등록 시 입력한 원본 링크. 이미지로 등록한 경우 null.
+            토너먼트 참여자만 조회할 수 있다.
+        """,
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "아이템 조회 성공",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "미인증 (JWT 토큰 없음 또는 유효하지 않음)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "403",
+                description = "권한 없음 (토너먼트 참여자가 아님)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "토너먼트를 찾을 수 없음 · 토너먼트 아이템을 찾을 수 없음 · 아이템이 해당 토너먼트에 속하지 않음",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun getTournamentItem(
+        @Parameter(hidden = true) userId: UUID,
+        @Parameter(description = "토너먼트 ID", example = "1") tournamentId: Long,
+        @Parameter(description = "토너먼트 아이템 ID", example = "10") tournamentItemId: Long,
+    ): ApiResponseBody<TournamentItemDetailResponse>
+
     @Operation(
         summary = "위시에서 토너먼트 아이템 추가",
         description = """
@@ -412,67 +476,4 @@ interface TournamentItemApi {
         @Parameter(description = "토너먼트 ID", example = "1") tournamentId: Long,
         @Parameter(description = "토너먼트 아이템 ID", example = "10") tournamentItemId: Long,
     ): ApiResponseBody<Unit>
-
-    @Operation(
-        summary = "토너먼트 아이템 단건 조회",
-        description = """
-            토너먼트 아이템의 상세 정보와 파싱 상태를 조회한다.
-            링크·이미지로 아이템을 추가하면 비동기 파싱이 진행되므로,
-            클라이언트가 status 필드를 폴링해 PROCESSING → READY/FAILED 전환을 감지할 수 있다.
-            - PROCESSING: 파싱 진행 중 (name·price·imageUrl 은 null)
-            - READY: 파싱 완료 (모든 필드 채워짐)
-            - FAILED: 파싱 실패 (상품 페이지 아님 또는 추출 불가)
-            sourceUrl: 등록 시 입력한 원본 링크. 이미지로 등록한 경우 null.
-            토너먼트 참여자만 조회할 수 있다.
-        """,
-    )
-    @ApiResponses(
-        value = [
-            ApiResponse(
-                responseCode = "200",
-                description = "아이템 조회 성공",
-                content = [
-                    Content(
-                        mediaType = MediaType.APPLICATION_JSON_VALUE,
-                        schema = Schema(implementation = ApiResponseBody::class),
-                    ),
-                ],
-            ),
-            ApiResponse(
-                responseCode = "401",
-                description = "미인증 (JWT 토큰 없음 또는 유효하지 않음)",
-                content = [
-                    Content(
-                        mediaType = MediaType.APPLICATION_JSON_VALUE,
-                        schema = Schema(implementation = ApiResponseBody::class),
-                    ),
-                ],
-            ),
-            ApiResponse(
-                responseCode = "403",
-                description = "권한 없음 (토너먼트 참여자가 아님)",
-                content = [
-                    Content(
-                        mediaType = MediaType.APPLICATION_JSON_VALUE,
-                        schema = Schema(implementation = ApiResponseBody::class),
-                    ),
-                ],
-            ),
-            ApiResponse(
-                responseCode = "404",
-                description = "토너먼트를 찾을 수 없음 · 토너먼트 아이템을 찾을 수 없음 · 아이템이 해당 토너먼트에 속하지 않음",
-                content = [
-                    Content(
-                        mediaType = MediaType.APPLICATION_JSON_VALUE,
-                        schema = Schema(implementation = ApiResponseBody::class),
-                    ),
-                ],
-            ),
-        ],
-    )
-    fun getTournamentItem(
-        @Parameter(hidden = true) userId: UUID,
-        @Parameter(description = "토너먼트 ID", example = "1") tournamentId: Long,
-        @Parameter(description = "토너먼트 아이템 ID", example = "10") tournamentItemId: Long,
-    ): ApiResponseBody<TournamentItemDetailResponse>
 }


### PR DESCRIPTION
## Situation

- `TournamentApi`와 `TournamentItemApi`의 메서드 순서가 GET-POST-PATCH-DELETE를 따르지 않고 뒤섞여 있어 API 문서를 훑을 때 일관성이 없었음
- 참여 전 정보 조회 용도의 일부 엔드포인트 summary가 실제 동작을 오해하게 만드는 표현이었음 (예: GET 조회 엔드포인트에 "입장"이라는 액션성 워딩 사용)

## Task

- API 인터페이스 파일의 메서드 순서를 HTTP 메서드 기준(GET → POST → PATCH → DELETE)으로 정렬
- 참여 직전 화면 진입용 GET 엔드포인트 3개의 summary 워딩을 실제 역할에 맞게 수정

## Action

### 메서드 재정렬

- `TournamentApi`: 15개 메서드를 GET(6개) → POST(7개) → PATCH(1개) → DELETE(1개) 순으로 재정렬. 기존에는 GET-POST-DELETE-PATCH-GET(혼재) 순으로 뒤섞여 있었음
- `TournamentItemApi`: `getTournamentItem`(GET)이 마지막에 있었고, 나머지 POST/PATCH/DELETE 순서는 이미 맞아 해당 메서드를 첫 번째로 이동하는 것만으로 정렬 완료

### summary 워딩 수정

- 대상: `getInvitePreview`, `getInvitePreviewByCode`, `getPlayLinkInfo` 3개
- "입장"은 토너먼트에 실제 합류한다는 뉘앙스라 GET 조회 엔드포인트에 부적절
- "미리보기"는 참여 직전 화면 진입이라는 UX 맥락을 충분히 전달하지 못함
- "진입"은 화면/흐름에 들어가는 중립적 표현으로 세 엔드포인트 모두에 균일하게 적용 가능 → "초대 링크로 참여 화면 진입", "초대 코드로 참여 화면 진입", "플레이 링크로 참여 화면 진입"으로 통일

## Result

- API 문서에서 같은 HTTP 메서드끼리 모여 빠르게 훑어볼 수 있음
- summary만 보고 실제 join 동작(POST)인지 화면 진입용 조회(GET)인지 구분 가능해짐

---
## 연관 이슈

- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 토너먼트 초대 링크와 플레이 링크 생성 관련 API의 오류 응답 설명을 추가하여 시스템의 제약 조건 및 문제 상황 정보의 명확성을 개선
  * 토너먼트 아이템 조회 API 문서화를 개선하여 API 명세의 일관성 및 가독성을 강화

* **Chores**
  * 토너먼트 API 엔드포인트의 논리적 배치를 정렬하여 코드 구조 최적화
  * 코드 스타일 및 포맷팅 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->