### PR TITLE
from-play-link 재호출 시 기존 토너먼트로 이동 (idempotent get-or-create)

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
@@ -650,13 +650,15 @@ interface TournamentApi {
         description = """
             플레이 링크가 유효한 토너먼트와 동일한 아이템 구성으로 새 토너먼트를 생성한다.
             생성된 토너먼트는 PENDING 상태이며 아이템이 미리 복사되어 있어 바로 시작할 수 있다.
+            idempotent: 같은 사용자가 같은 원본의 플레이 링크를 다시 호출하면 새로 만들지 않고
+            기존 본인 클론의 tournamentId 를 그대로 반환한다 (원본 링크 만료와 무관하게 이어서 진행 가능).
         """,
     )
     @ApiResponses(
         value = [
             ApiResponse(
-                responseCode = "201",
-                description = "복제 토너먼트 생성 성공 (tournamentId 반환)",
+                responseCode = "200",
+                description = "복제 토너먼트 생성 또는 기존 본인 클론 반환 (tournamentId 반환)",
                 content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
             ),
             ApiResponse(
@@ -671,7 +673,7 @@ interface TournamentApi {
             ),
             ApiResponse(
                 responseCode = "409",
-                description = "상태 충돌 (플레이 링크 만료 · 이미 해당 플레이 링크로 토너먼트를 생성한 경우)",
+                description = "상태 충돌 (플레이 링크 만료)",
                 content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
             ),
         ],

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApiExamples.kt
@@ -563,10 +563,14 @@ class TournamentApiExamples(
                 handlerMethod.binds(TournamentController::createFromPlayLink) ->
                     operation.examples(openApiObjectMapper.delegate) {
                         add(
-                            status = HttpStatus.CREATED,
-                            name = "복제 토너먼트 생성 성공",
-                            payload = ApiResponseBody.created(42L),
+                            status = HttpStatus.OK,
+                            name = "복제 토너먼트 생성 또는 기존 본인 클론 반환",
+                            payload = ApiResponseBody.ok(42L),
                         )
+                        unauthorized()
+                        add(TournamentException.notFoundTournament(), name = "토너먼트를 찾을 수 없음")
+                        add(TournamentException.playLinkNotCreated(), name = "플레이 링크가 생성되지 않은 토너먼트")
+                        add(TournamentException.playLinkExpired(), name = "플레이 링크 만료")
                     }
 
                 handlerMethod.binds(TournamentController::getGroupResult) ->

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentController.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentController.kt
@@ -150,13 +150,13 @@ class TournamentController(
     }
 
     @PostMapping("/{sourceTournamentId}/from-play-link")
-    @ResponseStatus(HttpStatus.CREATED)
     override fun createFromPlayLink(
         @AuthenticationPrincipal userId: UUID,
         @PathVariable sourceTournamentId: Long,
     ): ApiResponseBody<Long> {
-        val newTournamentId = tournamentService.createFromPlayLink(userId, sourceTournamentId)
-        return ApiResponseBody.created(newTournamentId)
+        // idempotent get-or-create: 신규 생성·기존 클론 반환 모두 200. 항상 "생성"이 아니므로 201 을 쓰지 않는다.
+        val tournamentId = tournamentService.createFromPlayLink(userId, sourceTournamentId)
+        return ApiResponseBody.ok(tournamentId)
     }
 
     @PatchMapping("/{tournamentId}/invite")

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
@@ -730,16 +730,20 @@ class TournamentService(
         val sourceTournament =
             tournamentRepository.findTournamentByIdForUpdate(sourceTournamentId)
                 ?: throw TournamentException.notFoundTournament()
-        sourceTournament.playLinkExpiresAt ?: throw TournamentException.playLinkNotCreated()
-        if (!sourceTournament.isPlayLinkValid()) throw TournamentException.playLinkExpired()
 
+        // get-or-create: 이미 본인 클론이 있으면 그 id 로 "이어서 진행하기".
+        // 원본 플레이링크 만료와 무관하게 돌려준다 — 클론은 자체 라이프사이클을 가진다.
         val existingTournamentIds = tournamentUserRepository
             .findTournamentIdsByUserId(userId)
             .toSet()
-        val alreadyCloned = tournamentRepository
+        tournamentRepository
             .findBySourceTournamentId(sourceTournamentId)
-            .any { it.getId() in existingTournamentIds }
-        if (alreadyCloned) throw TournamentException.alreadyCloned()
+            .firstOrNull { it.getId() in existingTournamentIds }
+            ?.let { return it.getId() }
+
+        // 신규 클론 생성 경로에서만 플레이링크 유효성을 검증한다.
+        sourceTournament.playLinkExpiresAt ?: throw TournamentException.playLinkNotCreated()
+        if (!sourceTournament.isPlayLinkValid()) throw TournamentException.playLinkExpired()
 
         val inviteCode = generateUniqueInviteCode()
         val newTournament = tournamentRepository.saveTournament(

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
@@ -230,11 +230,15 @@ class TournamentService(
     ): StartResult {
         // 오너가 이미 시작한 뒤에만 멤버가 클론을 만들 수 있다.
         if (rootTournament.isPending()) throw TournamentException.notInProgressTournament()
-        // 이미 클론이 있으면 중복 생성 방지
+        // 이미 본인이 소유한 클론이 있으면 중복 생성 방지.
+        // 참여자 기준이 아니라 소유자(ownerTournamentUserId) 기준 — 타인 클론에 참여만 한 경우를 본인 클론으로 오인하지 않는다.
         val existingClones = tournamentRepository.findBySourceTournamentId(rootTournamentId)
-        val alreadyCloned = existingClones.any { clone ->
-            tournamentUserRepository.findByTournamentIdAndUserId(clone.getId(), userId)?.let { true } ?: false
-        }
+        val ownedTournamentUserIds = tournamentUserRepository
+            .findByIds(existingClones.map { it.ownerTournamentUserId }.toSet())
+            .filter { it.userId == userId }
+            .map { it.getId() }
+            .toSet()
+        val alreadyCloned = existingClones.any { it.ownerTournamentUserId in ownedTournamentUserIds }
         if (alreadyCloned) throw TournamentException.alreadyCloned()
 
         val effectiveItems = getEffectiveTournamentItems(rootTournament)
@@ -731,14 +735,18 @@ class TournamentService(
             tournamentRepository.findTournamentByIdForUpdate(sourceTournamentId)
                 ?: throw TournamentException.notFoundTournament()
 
-        // get-or-create: 이미 본인 클론이 있으면 그 id 로 "이어서 진행하기".
+        // get-or-create: 이미 "본인이 소유한" 클론이 있으면 그 id 로 "이어서 진행하기".
+        // 참여자(TournamentUser) 기준이 아니라 소유자(ownerTournamentUserId) 기준으로 판별한다 —
+        // 타인 클론에 초대코드로 참여만 한 경우를 본인 클론으로 오인해 잘못 라우팅하지 않기 위함.
         // 원본 플레이링크 만료와 무관하게 돌려준다 — 클론은 자체 라이프사이클을 가진다.
-        val existingTournamentIds = tournamentUserRepository
-            .findTournamentIdsByUserId(userId)
+        val clones = tournamentRepository.findBySourceTournamentId(sourceTournamentId)
+        val ownedTournamentUserIds = tournamentUserRepository
+            .findByIds(clones.map { it.ownerTournamentUserId }.toSet())
+            .filter { it.userId == userId }
+            .map { it.getId() }
             .toSet()
-        tournamentRepository
-            .findBySourceTournamentId(sourceTournamentId)
-            .firstOrNull { it.getId() in existingTournamentIds }
+        clones
+            .firstOrNull { it.ownerTournamentUserId in ownedTournamentUserIds }
             ?.let { return it.getId() }
 
         // 신규 클론 생성 경로에서만 플레이링크 유효성을 검증한다.

--- a/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
@@ -2108,7 +2108,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
             .perform(
                 post("/api/v1/tournaments/$tournamentId/from-play-link")
                     .header(HttpHeaders.AUTHORIZATION, authHeader(otherUserId)),
-            ).andExpect(status().isCreated)
+            ).andExpect(status().isOk)
             .andExpect(jsonPath("$.data").isNumber)
             .andReturn()
 
@@ -2122,7 +2122,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
     }
 
     @Test
-    fun `POST from-play-link 는 같은 유저가 동일 플레이 링크로 재복제 시 409 를 반환한다`() {
+    fun `POST from-play-link 는 같은 유저가 동일 플레이 링크로 재호출 시 200 으로 기존 클론 id 를 반환한다`() {
         val mockMvc = buildMockMvc()
         saveUser(otherUserId, "https://cdn.example.com/other.jpg", "다른유저")
         val (tournamentId, _, _) = completeTournamentWith2Items(mockMvc)
@@ -2132,11 +2132,75 @@ class TournamentControllerTest : IntegrationTestSupport() {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{}"),
         )
-        mockMvc.perform(
-            post("/api/v1/tournaments/$tournamentId/from-play-link")
-                .header(HttpHeaders.AUTHORIZATION, authHeader(otherUserId)),
-        )
+        val firstResult = mockMvc
+            .perform(
+                post("/api/v1/tournaments/$tournamentId/from-play-link")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(otherUserId)),
+            ).andExpect(status().isOk)
+            .andReturn()
+        val firstCloneId = objectMapper.readTree(firstResult.response.contentAsString)["data"].asLong()
 
+        // 재호출은 새로 만들지 않고 기존 본인 클론 id 를 그대로 반환한다 (idempotent get-or-create).
+        mockMvc
+            .perform(
+                post("/api/v1/tournaments/$tournamentId/from-play-link")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(otherUserId)),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.data").value(firstCloneId))
+
+        // 클론은 정확히 1개만 생성된다.
+        assertEquals(1, tournamentJpaRepository.findAll().count { it.sourceTournamentId == tournamentId })
+    }
+
+    @Test
+    fun `POST from-play-link 는 원본 플레이 링크가 만료돼도 이미 만든 본인 클론 id 를 반환한다`() {
+        val mockMvc = buildMockMvc()
+        saveUser(otherUserId, "https://cdn.example.com/other.jpg", "다른유저")
+        val (tournamentId, _, _) = completeTournamentWith2Items(mockMvc)
+        mockMvc.perform(
+            post("/api/v1/tournaments/$tournamentId/play-link")
+                .header(HttpHeaders.AUTHORIZATION, authHeader(userId))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"),
+        )
+        val firstResult = mockMvc
+            .perform(
+                post("/api/v1/tournaments/$tournamentId/from-play-link")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(otherUserId)),
+            ).andExpect(status().isOk)
+            .andReturn()
+        val cloneId = objectMapper.readTree(firstResult.response.contentAsString)["data"].asLong()
+
+        // 원본 플레이 링크를 만료시킨다.
+        val source = tournamentJpaRepository.findByIdAndDeletedAtIsNull(tournamentId)!!
+        source.expirePlayLink()
+        tournamentJpaRepository.save(source)
+
+        // 이미 만든 본인 클론은 원본 링크 만료와 무관하게 그대로 반환된다 (이어서 진행하기).
+        mockMvc
+            .perform(
+                post("/api/v1/tournaments/$tournamentId/from-play-link")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(otherUserId)),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.data").value(cloneId))
+    }
+
+    @Test
+    fun `POST from-play-link 는 클론이 없는 유저가 만료된 플레이 링크로 호출하면 409 를 반환한다`() {
+        val mockMvc = buildMockMvc()
+        saveUser(otherUserId, "https://cdn.example.com/other.jpg", "다른유저")
+        val (tournamentId, _, _) = completeTournamentWith2Items(mockMvc)
+        mockMvc.perform(
+            post("/api/v1/tournaments/$tournamentId/play-link")
+                .header(HttpHeaders.AUTHORIZATION, authHeader(userId))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"),
+        )
+        val source = tournamentJpaRepository.findByIdAndDeletedAtIsNull(tournamentId)!!
+        source.expirePlayLink()
+        tournamentJpaRepository.save(source)
+
+        // 아직 본인 클론이 없는 유저는 신규 생성 경로의 만료 검증에 걸려 409.
         mockMvc
             .perform(
                 post("/api/v1/tournaments/$tournamentId/from-play-link")

--- a/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
@@ -55,6 +55,7 @@ import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.UUID
 import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 
 @RecordApplicationEvents
@@ -2206,6 +2207,49 @@ class TournamentControllerTest : IntegrationTestSupport() {
                 post("/api/v1/tournaments/$tournamentId/from-play-link")
                     .header(HttpHeaders.AUTHORIZATION, authHeader(otherUserId)),
             ).andExpect(status().isConflict)
+    }
+
+    @Test
+    fun `POST from-play-link 는 타인 클론에 참여만 한 유저를 본인 클론으로 오인하지 않고 새로 생성한다`() {
+        val mockMvc = buildMockMvc()
+        val thirdUserId = UUID.randomUUID()
+        saveUser(otherUserId, "https://cdn.example.com/other.jpg", "다른유저")
+        saveUser(thirdUserId, "https://cdn.example.com/third.jpg", "제3유저")
+        val (tournamentId, _, _) = completeTournamentWith2Items(mockMvc)
+        mockMvc.perform(
+            post("/api/v1/tournaments/$tournamentId/play-link")
+                .header(HttpHeaders.AUTHORIZATION, authHeader(userId))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"),
+        )
+        // otherUser 가 클론을 생성 (소유자)
+        val cloneResult = mockMvc
+            .perform(
+                post("/api/v1/tournaments/$tournamentId/from-play-link")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(otherUserId)),
+            ).andExpect(status().isOk)
+            .andReturn()
+        val otherCloneId = objectMapper.readTree(cloneResult.response.contentAsString)["data"].asLong()
+
+        // thirdUser 가 otherUser 의 클론(PENDING)에 초대코드로 참여만 한다 (소유자가 아님)
+        val otherClone = tournamentJpaRepository.findByIdAndDeletedAtIsNull(otherCloneId)!!
+        mockMvc
+            .perform(
+                post("/api/v1/tournaments/$otherCloneId/join")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(thirdUserId))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"inviteCode":"${otherClone.inviteCode}"}"""),
+            ).andExpect(status().isOk)
+
+        // thirdUser 의 from-play-link 는 타인 클론을 돌려주지 않고 본인 새 클론을 만든다.
+        val result = mockMvc
+            .perform(
+                post("/api/v1/tournaments/$tournamentId/from-play-link")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(thirdUserId)),
+            ).andExpect(status().isOk)
+            .andReturn()
+        val thirdCloneId = objectMapper.readTree(result.response.contentAsString)["data"].asLong()
+        assertNotEquals(otherCloneId, thirdCloneId)
     }
 
     // ── 그룹 결과 ──────────────────────────────────────────────────

--- a/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentFromPlayLinkConcurrencyIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentFromPlayLinkConcurrencyIntegrationTest.kt
@@ -50,7 +50,7 @@ class TournamentFromPlayLinkConcurrencyIntegrationTest : IntegrationTestSupport(
     @Autowired private lateinit var jdbcTemplate: JdbcTemplate
 
     @Test
-    fun `같은 유저가 from-play-link 를 동시에 두 번 요청하면 하나만 201 나머지는 409 로 처리된다`() {
+    fun `같은 유저가 from-play-link 를 동시에 두 번 요청해도 클론은 하나만 생성되고 둘 다 200 으로 같은 id 를 받는다`() {
         val ownerId = UUID.randomUUID()
         val clonerId = UUID.randomUUID()
         userJpaRepository.save(User(id = ownerId, nickname = "race-owner", profileImage = "https://cdn.example.com/o.jpg", identityType = IdentityType.GUEST))
@@ -131,8 +131,10 @@ class TournamentFromPlayLinkConcurrencyIntegrationTest : IntegrationTestSupport(
             tId
         }
 
-        val status201 = AtomicInteger(0)
-        val status409 = AtomicInteger(0)
+        // idempotent get-or-create: 동시 두 호출 모두 200 이고, source 행 FOR UPDATE 락으로 직렬화되어
+        // 먼저 들어온 쪽이 클론을 만들고 뒤이은 쪽은 그 클론 id 를 그대로 받는다.
+        val status200 = AtomicInteger(0)
+        val returnedIds = java.util.concurrent.ConcurrentLinkedQueue<Long>()
         val executor = Executors.newFixedThreadPool(2)
         val ready = CountDownLatch(2)
         val start = CountDownLatch(1)
@@ -147,9 +149,9 @@ class TournamentFromPlayLinkConcurrencyIntegrationTest : IntegrationTestSupport(
                         post("/api/v1/tournaments/$sourceTournamentId/from-play-link")
                             .header(HttpHeaders.AUTHORIZATION, clonerAuth),
                     ).andReturn()
-                    when (res.response.status) {
-                        201 -> status201.incrementAndGet()
-                        409 -> status409.incrementAndGet()
+                    if (res.response.status == 200) {
+                        status200.incrementAndGet()
+                        returnedIds.add(objectMapper.readTree(res.response.contentAsString)["data"].asLong())
                     }
                 } finally {
                     done.countDown()
@@ -162,8 +164,8 @@ class TournamentFromPlayLinkConcurrencyIntegrationTest : IntegrationTestSupport(
         done.await(10, TimeUnit.SECONDS)
         executor.shutdown()
 
-        assertEquals(1, status201.get(), "정확히 하나만 201 이어야 한다")
-        assertEquals(1, status409.get(), "정확히 하나만 409 이어야 한다")
+        assertEquals(2, status200.get(), "두 호출 모두 200 이어야 한다")
+        assertEquals(1, returnedIds.toSet().size, "두 호출이 같은 클론 id 를 받아야 한다")
 
         val cloneCount = jdbcTemplate.queryForObject(
             """SELECT COUNT(*) FROM tournaments t


### PR DESCRIPTION
## Situation

- 플레이 링크로 토너먼트를 복제(CLONE)하는 화면에서, 같은 게스트가 같은 링크를 다시 누르면 409가 떨어졌다.
- 클라는 409만 받고 본인이 이전에 만든 CLONE id를 알 길이 없어, "플레이 링크가 유효하지 않아요" 같은 어색한 안내를 노출하고 있었다.
- 제품 의도는 "같은 게스트가 같은 플레이 링크를 누르면 기존에 생성된 토너먼트로 이동(이어서 진행)"인데, 당시 계약으로는 그게 불가능했다.

## Task

- from-play-link를 다시 호출해도 클라가 단일 호출로 본인 토너먼트 id를 받아 라우팅할 수 있게 만든다.
- 프론트가 제시한 세 안(409 data에 id 포함 / 별도 GET 엔드포인트 / idempotent) 중 복잡성, 확장성, 컨벤션 적합성을 따져 하나를 고른다.

## Action

### 방식 선택
- 409 응답 data에 id를 싣는 안은 응답 래퍼 `ApiResponseBody.fail()`이 항상 `data=null`이라, 전역 에러 변환 규약을 이 예외 하나 때문에 깨야 해서 배제했다.
- 별도 GET 엔드포인트(왕복 2회) 대신, 단일 호출로 끝나는 idempotent get-or-create를 택했다. 단일 클론 모델(유저당 소스당 1개)과도 정확히 맞고, 향후 "재호출마다 새 판" 정책이 와도 분기만 풀면 되는 구조다.

### 구현
- `createFromPlayLink`: 재호출이면 새로 만들지 않고 기존 본인 CLONE id를 반환한다. 신규면 종전대로 생성한다.
- 응답 status를 신규/기존 모두 200으로 통일했다. get-or-create는 "항상 생성"이 아니므로 201보다 정직하고, 컨트롤러의 `ResponseEntity` 직접 반환 금지(고정 `@ResponseStatus`) 컨벤션과도 충돌하지 않는다.
- 기존 클론 조회를 플레이 링크 만료 검증보다 앞에 두었다. 원본 링크가 14일이 지나 만료돼도, 이미 만든 본인 클론으로는 이어서 진행할 수 있어야 하기 때문이다 (클론은 자체 라이프사이클을 가진다).
- 멤버 시작 경로(`startAsMember`)는 같은 `alreadyCloned()` 예외를 계속 쓰므로 손대지 않았다. from-play-link에서만 throw를 제거했다.

### 문서
- `TournamentApi` / `TournamentApiExamples`의 응답 계약을 200/401/404/409로 갱신했다. 성공 example을 200으로 바꾸고, 빠져 있던 401/404(플레이 링크 미생성)/409(만료) example을 예외 팩토리에서 끌어와 채웠다.

## Result

- 같은 게스트의 from-play-link 재호출이 에러가 아니라 정상 흐름이 되어, 클라가 받은 id로 바로 기존 토너먼트로 이동한다.
- 프론트가 인지해야 할 계약 변화는 한 줄이다: 성공 status가 201에서 200으로 바뀌고, 재호출도 200으로 항상 기존 토너먼트 id를 반환한다 (409 제거, 만료 409는 신규 생성 경로에만 남음).
- 동시 호출도 source 행 락으로 직렬화되어 클론은 정확히 1개만 생기고 두 호출이 같은 id를 받는다는 점, 만료 링크에서 기존 클론은 반환되고 신규는 409가 된다는 점을 통합 테스트로 고정했다.

---
## 연관 이슈

- close #470


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Play 링크 기반 토너먼트 복제 시 멱등성 지원: 동일 사용자가 같은 링크로 재호출 시 기존 클론의 ID를 반환합니다.
  * 원본 플레이 링크 만료 후에도 이미 생성한 본인 클론으로 계속 진행 가능합니다.

* **API 변경**
  * Play 링크 복제 응답 상태코드가 201에서 200으로 변경됩니다.
  * 충돌 응답(409)은 플레이 링크 만료 시에만 반환됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->