### PR TITLE
파싱 실행 at-least-once 보장 (멈춘 작업 재실행으로 되살림)

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/common/config/AsyncConfig.kt
+++ b/src/main/kotlin/com/depromeet/piki/common/config/AsyncConfig.kt
@@ -8,7 +8,8 @@ import org.springframework.scheduling.annotation.EnableAsync
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
 import java.util.concurrent.Executor
 
-// 등록 시 item 파싱(외부 LLM 호출, read-timeout 60s)을 HTTP 응답과 분리해 백그라운드로 돌리기 위한 executor.
+// 등록 시 item 파싱(외부 LLM 호출)을 HTTP 응답과 분리해 백그라운드로 돌리기 위한 executor.
+// 단건 파싱은 60s 안에 끝나도록 외부 timeout 을 잡아 둔다(#461, Gemini read 30s + 내부 재시도 off + fetch 약 20s ≤ 약 55s).
 // 단일 인스턴스 MVP 기준의 보수적 풀 크기다. 운영 트래픽이 보이면 application.yml 로 빼 튜닝한다.
 @Configuration
 @EnableAsync
@@ -28,9 +29,10 @@ class AsyncConfig {
             // ContextSnapshot 으로 등록된 모든 ThreadLocalAccessor(brave trace context·MDC 등)를 전파한다.
             setTaskDecorator(ContextPropagatingTaskDecorator())
             // 포화 시 기본 AbortPolicy 로 거부한다. 호출 스레드(톰캣)에서 동기 실행하는 CallerRunsPolicy 는
-            // 외부 LLM 호출(최대 60s)로 톰캣 워커 풀을 고갈시켜 무관한 API 까지 번지므로 쓰지 않는다.
-            // 거부는 호출부(WishlistService.register, TournamentItemService.addItemsFromImages 등)가 잡아
-            // 해당 item 을 즉시 FAILED 로 떨어뜨린다(PROCESSING 방치 금지).
+            // 외부 LLM 호출로 톰캣 워커 풀을 고갈시켜 무관한 API 까지 번지므로 쓰지 않는다.
+            // 거부 처리는 경로마다 다르다: URL 파싱은 디스패처(ItemParsingScheduler)가 거부 시 PROCESSING 그대로 둬
+            // recover 가 재실행하고(execution at-least-once, #461), 이미지 파싱은 등록 경로가 거부를 잡아 즉시 FAILED 로
+            // 떨어뜨린다(이미지는 원본이 메모리 ByteArray 라 되살릴 수 없음).
             initialize()
         }
 

