### PR TITLE
토너먼트 시작 시 참여자 실시간 진입을 위한 SSE 알림 추가

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/notification/domain/NotificationType.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/domain/NotificationType.kt
@@ -5,6 +5,7 @@ package com.depromeet.piki.notification.domain
 enum class NotificationType {
     TOURNAMENT_JOINED,
     TOURNAMENT_ITEM_ADDED,
+    TOURNAMENT_STARTED,
     ITEM_PARSING_COMPLETED,
     ITEM_PARSING_FAILED,
 }

--- a/src/main/kotlin/com/depromeet/piki/notification/handler/TournamentStartedHandler.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/handler/TournamentStartedHandler.kt
@@ -1,0 +1,23 @@
+package com.depromeet.piki.notification.handler
+
+import com.depromeet.piki.notification.domain.NotificationType
+import com.depromeet.piki.tournament.event.TournamentStarted
+import com.depromeet.piki.tournament.repository.TournamentUserRepository
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+// 토너먼트 시작 알림. 주최자가 시작하면 나머지 참가자에게 "OO님이 토너먼트를 시작했어요" 를 보내 함께 진입하게 한다.
+// 시작시킨 본인(actor=주최자)은 자기 화면이 이미 시작 상태로 넘어가므로 제외한다 — joined/itemAdded 와 같은 actor 제외 패턴.
+@Component
+class TournamentStartedHandler(
+    private val tournamentUserRepository: TournamentUserRepository,
+    private val actorNameResolver: ActorNameResolver,
+) : NotificationEventHandler<TournamentStarted>(NotificationType.TOURNAMENT_STARTED) {
+    override fun resolveRefId(event: TournamentStarted): Long = event.tournamentId
+
+    override fun resolveRecipients(event: TournamentStarted): Set<UUID> =
+        tournamentUserRepository.findByTournamentId(event.tournamentId).map { it.userId }.toSet() - event.actorId
+
+    override fun resolveVariables(event: TournamentStarted): Map<String, String> =
+        mapOf("actorName" to actorNameResolver.resolve(event.actorId))
+}

