### PR TITLE
상품 추출 방법(직접 파싱 vs LLM) 비율 모니터링 메트릭

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/product/service/DefaultProductLinkExtractor.kt
+++ b/src/main/kotlin/com/depromeet/piki/product/service/DefaultProductLinkExtractor.kt
@@ -3,6 +3,8 @@ package com.depromeet.piki.product.service
 import com.depromeet.piki.product.domain.ProductLink
 import com.depromeet.piki.product.service.gemini.GeminiHtmlExtractor
 import com.depromeet.piki.product.service.structured.StructuredDataExtractor
+import com.depromeet.piki.product.service.structured.StructuredExtraction
+import io.micrometer.core.instrument.MeterRegistry
 import org.jsoup.Jsoup
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
@@ -10,11 +12,16 @@ import org.springframework.stereotype.Component
 // 상품 URL 추출의 오케스트레이터. fetch 를 1회 수행하고, 구조화 데이터(JSON-LD/OpenGraph)로 먼저 파싱한다.
 // 필수 필드가 검증을 통과하면 LLM 을 건너뛰고, 미달이면 같은 HTML 을 Gemini 로 넘겨 추출한다(재fetch 없음).
 // 진입점은 ProductLinkExtractor 단일 빈이라 AsyncItemParsingWorker 의 호출·통합 테스트 stub 구조가 그대로 유지된다.
+//
+// 추출 방법을 product.extract 카운터로 집계한다 — via=structured(직접 파싱) 대 via=llm(LLM fallback) 의 비율이
+// 곧 비싼 LLM 호출을 얼마나 줄였는지의 비용 지표다. fallback 은 reason 라벨로 사유(no_data/missing_field/invalid_value)를
+// 분해해 "직접 파싱 적중률을 올리려면 어디를 보강할지"를 본다. application 태그는 management.metrics.tags 가 자동 부착한다.
 @Component
 class DefaultProductLinkExtractor(
     private val pageFetcher: PageFetcher,
     private val structuredDataExtractor: StructuredDataExtractor,
     private val geminiHtmlExtractor: GeminiHtmlExtractor,
+    private val meterRegistry: MeterRegistry,
 ) : ProductLinkExtractor {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -26,26 +33,52 @@ class DefaultProductLinkExtractor(
         // HTML 을 한 번만 파싱해 구조화 파서와 Gemini fallback 이 같은 Document 를 공유한다(파싱·ld+json 식별 중복 제거).
         val document = Jsoup.parse(page.html, link.value.toString())
 
-        structuredDataExtractor.extract(document, link)?.let { snapshot ->
-            log.info(
-                "extract via=structured fetch={}ms html={}chars url={}",
-                fetchMs,
-                page.html.length,
-                link.safeLogString(),
-            )
-            return snapshot
-        }
+        val result = structuredDataExtractor.extract(document, link)
 
-        val llmStart = System.nanoTime()
-        val snapshot = geminiHtmlExtractor.extract(document, link)
-        val llmMs = (System.nanoTime() - llmStart) / 1_000_000
-        log.info(
-            "extract via=llm fetch={}ms llm={}ms html={}chars url={}",
-            fetchMs,
-            llmMs,
-            page.html.length,
-            link.safeLogString(),
-        )
-        return snapshot
+        // 카운터는 한 곳에서 항상 {via, reason} 두 키로 발행한다 — 경로마다 태그 키가 갈라지면 Prometheus 가
+        // 같은 메트릭 이름의 뒤 시계열을 조용히 드롭하므로(라벨 키 집합 불일치), 키를 단일 지점에서 통일한다.
+        // Miss 일 때 LLM 호출 전에 올려, LLM 이 실패해도 "직접 파싱으로 못 끝내 LLM 에 의존한 비율"에 포함되게 한다.
+        val (via, reason) =
+            when (result) {
+                is StructuredExtraction.Extracted -> VIA_STRUCTURED to REASON_NONE
+                is StructuredExtraction.Miss -> VIA_LLM to result.reason
+            }
+        meterRegistry.counter(EXTRACT_METRIC, TAG_VIA, via, TAG_REASON, reason).increment()
+
+        return when (result) {
+            is StructuredExtraction.Extracted -> {
+                log.info(
+                    "extract via=structured fetch={}ms html={}chars url={}",
+                    fetchMs,
+                    page.html.length,
+                    link.safeLogString(),
+                )
+                result.snapshot
+            }
+
+            is StructuredExtraction.Miss -> {
+                val llmStart = System.nanoTime()
+                val snapshot = geminiHtmlExtractor.extract(document, link)
+                val llmMs = (System.nanoTime() - llmStart) / 1_000_000
+                log.info(
+                    "extract via=llm reason={} fetch={}ms llm={}ms html={}chars url={}",
+                    result.reason,
+                    fetchMs,
+                    llmMs,
+                    page.html.length,
+                    link.safeLogString(),
+                )
+                snapshot
+            }
+        }
+    }
+
+    companion object {
+        private const val EXTRACT_METRIC = "product.extract"
+        private const val TAG_VIA = "via"
+        private const val TAG_REASON = "reason"
+        private const val VIA_STRUCTURED = "structured"
+        private const val VIA_LLM = "llm"
+        private const val REASON_NONE = "none"
     }
 }