--- a/src/main/kotlin/com/depromeet/piki/item/domain/ItemSnapshot.kt
+++ b/src/main/kotlin/com/depromeet/piki/item/domain/ItemSnapshot.kt
@@ -28,6 +28,7 @@ class ItemSnapshot(
     currency: String? = null,
     status: ItemStatus = ItemStatus.PROCESSING,
     extractedAt: LocalDateTime? = null,
+    attemptCount: Int = 0,
 ) : LongBaseEntity() {
     // 추출 필드 — setter 직접 노출 대신, 의도가 박힌 명령(markReady·markFailed·recover)으로만 바꾼다.
     @Column(name = "name", length = 512)
@@ -55,6 +56,13 @@ class ItemSnapshot(
     // 추출이 완료(READY)된 시각. PROCESSING 동안은 비어 있다(null). 정체성 row 생성 시각(created_at)과 구분된다.
     @Column(name = "extracted_at")
     var extractedAt: LocalDateTime? = extractedAt
+        protected set
+
+    // 파싱 실행 시도 횟수 (execution at-least-once, #461). claim(markProcessing)에서 1 이 되고, recover 의 재실행(reclaim)마다 +1.
+    // recover 가 이 값으로 "상한 도달 → FAILED 종결" 여부를 판단한다(무한 재큐잉 방지). 증가 자체가 updated_at 을
+    // 갱신(dirty checking)해 재실행 시점부터 stale 시계를 다시 흐르게 한다 — recover 가 막 재실행한 행을 또 stale 로 오판하지 않는다.
+    @Column(name = "attempt_count", nullable = false)
+    var attemptCount: Int = attemptCount
         protected set
 
     // 엔티티 불변식 — 최후의 보루. 범위·길이만 보고 null 은 통과시킨다.
@@ -85,10 +93,21 @@ class ItemSnapshot(
 
     // PENDING → PROCESSING. 디스패처가 outbox 에서 작업을 집어(claim) 실행을 시작할 때 전이한다.
     // PENDING 이 아닌데 호출되면 디스패처가 잘못된 버전을 집은 코드 버그이므로 check(500).
-    // 이 전이로 updated_at 이 갱신돼, recover 의 stale 판정(claim 시각 기준)이 이 시각을 본다.
+    // attemptCount 를 1 로 올려 "첫 실행 시도"를 기록한다. 이 전이로 updated_at 이 갱신돼, recover 의 stale 판정이 이 시각을 본다.
     fun markProcessing() {
         check(status == ItemStatus.PENDING) { "PENDING 이 아닌 snapshot(status=$status)은 PROCESSING 으로 claim 할 수 없다" }
         status = ItemStatus.PROCESSING
+        attemptCount++
+    }
+
+    // PROCESSING 유지 + 시도 횟수 +1. recover 가 stale PROCESSING(워커 크래시·실행 누락 등으로 실행이 끝나지 않은 행)을
+    // 재실행할 때 호출한다 — claim-at-least-once 를 execution at-least-once 로 끌어올리는 핵심 전이다(#461).
+    // PROCESSING 이 아닌데 호출되면 recover 가 잘못된 행을 집은 코드 버그이므로 check(500).
+    // 상태는 그대로 두되 attemptCount 증가가 updated_at 을 갱신(dirty checking)해, 이번 재실행 시점부터 stale 윈도가 다시 흐른다.
+    // 상한 도달 여부 판단은 호출부(recover)가 attemptCount 로 한다 — 도메인은 전이만, 정책(상한 수)은 스케줄러가 쥔다.
+    fun reclaim() {
+        check(status == ItemStatus.PROCESSING) { "PROCESSING 이 아닌 snapshot(status=$status)은 재실행 claim 할 수 없다" }
+        attemptCount++
     }
 
     // PROCESSING → READY. 백그라운드 파싱이 성공해 추출 결과(snapshot)를 채우며 전이한다.

--- a/src/main/kotlin/com/depromeet/piki/item/domain/ItemStatus.kt
+++ b/src/main/kotlin/com/depromeet/piki/item/domain/ItemStatus.kt
@@ -9,12 +9,14 @@ enum class ItemStatus {
     PENDING,
 
     // 디스패처가 claim 했거나(URL) 등록 즉시 시작된(이미지) 파싱 진행 중. name·currentPrice·imageUrl 은 아직 비어 있다.
+    // 워커 크래시·실행 누락으로 여기 갇힌 행은 recover 가 재실행으로 되살린다(execution at-least-once, #461) — 재시도 중도 이 상태다.
     PROCESSING,
 
     // 파싱 완료. 추출된 상품 정보가 채워졌다.
     READY,
 
-    // 파싱 실패. 상품 페이지가 아니거나(notProductPage) 추출값을 신뢰할 수 없거나(untrustworthyValue)
-    // 인스턴스 크래시 등으로 타임아웃됐다. 동기 400 이 아니라 상태로 표현해 클라이언트가 폴링으로 인지한다.
+    // 파싱 실패. 두 갈래다: (1) 확정 실패 — 상품 페이지가 아니거나(notProductPage) 추출값을 신뢰할 수 없음(untrustworthyValue).
+    // 재시도해도 결과가 같으므로 워커가 즉시 종결한다. (2) 재시도 소진 — 일시 외부 오류·크래시로 실행이 끝나지 않은 행을
+    // recover 가 재실행 상한(현재 2회)까지 되살려봤으나 끝내 완료하지 못함. 동기 400 이 아니라 상태로 표현해 클라이언트가 폴링으로 인지한다.
     FAILED,
 }

--- a/src/main/kotlin/com/depromeet/piki/item/service/AsyncItemParsingWorker.kt
+++ b/src/main/kotlin/com/depromeet/piki/item/service/AsyncItemParsingWorker.kt
@@ -9,10 +9,12 @@ import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
 
-// itemParsingExecutor 스레드에서 파싱을 수행한다. 외부 호출(extract)은 트랜잭션 바깥에서 끝내고,
+// itemParsingExecutor 스레드에서 "단건 파싱 한 번"을 수행한다. 외부 호출(extract)은 트랜잭션 바깥에서 끝내고,
 // 상태 전이 영속화만 ItemParsingService(@Transactional) 에 위임해 짧은 트랜잭션으로 묶는다.
-// 전이 호출(markReady/markFailed)은 모두 runCatching 으로 감싸 워커 스레드로 예외가 새지 않게 한다
-// (sweeper 와의 레이스로 이미 전이됐거나, 추출값이 도메인 불변식을 위반하는 경우).
+// 결과 처리는 셋으로 갈린다(execution at-least-once, #461): 성공 → READY, 확정 실패(상품 아님·이름 없음) → 즉시 FAILED,
+// 일시 외부 오류 → 아무것도 안 하고 PROCESSING 유지(recover 가 상한까지 재실행). 재시도·종결 정책은 워커가 아니라 recover 가 쥔다.
+// 전이 호출(markReady/markFailed)은 runCatching 으로 감싸 워커 스레드로 예외가 새지 않게 한다
+// (recover 와의 레이스로 이미 전이됐거나, 추출값이 도메인 불변식을 위반하는 경우).
 @Component
 class AsyncItemParsingWorker(
     private val productLinkExtractor: ProductLinkExtractor,
@@ -48,21 +50,24 @@ class AsyncItemParsingWorker(
             }
     }
 
-    // 파싱 실패는 동기 400 이 아니라 FAILED 상태로 남긴다. 사유에 따라 로그 레벨만 구분한다.
+    // 파싱 실패는 두 갈래다 — 확정 실패는 즉시 종결, 일시 실패는 recover 에 맡긴다.
     private fun onExtractFailed(
         itemId: Long,
         link: ProductLink,
         e: Throwable,
     ) {
         when (e) {
-            // 상품 아님·추출값 신뢰 불가 — 클라이언트 입력 계약 위반이라 서버 입장에선 정상 동작(info).
-            is ProductSnapshotException ->
-                log.info("item {} 파싱 실패(계약): {} url={}", itemId, e.message, link.safeLogString())
-            // 외부 호출 실패(네트워크·timeout 등) — warn.
+            // 확정 실패 — 상품 아님·추출값 신뢰 불가. 같은 URL 을 다시 파싱해도 결과가 같으므로 즉시 FAILED 로 종결한다
+            // (사용자에게 빨리 알림). 클라이언트 입력 계약 위반이라 서버 입장에선 정상 동작(info).
+            is ProductSnapshotException -> {
+                log.info("item {} 파싱 실패(확정·재시도 무의미): {} url={}", itemId, e.message, link.safeLogString())
+                markFailedQuietly(itemId)
+            }
+            // 일시 외부 오류(네트워크·timeout·Gemini 5xx 등) — 다시 하면 될 수도 있으므로 FAILED 로 종결하지 않고
+            // PROCESSING 그대로 둔다. recover 가 stale 로 잡아 상한까지 재실행한다(execution at-least-once, #461).
             else ->
-                log.warn("item {} 파싱 실패(외부 호출): url={}", itemId, link.safeLogString(), e)
+                log.warn("item {} 파싱 실패(일시 외부 오류) → PROCESSING 유지, recover 가 재실행: url={}", itemId, link.safeLogString(), e)
         }
-        markFailedQuietly(itemId)
     }
 
     // FAILED 전이도 sweeper 와의 레이스로 실패할 수 있어(이미 전이됨) 잡아 흡수한다.

--- a/src/main/kotlin/com/depromeet/piki/item/service/ClaimedItem.kt
+++ b/src/main/kotlin/com/depromeet/piki/item/service/ClaimedItem.kt
@@ -8,3 +8,11 @@ data class ClaimedItem(
     val itemId: Long,
     val link: ProductLink,
 )
+
+// recover 한 사이클의 결과. toRetry 는 재실행(reclaim)해 워커에 다시 넘길 작업, failedCount 는 이번에 종결(FAILED)한 건수.
+// 재실행 디스패치는 트랜잭션 밖에서 스케줄러가 하므로(트랜잭션 안에서 외부 호출 금지), 서비스는 재실행 대상만 반환하고
+// 실제 워커 제출은 호출부(ItemParsingScheduler)가 한다.
+data class StaleProcessingOutcome(
+    val toRetry: List<ClaimedItem>,
+    val failedCount: Int,
+)

--- a/src/main/kotlin/com/depromeet/piki/item/service/ItemParsingScheduler.kt
+++ b/src/main/kotlin/com/depromeet/piki/item/service/ItemParsingScheduler.kt
@@ -12,8 +12,13 @@ import java.time.LocalDateTime
 // PENDING 은 반드시 한 번은 claim 돼 실행이 시작된다. item_snapshots 테이블 자체가 outbox(상태머신을 가진 작업 큐)라
 // 별도 테이블이 없다.
 //
-// 한계 — 보장은 'claim-at-least-once' 이지 '실행 at-least-once' 가 아니다: claim(PROCESSING 커밋) 직후 워커 제출
-// 전에 인스턴스가 죽으면 그 작업은 실행 0회로 PROCESSING 에 갇히고, recover 가 FAILED 로 종결한다(재큐잉 없음 — 사용자가 재등록).
+// 보장은 execution at-least-once(#461): claim 직후 크래시(실행 0회)·실행 중 크래시·일시 외부 오류로 단건 실행이
+// 끝나지 않은 작업을 recover 가 재실행으로 되살린다. 핵심 불변식 두 가지:
+//   1. 단건 시도는 60s 안에 끝난다 — fetch(≤약 20s) + Gemini(≤약 35s, 내부 재시도 off) 외부 timeout 합이 ≤ 약 55s.
+//      그래서 updated_at 이 60s(STALE_TIMEOUT_SECONDS) 보다 오래된 PROCESSING 은 "워커가 더는 돌고 있지 않다" 로 단정할 수 있고,
+//      정상적으로 도는 시도를 stale 로 오판해 죽이지 않는다.
+//   2. 재실행 상한 2회(MAX_ATTEMPTS). 최악 총 시간 = 2 x (60s 윈도 + recover 주기 15s) = 약 150s 로, 절대 3분을 넘지 않는다.
+// 재시도해도 결과가 뻔한 확정 실패(상품 아님 등)는 워커가 즉시 FAILED 하고, recover 는 "실행이 안 끝난" 행만 맡는다.
 //
 // 단일 인스턴스 기준의 @Scheduled 다. 멀티 인스턴스로 가면 claim 의 FOR UPDATE 가 중복 파싱(두 워커가 같은 행)은
 // 막지만, SKIP LOCKED 가 없어 두 디스패처가 같은 선두 batch 를 두고 락 대기로 직렬화된다 — 그때는 SKIP LOCKED
@@ -35,24 +40,27 @@ class ItemParsingScheduler(
         claimed.forEach { dispatchToWorker(it) }
     }
 
+    // 디스패처·recover 가 공유하는 워커 제출. 풀 포화(queue 초과)로 거부되면 PROCESSING 그대로 둔다 —
+    // recover 가 stale 로 잡아 재실행한다(execution at-least-once). "claim 됐는데 실행 0회" 도 되살릴 대상이라 종결하지 않는다.
+    // (#411 까지는 거부 시 즉시 FAILED 였으나, 실패·재시도 판정을 recover 한 곳으로 모으면서 여기선 종결하지 않는다.)
     private fun dispatchToWorker(claimed: ClaimedItem) {
-        // 워커 풀 포화(queue 초과)로 거부되면 PROCESSING 방치 대신 즉시 FAILED 로 떨군다 (기존 등록 경로와 같은 정책).
         runCatching { itemParsingWorker.parse(claimed.itemId, claimed.link) }
-            .onFailure { e ->
-                log.warn("item {} 워커 디스패치 거부 → FAILED: {}", claimed.itemId, e.message)
-                runCatching { itemParsingService.markFailed(claimed.itemId) }
-                    .onFailure { ex -> log.error("item {} FAILED 전이 실패, PROCESSING 방치 위험", claimed.itemId, ex) }
-            }
+            .onFailure { e -> log.warn("item {} 워커 디스패치 거부 → PROCESSING 유지, recover 가 재실행: {}", claimed.itemId, e.message) }
     }
 
-    // recover — 워커가 죽어(인스턴스 크래시 등) PROCESSING 에 갇힌 stale 작업을 주기적으로 FAILED 로 정리한다.
-    // 재시도(재큐잉)는 하지 않는다: 사용자와 맞닿은 작업이라 뒤늦은 자동 재실행은 의미가 없고, 사용자가 직접 재등록한다.
-    // stale 판정은 updated_at(PROCESSING claim 시각) 기준이라, 정상 처리 중(외부 LLM 60s)인 작업은 걸리지 않는다.
+    // recover — 단건 실행이 끝나지 않아 stale 해진 PROCESSING 을 재실행하거나(execution at-least-once) 상한 도달·되살림 불가 시 종결한다.
+    // stale 판정은 updated_at(claim·재실행 시각) 기준이라, 정상적으로 도는 단건(≤ 약 55s)은 60s 윈도에 걸리지 않는다.
     @Scheduled(fixedDelay = RECOVER_INTERVAL_MS)
     fun recover() {
-        val threshold = LocalDateTime.now().minusMinutes(STALE_TIMEOUT_MINUTES)
-        val recovered = itemParsingService.recoverStaleProcessing(threshold, BATCH_SIZE)
-        if (recovered > 0) log.warn("stale PROCESSING {}건 → FAILED 정리", recovered)
+        val threshold = LocalDateTime.now().minusSeconds(STALE_TIMEOUT_SECONDS)
+        val outcome = itemParsingService.retryOrFailStaleProcessing(threshold, BATCH_SIZE, MAX_ATTEMPTS)
+        if (outcome.toRetry.isNotEmpty()) {
+            log.warn("stale PROCESSING {}건 재실행 디스패치", outcome.toRetry.size)
+            outcome.toRetry.forEach { dispatchToWorker(it) }
+        }
+        if (outcome.failedCount > 0) {
+            log.warn("stale PROCESSING {}건 → FAILED (재시도 상한 도달 또는 되살릴 수 없음)", outcome.failedCount)
+        }
     }
 
     companion object {
@@ -60,9 +68,14 @@ class ItemParsingScheduler(
 
         // 사용자 대면 작업이라 짧게 둔다 — 등록 직후 파싱이 시작되기까지의 지연이 이 주기로 결정된다.
         private const val DISPATCH_INTERVAL_MS = 1_000L
-        private const val RECOVER_INTERVAL_MS = 60_000L
 
-        // 정상 파싱이 끝났어야 할 시간(외부 LLM read-timeout 60s)을 넉넉히 넘긴 기준. 이보다 오래 PROCESSING 이면 방치로 본다.
-        private const val STALE_TIMEOUT_MINUTES = 5L
+        // recover 주기. stale 윈도(60s) + 이 주기가 stale 감지 지연이므로, 최악 총 시간(2 x (60s + 15s) = 약 150s)을 3분 밑으로 둔다.
+        private const val RECOVER_INTERVAL_MS = 15_000L
+
+        // 단건 시도가 60s 안에 끝나는 구조라(외부 timeout 합 ≤ 약 55s), 60s 넘게 PROCESSING 이면 워커가 더는 돌고 있지 않다고 본다.
+        private const val STALE_TIMEOUT_SECONDS = 60L
+
+        // 실행 시도 상한(초회 1 + 재시도 1). 단건 ≤ 60s 와 함께 "절대 3분 초과 금지" 를 보장한다.
+        private const val MAX_ATTEMPTS = 2
     }
 }

--- a/src/main/kotlin/com/depromeet/piki/item/service/ItemParsingService.kt
+++ b/src/main/kotlin/com/depromeet/piki/item/service/ItemParsingService.kt
@@ -76,20 +76,48 @@ class ItemParsingService(
         }
     }
 
-    // 워커가 죽어(인스턴스 크래시 등) PROCESSING 에 갇힌 stale 작업을 FAILED 로 정리한다 (재시도/재큐잉 없음 — 사용자가 재등록).
-    // snapshot 은 FOR UPDATE 로 PROCESSING 으로 잠겨 markFailed 가 throw 하지 않으므로 batch poison 이 없다.
-    // 정리 건수를 반환해 호출부가 요약 로그를 남긴다.
+    // stale PROCESSING(워커 크래시·실행 누락·일시 오류로 단건 실행이 끝나지 않은 행)을 집어 재실행 또는 종결한다.
+    // claim-at-least-once 를 execution at-least-once 로 끌어올리는 핵심(#461) — 기존의 "무조건 FAILED" 를 "재실행 우선"으로 바꿨다.
+    //
+    // 단건 시도는 워커가 60s 안에 끝내므로(외부 timeout 합 ≤ 약 55s, Gemini 내부 재시도 off), updated_at 이 60s 보다 오래된
+    // PROCESSING 은 워커가 더는 돌고 있지 않다는 뜻이다. 그런 행을:
+    //   - link 가 없으면(이미지 경로 — 원본이 메모리 ByteArray 라 크래시 시 소실) 되살릴 수 없으므로 즉시 FAILED.
+    //   - attempt 가 상한(maxAttempts)에 도달했으면 더 시도하지 않고 FAILED (무한 재큐잉 방지, 절대 3분 초과 금지).
+    //   - 그 외에는 reclaim(attempt++, PROCESSING 유지)해 재실행 대상으로 반환한다 — 실제 워커 제출은 스케줄러가 트랜잭션 밖에서 한다.
+    //
+    // snapshot 은 FOR UPDATE 로 PROCESSING 으로 잠겨 reclaim·markFailed 가 throw 하지 않으므로 batch poison 이 없다.
     @Transactional
-    fun recoverStaleProcessing(
+    fun retryOrFailStaleProcessing(
         threshold: LocalDateTime,
         batchSize: Int,
-    ): Int {
+        maxAttempts: Int,
+    ): StaleProcessingOutcome {
         val stale = itemSnapshotRepository.findStaleProcessing(threshold, batchSize)
-        if (stale.isEmpty()) return 0
+        if (stale.isEmpty()) return StaleProcessingOutcome(emptyList(), 0)
+        // per-snapshot N+1 대신 link 를 item 에서 한 번에 로드한다 (snapshot 은 itemId 만 들고 link 는 item 소관).
+        val linkByItemId = itemRepository.findByIds(stale.map { it.itemId }).associateBy({ it.getId() }, { it.link })
+        val toRetry = mutableListOf<ClaimedItem>()
+        var failedCount = 0
         stale.forEach { snapshot ->
-            snapshot.markFailed()
-            eventPublisher.publishEvent(ItemParsingFailed(snapshot.itemId))
+            // link 없음(이미지·orphan): 되살릴 원본이 없으므로 종결. associateBy 값이 null(이미지)이든 키 부재(orphan)든 Elvis 로 동일 처리.
+            val link =
+                linkByItemId[snapshot.itemId] ?: run {
+                    snapshot.markFailed()
+                    eventPublisher.publishEvent(ItemParsingFailed(snapshot.itemId))
+                    failedCount++
+                    return@forEach
+                }
+            // 재시도 상한 도달: 더 되살리지 않고 종결.
+            if (snapshot.attemptCount >= maxAttempts) {
+                snapshot.markFailed()
+                eventPublisher.publishEvent(ItemParsingFailed(snapshot.itemId))
+                failedCount++
+                return@forEach
+            }
+            // 재실행: PROCESSING 유지 + attempt++ (updated_at 갱신으로 stale 시계 리셋). 디스패치는 스케줄러가.
+            snapshot.reclaim()
+            toRetry.add(ClaimedItem(itemId = snapshot.itemId, link = link))
         }
-        return stale.size
+        return StaleProcessingOutcome(toRetry, failedCount)
     }
 }

--- a/src/main/kotlin/com/depromeet/piki/product/service/gemini/GeminiHttpClient.kt
+++ b/src/main/kotlin/com/depromeet/piki/product/service/gemini/GeminiHttpClient.kt
@@ -87,7 +87,8 @@ class GeminiHttpClient(
         private const val BASE_URL = "https://generativelanguage.googleapis.com"
         private const val CONNECT_TIMEOUT_MS = 5_000
 
-        // LLM 응답이 길어질 수 있어 넉넉히 두되, 1 분 안에 재시도(최대 2회)까지 끝낼 수 있도록 30 초로 제한.
+        // LLM 응답이 길어질 수 있어 넉넉히 두되, 단건 파싱을 60s 안에 끝내기 위해(#461) 30 초로 제한한다.
+        // Gemini 내부 재시도는 기본 off(maxAttempts=1)라 이 30s 가 곧 한 번 호출의 상한이다 — fetch(≤약 20s)와 합쳐 단건 ≤ 약 55s.
         private const val READ_TIMEOUT_MS = 30_000
 
         // API 키는 access log 에 남지 않도록 쿼리 대신 헤더로 전달.

--- a/src/main/kotlin/com/depromeet/piki/product/service/gemini/GeminiProperties.kt
+++ b/src/main/kotlin/com/depromeet/piki/product/service/gemini/GeminiProperties.kt
@@ -21,9 +21,10 @@ data class GeminiProperties(
      * billed API 호출 횟수 상한이므로, API 비용·quota 를 고려해 운영에서 직접 조정한다.
      */
     data class Retry(
-        // max-attempts 는 총 시도 횟수(초기 호출 + 재시도). 기본 2 = 초기 호출 1회 + 재시도 1회.
-        // 한 요청이 유발하는 billed API 호출 횟수 상한이므로 비용·quota 에 맞춰 운영에서 조정한다.
-        val maxAttempts: Int = 2,
+        // max-attempts 는 총 시도 횟수(초기 호출 + 재시도). 기본 1 = 재시도 없음.
+        // URL 파싱 재시도를 outbox recover 로 일원화해(#461) Gemini 내부 재시도를 끈 것이 기본값이다 — 켜면 단건 파싱이
+        // 60s 를 넘겨 "단건 ≤60s, 절대 3분 초과 금지" 보장이 깨지므로 비용·quota 와 함께 그 영향을 확인하고 조정한다.
+        val maxAttempts: Int = 1,
         val initialDelayMs: Long = 1_000,
     ) {
         init {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -78,9 +78,11 @@ gemini:
   # 기본 모델은 GeminiProperties.DEFAULT_MODEL 한 곳에서만 정의한다 (drift 방지). 여기엔 리터럴을 두지 않는다.
   # 운영에서 모델을 바꾸려면 GEMINI_MODEL 환경변수로 override (relaxed binding: GEMINI_MODEL -> gemini.model).
   retry:
-    # max-attempts 는 총 시도 횟수(초기 호출 + 재시도). 기본 2 = 초기 호출 1회 + 재시도 1회.
-    # 한 요청이 유발하는 billed API 호출 횟수 상한이므로 비용·quota 에 맞춰 환경변수로 조정.
-    max-attempts: ${GEMINI_RETRY_MAX_ATTEMPTS:2}
+    # max-attempts 는 총 시도 횟수(초기 호출 + 재시도). 기본 1 = 재시도 없음.
+    # URL 파싱 재시도를 outbox recover(ItemParsingScheduler) 한 곳으로 모았다(#461) — Gemini 내부 재시도를 켜면
+    # 단건 파싱이 재시도 1회당 약 +35s 늘어 60s 를 넘기고 "단건 ≤60s, 절대 3분 초과 금지" 보장이 깨진다. 올리기 전 그 영향을 반드시 확인.
+    # 한 요청이 유발하는 billed API 호출 횟수 상한이기도 해 비용·quota 와도 직결된다.
+    max-attempts: ${GEMINI_RETRY_MAX_ATTEMPTS:1}
     initial-delay-ms: ${GEMINI_RETRY_INITIAL_DELAY_MS:1000}
 
 admin:

--- a/src/main/resources/db/migration/V20260608215533__add_attempt_count_to_item_snapshots.sql
+++ b/src/main/resources/db/migration/V20260608215533__add_attempt_count_to_item_snapshots.sql
@@ -1,0 +1,9 @@
+-- 파싱 실행 재시도 상한 카운터 (execution at-least-once, #461).
+-- 디스패처가 PENDING 을 claim 할 때(markProcessing) 1 이 되고, recover 가 stale PROCESSING 을 재실행할 때마다 +1 된다.
+-- recover 는 attempt_count 가 상한(현재 2)에 도달하면 재실행 대신 FAILED 로 종결한다 — 무한 재큐잉 방지.
+-- attempt_count 증가는 곧 updated_at 을 갱신(dirty checking)해, 재실행 시점부터 stale 시계가 다시 흐르게 한다.
+--
+-- additive·commutative: 기존 행은 DEFAULT 0 으로 채워지고, 적용 순서가 결과를 바꾸지 않는다.
+-- 조회 필터가 아니라 fetch 후 메모리 분기 값이라 별도 인덱스는 두지 않는다 (recover 는 (status, updated_at) 인덱스로 조회).
+ALTER TABLE item_snapshots
+    ADD COLUMN attempt_count INT NOT NULL DEFAULT 0;

--- a/src/test/kotlin/com/depromeet/piki/item/domain/ItemSnapshotTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/item/domain/ItemSnapshotTest.kt
@@ -190,4 +190,33 @@ class ItemSnapshotTest {
         assertEquals(HttpStatus.CONFLICT, ex.httpStatus)
         assertEquals(ItemStatus.PENDING, snapshot.status)
     }
+
+    // --- 재실행 claim (reclaim) — execution at-least-once (#461) ---
+
+    @Test
+    fun `markProcessing 은 attemptCount 를 1 로 올려 첫 실행 시도를 기록한다`() {
+        val snapshot = ItemSnapshot.pending(itemId = 1L)
+        assertEquals(0, snapshot.attemptCount)
+        snapshot.markProcessing()
+        assertEquals(1, snapshot.attemptCount)
+    }
+
+    @Test
+    fun `reclaim 은 PROCESSING 을 유지하며 attemptCount 를 올린다`() {
+        // 워커 크래시 등으로 PROCESSING 에 갇힌 행을 recover 가 재실행할 때의 전이.
+        val snapshot = ItemSnapshot.pending(itemId = 1L).apply { markProcessing() } // PROCESSING, attempt 1
+        snapshot.reclaim()
+        assertEquals(ItemStatus.PROCESSING, snapshot.status)
+        assertEquals(2, snapshot.attemptCount)
+    }
+
+    @Test
+    fun `PROCESSING 이 아닌 스냅샷을 reclaim 하면 IllegalStateException`() {
+        // PENDING(claim 전)·READY(완료)·FAILED(실패)는 재실행 claim 대상이 아니다 — recover 가 잘못된 행을 집은 코드 버그 방어.
+        assertFailsWith<IllegalStateException> { ItemSnapshot.pending(1L).reclaim() }
+        assertFailsWith<IllegalStateException> {
+            ItemSnapshot(itemId = 1L).apply { markReady(ProductSnapshot(name = "x")) }.reclaim()
+        }
+        assertFailsWith<IllegalStateException> { ItemSnapshot(itemId = 1L).apply { markFailed() }.reclaim() }
+    }
 }

--- a/src/test/kotlin/com/depromeet/piki/wishlist/controller/WishlistRegisterAsyncIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/wishlist/controller/WishlistRegisterAsyncIntegrationTest.kt
@@ -8,7 +8,7 @@ import com.depromeet.piki.item.domain.ItemSnapshot
 import com.depromeet.piki.item.domain.ItemStatus
 import com.depromeet.piki.item.repository.ItemRepository
 import com.depromeet.piki.item.repository.ItemSnapshotRepository
-import com.depromeet.piki.item.service.ItemParsingService
+import com.depromeet.piki.item.service.ItemParsingScheduler
 import com.depromeet.piki.product.domain.ProductLink
 import com.depromeet.piki.product.service.ProductSnapshot
 import com.depromeet.piki.product.service.ProductSnapshotException
@@ -42,6 +42,7 @@ import java.io.ByteArrayOutputStream
 import java.time.Duration
 import java.time.LocalDateTime
 import java.util.UUID
+import java.util.concurrent.atomic.AtomicInteger
 import javax.imageio.ImageIO
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -69,7 +70,7 @@ class WishlistRegisterAsyncIntegrationTest : IntegrationTestSupport() {
     private lateinit var itemSnapshotRepository: ItemSnapshotRepository
 
     @Autowired
-    private lateinit var itemParsingService: ItemParsingService
+    private lateinit var itemParsingScheduler: ItemParsingScheduler
 
     @Autowired
     private lateinit var jdbcTemplate: JdbcTemplate
@@ -340,27 +341,99 @@ class WishlistRegisterAsyncIntegrationTest : IntegrationTestSupport() {
     }
 
     @Test
-    fun `updated_at 이 오래된 PROCESSING snapshot 을 recover 가 FAILED 로 정리한다`() {
-        // 워커가 죽어 PROCESSING 에 갇힌 상황 — 디스패처는 PENDING 만 집으므로 이 행은 recover 가 책임진다.
-        val item = itemRepository.save(Item(ProductLink.parse("https://shop.example.com/products/stale")))
-        val snapshot = itemSnapshotRepository.save(ItemSnapshot.processing(item.getId()))
+    fun `link 있는 stale PROCESSING 을 recover 가 재실행해 READY 로 되살린다`() {
+        // 디스패처가 claim(attempt 1)한 직후 워커가 크래시해 실행 0회로 PROCESSING 에 갇힌 상황.
+        // recover 가 재실행(reclaim)해 완성시킨다 — claim-at-least-once 를 execution at-least-once 로 끌어올리는 핵심(#461).
+        stubProductLinkExtractor.build = {
+            ProductSnapshot(link = it, name = "되살아난 상품", currentPrice = 1_000, currency = "KRW")
+        }
+        val item = itemRepository.save(Item(ProductLink.parse("https://shop.example.com/products/revive")))
+        val snapshot = itemSnapshotRepository.save(ItemSnapshot.pending(item.getId()).apply { markProcessing() })
         val itemId = item.getId()
         try {
-            // 이 snapshot 의 updated_at 만 과거로 밀어 stale 로 만들고, 현실적 threshold(now-5분)로 recover 를 부른다.
-            // future threshold 로 부르면 다른 테스트가 막 만든 PROCESSING(updated_at 최근)까지 쓸어버리므로(공유 컨텍스트),
-            // updated_at 기반 stale 판정을 실제로 검증하면서 자기 snapshot 만 대상이 되도록 격리한다.
+            // 이 행의 updated_at 만 과거로 밀어 stale 로 만든다. 현실적 threshold(스케줄러의 now-60초)라
+            // 다른 테스트가 막 만든 최근 PROCESSING 은 안 건드리고, 이 행만 대상이 된다(공유 컨텍스트 격리).
             jdbcTemplate.update(
                 "UPDATE item_snapshots SET updated_at = ? WHERE id = ?",
-                LocalDateTime.now().minusMinutes(10),
+                LocalDateTime.now().minusSeconds(120),
                 snapshot.getId(),
             )
 
-            itemParsingService.recoverStaleProcessing(LocalDateTime.now().minusMinutes(5), 100)
+            itemParsingScheduler.recover() // reclaim(attempt 2) + 재실행 디스패치
 
-            assertEquals(ItemStatus.FAILED, itemSnapshotRepository.findLatestByItemId(itemId)?.status)
+            await().atMost(Duration.ofSeconds(5)).until { latestSnapshot(itemId)?.status == ItemStatus.READY }
+            val recovered = latestSnapshot(itemId) ?: error("item $itemId 의 snapshot 이 없다")
+            assertEquals("되살아난 상품", recovered.name)
+            assertEquals(2, recovered.attemptCount) // 초회 claim 1 + 재실행 1
         } finally {
             jdbcTemplate.update("DELETE FROM item_snapshots WHERE item_id = ?", itemId)
             jdbcTemplate.update("DELETE FROM items WHERE id = ?", itemId)
+        }
+    }
+
+    @Test
+    fun `재시도 상한에 도달한 stale PROCESSING 은 recover 가 FAILED 로 종결한다`() {
+        // 이미 상한(2회)까지 시도된 채 stale — 더 되살리지 않고 종결한다 (무한 재큐잉 방지, 절대 3분 초과 금지).
+        val item = itemRepository.save(Item(ProductLink.parse("https://shop.example.com/products/exhausted")))
+        val snapshot = itemSnapshotRepository.save(ItemSnapshot.pending(item.getId()).apply { markProcessing() })
+        val itemId = item.getId()
+        try {
+            jdbcTemplate.update(
+                "UPDATE item_snapshots SET attempt_count = 2, updated_at = ? WHERE id = ?",
+                LocalDateTime.now().minusSeconds(120),
+                snapshot.getId(),
+            )
+
+            itemParsingScheduler.recover() // attempt 2 >= 2 → FAILED (재실행 없음, 동기 종결)
+
+            assertEquals(ItemStatus.FAILED, latestSnapshot(itemId)?.status)
+        } finally {
+            jdbcTemplate.update("DELETE FROM item_snapshots WHERE item_id = ?", itemId)
+            jdbcTemplate.update("DELETE FROM items WHERE id = ?", itemId)
+        }
+    }
+
+    @Test
+    fun `link 없는 이미지 stale PROCESSING 은 recover 가 FAILED 로 종결한다`() {
+        // 이미지 경로(link 없음)는 원본이 메모리 ByteArray 라 크래시 시 소실 — 되살릴 수 없으므로 attempt 와 무관하게 종결한다.
+        val item = itemRepository.save(Item(link = null))
+        val snapshot = itemSnapshotRepository.save(ItemSnapshot.processing(item.getId()))
+        val itemId = item.getId()
+        try {
+            jdbcTemplate.update(
+                "UPDATE item_snapshots SET updated_at = ? WHERE id = ?",
+                LocalDateTime.now().minusSeconds(120),
+                snapshot.getId(),
+            )
+
+            itemParsingScheduler.recover() // link 없음 → FAILED
+
+            assertEquals(ItemStatus.FAILED, latestSnapshot(itemId)?.status)
+        } finally {
+            jdbcTemplate.update("DELETE FROM item_snapshots WHERE item_id = ?", itemId)
+            jdbcTemplate.update("DELETE FROM items WHERE id = ?", itemId)
+        }
+    }
+
+    @Test
+    fun `URL 파싱이 일시 외부 오류면 FAILED 가 아니라 PROCESSING 으로 남아 recover 재시도 대상이 된다`() {
+        // 일시 외부 오류(Gemini 5xx 등)는 워커가 FAILED 로 종결하지 않고 PROCESSING 그대로 둔다 — 재시도 판정은 recover 몫(#461).
+        val calls = AtomicInteger(0)
+        stubProductLinkExtractor.build = {
+            calls.incrementAndGet()
+            throw GeminiApiException.upstreamError(RuntimeException("transient 503"))
+        }
+        val mockMvc = buildMockMvc()
+        val userId = UUID.randomUUID()
+        insertMember(userId)
+        try {
+            val itemId = registerAndGetItemId(mockMvc, userId, "https://shop.example.com/products/transient")
+            // 디스패처 claim → 워커가 일시 오류로 throw → 워커가 실제로 한 번 실행됐는지 확인.
+            await().atMost(Duration.ofSeconds(5)).until { calls.get() >= 1 }
+            // 확정 실패가 아니므로 FAILED 로 떨어지지 않고 PROCESSING 으로 남아야 한다 (recover 재시도 대상).
+            assertEquals(ItemStatus.PROCESSING, latestSnapshot(itemId)?.status)
+        } finally {
+            cleanup(userId)
         }
     }
 


### PR DESCRIPTION
## Situation

- 파싱 등록은 #411 에서 transactional outbox 로 바꿔 "작업은 반드시 한 번 집어진다(claim)"까지 보장했다. 하지만 거기까지였다.
- 디스패처가 작업을 집은 직후 인스턴스가 죽거나 워커 실행이 누락되면, 파싱이 한 번도 안 돈 채 "처리 중"(PROCESSING)에 갇힌다. 그러면 그 작업은 자동으로 완수되지 못하고, 정리 작업(recover)이 그대로 실패 처리해 사용자가 직접 다시 등록해야 했다.

## Task

- "처리 중"에 갇혀 멈춘 파싱을 자동으로 되살려, 작업이 결국 완수되게 한다(execution at-least-once).
- 단 두 가지 제약을 동시에 지켜야 했다. 사용자 대면 작업이라 무한 재시도는 없다. 그리고 어떤 경우에도 한 아이템 파싱이 3분을 넘지 않는다. 이 3분 상한이 설계를 강하게 제약했다.

## Action

### 멈춘 작업을 실패가 아니라 재실행으로

- 주기적으로 도는 정리 작업(recover)을, 멈춘 걸 "실패 처리"하던 데서 "다시 실행"으로 바꿨다. 재시도할지 끝낼지의 판정을 이 한 곳으로 모았다. 워커는 한 번 시도만 책임진다.

| 한 아이템의 상태 | 처리 | 담당 |
|---|---|---|
| 한 번 시도 성공 | READY | 워커 |
| 확정 실패 (상품 페이지가 아님 등) | 즉시 FAILED (재시도 무의미) | 워커 |
| 시간 초과·일시 외부 오류·크래시로 안 끝남 | "처리 중" 유지 후 recover 가 다시 실행 | 워커, recover |
| 재실행 상한(2회) 도달 | FAILED | recover |
| 이미지 작업이 멈춤 (원본 소실로 되살림 불가) | FAILED | recover |

### "3분 안에"를 지키기 위한 핵심 결정

- 멈춘 걸 되살리려면 먼저 "얘 멈췄다"고 판단해야 한다. 그런데 이 판단을 너무 빨리 하면, 정상적으로 느리게 도는 파싱을 죽은 걸로 오판해 죽인다. 그래서 판단 대기시간(stale 윈도)은 "한 번 파싱의 최악 소요 시간"보다 길어야 한다.
- 문제는 한 번 파싱이 최악 약 90초까지 걸렸다는 점이다. 외부 호출이 느릴 때 Gemini 가 자기 재시도를 한 번 더 부르는 게 주범이었다. 90초짜리가 멈췄다고 판단할 때까지 기다렸다가 다시 시도하면, 그것만으로 3분을 넘긴다.
- 그래서 한 번 파싱을 60초 안에 묶기로 했다. Gemini 자기 재시도를 끄고(재시도는 위 recover 한 곳으로 일원화), 한 번 파싱을 약 55초(페이지 fetch 약 20초 + Gemini 약 35초)로 줄였다. 판단 대기 60초에 상한 2회를 곱해 최악 약 150초(2 x (60초 윈도 + recover 주기 15초))로, 절대 3분을 넘지 않는다.

### 구현

- 단조 증가하는 시도 횟수(`attempt_count`)를 스냅샷에 추가했다. 이 값이 재시도 상한 카운터이자, 증가가 곧 `updated_at` 을 갱신해 재실행 시점부터 stale 시계를 다시 흐르게 한다.
- 핵심 전이는 `ItemSnapshot.reclaim()`(PROCESSING 유지 + attempt 증가), 판정은 `ItemParsingService.retryOrFailStaleProcessing`, 재실행 디스패치는 기존 워커 제출 경로를 그대로 재사용한다. Gemini 내부 재시도는 `maxAttempts` 기본값을 1 로 내려 껐다.

## Result

- 한 아이템 파싱은 성공이든 실패든 최악 약 150초 안에 결판난다(절대 3분 초과 없음). 클라이언트가 보는 상태 흐름(PENDING→PROCESSING→READY/FAILED)과 폴링 방식은 그대로다. 재시도는 내부에서만 일어나 계약이 바뀌지 않는다.
- 트레이드오프: Gemini 자기 재시도를 끈 것은 이미지 OCR 과 같은 클라이언트를 공유한다. 그래서 이미지 일시 오류도 이제 바로 실패 처리된다(재업로드 필요). 이미지는 원본이 메모리에만 있는 비-durable 경로라 수용했고, 이미지 전용 재시도와 durable 저장은 후속으로 둔다.
- 검증의 비자명한 부분: stale 윈도 60초가 단건 최악 약 55초보다 커서 정상 파싱을 오판해 죽이지 않는다는 게 안전성의 핵심이다. 되살림 성공(READY), 상한 도달 종결(FAILED), 이미지 종결(FAILED), 일시 오류 시 "처리 중" 유지의 네 갈래를 통합 테스트로 고정했다.

---
## 연관 이슈

- close #461


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 상품 파싱 재시도 로직 개선: 최대 시도 횟수 기반의 유한 재시도 메커니즘 도입으로 무한 재큐잉 방지
  * 처리 중 상태 복구 개선: 일시적 외부 오류 시 처리 중 상태 유지하여 자동 재시도 대상으로 전환
  * 실패 처리 분류: 확정 실패(상품 아님/신뢰 불가)와 일시 오류 구분으로 처리 정확도 향상

* **Chores**
  * 외부 API 재시도 기본값 조정: 비용 최적화를 위한 설정 값 변경

<!-- end of auto-generated comment: release notes by coderabbit.ai -->