### PR TITLE
TournamentController 메서드 순서 정렬

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentController.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentController.kt
@@ -60,6 +60,39 @@ class TournamentController(
         return ApiResponseBody.ok(TournamentDetailResponse.from(detail))
     }
 
+    @GetMapping("/{tournamentId}/invite-preview")
+    override fun getInvitePreview(
+        @PathVariable tournamentId: Long,
+    ): ApiResponseBody<TournamentInvitePreviewResponse> {
+        val preview = tournamentService.getInvitePreview(tournamentId)
+        return ApiResponseBody.ok(TournamentInvitePreviewResponse.from(preview))
+    }
+
+    @GetMapping("/by-invite-code")
+    override fun getInvitePreviewByCode(
+        @RequestParam code: String,
+    ): ApiResponseBody<TournamentInvitePreviewResponse> {
+        val preview = tournamentService.getInvitePreviewByCode(code)
+        return ApiResponseBody.ok(TournamentInvitePreviewResponse.from(preview))
+    }
+
+    @GetMapping("/{tournamentId}/play-link-info")
+    override fun getPlayLinkInfo(
+        @PathVariable tournamentId: Long,
+    ): ApiResponseBody<PlayLinkInfoResponse> {
+        val info = tournamentService.getPlayLinkInfo(tournamentId)
+        return ApiResponseBody.ok(PlayLinkInfoResponse.from(info))
+    }
+
+    @GetMapping("/{tournamentId}/group-result")
+    override fun getGroupResult(
+        @AuthenticationPrincipal userId: UUID,
+        @PathVariable tournamentId: Long,
+    ): ApiResponseBody<GroupResultResponse> {
+        val result = tournamentService.getGroupResult(userId, tournamentId)
+        return ApiResponseBody.ok(GroupResultResponse.from(result))
+    }
+
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     override fun create(
@@ -68,6 +101,15 @@ class TournamentController(
     ): ApiResponseBody<CreateTournamentResponse> {
         val result = tournamentService.create(userId, request.toCreateTournament())
         return ApiResponseBody.created(CreateTournamentResponse.from(result))
+    }
+
+    @PostMapping("/{tournamentId}/start")
+    override fun start(
+        @AuthenticationPrincipal userId: UUID,
+        @PathVariable tournamentId: Long,
+    ): ApiResponseBody<TournamentStartResponse> {
+        val result = tournamentService.start(userId, tournamentId)
+        return ApiResponseBody.ok(TournamentStartResponse.from(result))
     }
 
     @PostMapping("/{tournamentId}/join")
@@ -90,15 +132,6 @@ class TournamentController(
         return ApiResponseBody.created(JoinTournamentAsGuestResponse.from(result))
     }
 
-    @PostMapping("/{tournamentId}/start")
-    override fun start(
-        @AuthenticationPrincipal userId: UUID,
-        @PathVariable tournamentId: Long,
-    ): ApiResponseBody<TournamentStartResponse> {
-        val result = tournamentService.start(userId, tournamentId)
-        return ApiResponseBody.ok(TournamentStartResponse.from(result))
-    }
-
     @PostMapping("/{tournamentId}/matches")
     override fun recordMatch(
         @AuthenticationPrincipal userId: UUID,
@@ -109,41 +142,6 @@ class TournamentController(
         return ApiResponseBody.ok(result?.let { TournamentDetailResponse.CompletedData.from(it) })
     }
 
-    @DeleteMapping("/{tournamentId}")
-    override fun deleteTournament(
-        @AuthenticationPrincipal userId: UUID,
-        @PathVariable tournamentId: Long,
-    ): ApiResponseBody<Unit> {
-        tournamentService.deleteTournament(userId, tournamentId)
-        return ApiResponseBody.ok()
-    }
-
-    @PatchMapping("/{tournamentId}/invite")
-    override fun updateInviteExpiry(
-        @AuthenticationPrincipal userId: UUID,
-        @PathVariable tournamentId: Long,
-        @Valid @RequestBody request: UpdateInviteDurationRequest,
-    ): ApiResponseBody<LocalDateTime> {
-        val newExpiresAt = tournamentService.updateInviteExpiry(userId, tournamentId, request.inviteDurationMinutes)
-        return ApiResponseBody.ok(newExpiresAt)
-    }
-
-    @GetMapping("/{tournamentId}/invite-preview")
-    override fun getInvitePreview(
-        @PathVariable tournamentId: Long,
-    ): ApiResponseBody<TournamentInvitePreviewResponse> {
-        val preview = tournamentService.getInvitePreview(tournamentId)
-        return ApiResponseBody.ok(TournamentInvitePreviewResponse.from(preview))
-    }
-
-    @GetMapping("/by-invite-code")
-    override fun getInvitePreviewByCode(
-        @RequestParam code: String,
-    ): ApiResponseBody<TournamentInvitePreviewResponse> {
-        val preview = tournamentService.getInvitePreviewByCode(code)
-        return ApiResponseBody.ok(TournamentInvitePreviewResponse.from(preview))
-    }
-
     @PostMapping("/{tournamentId}/play-link")
     override fun createPlayLink(
         @AuthenticationPrincipal userId: UUID,
@@ -151,14 +149,6 @@ class TournamentController(
     ): ApiResponseBody<LocalDateTime> {
         val expiresAt = tournamentService.createPlayLink(userId, tournamentId)
         return ApiResponseBody.ok(expiresAt)
-    }
-
-    @GetMapping("/{tournamentId}/play-link-info")
-    override fun getPlayLinkInfo(
-        @PathVariable tournamentId: Long,
-    ): ApiResponseBody<PlayLinkInfoResponse> {
-        val info = tournamentService.getPlayLinkInfo(tournamentId)
-        return ApiResponseBody.ok(PlayLinkInfoResponse.from(info))
     }
 
     @PostMapping("/{sourceTournamentId}/from-play-link")
@@ -171,12 +161,22 @@ class TournamentController(
         return ApiResponseBody.created(newTournamentId)
     }
 
-    @GetMapping("/{tournamentId}/group-result")
-    override fun getGroupResult(
+    @PatchMapping("/{tournamentId}/invite")
+    override fun updateInviteExpiry(
         @AuthenticationPrincipal userId: UUID,
         @PathVariable tournamentId: Long,
-    ): ApiResponseBody<GroupResultResponse> {
-        val result = tournamentService.getGroupResult(userId, tournamentId)
-        return ApiResponseBody.ok(GroupResultResponse.from(result))
+        @Valid @RequestBody request: UpdateInviteDurationRequest,
+    ): ApiResponseBody<LocalDateTime> {
+        val newExpiresAt = tournamentService.updateInviteExpiry(userId, tournamentId, request.inviteDurationMinutes)
+        return ApiResponseBody.ok(newExpiresAt)
+    }
+
+    @DeleteMapping("/{tournamentId}")
+    override fun deleteTournament(
+        @AuthenticationPrincipal userId: UUID,
+        @PathVariable tournamentId: Long,
+    ): ApiResponseBody<Unit> {
+        tournamentService.deleteTournament(userId, tournamentId)
+        return ApiResponseBody.ok()
     }
 }


### PR DESCRIPTION
## Situation

- `TournamentApi.kt` 메서드 순서는 GET-POST-PATCH-DELETE 로 정렬했으나, SpringDoc 는 컨트롤러의 메서드 순서를 기준으로 OpenAPI spec 을 생성하므로 Swagger UI 에 반영되지 않았음

## Task

- `TournamentController.kt` 메서드 순서를 `TournamentApi.kt` 와 동일하게 GET-POST-PATCH-DELETE 로 정렬

## Action

- GET(6개) → POST(7개) → PATCH(1개) → DELETE(1개) 순으로 재정렬
- `TournamentItemController.kt` 는 이미 순서가 맞아 변경 없음

## Result

- Swagger UI 에서 GET-POST-PATCH-DELETE 순서로 노출됨

---
## 연관 이슈

- 