--- a/src/main/kotlin/com/depromeet/piki/notification/service/InMemoryNotificationTemplateProvider.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/service/InMemoryNotificationTemplateProvider.kt
@@ -13,6 +13,8 @@ class InMemoryNotificationTemplateProvider : NotificationTemplateProvider {
                 NotificationTemplate(title = "\${actorName}님이 참가했어요", body = ""),
             NotificationType.TOURNAMENT_ITEM_ADDED to
                 NotificationTemplate(title = "\${actorName}님이 아이템을 추가했어요", body = ""),
+            NotificationType.TOURNAMENT_STARTED to
+                NotificationTemplate(title = "\${actorName}님이 토너먼트를 시작했어요", body = ""),
             NotificationType.ITEM_PARSING_COMPLETED to
                 NotificationTemplate(title = "상품 정보가 저장됐어요", body = ""),
             NotificationType.ITEM_PARSING_FAILED to

--- a/src/main/kotlin/com/depromeet/piki/notification/service/NotificationEventListener.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/service/NotificationEventListener.kt
@@ -5,6 +5,7 @@ import com.depromeet.piki.item.event.ItemParsingCompleted
 import com.depromeet.piki.item.event.ItemParsingFailed
 import com.depromeet.piki.tournament.event.TournamentItemAdded
 import com.depromeet.piki.tournament.event.TournamentJoined
+import com.depromeet.piki.tournament.event.TournamentStarted
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
 import org.springframework.transaction.event.TransactionPhase
@@ -39,6 +40,12 @@ class NotificationEventListener(
     @Async(AsyncConfig.NOTIFICATION_EXECUTOR)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     fun on(event: TournamentJoined) {
+        dispatcher.dispatch(event)
+    }
+
+    @Async(AsyncConfig.NOTIFICATION_EXECUTOR)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun on(event: TournamentStarted) {
         dispatcher.dispatch(event)
     }
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/event/TournamentStarted.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/event/TournamentStarted.kt
@@ -1,0 +1,11 @@
+package com.depromeet.piki.tournament.event
+
+import java.util.UUID
+
+// 토너먼트 시작 — 도메인 사실. 주최자가 PENDING→IN_PROGRESS 로 전이시킨 순간이다. actorId 는 시작시킨 주최자.
+// 수신자(참여자 − 주최자)에게 알려, 주최자의 시작 버튼만으로 나머지 참여자도 함께 토너먼트로 진입하게 한다 —
+// 시작 시점은 클라가 알 방법이 없어 서버 push 로만 전달된다.
+data class TournamentStarted(
+    val tournamentId: Long,
+    val actorId: UUID,
+)

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
@@ -163,8 +163,11 @@ class TournamentService(
         userId: UUID,
         tournamentId: Long,
     ): List<TournamentStartResult> {
+        // 상태 전이(PENDING→IN_PROGRESS) + 이벤트 발행을 하므로 행 락으로 읽는다. 락 없이 읽으면 동시 요청이 둘 다
+        // PENDING 검증을 통과해 TournamentStarted 를 중복 발행(참가자에게 시작 알림 중복 도달)할 수 있다.
+        // 다른 상태 전이 메서드(join·recordMatch 등)와 동일한 forUpdate 패턴.
         val tournament =
-            tournamentRepository.findTournamentById(tournamentId)
+            tournamentRepository.findTournamentByIdForUpdate(tournamentId)
                 ?: throw TournamentException.notFoundTournament()
         if (!tournament.isPending()) throw TournamentException.notPendingTournament()
         val owner =

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
@@ -10,6 +10,7 @@ import com.depromeet.piki.tournament.domain.TournamentStatus
 import com.depromeet.piki.tournament.domain.TournamentUser
 import com.depromeet.piki.tournament.event.TournamentItemAdded
 import com.depromeet.piki.tournament.event.TournamentJoined
+import com.depromeet.piki.tournament.event.TournamentStarted
 import com.depromeet.piki.tournament.repository.TournamentItemRepository
 import com.depromeet.piki.tournament.repository.TournamentRepository
 import com.depromeet.piki.tournament.repository.TournamentUserRepository
@@ -190,6 +191,8 @@ class TournamentService(
         }
 
         tournament.start()
+        // 시작이 커밋된 뒤에만 참가자에게 전달되도록 트랜잭션 안에서 발행한다 (롤백 시 미발행).
+        eventPublisher.publishEvent(TournamentStarted(tournamentId = tournamentId, actorId = userId))
         return tournamentItems
             .map { tournamentItem ->
                 val snapshot = tournamentItem.requireSnapshot(snapshotById)

--- a/src/test/kotlin/com/depromeet/piki/notification/handler/NotificationEventHandlerTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/notification/handler/NotificationEventHandlerTest.kt
@@ -6,6 +6,7 @@ import com.depromeet.piki.notification.domain.NotificationType
 import com.depromeet.piki.support.IntegrationTestSupport
 import com.depromeet.piki.tournament.event.TournamentItemAdded
 import com.depromeet.piki.tournament.event.TournamentJoined
+import com.depromeet.piki.tournament.event.TournamentStarted
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import kotlin.test.assertEquals
@@ -21,6 +22,8 @@ class NotificationEventHandlerTest : IntegrationTestSupport() {
 
     @Autowired private lateinit var tournamentJoinedHandler: TournamentJoinedHandler
 
+    @Autowired private lateinit var tournamentStartedHandler: TournamentStartedHandler
+
     @Autowired private lateinit var handlers: List<NotificationEventHandler<*>>
 
     // eventType 은 제네릭 타입 인자 E 에서 GenericTypeResolver 로 자동 도출된다(::class 명시 제거).
@@ -31,6 +34,7 @@ class NotificationEventHandlerTest : IntegrationTestSupport() {
         assertEquals(ItemParsingFailed::class, itemParsingFailedHandler.eventType)
         assertEquals(TournamentItemAdded::class, tournamentItemAddedHandler.eventType)
         assertEquals(TournamentJoined::class, tournamentJoinedHandler.eventType)
+        assertEquals(TournamentStarted::class, tournamentStartedHandler.eventType)
     }
 
     @Test
@@ -39,6 +43,7 @@ class NotificationEventHandlerTest : IntegrationTestSupport() {
         assertEquals(NotificationType.ITEM_PARSING_FAILED, itemParsingFailedHandler.notificationType)
         assertEquals(NotificationType.TOURNAMENT_ITEM_ADDED, tournamentItemAddedHandler.notificationType)
         assertEquals(NotificationType.TOURNAMENT_JOINED, tournamentJoinedHandler.notificationType)
+        assertEquals(NotificationType.TOURNAMENT_STARTED, tournamentStartedHandler.notificationType)
     }
 
     // Dispatcher 는 eventType 으로 라우팅하므로 키가 유일해야 한다(중복이면 associateBy 가 조용히 덮어쓴다).

--- a/src/test/kotlin/com/depromeet/piki/notification/handler/NotificationRecipientResolutionIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/notification/handler/NotificationRecipientResolutionIntegrationTest.kt
@@ -7,6 +7,7 @@ import com.depromeet.piki.tournament.domain.TournamentItem
 import com.depromeet.piki.tournament.domain.TournamentUser
 import com.depromeet.piki.tournament.event.TournamentItemAdded
 import com.depromeet.piki.tournament.event.TournamentJoined
+import com.depromeet.piki.tournament.event.TournamentStarted
 import com.depromeet.piki.tournament.repository.TournamentItemRepository
 import com.depromeet.piki.tournament.repository.TournamentUserRepository
 import com.depromeet.piki.user.domain.IdentityType
@@ -28,6 +29,8 @@ class NotificationRecipientResolutionIntegrationTest : IntegrationTestSupport() 
     @Autowired private lateinit var itemAddedHandler: TournamentItemAddedHandler
 
     @Autowired private lateinit var joinedHandler: TournamentJoinedHandler
+
+    @Autowired private lateinit var startedHandler: TournamentStartedHandler
 
     @Autowired private lateinit var parsingCompletedHandler: ItemParsingCompletedHandler
 
@@ -66,6 +69,31 @@ class NotificationRecipientResolutionIntegrationTest : IntegrationTestSupport() 
         val recipients = joinedHandler.resolveRecipients(TournamentJoined(tournamentId, joiner))
 
         assertEquals(setOf(existing1, existing2), recipients)
+    }
+
+    @Test
+    fun `토너먼트 시작 수신자는 참가자에서 시작시킨 주최자(actor)를 뺀 집합이다`() {
+        val tournamentId = 1007L
+        val owner = UUID.randomUUID()
+        val participant1 = UUID.randomUUID()
+        val participant2 = UUID.randomUUID()
+        // 주최자는 본인 화면이 이미 시작 상태로 넘어가므로, 나머지 참가자에게만 시작을 알린다.
+        listOf(owner, participant1, participant2).forEach { tournamentUserRepository.save(TournamentUser(tournamentId, it)) }
+
+        val recipients = startedHandler.resolveRecipients(TournamentStarted(tournamentId, owner))
+
+        assertEquals(setOf(participant1, participant2), recipients)
+    }
+
+    @Test
+    fun `토너먼트 시작 변수 actorName 은 시작시킨 주최자 닉네임이다`() {
+        val tournamentId = 1008L
+        val owner = UUID.randomUUID()
+        userRepository.save(User(id = owner, nickname = "주최자", profileImage = "https://x/p.jpg", identityType = IdentityType.GUEST))
+
+        val variables = startedHandler.resolveVariables(TournamentStarted(tournamentId, owner))
+
+        assertEquals(mapOf("actorName" to "주최자"), variables)
     }
 
     @Test

--- a/src/test/kotlin/com/depromeet/piki/notification/service/InMemoryNotificationTemplateProviderTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/notification/service/InMemoryNotificationTemplateProviderTest.kt
@@ -24,6 +24,12 @@ class InMemoryNotificationTemplateProviderTest {
     }
 
     @Test
+    fun `TOURNAMENT_STARTED 템플릿은 actorName 플레이스홀더를 담는다`() {
+        val template = provider.find(NotificationType.TOURNAMENT_STARTED)
+        assertTrue(template.title.contains("\${actorName}"))
+    }
+
+    @Test
     fun `변수가 없는 ITEM_PARSING_COMPLETED 템플릿은 플레이스홀더가 없다`() {
         val template = provider.find(NotificationType.ITEM_PARSING_COMPLETED)
         assertTrue(!template.title.contains("\${"))

--- a/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentStartConcurrencyIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentStartConcurrencyIntegrationTest.kt
@@ -1,0 +1,130 @@
+package com.depromeet.piki.tournament.controller
+
+import com.depromeet.piki.auth.infrastructure.jwt.JwtProvider
+import com.depromeet.piki.item.domain.Item
+import com.depromeet.piki.item.domain.ItemSnapshot
+import com.depromeet.piki.item.domain.ItemStatus
+import com.depromeet.piki.item.repository.ItemJpaRepository
+import com.depromeet.piki.item.repository.ItemSnapshotJpaRepository
+import com.depromeet.piki.support.IntegrationTestSupport
+import com.depromeet.piki.support.uuidToBytes
+import com.depromeet.piki.tournament.domain.TournamentItem
+import com.depromeet.piki.tournament.repository.TournamentItemJpaRepository
+import com.depromeet.piki.user.domain.IdentityType
+import com.depromeet.piki.user.domain.User
+import com.depromeet.piki.user.repository.UserJpaRepository
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.web.context.WebApplicationContext
+import tools.jackson.databind.ObjectMapper
+import java.time.LocalDateTime
+import java.util.UUID
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.assertEquals
+
+// start 는 PENDING→IN_PROGRESS 상태 전이와 TournamentStarted 발행을 함께 한다. 락 없이 읽으면 동시 두 요청이
+// 모두 PENDING 검증을 통과해 시작 알림을 중복 발행(참가자에게 시작 알림 2번 도달)할 수 있어, forUpdate 행 락으로
+// 직렬화한다. "정확히 1개만 200, 나머지는 409" 가 그 락 동작의 시그니처다 — 200 이 1개 = start 성공(곧 발행) 1회.
+//
+// 일반 통합 테스트와 달리 @Transactional 을 쓰지 않는다 — 별도 트랜잭션 동시 진행이 race 시뮬레이션의 본질이다.
+// 데이터 격리는 새 UUID 를 쓰고 finally 에서 직접 정리한다.
+class TournamentStartConcurrencyIntegrationTest : IntegrationTestSupport() {
+    @Autowired private lateinit var webApplicationContext: WebApplicationContext
+    @Autowired private lateinit var objectMapper: ObjectMapper
+    @Autowired private lateinit var jwtProvider: JwtProvider
+    @Autowired private lateinit var userJpaRepository: UserJpaRepository
+    @Autowired private lateinit var itemJpaRepository: ItemJpaRepository
+    @Autowired private lateinit var itemSnapshotJpaRepository: ItemSnapshotJpaRepository
+    @Autowired private lateinit var tournamentItemJpaRepository: TournamentItemJpaRepository
+    @Autowired private lateinit var jdbcTemplate: JdbcTemplate
+
+    @Test
+    fun `같은 주최자가 start 를 동시에 두 번 요청하면 하나만 200 나머지는 409 로 처리된다`() {
+        val ownerId = UUID.randomUUID()
+        userJpaRepository.save(
+            User(id = ownerId, nickname = "race-start", profileImage = "https://cdn.example.com/o.jpg", identityType = IdentityType.GUEST),
+        )
+
+        val mockMvc = MockMvcBuilders
+            .webAppContextSetup(webApplicationContext)
+            .apply<DefaultMockMvcBuilder>(springSecurity())
+            .build()
+
+        val ownerAuth = "Bearer ${jwtProvider.generateAccessToken(ownerId, IdentityType.GUEST)}"
+
+        // PENDING 토너먼트 + READY 아이템 2개 준비 (단일 스레드, 직렬). @Transactional 이 없어 실제 커밋되므로,
+        // 만든 item/snapshot id 를 끝의 정리에서 쓰기 위해 메서드 스코프로 잡는다(다른 테스트의 item 카운트 오염 방지).
+        val createResult = mockMvc.perform(
+            post("/api/v1/tournaments")
+                .header(HttpHeaders.AUTHORIZATION, ownerAuth)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"name":"start동시성토너먼트"}"""),
+        ).andReturn()
+        val tournamentId = objectMapper.readTree(createResult.response.contentAsString)["data"]["tournamentId"].asLong()
+
+        // tournament_item 은 고정 snapshot 을 참조한다(4a). item 은 정체성(link)만 들고, 표시값·상태는 READY snapshot 이 보유한다.
+        val item1 = itemJpaRepository.save(Item())
+        val item2 = itemJpaRepository.save(Item())
+        val snapshot1 = itemSnapshotJpaRepository.save(
+            ItemSnapshot(itemId = item1.getId(), name = "race-item1", currentPrice = 10_000, currency = "KRW", status = ItemStatus.READY, extractedAt = LocalDateTime.now()),
+        )
+        val snapshot2 = itemSnapshotJpaRepository.save(
+            ItemSnapshot(itemId = item2.getId(), name = "race-item2", currentPrice = 20_000, currency = "KRW", status = ItemStatus.READY, extractedAt = LocalDateTime.now()),
+        )
+        tournamentItemJpaRepository.save(TournamentItem(tournamentId = tournamentId, itemId = item1.getId(), userId = ownerId, snapshotId = snapshot1.getId()))
+        tournamentItemJpaRepository.save(TournamentItem(tournamentId = tournamentId, itemId = item2.getId(), userId = ownerId, snapshotId = snapshot2.getId()))
+
+        val status200 = AtomicInteger(0)
+        val status409 = AtomicInteger(0)
+        val executor = Executors.newFixedThreadPool(2)
+        val ready = CountDownLatch(2)
+        val start = CountDownLatch(1)
+        val done = CountDownLatch(2)
+
+        repeat(2) {
+            executor.submit {
+                ready.countDown()
+                start.await()
+                try {
+                    val res = mockMvc.perform(
+                        post("/api/v1/tournaments/$tournamentId/start")
+                            .header(HttpHeaders.AUTHORIZATION, ownerAuth),
+                    ).andReturn()
+                    when (res.response.status) {
+                        200 -> status200.incrementAndGet()
+                        409 -> status409.incrementAndGet()
+                    }
+                } finally {
+                    done.countDown()
+                }
+            }
+        }
+
+        ready.await()
+        start.countDown()
+        done.await(10, TimeUnit.SECONDS)
+        executor.shutdown()
+
+        assertEquals(1, status200.get(), "정확히 하나만 200 이어야 한다 (start 성공 1회 = 발행 1회)")
+        assertEquals(1, status409.get(), "나머지 하나는 락 대기 후 PENDING 아님으로 409 여야 한다")
+
+        // 정리 — @Transactional 자동 롤백이 없으므로 만든 행을 전부 직접 지운다. item/snapshot 까지 지워야
+        // 다른 테스트(예: AdminItemControllerIntegrationTest)의 전체 item 카운트가 오염되지 않는다.
+        jdbcTemplate.update("DELETE FROM tournament_items WHERE tournament_id = ?", tournamentId)
+        jdbcTemplate.update("DELETE FROM tournament_users WHERE tournament_id = ?", tournamentId)
+        jdbcTemplate.update("DELETE FROM tournaments WHERE id = ?", tournamentId)
+        jdbcTemplate.update("DELETE FROM item_snapshots WHERE id IN (?, ?)", snapshot1.getId(), snapshot2.getId())
+        jdbcTemplate.update("DELETE FROM items WHERE id IN (?, ?)", item1.getId(), item2.getId())
+        jdbcTemplate.update("DELETE FROM users WHERE id = ?", uuidToBytes(ownerId))
+    }
+}

--- a/src/test/kotlin/com/depromeet/piki/tournament/service/TournamentServiceTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/service/TournamentServiceTest.kt
@@ -13,6 +13,7 @@ import com.depromeet.piki.tournament.domain.TournamentStatus
 import com.depromeet.piki.tournament.domain.TournamentUser
 import com.depromeet.piki.tournament.event.TournamentItemAdded
 import com.depromeet.piki.tournament.event.TournamentJoined
+import com.depromeet.piki.tournament.event.TournamentStarted
 import com.depromeet.piki.tournament.repository.TournamentItemRepository
 import com.depromeet.piki.tournament.repository.TournamentRepository
 import com.depromeet.piki.tournament.repository.TournamentUserRepository
@@ -554,6 +555,18 @@ class TournamentServiceTest {
         service.start(userId, tournamentId)
 
         assertEquals(TournamentStatus.IN_PROGRESS, repository.tournaments[tournamentId]!!.status)
+    }
+
+    @Test
+    fun `start 는 시작 후 시작시킨 주최자를 actor 로 하는 TournamentStarted 이벤트를 발행한다`() {
+        val tournamentId = service.create(userId, CreateTournament("토너먼트")).tournamentId
+        testWishRepository.addWish(userId, 1L, 2L)
+        service.addItemsFromWish(userId, AddTournamentItemsFromWish(tournamentId, listOf(1L, 2L)))
+        publishedEvents.clear() // addItemsFromWish 가 발행한 TournamentItemAdded 를 비우고 start 발행만 본다
+
+        service.start(userId, tournamentId)
+
+        assertEquals(listOf<Any>(TournamentStarted(tournamentId, userId)), publishedEvents)
     }
 
     @Test


### PR DESCRIPTION
## Situation
- 주최자가 토너먼트 '시작하기'를 누르면, 초대받은 참여자도 같은 순간 토너먼트 화면으로 함께 진입해야 한다 (기획상 반드시 그래야 하는 흐름). 그런데 시작은 주최자 기기에서만 일어나는 행동이라, 다른 참여자의 클라이언트는 그 순간을 스스로 알 방법이 없다.
- 현재 SSE 실시간 알림은 4종(친구 참여, 아이템 추가, 파싱 완료, 파싱 실패)뿐이고 '토너먼트 시작' 알림이 없었다. 시작 시점을 참여자에게 밀어줄 통로가 비어 있던 셈이다.

## Task
- 토너먼트 시작 순간을 서버가 참여자에게 실시간으로 밀어주는 알림을 추가한다. 클라이언트는 이 신호를 받아 토너먼트 화면으로 전환한다.
- 정책 결정: 이 알림을 누가 받아야 하는가.

## Action
- 시작 순간을 알리는 새 알림 종류 하나를 추가했다. 기존 4개 알림이 쓰는 발행 흐름(도메인 사실 발행, 커밋 후 비동기 수신, 수신자 결정, 저장, 채널 전달)을 그대로 타므로, 새로 만든 것은 이 흐름에 꽂는 조각들뿐이다.

### 수신자 정책
- 시작 알림은 주최자를 뺀 나머지 참여자 전원에게 간다. 주최자 본인은 자기가 시작 버튼을 눌러 이미 화면이 넘어가므로 다시 알릴 필요가 없다. '친구 참여', '아이템 추가' 알림이 행동한 본인을 빼는 것과 같은 규칙이다.

| 알림 | 받는 사람 |
| --- | --- |
| TOURNAMENT_STARTED | 그 토너먼트 참여자 전원에서 시작시킨 주최자만 제외 |

### 문구
- "OO님이 토너먼트를 시작했어요"처럼 주최자 이름을 넣는 문구로 두었다. 고정 문구로 둘 수도 있었지만, 같은 토너먼트 계열인 '친구 참여', '아이템 추가' 알림이 이미 이름을 넣는 형식이라 표현을 맞췄다.

### 구현
- 도메인 이벤트 `TournamentStarted`, 알림 종류 `TOURNAMENT_STARTED`, 전용 핸들러 `TournamentStartedHandler`, 알림 문구 템플릿을 각각 추가했다.
- 토너먼트 시작 메서드가 상태를 진행 중으로 바꾼 직후, 트랜잭션 안에서 이벤트를 발행한다. 커밋된 뒤에만 발송되고 롤백되면 알림도 나가지 않는다.

## Result
- 클라이언트는 기존 단일 SSE 스트림(구독 엔드포인트 그대로)에서 `type=TOURNAMENT_STARTED`, `refId=토너먼트 ID`를 받는다. 프론트는 이 type을 시작 화면 진입 트리거로 쓰면 된다. payload 스키마가 알림 종류를 enum으로 노출하므로 OpenAPI 문서에는 별도 수정 없이 자동 반영된다.
- SSE 자체는 best-effort라, 연결이 끊긴 참여자는 그 순간 신호를 놓칠 수 있다. 지금은 클라이언트 재연결로 보완하는 수준이고, 더 강한 도달 보장이 필요하면 별도 논의가 필요하다.

---
## 연관 이슈

- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 토너먼트 시작 시 다른 참가자들에게 알림 발송 기능 추가

* **테스트**
  * 토너먼트 시작 알림 처리 관련 단위 및 통합 테스트 추가
  * 알림 수신자 해석 및 템플릿 검증 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->