--- a/src/main/kotlin/com/depromeet/piki/product/service/ProductSnapshot.kt
+++ b/src/main/kotlin/com/depromeet/piki/product/service/ProductSnapshot.kt
@@ -23,7 +23,7 @@ data class ProductSnapshot(
         // currency 는 ISO 4217 로 정규화한다. 추출값이 DB 컬럼 제약·상식을 벗어나면(가격 음수·길이 초과)
         // 추출 실패로 보고 untrustworthyValue 를 던진다 — 입력 경계의 계약 검증.
         //
-        // 실패 처리는 호출부가 고른다: 구조화 경로는 이 예외를 runCatching 으로 흡수해 null(→LLM fallback)로,
+        // 실패 처리는 호출부가 고른다: 구조화 경로는 이 예외를 runCatching 으로 흡수해 Miss.INVALID_VALUE(→LLM fallback)로,
         // LLM 경로는 그대로 흘려 FAILED 로 떨어뜨린다. 같은 검증, 실패 표현만 다르다.
         fun fromExtracted(
             link: ProductLink?,

--- a/src/main/kotlin/com/depromeet/piki/product/service/structured/StructuredDataExtractor.kt
+++ b/src/main/kotlin/com/depromeet/piki/product/service/structured/StructuredDataExtractor.kt
@@ -11,8 +11,8 @@ import tools.jackson.databind.JsonNode
 import tools.jackson.databind.ObjectMapper
 
 // fetch 된 HTML 의 구조화 데이터(JSON-LD schema.org/Product · OpenGraph)를 코드로 파싱해
-// LLM 호출 없이 ProductSnapshot 을 만든다. 필수 필드(name+currentPrice)가 검증을 통과하면 성공,
-// 미달·부재·검증위반이면 null 을 돌려 오케스트레이터가 Gemini fallback 으로 넘어가게 한다.
+// LLM 호출 없이 ProductSnapshot 을 만든다. 필수 필드(name+currentPrice)가 검증을 통과하면 Extracted,
+// 미달·부재·검증위반이면 사유를 담은 Miss 를 돌려 오케스트레이터가 Gemini fallback 으로 넘어가게 한다.
 //
 // jsoup 은 마크업에서 <script ld+json>·<meta og:*> 블록을 정확히 꺼내는 책임만 지고, JSON-LD 값 자체는
 // Jackson 3 트리(JsonNode)로 다룬다. 깨진 ld+json 한 덩어리가 전체를 죽이지 않도록 각 script 를 runCatching 으로 격리한다.
@@ -22,41 +22,70 @@ class StructuredDataExtractor(
 ) {
     // 오케스트레이터가 파싱한 Document 를 공유받아 읽기만 한다(Document 를 변형하지 않으므로 이후 Gemini fallback 과 안전하게 공유).
     // 우선순위: JSON-LD(구조적 가격을 정확히 들고 있음) > OpenGraph(가격 표준 태그가 없어 보조).
+    // 둘 다 실패하면 더 데이터에 근접했던 사유(worse)를 reason 으로 보고한다.
     fun extract(
         document: Document,
         link: ProductLink,
-    ): ProductSnapshot? = fromJsonLd(document, link) ?: fromOpenGraph(document, link)
+    ): StructuredExtraction =
+        when (val fromJsonLd = fromJsonLd(document, link)) {
+            is StructuredExtraction.Extracted -> fromJsonLd
+            is StructuredExtraction.Miss ->
+                when (val fromOpenGraph = fromOpenGraph(document, link)) {
+                    is StructuredExtraction.Extracted -> fromOpenGraph
+                    is StructuredExtraction.Miss -> worse(fromJsonLd, fromOpenGraph)
+                }
+        }
 
     // 단독 호출·테스트 편의: HTML 을 직접 파싱해 위임한다. 운영 경로는 오케스트레이터가 Document 를 만들어 공유한다.
-    fun extract(page: PageContent): ProductSnapshot? = extract(Jsoup.parse(page.html, page.link.value.toString()), page.link)
+    fun extract(page: PageContent): StructuredExtraction = extract(Jsoup.parse(page.html, page.link.value.toString()), page.link)
+
+    // 두 실패 사유 중 데이터에 더 근접한(=정보량이 큰) 쪽. enum 선언 순서가 아니라 명시 rank 로 비교한다(선언 순서 변경에 독립).
+    private fun worse(
+        a: StructuredExtraction.Miss,
+        b: StructuredExtraction.Miss,
+    ): StructuredExtraction.Miss = if (a.rank >= b.rank) a else b
 
     // --- JSON-LD (schema.org/Product) ---
 
     private fun fromJsonLd(
         document: Document,
         link: ProductLink,
-    ): ProductSnapshot? =
-        // type 속성에 charset 파라미터·따옴표·공백 변형이 붙어도 application/ld+json 으로 인식한다(jsoup 이 파싱한 attr 기준).
-        document
-            .select("script[type]")
-            .filter { it.attr("type").trim().startsWith("application/ld+json", ignoreCase = true) }
-            .flatMap { script ->
-                val root = runCatching { objectMapper.readTree(script.data()) }.getOrNull()
-                root?.let { collectProductNodes(it) } ?: emptyList()
+    ): StructuredExtraction {
+        val products =
+            document
+                // type 속성에 charset 파라미터·따옴표·공백 변형이 붙어도 application/ld+json 으로 인식한다(jsoup 이 파싱한 attr 기준).
+                .select("script[type]")
+                .filter { it.attr("type").trim().startsWith("application/ld+json", ignoreCase = true) }
+                .flatMap { script ->
+                    val root = runCatching { objectMapper.readTree(script.data()) }.getOrNull()
+                    root?.let { collectProductNodes(it) } ?: emptyList()
+                }
+        // Product 노드가 하나도 없으면 구조화 데이터 부재.
+        if (products.isEmpty()) return StructuredExtraction.Miss.NO_DATA
+
+        // 시드는 최저 rank(NO_DATA)에서 시작해 노드 결과로 올린다. 노드가 있으므로 toSnapshotFromProduct 는
+        // 항상 MISSING_FIELD 이상(또는 Extracted)을 주어, 첫 반복에서 곧바로 실제 사유로 덮인다.
+        var worst: StructuredExtraction.Miss = StructuredExtraction.Miss.NO_DATA
+        // 앞 Product 가 검증에 실패해도(요약용 불완전 노드 등) 뒤의 완전한 Product 까지 모두 시도한다.
+        for (product in products) {
+            when (val result = toSnapshotFromProduct(product, link)) {
+                is StructuredExtraction.Extracted -> return result
+                is StructuredExtraction.Miss -> worst = worse(worst, result)
             }
-            // 앞 Product 가 검증에 실패해도(요약용 불완전 노드 등) 뒤의 완전한 Product 까지 모두 시도한다.
-            .firstNotNullOfOrNull { product -> toSnapshotFromProduct(product, link) }
+        }
+        return worst
+    }
 
     private fun toSnapshotFromProduct(
         product: JsonNode,
         link: ProductLink,
-    ): ProductSnapshot? {
+    ): StructuredExtraction {
         val offer = firstOffer(product)
-        return toSnapshotOrNull(
+        return toResult(
             link = link,
             name = textOf(product.get("name")),
             imageUrl = imageUrlOf(product),
-            price = parsePrice(textOf(priceNode(offer))),
+            priceText = textOf(priceNode(offer)),
             currency = textOf(offer?.get("priceCurrency")),
         )
     }
@@ -137,15 +166,17 @@ class StructuredDataExtractor(
     private fun fromOpenGraph(
         document: Document,
         link: ProductLink,
-    ): ProductSnapshot? =
-        toSnapshotOrNull(
-            link = link,
-            name = stripSiteSuffix(metaContent(document, "og:title"), metaContent(document, "og:site_name")),
-            imageUrl = metaContent(document, "og:image"),
-            // OG 표준엔 가격이 없어 product:price:amount(OG product 확장)를 best-effort 로 시도한다.
-            price = parsePrice(metaContent(document, "product:price:amount")),
-            currency = metaContent(document, "product:price:currency"),
-        )
+    ): StructuredExtraction {
+        val name = stripSiteSuffix(metaContent(document, "og:title"), metaContent(document, "og:site_name"))
+        // OG 표준엔 가격이 없어 product:price:amount(OG product 확장)를 best-effort 로 시도한다.
+        val priceText = metaContent(document, "product:price:amount")
+        val imageUrl = metaContent(document, "og:image")
+        val currency = metaContent(document, "product:price:currency")
+        // OG 관련 태그(title·price·image·currency)가 하나도 없으면 구조화 데이터 부재. 하나라도 있으면 toResult 가 missing/invalid 를 가린다.
+        // currency 도 포함해, 통화 태그만 단독으로 있는 페이지가 no_data 로 오분류되지 않게 한다(부분 제공 → missing_field).
+        if (listOfNotNull(name, priceText, imageUrl, currency).isEmpty()) return StructuredExtraction.Miss.NO_DATA
+        return toResult(link = link, name = name, imageUrl = imageUrl, priceText = priceText, currency = currency)
+    }
 
     private fun metaContent(
         document: Document,
@@ -169,23 +200,26 @@ class StructuredDataExtractor(
 
     // --- 공통 ---
 
-    // 필수 필드(name+price)가 모두 있고 정규화·범위검증을 통과해야 성공. 하나라도 미달이면 null(→fallback).
-    private fun toSnapshotOrNull(
+    // 필수 필드(name+price)가 모두 있고 정규화·범위검증을 통과하면 Extracted.
+    //   name·priceText 부재 → MISSING_FIELD (가격은 raw 텍스트 유무로 판단해, 값이 있으나 못 뽑은 경우와 구분한다)
+    //   price 파싱 불가(음수·범위초과·비숫자) → INVALID_VALUE
+    //   fromExtracted 범위 위반(name 길이초과 등) → INVALID_VALUE
+    //   정규화 후 name 이 blank→null (OG site suffix 제거로 빈 문자열이 된 경우 등) → MISSING_FIELD
+    private fun toResult(
         link: ProductLink,
         name: String?,
         imageUrl: String?,
-        price: Int?,
+        priceText: String?,
         currency: String?,
-    ): ProductSnapshot? {
-        name ?: return null
-        price ?: return null
-        // 범위 위반(가격 음수·길이 초과)은 fromExtracted 가 예외를 던지므로 흡수해 null(→fallback)로 다룬다.
+    ): StructuredExtraction {
+        name ?: return StructuredExtraction.Miss.MISSING_FIELD
+        priceText ?: return StructuredExtraction.Miss.MISSING_FIELD
+        val price = parsePrice(priceText) ?: return StructuredExtraction.Miss.INVALID_VALUE
         val snapshot =
             runCatching { ProductSnapshot.fromExtracted(link, name, imageUrl, price, currency) }
-                .getOrNull() ?: return null
-        // 정규화 후 name 이 blank→null 이 됐으면 필수 필드 상실로 보고 fallback (price 는 fromExtracted 가 보존).
-        snapshot.name ?: return null
-        return snapshot
+                .getOrNull() ?: return StructuredExtraction.Miss.INVALID_VALUE
+        snapshot.name ?: return StructuredExtraction.Miss.MISSING_FIELD
+        return StructuredExtraction.Extracted(snapshot)
     }
 
     private fun textOf(node: JsonNode?): String? {

--- a/src/main/kotlin/com/depromeet/piki/product/service/structured/StructuredExtraction.kt
+++ b/src/main/kotlin/com/depromeet/piki/product/service/structured/StructuredExtraction.kt
@@ -1,0 +1,22 @@
+package com.depromeet.piki.product.service.structured
+
+import com.depromeet.piki.product.service.ProductSnapshot
+
+// 구조화 데이터(JSON-LD/OpenGraph) 파싱 결과. 성공(Extracted)이면 오케스트레이터가 그대로 쓰고,
+// 실패(Miss)면 그 사유(reason)를 메트릭 라벨로 남긴 뒤 LLM fallback 으로 넘어간다.
+// reason 은 "직접 파싱 적중률을 올리려면 어디를 보강할지" 판단의 단서다:
+//   no_data       구조화 데이터(JSON-LD Product 노드·OG 태그) 자체가 없음 → 사이트가 미제공, LLM 불가피
+//   missing_field 데이터는 있으나 필수 필드(name·price)가 없음 → 파서가 더 많은 위치를 봐야 할 수 있음
+//   invalid_value 값은 있으나 검증·범위를 통과 못 함(가격 음수·파싱불가·길이초과 등) → 정규화 보강 여지
+//
+// rank 는 "데이터에 근접한 정도"(클수록 근접)다. 여러 후보의 사유를 합칠 때 worse 가 이 rank 로 더 근접한 쪽을 고른다
+// (StructuredDataExtractor.worse). enum 선언 순서(ordinal)가 아니라 명시 rank 로 비교해, 상수 재배치·중간 추가에도 비교가 깨지지 않는다.
+sealed interface StructuredExtraction {
+    data class Extracted(val snapshot: ProductSnapshot) : StructuredExtraction
+
+    enum class Miss(val reason: String, val rank: Int) : StructuredExtraction {
+        NO_DATA("no_data", 0),
+        MISSING_FIELD("missing_field", 1),
+        INVALID_VALUE("invalid_value", 2),
+    }
+}

--- a/src/test/kotlin/com/depromeet/piki/product/service/DefaultProductLinkExtractorMetricTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/product/service/DefaultProductLinkExtractorMetricTest.kt
@@ -1,0 +1,63 @@
+package com.depromeet.piki.product.service
+
+import com.depromeet.piki.product.domain.ProductLink
+import com.depromeet.piki.product.service.gemini.GeminiExtractionResult
+import com.depromeet.piki.product.service.gemini.GeminiHtmlExtractor
+import com.depromeet.piki.product.service.structured.StructuredDataExtractor
+import com.depromeet.piki.support.StubGeminiClient
+import io.micrometer.prometheusmetrics.PrometheusConfig
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
+import org.junit.jupiter.api.Test
+import tools.jackson.module.kotlin.jacksonObjectMapper
+import kotlin.test.assertTrue
+
+// product.extract 카운터가 운영 레지스트리(Prometheus)에서 두 경로(via=structured/llm) 모두 scrape 되는지 검증한다.
+// Prometheus(client 1.x)는 같은 메트릭 이름의 태그 키 집합이 다르면 뒤 시계열을 예외 없이 조용히 드롭하므로,
+// structured 와 llm 두 경로의 태그 키가 {via, reason} 으로 일치해야 둘 다 남는다. 일반 통합 테스트는
+// SimpleMeterRegistry(이 제약 미적용)를 주입해 이 회귀를 못 잡으므로, 운영과 같은 PrometheusMeterRegistry 로
+// 추출기를 직접 구성하는 별도 분류로 둔다(외부 경계 PageFetcher·GeminiClient 만 stub).
+class DefaultProductLinkExtractorMetricTest {
+    private val link = ProductLink.parse("https://shop.example.com/products/42")
+
+    @Test
+    fun `structured 와 llm 두 경로의 product_extract 시계열이 Prometheus scrape 에 모두 남는다`() {
+        val registry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+        val stubGemini = StubGeminiClient()
+        val pageFetcher = StubFetcher()
+        val extractor =
+            DefaultProductLinkExtractor(
+                pageFetcher = pageFetcher,
+                structuredDataExtractor = StructuredDataExtractor(jacksonObjectMapper()),
+                geminiHtmlExtractor = GeminiHtmlExtractor(stubGemini),
+                meterRegistry = registry,
+            )
+
+        // 1) 구조화 데이터로 직접 파싱 성공 → via=structured
+        pageFetcher.html =
+            """<html><head><script type="application/ld+json">{"@type":"Product","name":"직접파싱","offers":{"price":"1000"}}</script></head><body></body></html>"""
+        extractor.extract(link)
+
+        // 2) 구조화 데이터 없음 → LLM fallback → via=llm,reason=no_data
+        stubGemini.build = { GeminiExtractionResult(isProductPage = true, name = "엘엘엠", currentPrice = 2_000) }
+        pageFetcher.html = "<html><body>구조화 없음</body></html>"
+        extractor.extract(link)
+
+        val scrape = registry.scrape()
+        val lines = scrape.lines().filter { it.startsWith("product_extract_total{") }
+        // 라벨 출력 순서는 Prometheus 가 정렬하므로(via/reason 순서 비보장) 부분 문자열로 단언한다.
+        assertTrue(
+            lines.any { it.contains("""via="structured"""") && it.contains("""reason="none"""") },
+            "structured 시계열(reason=none)이 scrape 에 있어야 한다:\n$scrape",
+        )
+        assertTrue(
+            lines.any { it.contains("""via="llm"""") },
+            "llm 시계열이 scrape 에 있어야 한다 — 태그 키 불일치로 드롭되면 안 된다:\n$scrape",
+        )
+    }
+
+    private class StubFetcher : PageFetcher {
+        var html: String = ""
+
+        override fun fetch(link: ProductLink): PageContent = PageContent(link, html)
+    }
+}

--- a/src/test/kotlin/com/depromeet/piki/product/service/ProductLinkExtractE2ETest.kt
+++ b/src/test/kotlin/com/depromeet/piki/product/service/ProductLinkExtractE2ETest.kt
@@ -6,6 +6,7 @@ import com.depromeet.piki.product.service.gemini.GeminiHttpClient
 import com.depromeet.piki.product.service.gemini.GeminiProperties
 import com.depromeet.piki.product.service.http.HttpPageFetcher
 import com.depromeet.piki.product.service.structured.StructuredDataExtractor
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.micrometer.observation.ObservationRegistry
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
@@ -36,6 +37,7 @@ class ProductLinkExtractE2ETest {
             pageFetcher = pageFetcher,
             structuredDataExtractor = StructuredDataExtractor(objectMapper),
             geminiHtmlExtractor = GeminiHtmlExtractor(httpClient),
+            meterRegistry = SimpleMeterRegistry(),
         )
 
     @Test

--- a/src/test/kotlin/com/depromeet/piki/product/service/StructuredFirstExtractionIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/product/service/StructuredFirstExtractionIntegrationTest.kt
@@ -7,6 +7,7 @@ import com.depromeet.piki.product.service.gemini.GeminiExtractionResult
 import com.depromeet.piki.support.IntegrationTestSupport
 import com.depromeet.piki.support.StubGeminiClient
 import com.depromeet.piki.support.StubPageFetcher
+import io.micrometer.core.instrument.MeterRegistry
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import kotlin.test.assertEquals
@@ -28,6 +29,9 @@ class StructuredFirstExtractionIntegrationTest : IntegrationTestSupport() {
     @Autowired
     private lateinit var stubGeminiClient: StubGeminiClient
 
+    @Autowired
+    private lateinit var meterRegistry: MeterRegistry
+
     private val link = ProductLink.parse("https://shop.example.com/products/42")
 
     @Test
@@ -36,11 +40,13 @@ class StructuredFirstExtractionIntegrationTest : IntegrationTestSupport() {
         stubGeminiClient.build = { error("구조화 성공 경로에서는 LLM 이 호출되면 안 된다") }
         stubPageFetcher.build = { PageContent(it, productJsonLdHtml(name = "나이키 에어포스", price = "99000")) }
 
+        val before = extractCount("via", "structured", "reason", "none")
         val snapshot = extractor.extract(link)
 
         assertEquals("나이키 에어포스", snapshot.name)
         assertEquals(99_000, snapshot.currentPrice)
         assertEquals(0, stubGeminiClient.invocations)
+        assertEquals(1.0, extractCount("via", "structured", "reason", "none") - before)
     }
 
     @Test
@@ -49,24 +55,29 @@ class StructuredFirstExtractionIntegrationTest : IntegrationTestSupport() {
         stubGeminiClient.build = { GeminiExtractionResult(isProductPage = true, name = "엘엘엠상품", currentPrice = 50_000) }
         stubPageFetcher.build = { PageContent(it, "<html><body>구조화 데이터 없음</body></html>") }
 
+        // 구조화 데이터 자체가 없어 reason=no_data 로 LLM fallback.
+        val before = extractCount("via", "llm", "reason", "no_data")
         val snapshot = extractor.extract(link)
 
         assertEquals("엘엘엠상품", snapshot.name)
         assertEquals(50_000, snapshot.currentPrice)
         assertEquals(1, stubGeminiClient.invocations)
+        assertEquals(1.0, extractCount("via", "llm", "reason", "no_data") - before)
     }
 
     @Test
     fun `구조화 데이터의 필수 필드가 미달이면 LLM fallback 으로 간다`() {
         stubGeminiClient.reset()
         stubGeminiClient.build = { GeminiExtractionResult(isProductPage = true, name = "보충상품", currentPrice = 30_000) }
-        // JSON-LD 에 price 만 있고 name 이 없어 구조화 파서가 null → fallback.
+        // JSON-LD 에 price 만 있고 name 이 없어 구조화 파서가 missing_field → fallback.
         stubPageFetcher.build = { PageContent(it, priceOnlyJsonLdHtml(price = "30000")) }
 
+        val before = extractCount("via", "llm", "reason", "missing_field")
         val snapshot = extractor.extract(link)
 
         assertEquals("보충상품", snapshot.name)
         assertEquals(1, stubGeminiClient.invocations)
+        assertEquals(1.0, extractCount("via", "llm", "reason", "missing_field") - before)
     }
 
     @Test
@@ -75,8 +86,11 @@ class StructuredFirstExtractionIntegrationTest : IntegrationTestSupport() {
         stubGeminiClient.build = { throw GeminiApiException.upstreamError(RuntimeException("gemini down")) }
         stubPageFetcher.build = { PageContent(it, "<html><body>구조화 없음</body></html>") }
 
+        // 카운터는 LLM 호출 직전에 증가하므로, LLM 이 throw 해도 via=llm,reason=no_data 는 +1 이어야 한다("직접 파싱으로 못 끝내 LLM 에 의존한 비율"에 포함).
+        val before = extractCount("via", "llm", "reason", "no_data")
         assertFailsWith<GeminiApiException> { extractor.extract(link) }
         assertEquals(1, stubGeminiClient.invocations)
+        assertEquals(1.0, extractCount("via", "llm", "reason", "no_data") - before)
     }
 
     @Test
@@ -103,6 +117,9 @@ class StructuredFirstExtractionIntegrationTest : IntegrationTestSupport() {
         assertFalse(sentHtml.contains("color:red"), "style 은 제거돼야 한다")
         assertFalse(sentHtml.contains("제거대상주석"), "주석은 제거돼야 한다")
     }
+
+    // product.extract 카운터의 현재 값. 컨텍스트 공유로 다른 테스트와 누적되므로 호출 전후 증가분(delta)으로 단언한다.
+    private fun extractCount(vararg tags: String): Double = meterRegistry.counter("product.extract", *tags).count()
 
     // GeminiExtractionRequest 의 HTML part(마지막 Part)에서 sanitize 된 LLM 입력 HTML 을 꺼낸다.
     private fun llmInputHtmlOf(request: Any?): String {

--- a/src/test/kotlin/com/depromeet/piki/product/service/structured/StructuredDataExtractorTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/product/service/structured/StructuredDataExtractorTest.kt
@@ -2,16 +2,17 @@ package com.depromeet.piki.product.service.structured
 
 import com.depromeet.piki.product.domain.ProductLink
 import com.depromeet.piki.product.service.PageContent
+import com.depromeet.piki.product.service.ProductSnapshot
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.ValueSource
 import tools.jackson.module.kotlin.jacksonObjectMapper
 import kotlin.test.assertEquals
-import kotlin.test.assertNull
 
 // 구조화 파서는 순수 컴포넌트라 Spring·DB 없이 HTML 문자열을 직접 넣어 분기를 망라한다.
-// 성공 = name+currentPrice 가 검증을 통과한 ProductSnapshot, 실패/미달 = null(→오케스트레이터가 LLM fallback).
+// 성공 = name+currentPrice 가 검증을 통과한 Extracted(snapshot), 실패 = 사유를 담은 Miss(→오케스트레이터가 LLM fallback).
+// 실패 케이스는 reason(no_data/missing_field/invalid_value)까지 단언해 reason 분류 로직도 함께 검증한다.
 class StructuredDataExtractorTest {
     private val extractor = StructuredDataExtractor(jacksonObjectMapper())
 
@@ -20,13 +21,14 @@ class StructuredDataExtractorTest {
     @Test
     fun `최상위 단일 Product 에서 name 과 price 를 뽑는다`() {
         val snapshot =
-            extractor.extract(
-                pageOf(
-                    jsonLd(
-                        """{"@type":"Product","name":"나이키 에어포스","offers":{"@type":"Offer","price":"99000","priceCurrency":"KRW"}}""",
+            extractor
+                .extract(
+                    pageOf(
+                        jsonLd(
+                            """{"@type":"Product","name":"나이키 에어포스","offers":{"@type":"Offer","price":"99000","priceCurrency":"KRW"}}""",
+                        ),
                     ),
-                ),
-            )
+                ).snapshotOrNull()
 
         assertEquals("나이키 에어포스", snapshot?.name)
         assertEquals(99_000, snapshot?.currentPrice)
@@ -36,13 +38,14 @@ class StructuredDataExtractorTest {
     @Test
     fun `@graph 로 래핑된 Product 를 평탄화해 뽑는다`() {
         val snapshot =
-            extractor.extract(
-                pageOf(
-                    jsonLd(
-                        """{"@graph":[{"@type":"BreadcrumbList"},{"@type":"Product","name":"그래프상품","offers":{"price":"50000"}}]}""",
+            extractor
+                .extract(
+                    pageOf(
+                        jsonLd(
+                            """{"@graph":[{"@type":"BreadcrumbList"},{"@type":"Product","name":"그래프상품","offers":{"price":"50000"}}]}""",
+                        ),
                     ),
-                ),
-            )
+                ).snapshotOrNull()
 
         assertEquals("그래프상품", snapshot?.name)
         assertEquals(50_000, snapshot?.currentPrice)
@@ -51,13 +54,14 @@ class StructuredDataExtractorTest {
     @Test
     fun `최상위 배열 안의 Product 를 뽑는다`() {
         val snapshot =
-            extractor.extract(
-                pageOf(
-                    jsonLd(
-                        """[{"@type":"WebSite"},{"@type":"Product","name":"배열상품","offers":{"price":"30000"}}]""",
+            extractor
+                .extract(
+                    pageOf(
+                        jsonLd(
+                            """[{"@type":"WebSite"},{"@type":"Product","name":"배열상품","offers":{"price":"30000"}}]""",
+                        ),
                     ),
-                ),
-            )
+                ).snapshotOrNull()
 
         assertEquals("배열상품", snapshot?.name)
         assertEquals(30_000, snapshot?.currentPrice)
@@ -66,13 +70,14 @@ class StructuredDataExtractorTest {
     @Test
     fun `ItemList 의 itemListElement 안의 Product 를 뽑는다`() {
         val snapshot =
-            extractor.extract(
-                pageOf(
-                    jsonLd(
-                        """{"@type":"ItemList","itemListElement":[{"@type":"ListItem","item":{"@type":"Product","name":"리스트상품","offers":{"price":"25000"}}}]}""",
+            extractor
+                .extract(
+                    pageOf(
+                        jsonLd(
+                            """{"@type":"ItemList","itemListElement":[{"@type":"ListItem","item":{"@type":"Product","name":"리스트상품","offers":{"price":"25000"}}}]}""",
+                        ),
                     ),
-                ),
-            )
+                ).snapshotOrNull()
 
         assertEquals("리스트상품", snapshot?.name)
         assertEquals(25_000, snapshot?.currentPrice)
@@ -81,13 +86,14 @@ class StructuredDataExtractorTest {
     @Test
     fun `@type 이 배열이고 Product 를 포함하면 인식한다`() {
         val snapshot =
-            extractor.extract(
-                pageOf(
-                    jsonLd(
-                        """{"@type":["Product","IndividualProduct"],"name":"멀티타입","offers":{"price":"15000"}}""",
+            extractor
+                .extract(
+                    pageOf(
+                        jsonLd(
+                            """{"@type":["Product","IndividualProduct"],"name":"멀티타입","offers":{"price":"15000"}}""",
+                        ),
                     ),
-                ),
-            )
+                ).snapshotOrNull()
 
         assertEquals("멀티타입", snapshot?.name)
         assertEquals(15_000, snapshot?.currentPrice)
@@ -96,11 +102,12 @@ class StructuredDataExtractorTest {
     @Test
     fun `offers 가 배열이면 첫 유효 price 를 쓴다`() {
         val snapshot =
-            extractor.extract(
-                pageOf(
-                    jsonLd("""{"@type":"Product","name":"오퍼배열","offers":[{"price":"12000"},{"price":"99999"}]}"""),
-                ),
-            )
+            extractor
+                .extract(
+                    pageOf(
+                        jsonLd("""{"@type":"Product","name":"오퍼배열","offers":[{"price":"12000"},{"price":"99999"}]}"""),
+                    ),
+                ).snapshotOrNull()
 
         assertEquals(12_000, snapshot?.currentPrice)
     }
@@ -108,13 +115,14 @@ class StructuredDataExtractorTest {
     @Test
     fun `offers_price 가 없으면 priceSpecification_price 를 쓴다`() {
         val snapshot =
-            extractor.extract(
-                pageOf(
-                    jsonLd(
-                        """{"@type":"Product","name":"스펙","offers":{"@type":"Offer","priceSpecification":{"@type":"UnitPriceSpecification","price":"77000"}}}""",
+            extractor
+                .extract(
+                    pageOf(
+                        jsonLd(
+                            """{"@type":"Product","name":"스펙","offers":{"@type":"Offer","priceSpecification":{"@type":"UnitPriceSpecification","price":"77000"}}}""",
+                        ),
                     ),
-                ),
-            )
+                ).snapshotOrNull()
 
         assertEquals(77_000, snapshot?.currentPrice)
     }
@@ -122,13 +130,14 @@ class StructuredDataExtractorTest {
     @Test
     fun `AggregateOffer 의 lowPrice 를 currentPrice 로 쓴다`() {
         val snapshot =
-            extractor.extract(
-                pageOf(
-                    jsonLd(
-                        """{"@type":"Product","name":"애그리게이트","offers":{"@type":"AggregateOffer","lowPrice":"11000","highPrice":"22000"}}""",
+            extractor
+                .extract(
+                    pageOf(
+                        jsonLd(
+                            """{"@type":"Product","name":"애그리게이트","offers":{"@type":"AggregateOffer","lowPrice":"11000","highPrice":"22000"}}""",
+                        ),
                     ),
-                ),
-            )
+                ).snapshotOrNull()
 
         assertEquals(11_000, snapshot?.currentPrice)
     }
@@ -143,7 +152,7 @@ class StructuredDataExtractorTest {
             </head><body></body></html>
             """.trimIndent()
 
-        val snapshot = extractor.extract(pageOf(html))
+        val snapshot = extractor.extract(pageOf(html)).snapshotOrNull()
 
         assertEquals("정상상품", snapshot?.name)
         assertEquals(40_000, snapshot?.currentPrice)
@@ -154,7 +163,7 @@ class StructuredDataExtractorTest {
         val html =
             """<html><head><script type="application/ld+json; charset=utf-8">{"@type":"Product","name":"차셋상품","offers":{"price":"12000"}}</script></head><body></body></html>"""
 
-        val snapshot = extractor.extract(pageOf(html))
+        val snapshot = extractor.extract(pageOf(html)).snapshotOrNull()
 
         assertEquals("차셋상품", snapshot?.name)
         assertEquals(12_000, snapshot?.currentPrice)
@@ -164,13 +173,14 @@ class StructuredDataExtractorTest {
     fun `앞 Product 가 검증 미달이면 같은 배열의 뒤 완전한 Product 를 쓴다`() {
         // 첫 Product 는 name 만(price 없음), 둘째 Product 는 name+price.
         val snapshot =
-            extractor.extract(
-                pageOf(
-                    jsonLd(
-                        """[{"@type":"Product","name":"요약"},{"@type":"Product","name":"상세상품","offers":{"price":"45000"}}]""",
+            extractor
+                .extract(
+                    pageOf(
+                        jsonLd(
+                            """[{"@type":"Product","name":"요약"},{"@type":"Product","name":"상세상품","offers":{"price":"45000"}}]""",
+                        ),
                     ),
-                ),
-            )
+                ).snapshotOrNull()
 
         assertEquals("상세상품", snapshot?.name)
         assertEquals(45_000, snapshot?.currentPrice)
@@ -186,7 +196,7 @@ class StructuredDataExtractorTest {
             </head><body></body></html>
             """.trimIndent()
 
-        assertEquals("완전상품", extractor.extract(pageOf(html))?.name)
+        assertEquals("완전상품", extractor.extract(pageOf(html)).snapshotOrNull()?.name)
     }
 
     // --- 가격 문자열 파싱 ---
@@ -204,9 +214,10 @@ class StructuredDataExtractorTest {
         expected: Int,
     ) {
         val snapshot =
-            extractor.extract(
-                pageOf(jsonLd("""{"@type":"Product","name":"상품","offers":{"price":"$priceText"}}""")),
-            )
+            extractor
+                .extract(
+                    pageOf(jsonLd("""{"@type":"Product","name":"상품","offers":{"price":"$priceText"}}""")),
+                ).snapshotOrNull()
 
         assertEquals(expected, snapshot?.currentPrice)
     }
@@ -214,33 +225,35 @@ class StructuredDataExtractorTest {
     @Test
     fun `price 가 숫자형이어도 정수로 파싱한다`() {
         val snapshot =
-            extractor.extract(
-                pageOf(jsonLd("""{"@type":"Product","name":"숫자가격","offers":{"price":39000}}""")),
-            )
+            extractor
+                .extract(
+                    pageOf(jsonLd("""{"@type":"Product","name":"숫자가격","offers":{"price":39000}}""")),
+                ).snapshotOrNull()
 
         assertEquals(39_000, snapshot?.currentPrice)
     }
 
     @ParameterizedTest
     @ValueSource(strings = ["무료", "Sold Out", "-100"])
-    fun `가격을 정수로 파싱할 수 없으면(필수 필드 미달) null 을 반환한다`(priceText: String) {
-        val snapshot =
+    fun `가격 텍스트는 있으나 정수로 파싱할 수 없으면 invalid_value 로 fallback 한다`(priceText: String) {
+        // 가격 노드(텍스트)는 존재하므로 missing 이 아니라 invalid_value — 파서의 정규화 보강 여지를 가리킨다.
+        val result =
             extractor.extract(
                 pageOf(jsonLd("""{"@type":"Product","name":"상품","offers":{"price":"$priceText"}}""")),
             )
 
-        assertNull(snapshot)
+        assertEquals(StructuredExtraction.Miss.INVALID_VALUE, result)
     }
 
     @Test
-    fun `가격이 Int 범위를 초과하면 null 을 반환한다`() {
+    fun `가격이 Int 범위를 초과하면 invalid_value 로 fallback 한다`() {
         // 999999999999 는 Int.MAX(약 21억)를 한참 초과 — toInt 로는 wrap 되지만 intValueExact 로 거른다.
-        val snapshot =
+        val result =
             extractor.extract(
                 pageOf(jsonLd("""{"@type":"Product","name":"초대형가격","offers":{"price":"999999999999"}}""")),
             )
 
-        assertNull(snapshot)
+        assertEquals(StructuredExtraction.Miss.INVALID_VALUE, result)
     }
 
     // --- 이미지 ---
@@ -248,13 +261,14 @@ class StructuredDataExtractorTest {
     @Test
     fun `image 가 배열이면 첫 원소를 imageUrl 로 쓴다`() {
         val snapshot =
-            extractor.extract(
-                pageOf(
-                    jsonLd(
-                        """{"@type":"Product","name":"이미지","image":["https://cdn.example.com/1.jpg","https://cdn.example.com/2.jpg"],"offers":{"price":"5000"}}""",
+            extractor
+                .extract(
+                    pageOf(
+                        jsonLd(
+                            """{"@type":"Product","name":"이미지","image":["https://cdn.example.com/1.jpg","https://cdn.example.com/2.jpg"],"offers":{"price":"5000"}}""",
+                        ),
                     ),
-                ),
-            )
+                ).snapshotOrNull()
 
         assertEquals("https://cdn.example.com/1.jpg", snapshot?.imageUrl)
     }
@@ -262,28 +276,30 @@ class StructuredDataExtractorTest {
     @Test
     fun `https 가 아닌 image 는 imageUrl 만 null 이고 나머지로 성공한다`() {
         val snapshot =
-            extractor.extract(
-                pageOf(
-                    jsonLd(
-                        """{"@type":"Product","name":"비https이미지","image":"http://cdn.example.com/p.jpg","offers":{"price":"5000"}}""",
+            extractor
+                .extract(
+                    pageOf(
+                        jsonLd(
+                            """{"@type":"Product","name":"비https이미지","image":"http://cdn.example.com/p.jpg","offers":{"price":"5000"}}""",
+                        ),
                     ),
-                ),
-            )
+                ).snapshotOrNull()
 
         assertEquals("비https이미지", snapshot?.name)
-        assertNull(snapshot?.imageUrl)
+        assertEquals(null, snapshot?.imageUrl)
     }
 
     @Test
     fun `image 가 ImageObject 면 contentUrl 을 imageUrl 로 뽑는다`() {
         val snapshot =
-            extractor.extract(
-                pageOf(
-                    jsonLd(
-                        """{"@type":"Product","name":"이미지객체","image":{"@type":"ImageObject","contentUrl":"https://cdn.example.com/c.jpg"},"offers":{"price":"5000"}}""",
+            extractor
+                .extract(
+                    pageOf(
+                        jsonLd(
+                            """{"@type":"Product","name":"이미지객체","image":{"@type":"ImageObject","contentUrl":"https://cdn.example.com/c.jpg"},"offers":{"price":"5000"}}""",
+                        ),
                     ),
-                ),
-            )
+                ).snapshotOrNull()
 
         assertEquals("https://cdn.example.com/c.jpg", snapshot?.imageUrl)
     }
@@ -291,13 +307,14 @@ class StructuredDataExtractorTest {
     @Test
     fun `image 가 ImageObject 배열이면 첫 원소의 contentUrl 을 뽑는다`() {
         val snapshot =
-            extractor.extract(
-                pageOf(
-                    jsonLd(
-                        """{"@type":"Product","name":"이미지배열","image":[{"@type":"ImageObject","contentUrl":"https://cdn.example.com/1.jpg"},{"@type":"ImageObject","contentUrl":"https://cdn.example.com/2.jpg"}],"offers":{"price":"5000"}}""",
+            extractor
+                .extract(
+                    pageOf(
+                        jsonLd(
+                            """{"@type":"Product","name":"이미지배열","image":[{"@type":"ImageObject","contentUrl":"https://cdn.example.com/1.jpg"},{"@type":"ImageObject","contentUrl":"https://cdn.example.com/2.jpg"}],"offers":{"price":"5000"}}""",
+                        ),
                     ),
-                ),
-            )
+                ).snapshotOrNull()
 
         assertEquals("https://cdn.example.com/1.jpg", snapshot?.imageUrl)
     }
@@ -305,13 +322,14 @@ class StructuredDataExtractorTest {
     @Test
     fun `ImageObject 에 url 과 contentUrl 이 둘 다 있으면 url 을 우선한다`() {
         val snapshot =
-            extractor.extract(
-                pageOf(
-                    jsonLd(
-                        """{"@type":"Product","name":"우선순위","image":{"@type":"ImageObject","url":"https://cdn.example.com/url.jpg","contentUrl":"https://cdn.example.com/content.jpg"},"offers":{"price":"5000"}}""",
+            extractor
+                .extract(
+                    pageOf(
+                        jsonLd(
+                            """{"@type":"Product","name":"우선순위","image":{"@type":"ImageObject","url":"https://cdn.example.com/url.jpg","contentUrl":"https://cdn.example.com/content.jpg"},"offers":{"price":"5000"}}""",
+                        ),
                     ),
-                ),
-            )
+                ).snapshotOrNull()
 
         assertEquals("https://cdn.example.com/url.jpg", snapshot?.imageUrl)
     }
@@ -330,7 +348,7 @@ class StructuredDataExtractorTest {
             </head><body></body></html>
             """.trimIndent()
 
-        val snapshot = extractor.extract(pageOf(html))
+        val snapshot = extractor.extract(pageOf(html)).snapshotOrNull()
 
         assertEquals("오지상품", snapshot?.name)
         assertEquals(45_000, snapshot?.currentPrice)
@@ -339,11 +357,12 @@ class StructuredDataExtractorTest {
     }
 
     @Test
-    fun `og 에 title 만 있고 가격이 없으면 필수 필드 미달로 null 을 반환한다`() {
+    fun `og 에 title 만 있고 가격이 없으면 missing_field 로 fallback 한다`() {
+        // og 태그는 있으나(no_data 아님) 가격이 없어 필수 필드 미달.
         val html =
             """<html><head><meta property="og:title" content="이름만"/></head><body></body></html>"""
 
-        assertNull(extractor.extract(pageOf(html)))
+        assertEquals(StructuredExtraction.Miss.MISSING_FIELD, extractor.extract(pageOf(html)))
     }
 
     @Test
@@ -357,7 +376,7 @@ class StructuredDataExtractorTest {
             </head><body></body></html>
             """.trimIndent()
 
-        val snapshot = extractor.extract(pageOf(html))
+        val snapshot = extractor.extract(pageOf(html)).snapshotOrNull()
 
         assertEquals("제이슨엘디", snapshot?.name)
         assertEquals(10_000, snapshot?.currentPrice)
@@ -374,7 +393,7 @@ class StructuredDataExtractorTest {
             </head><body></body></html>
             """.trimIndent()
 
-        assertEquals("상품명 [Grey] - 사이즈 & 후기", extractor.extract(pageOf(html))?.name)
+        assertEquals("상품명 [Grey] - 사이즈 & 후기", extractor.extract(pageOf(html)).snapshotOrNull()?.name)
     }
 
     @Test
@@ -388,7 +407,7 @@ class StructuredDataExtractorTest {
             </head><body></body></html>
             """.trimIndent()
 
-        assertEquals("가방", extractor.extract(pageOf(html))?.name)
+        assertEquals("가방", extractor.extract(pageOf(html)).snapshotOrNull()?.name)
     }
 
     @Test
@@ -401,45 +420,83 @@ class StructuredDataExtractorTest {
             </head><body></body></html>
             """.trimIndent()
 
-        assertEquals("상품명 | 사이트", extractor.extract(pageOf(html))?.name)
+        assertEquals("상품명 | 사이트", extractor.extract(pageOf(html)).snapshotOrNull()?.name)
     }
 
-    // --- 필수 필드 / 검증 미달 → null (fallback 신호) ---
+    // --- 실패 사유(reason) 분류 ---
 
     @Test
-    fun `name 만 있고 price 가 없으면 null 을 반환한다`() {
-        assertNull(
+    fun `name 만 있고 price 가 없으면 missing_field 로 fallback 한다`() {
+        assertEquals(
+            StructuredExtraction.Miss.MISSING_FIELD,
             extractor.extract(pageOf(jsonLd("""{"@type":"Product","name":"이름만"}"""))),
         )
     }
 
     @Test
-    fun `price 만 있고 name 이 없으면 null 을 반환한다`() {
-        assertNull(
+    fun `price 만 있고 name 이 없으면 missing_field 로 fallback 한다`() {
+        assertEquals(
+            StructuredExtraction.Miss.MISSING_FIELD,
             extractor.extract(pageOf(jsonLd("""{"@type":"Product","offers":{"price":"10000"}}"""))),
         )
     }
 
     @Test
-    fun `name 이 공백뿐이면 정규화 후 null 이 되어 null 을 반환한다`() {
-        assertNull(
+    fun `name 이 공백뿐이면 missing_field 로 fallback 한다`() {
+        assertEquals(
+            StructuredExtraction.Miss.MISSING_FIELD,
             extractor.extract(pageOf(jsonLd("""{"@type":"Product","name":"   ","offers":{"price":"10000"}}"""))),
         )
     }
 
     @Test
-    fun `name 이 512자를 초과하면(범위 위반) null 을 반환한다`() {
+    fun `name 이 512자를 초과하면(범위 위반) invalid_value 로 fallback 한다`() {
         val longName = "가".repeat(513)
-        assertNull(
+        assertEquals(
+            StructuredExtraction.Miss.INVALID_VALUE,
             extractor.extract(pageOf(jsonLd("""{"@type":"Product","name":"$longName","offers":{"price":"10000"}}"""))),
         )
     }
 
     @Test
-    fun `Product 가 아닌 페이지(구조화 데이터 없음)는 null 을 반환한다`() {
+    fun `Product 도 og 태그도 없으면 no_data 로 fallback 한다`() {
         val html = """<html><head><title>그냥 글</title></head><body><p>본문</p></body></html>"""
-        assertNull(extractor.extract(pageOf(html)))
+        assertEquals(StructuredExtraction.Miss.NO_DATA, extractor.extract(pageOf(html)))
     }
+
+    @Test
+    fun `여러 Product 가 모두 실패하면 더 근접한 사유를 reason 으로 보고한다`() {
+        // 첫 노드: price 없음(missing_field), 둘째 노드: price 음수(invalid_value). 성공 노드 없음 → 더 근접한 invalid_value.
+        val html =
+            jsonLd(
+                """[{"@type":"Product","name":"미달"},{"@type":"Product","name":"음수","offers":{"price":"-100"}}]""",
+            )
+        assertEquals(StructuredExtraction.Miss.INVALID_VALUE, extractor.extract(pageOf(html)))
+    }
+
+    @Test
+    fun `JSON-LD 는 부재하고 OG 가격이 파싱 불가면 cross-source worse 로 invalid_value 를 보고한다`() {
+        // JSON-LD Product 없음(no_data) + OG 는 title·가격텍스트가 있으나 파싱 불가(invalid_value).
+        // extract() 가 두 소스를 worse 로 합쳐 더 근접한 invalid_value 를 골라야 한다.
+        val html =
+            """
+            <html><head>
+            <meta property="og:title" content="오지상품"/>
+            <meta property="product:price:amount" content="무료"/>
+            </head><body></body></html>
+            """.trimIndent()
+        assertEquals(StructuredExtraction.Miss.INVALID_VALUE, extractor.extract(pageOf(html)))
+    }
+
+    @Test
+    fun `og 에 통화만 있고 다른 태그가 없으면 no_data 가 아니라 missing_field 로 fallback 한다`() {
+        // product:price:currency 만 단독으로 있는 페이지 — OG 태그가 존재하므로 no_data 가 아니라 필수 필드 미달(missing_field).
+        val html =
+            """<html><head><meta property="product:price:currency" content="KRW"/></head><body></body></html>"""
+        assertEquals(StructuredExtraction.Miss.MISSING_FIELD, extractor.extract(pageOf(html)))
+    }
+
+    private fun StructuredExtraction.snapshotOrNull(): ProductSnapshot? = (this as? StructuredExtraction.Extracted)?.snapshot
 
     private fun jsonLd(body: String): String =
         """


### PR DESCRIPTION
## Situation
- 상품 URL 추출은 구조화 데이터(JSON-LD/OpenGraph) 직접 파싱을 먼저 시도하고, 실패하면 Gemini(LLM)로 넘어간다 (#437).
- 직접 파싱이 얼마나 적중하는지(=비싼 LLM 호출을 얼마나 줄였는지)가 곧 비용 지표인데, 지금은 로그로만 남아 Grafana에서 비율·추세·알림을 볼 수 없었다. 커스텀 Micrometer 메트릭은 이 프로젝트에 처음 들어간다.

## Task
- 추출 방법(직접 파싱 vs LLM)의 비율을 메트릭으로 집계해 Grafana에서 보이게 한다.
- LLM으로 넘어간 경우 그 사유까지 분해해, 직접 파싱 적중률을 어디서 올릴지 판단할 단서를 남긴다.

## Action

### 메트릭
- `product.extract` 카운터를 추가한다. `via` 라벨로 직접 파싱(structured)과 LLM fallback(llm)을 나누고, llm은 `reason` 라벨로 사유를 분해한다.
- 카운터는 LLM 호출 직전에 올린다. LLM이 실패해도 "직접 파싱으로 못 끝내 LLM에 의존한 비율"에 포함되어야 하기 때문.

| reason | 의미 | 시사점 |
|---|---|---|
| `no_data` | 사이트가 구조화 데이터를 아예 제공 안 함 | LLM 불가피 |
| `missing_field` | 데이터는 있으나 필수 필드(name·price) 없음 | 파서가 더 많은 위치를 봐야 할 수 있음 |
| `invalid_value` | 값은 있으나 검증·범위 실패(가격 음수·파싱불가·길이초과) | 정규화 보강 여지 |

### 사유 식별을 위한 반환 타입 변경
- 사유를 남기려면 직접 파서가 "왜 실패했는지"를 알려줘야 해서, 구조화 파서의 반환을 단순 nullable에서 sealed 결과(성공 | 사유를 담은 실패)로 바꿨다.
- 가격은 raw 텍스트가 있는지로 `missing_field`와 `invalid_value`를 가른다. 여러 후보(JSON-LD 여러 노드, JSON-LD와 OG)가 모두 실패하면 더 데이터에 근접한 사유를 고른다. 이 근접도 비교는 enum 선언 순서가 아니라 명시 `rank`로 둬서 상수 재배치에 깨지지 않는다.

### 리뷰에서 발견·정정한 버그
- 코드 리뷰 중, 두 경로의 라벨 키가 달라(structured는 `via`만, llm은 `via`+`reason`) Prometheus가 뒤 시계열을 조용히 드롭하는 문제를 발견했다. 실측으로 운영 레지스트리에서 `via=llm`이 scrape에서 통째로 사라지는 걸 확인했다. 이 작업의 목적 지표가 유실되는 버그였다.
- 카운터를 단일 발행 지점으로 모아 항상 `via`+`reason` 두 키를 쓰게 했다(structured는 `reason=none`). 경로가 늘어도 라벨 키가 갈라지지 않는다.

## Result
- Grafana 직접 파싱 비율: `sum(rate(product_extract_total{via="structured"}[1h])) / sum(rate(product_extract_total[1h]))`
- LLM 사유 분해: `sum by (reason) (rate(product_extract_total{via="llm"}[1h]))`
- `application` 태그는 자동 부착, environment(dev/prod) 분리는 Alloy 단에서 처리돼 환경별로 따로 조회된다.
- 검증 한 가지: 운영 PrometheusMeterRegistry의 라벨 드롭은 테스트의 SimpleMeterRegistry가 못 잡는다. 그래서 실제 PrometheusMeterRegistry로 두 경로를 태운 뒤 scrape에 두 시계열이 다 남는지 단언하는 가드를 별도 분류로 뒀다.

---
## 연관 이슈

- close #465

## Updates

### 최신 dev 머지 (finalUrl baseUri 충돌 해결)
- same-host redirect 작업(#454 등)이 들어온 최신 dev를 머지했다. 충돌은 `StructuredDataExtractor.extract(page)` 한 곳으로, redirect를 따라간 최종 URL을 baseUri로 쓰는 dev 변경(`page.finalUrl`)과 이 PR의 sealed 반환을 합쳤다. `DefaultProductLinkExtractor`와 E2E 테스트는 auto-merge로 dev의 finalUrl baseUri와 이 PR의 변경이 함께 반영됐다. (`60380e0`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 상품 추출 과정에 대한 메트릭 추적 기능 추가 (구조화 데이터 vs LLM 경로별)

* **개선사항**
  * 구조화된 데이터 추출 실패 시 LLM 폴백 프로세스 강화
  * 추출 결과 처리 로직 개선 및 오류 분류 체계 도입

* **테스트**
  * 메트릭 추적 및 폴백 경로 검증 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
