### PR TITLE
ROOT IN_PROGRESS 시 참여자 대기 화면 정보 유지 (ownerStarted 플래그)

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
@@ -75,10 +75,15 @@ interface TournamentApi {
             응답의 status 필드에 따라 포함되는 데이터가 달라진다.
             - PENDING: pending 필드 (아이템 목록, 참여자 목록)
               - 각 아이템에 status 포함 (READY / PENDING / PROCESSING / FAILED). PENDING·PROCESSING 이면 name·price·imageUrl 은 null 이라 응답에서 제외됨
-            - IN_PROGRESS: inProgress 필드
-              - currentRound: 다음에 진행할 라운드 번호
-              - lastHistory: 가장 최근에 기록된 매치 결과. 라운드 전환 직후에는 currentRound와 다른 라운드의 매치일 수 있음. 매치 기록이 없으면 null
-              - remainingItems: 현재 라운드에서 아직 대결하지 않은 생존 아이템 목록, 가격 오름차순. 이 순서가 클라이언트의 매치 페어링 순서([0]vs[1], [2]vs[3] …)를 결정함. 각 아이템에 status 포함
+              - pending.ownerStarted = false
+            - IN_PROGRESS: 요청자 역할에 따라 두 가지 응답이 있다.
+              - 소유자(isOwner=true) 또는 이미 매치를 시작한 멤버: inProgress 필드
+                - currentRound: 다음에 진행할 라운드 번호
+                - lastHistory: 가장 최근에 기록된 매치 결과. 라운드 전환 직후에는 currentRound와 다른 라운드의 매치일 수 있음. 매치 기록이 없으면 null
+                - remainingItems: 현재 라운드에서 아직 대결하지 않은 생존 아이템 목록, 가격 오름차순. 이 순서가 클라이언트의 매치 페어링 순서([0]vs[1], [2]vs[3] …)를 결정함
+              - 아직 매치를 시작하지 않은 멤버(isOwner=false): pending 필드 (ROOT 아이템·참여자 목록)
+                - pending.ownerStarted = true. 클라이언트는 이 플래그로 "주최자 대기" vs "주최자 시작 완료·지금 시작하세요" UI 를 분기한다
+                - pending.inviteCode, pending.inviteExpiresAt 은 null (초대 기간 종료)
             - COMPLETED: completed 필드
               - result: 1위부터 최대 4위까지 순위 아이템 목록
               - hasGroupResult: 참여자 2명 이상이면 true. 클라이언트는 이 값으로 친구 토너먼트 결과 보기 버튼을 제어한다.

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
@@ -71,7 +71,9 @@ interface TournamentApi {
         summary = "토너먼트 단건 조회",
         description = """
             토너먼트 ID로 상태에 따른 상세 정보를 조회한다.
-            isOwner: 요청자가 토너먼트 소유자이면 true. 클라이언트는 이 값으로 위시 추가·플레이링크 공유 버튼 등 소유자 전용 UI를 제어한다.
+            isOwner: 요청자가 해당 토너먼트 인스턴스(ROOT 또는 CLONE)의 소유자이면 true.
+            isRoot: 소셜 토너먼트 원본(ROOT)이면 true, 멤버·플레이링크용 복사본(CLONE)이면 false. 솔로 토너먼트는 항상 true.
+            플레이 링크 공유는 isRoot && isOwner 일 때만 허용된다. isOwner 단독으로 분기하면 CLONE 소유자에게도 공유 버튼이 노출되어 시안 위반이다.
             응답의 status 필드에 따라 포함되는 데이터가 달라진다.
             - PENDING: pending 필드 (아이템 목록, 참여자 목록)
               - 각 아이템에 status 포함 (READY / PENDING / PROCESSING / FAILED). PENDING·PROCESSING 이면 name·price·imageUrl 은 null 이라 응답에서 제외됨

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApiExamples.kt
@@ -244,6 +244,7 @@ class TournamentApiExamples(
                                         name = "내 토너먼트",
                                         status = TournamentStatus.PENDING,
                                         isOwner = true,
+                                        isRoot = true,
                                         pending =
                                             TournamentDetailResponse.PendingData(
                                                 inviteCode = "ABC123",
@@ -297,6 +298,7 @@ class TournamentApiExamples(
                                         name = "내 토너먼트",
                                         status = TournamentStatus.IN_PROGRESS,
                                         isOwner = false,
+                                        isRoot = true,
                                         pending =
                                             TournamentDetailResponse.PendingData(
                                                 inviteCode = null,
@@ -354,6 +356,7 @@ class TournamentApiExamples(
                                         name = "내 토너먼트",
                                         status = TournamentStatus.IN_PROGRESS,
                                         isOwner = false,
+                                        isRoot = false,
                                         pending = null,
                                         inProgress =
                                             TournamentDetailResponse.InProgressData(
@@ -401,6 +404,7 @@ class TournamentApiExamples(
                                         name = "내 토너먼트",
                                         status = TournamentStatus.COMPLETED,
                                         isOwner = true,
+                                        isRoot = true,
                                         pending = null,
                                         inProgress = null,
                                         completed =

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApiExamples.kt
@@ -289,6 +289,63 @@ class TournamentApiExamples(
                         )
                         add(
                             status = HttpStatus.OK,
+                            name = "IN_PROGRESS - 멤버 대기 중 (주최자 시작 완료, 본인 미시작)",
+                            payload =
+                                ApiResponseBody.ok(
+                                    TournamentDetailResponse(
+                                        tournamentId = 1,
+                                        name = "내 토너먼트",
+                                        status = TournamentStatus.IN_PROGRESS,
+                                        isOwner = false,
+                                        pending =
+                                            TournamentDetailResponse.PendingData(
+                                                inviteCode = null,
+                                                inviteExpiresAt = null,
+                                                items =
+                                                    listOf(
+                                                        TournamentDetailResponse.ItemDetailResponse(
+                                                            tournamentItemId = 1,
+                                                            itemId = 10,
+                                                            name = "나이키 에어맥스",
+                                                            price = 129_000,
+                                                            currency = "KRW",
+                                                            imageUrl = "https://cdn.example.com/items/1.jpg",
+                                                            status = ItemStatus.READY,
+                                                        ),
+                                                        TournamentDetailResponse.ItemDetailResponse(
+                                                            tournamentItemId = 2,
+                                                            itemId = 20,
+                                                            name = "아디다스 울트라부스트",
+                                                            price = 189_000,
+                                                            currency = "KRW",
+                                                            imageUrl = "https://cdn.example.com/items/2.jpg",
+                                                            status = ItemStatus.READY,
+                                                        ),
+                                                    ),
+                                                participants =
+                                                    listOf(
+                                                        TournamentDetailResponse.ParticipantResponse(
+                                                            userId = UUID.fromString("11111111-2222-3333-4444-555555555555"),
+                                                            nickname = "주최자",
+                                                            profileImage = "https://cdn.example.com/profiles/user1.jpg",
+                                                            isWithdrawn = false,
+                                                        ),
+                                                        TournamentDetailResponse.ParticipantResponse(
+                                                            userId = UUID.fromString("22222222-3333-4444-5555-666666666666"),
+                                                            nickname = "참여자",
+                                                            profileImage = "https://cdn.example.com/profiles/user2.jpg",
+                                                            isWithdrawn = false,
+                                                        ),
+                                                    ),
+                                                ownerStarted = true,
+                                            ),
+                                        inProgress = null,
+                                        completed = null,
+                                    ),
+                                ),
+                        )
+                        add(
+                            status = HttpStatus.OK,
                             name = "IN_PROGRESS - 진행 중 복원",
                             payload =
                                 ApiResponseBody.ok(

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/dto/TournamentDetailResponse.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/dto/TournamentDetailResponse.kt
@@ -62,10 +62,14 @@ data class TournamentDetailResponse(
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     data class PendingData(
-        val inviteCode: String,
-        val inviteExpiresAt: LocalDateTime,
+        // ownerStarted=true 이면 초대 기간이 이미 종료됐으므로 null
+        val inviteCode: String?,
+        val inviteExpiresAt: LocalDateTime?,
         val items: List<ItemDetailResponse>,
         val participants: List<ParticipantResponse>,
+        // true: ROOT 가 IN_PROGRESS 전환됐으나 이 멤버는 아직 매치 미시작.
+        // 클라이언트는 이 플래그로 "주최자 시작 대기" vs "주최자 시작 완료·지금 시작하세요" UI 를 분기한다.
+        val ownerStarted: Boolean = false,
     )
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -98,14 +102,16 @@ data class TournamentDetailResponse(
                     TournamentDetailResponse(
                         tournamentId = detail.tournamentId,
                         name = detail.name,
-                        status = TournamentStatus.PENDING,
+                        // ownerStarted=true 이면 실제 tournament 상태는 IN_PROGRESS 다.
+                        status = if (detail.ownerStarted) TournamentStatus.IN_PROGRESS else TournamentStatus.PENDING,
                         isOwner = detail.isOwner,
                         pending =
                             PendingData(
-                                inviteCode = detail.inviteCode,
-                                inviteExpiresAt = detail.inviteExpiresAt,
+                                inviteCode = if (detail.ownerStarted) null else detail.inviteCode,
+                                inviteExpiresAt = if (detail.ownerStarted) null else detail.inviteExpiresAt,
                                 items = detail.items.map { ItemDetailResponse.from(it) },
                                 participants = detail.participants.map { ParticipantResponse.from(it) },
+                                ownerStarted = detail.ownerStarted,
                             ),
                         inProgress = null,
                         completed = null,

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/dto/TournamentDetailResponse.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/dto/TournamentDetailResponse.kt
@@ -13,6 +13,9 @@ data class TournamentDetailResponse(
     val name: String,
     val status: TournamentStatus,
     val isOwner: Boolean,
+    // ROOT(소셜 토너먼트 원본) 이면 true, CLONE(멤버·플레이링크용 복사본) 이면 false.
+    // 플레이 링크 공유는 isRoot && isOwner 일 때만 허용된다.
+    val isRoot: Boolean,
     val pending: PendingData?,
     val inProgress: InProgressData?,
     val completed: CompletedData?,
@@ -105,6 +108,7 @@ data class TournamentDetailResponse(
                         // ownerStarted=true 이면 실제 tournament 상태는 IN_PROGRESS 다.
                         status = if (detail.ownerStarted) TournamentStatus.IN_PROGRESS else TournamentStatus.PENDING,
                         isOwner = detail.isOwner,
+                        isRoot = detail.isRoot,
                         pending =
                             PendingData(
                                 inviteCode = if (detail.ownerStarted) null else detail.inviteCode,
@@ -123,6 +127,7 @@ data class TournamentDetailResponse(
                         name = detail.name,
                         status = TournamentStatus.IN_PROGRESS,
                         isOwner = detail.isOwner,
+                        isRoot = detail.isRoot,
                         pending = null,
                         inProgress =
                             InProgressData(
@@ -139,6 +144,7 @@ data class TournamentDetailResponse(
                         name = detail.name,
                         status = TournamentStatus.COMPLETED,
                         isOwner = detail.isOwner,
+                        isRoot = detail.isRoot,
                         pending = null,
                         inProgress = null,
                         completed = CompletedData.from(detail),

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
@@ -283,6 +283,7 @@ class TournamentService(
         val currentUser = tournamentUserRepository.findByTournamentIdAndUserId(tournamentId, userId)
             ?: throw TournamentException.forbiddenTournament()
         val isOwner = currentUser.getId() == tournament.ownerTournamentUserId
+        val isRoot = tournament.sourceTournamentId?.let { false } ?: true
 
         return when (tournament.status) {
             TournamentStatus.PENDING -> {
@@ -314,6 +315,7 @@ class TournamentService(
                             }
                         },
                     isOwner = isOwner,
+                    isRoot = isRoot,
                 )
             }
 
@@ -359,6 +361,7 @@ class TournamentService(
                                 }
                             },
                             isOwner = false,
+                            isRoot = true,
                             ownerStarted = true,
                         )
                     }
@@ -395,6 +398,7 @@ class TournamentService(
                     lastHistory = lastHistory,
                     remainingItems = remainingItems,
                     isOwner = isOwner,
+                    isRoot = isRoot,
                 )
             }
 
@@ -571,6 +575,7 @@ class TournamentService(
         hasGroupResult: Boolean,
         isOwner: Boolean,
     ): TournamentDetail.Completed {
+        val isRoot = tournament.sourceTournamentId?.let { false } ?: true
         val rankedPairs = computeRanking(histories)
         val tournamentItemById = tournamentItemRepository
             .findByIds(rankedPairs.map { it.first })
@@ -594,6 +599,7 @@ class TournamentService(
             },
             hasGroupResult = hasGroupResult,
             isOwner = isOwner,
+            isRoot = isRoot,
             playLinkExpiresAt = tournament.playLinkExpiresAt,
         )
     }

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
@@ -330,6 +330,39 @@ class TournamentService(
                 val histories = tournamentRepository.findHistoriesByTournamentIdAndTournamentUserId(
                     tournamentId, currentUser.getId(),
                 )
+
+                // ROOT 가 IN_PROGRESS 인데 멤버 본인의 히스토리가 없으면, CLONE 을 아직 시작하지 않은 대기 상태다.
+                // sourceTournamentId 가 없으면(ROOT) pending 형태로 아이템·참여자를 내려준다.
+                // 클라이언트는 ownerStarted=true 로 "주최자가 시작했습니다, 지금 시작하세요" UI 를 분기한다.
+                if (!isOwner && histories.isEmpty()) {
+                    tournament.sourceTournamentId ?: run {
+                        val tournamentItems = tournamentItemRepository.findAllByTournamentId(tournamentId)
+                        val snapshotById = snapshotsOf(tournamentItems)
+                        val tournamentUsers = tournamentUserRepository.findByTournamentId(tournamentId)
+                        val userById = userRepository
+                            .findByIds(tournamentUsers.map { it.userId }.toSet())
+                            .associateBy { it.id }
+                        return TournamentDetail.Pending(
+                            tournamentId = tournament.getId(),
+                            name = tournament.name,
+                            inviteCode = tournament.inviteCode,
+                            inviteExpiresAt = tournament.inviteExpiresAt,
+                            items = tournamentItems.map { toItemDetail(it, snapshotById) },
+                            participants = tournamentUsers.mapNotNull { tu ->
+                                userById[tu.userId]?.let { user ->
+                                    TournamentDetail.ParticipantDetail(
+                                        userId = user.id,
+                                        nickname = user.nickname,
+                                        profileImage = user.profileImage,
+                                        isWithdrawn = !user.isActive(),
+                                    )
+                                }
+                            },
+                            isOwner = false,
+                            ownerStarted = true,
+                        )
+                    }
+                }
                 // 히스토리는 currentRound ASC, id ASC 정렬이라 lastOrNull()은 라운드가 바뀌면 틀림 — ID 최대값이 가장 최근 매치
                 val lastHistory = histories
                     .maxByOrNull { it.getId() }

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/dto/TournamentDetail.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/dto/TournamentDetail.kt
@@ -13,6 +13,9 @@ sealed class TournamentDetail {
         val items: List<ItemDetail>,
         val participants: List<ParticipantDetail>,
         val isOwner: Boolean,
+        // ROOT 가 IN_PROGRESS 로 전환됐으나 이 멤버는 아직 매치를 시작하지 않은 상태.
+        // true 이면 클라이언트가 "주최자가 시작했습니다, 지금 시작하세요" UI 를 보여야 한다.
+        val ownerStarted: Boolean = false,
     ) : TournamentDetail()
 
     data class InProgress(

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/dto/TournamentDetail.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/dto/TournamentDetail.kt
@@ -13,6 +13,7 @@ sealed class TournamentDetail {
         val items: List<ItemDetail>,
         val participants: List<ParticipantDetail>,
         val isOwner: Boolean,
+        val isRoot: Boolean,
         // ROOT 가 IN_PROGRESS 로 전환됐으나 이 멤버는 아직 매치를 시작하지 않은 상태.
         // true 이면 클라이언트가 "주최자가 시작했습니다, 지금 시작하세요" UI 를 보여야 한다.
         val ownerStarted: Boolean = false,
@@ -25,6 +26,7 @@ sealed class TournamentDetail {
         val lastHistory: HistoryEntry?,
         val remainingItems: List<ItemDetail>,
         val isOwner: Boolean,
+        val isRoot: Boolean,
     ) : TournamentDetail()
 
     data class Completed(
@@ -33,6 +35,7 @@ sealed class TournamentDetail {
         val result: List<RankedItem>,
         val hasGroupResult: Boolean,
         val isOwner: Boolean,
+        val isRoot: Boolean,
         val playLinkExpiresAt: java.time.LocalDateTime?,
     ) : TournamentDetail()
 


### PR DESCRIPTION
## Situation
- 소셜 토너먼트에서 주최자가 시작(ROOT: PENDING → IN_PROGRESS)하면, 대기 중이던 참여자의 polling 응답에서 `pending` 필드가 사라진다.
- 아이템·참여자 정보가 빠진 채 화면이 비어 "토너먼트가 초기화됐나?" 혼란이 생긴다는 프론트엔드 개발자 요청.

## Task
- ROOT IN_PROGRESS 전환 이후에도 참여자(isOwner=false)가 매치를 시작하기 전까지 아이템·참여자 목록을 유지해 내려준다.
- 클라이언트가 "주최자 대기" vs "주최자 시작 완료, 내 차례" UI를 한 플래그로 분기할 수 있게 한다.

## Action

### 설계 선택 — Option A vs B

| 옵션 | 방식 | 탈락 이유 |
|---|---|---|
| B | `rootView`, `sharedView` 등 별도 필드 추가 | 클라이언트가 `status`와 별개 필드를 이중 추론해야 해 계약 복잡도 증가 |
| **A (채택)** | 기존 `pending` 필드 + `ownerStarted` 플래그 | `pending`의 "공유 컨텍스트 데이터" 의미를 그대로 유지, 플래그 하나로 분기 |

### role별 응답 변화

| 조건 | status | pending 포함 여부 | inProgress 포함 여부 | pending.ownerStarted |
|---|---|---|---|---|
| PENDING (모두) | PENDING | O | null | false |
| IN_PROGRESS + isOwner=true | IN_PROGRESS | null | O | - |
| IN_PROGRESS + isOwner=false + 히스토리 있음 | IN_PROGRESS | null | O | - |
| IN_PROGRESS + isOwner=false + 히스토리 없음 | IN_PROGRESS | O (ROOT 아이템·참여자) | null | **true** |

### 구현

- `TournamentDetail.Pending`에 `ownerStarted: Boolean = false` 추가
- `PendingData.inviteCode`, `inviteExpiresAt`을 nullable로 변경. `ownerStarted=true`이면 초대 기간이 이미 종료됐으므로 null
- `TournamentService.getTournamentById`의 IN_PROGRESS 브랜치에 케이스 추가. `sourceTournamentId ?: run { ... return Pending(..., ownerStarted=true) }` 패턴으로 ROOT + 미시작 멤버를 분기
- API 설명(`TournamentApi.kt`) 및 Swagger example(`TournamentApiExamples.kt`) 업데이트. "IN_PROGRESS - 멤버 대기 중" 예제 추가

## Result
- 클라이언트 분기: `ownerStarted=false + status=PENDING` → "주최자가 시작해야 합니다...", `ownerStarted=true + status=IN_PROGRESS` → "주최자가 시작했습니다! 지금 시작하세요!"
- 클라이언트 임시 대응(아이템 수 검증 스킵)은 이 PR 머지 후 원복 가능

---
## Updates

### isRoot 필드 추가 — ROOT/CLONE 구분 (`654eaad`)

플레이 링크 공유 버튼 노출 조건이 `isOwner` 만으로는 부족해서 `isRoot` 를 추가했다.

- **배경**: CLONE 소유자도 `isOwner=true` 를 받아 플레이 링크 공유 버튼이 잘못 노출됐다. 플레이 링크 공유는 ROOT 소유자(`isRoot && isOwner`)만 허용돼야 한다.
- `TournamentDetailResponse` 최상단에 `isRoot: Boolean` 추가. ROOT(`sourceTournamentId == null`)이면 `true`, CLONE이면 `false`.
- 서비스에서 `tournament.sourceTournamentId?.let { false } ?: true` Elvis 패턴으로 계산해 `TournamentDetail` 모든 variant(Pending / InProgress / Completed)에 전달.
- API 명세(TournamentApi.kt) 에 isRoot 의미 및 플레이 링크 분기 조건 문서화. Swagger example 4건 모두 `isRoot` 값 반영.

---
## 연관 이슈

- close #466


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 토너먼트 진행 중 상태에서 주최자의 시작 완료 여부를 구분하여 표시할 수 있도록 개선했습니다.

* **Documentation**
  * 토너먼트 상세 조회 API의 응답 상태별 필드 설명을 정리하고, 새로운 상태 예시를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
