### PR TITLE
소셜 토너먼트 참여자 조회 — 복제본 아이템 노출 + 완료된 원본에서 참여자 진행 허용

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
@@ -291,7 +291,8 @@ class TournamentService(
 
         return when (tournament.status) {
             TournamentStatus.PENDING -> {
-                val tournamentItems = tournamentItemRepository.findAllByTournamentId(tournamentId)
+                // CLONE 은 DB 아이템 행이 없으므로 ROOT 아이템을 해소한다 (ROOT 는 자기 아이템).
+                val tournamentItems = getEffectiveTournamentItems(tournament)
                 val snapshotById = snapshotsOf(tournamentItems)
                 val tournamentUsers = tournamentUserRepository.findByTournamentId(tournamentId)
                 val userById = userRepository
@@ -338,37 +339,9 @@ class TournamentService(
                 )
 
                 // ROOT 가 IN_PROGRESS 인데 멤버 본인의 히스토리가 없으면, CLONE 을 아직 시작하지 않은 대기 상태다.
-                // sourceTournamentId 가 없으면(ROOT) pending 형태로 아이템·참여자를 내려준다.
-                // 클라이언트는 ownerStarted=true 로 "주최자가 시작했습니다, 지금 시작하세요" UI 를 분기한다.
+                // ROOT(sourceTournamentId 없음)면 pending+ownerStarted 로 "주최자가 시작했습니다, 지금 시작하세요" UI 를 분기한다.
                 if (!isOwner && histories.isEmpty()) {
-                    tournament.sourceTournamentId ?: run {
-                        val tournamentItems = tournamentItemRepository.findAllByTournamentId(tournamentId)
-                        val snapshotById = snapshotsOf(tournamentItems)
-                        val tournamentUsers = tournamentUserRepository.findByTournamentId(tournamentId)
-                        val userById = userRepository
-                            .findByIds(tournamentUsers.map { it.userId }.toSet())
-                            .associateBy { it.id }
-                        return TournamentDetail.Pending(
-                            tournamentId = tournament.getId(),
-                            name = tournament.name,
-                            inviteCode = tournament.inviteCode,
-                            inviteExpiresAt = tournament.inviteExpiresAt,
-                            items = tournamentItems.map { toItemDetail(it, snapshotById) },
-                            participants = tournamentUsers.mapNotNull { tu ->
-                                userById[tu.userId]?.let { user ->
-                                    TournamentDetail.ParticipantDetail(
-                                        userId = user.id,
-                                        nickname = user.nickname,
-                                        profileImage = user.profileImage,
-                                        isWithdrawn = !user.isActive(),
-                                    )
-                                }
-                            },
-                            isOwner = false,
-                            isRoot = true,
-                            ownerStarted = true,
-                        )
-                    }
+                    tournament.sourceTournamentId ?: return buildMemberPendingOnRoot(tournament)
                 }
                 // 히스토리는 currentRound ASC, id ASC 정렬이라 lastOrNull()은 라운드가 바뀌면 틀림 — ID 최대값이 가장 최근 매치
                 val lastHistory = histories
@@ -411,22 +384,58 @@ class TournamentService(
                     tournamentId, currentUser.getId(),
                 )
                 // Design B: 멤버는 ROOT 가 아닌 본인 CLONE 에서 플레이한다.
-                // ROOT 가 COMPLETED 이고 멤버의 ROOT history 가 없으면 CLONE 의 결과로 대신 응답한다.
+                // ROOT 가 COMPLETED 이고 멤버의 ROOT history 가 없으면 본인 CLONE 의 결과로 대신 응답한다.
                 if (!isOwner && histories.isEmpty()) {
-                    val sourceTournamentClones = tournamentRepository.findBySourceTournamentId(tournamentId)
-                    val sourceTournamentCloneTUs = tournamentUserRepository.findByTournamentIds(sourceTournamentClones.map { it.getId() })
-                    val cloneTU = sourceTournamentCloneTUs.firstOrNull { it.userId == userId }
-                        ?: throw TournamentException.forbiddenTournament()
-                    val myClone = sourceTournamentClones.first { it.getId() == cloneTU.tournamentId }
-                    if (!cloneTU.isCompleted()) throw TournamentException.forbiddenTournament()
+                    val clones = tournamentRepository.findBySourceTournamentId(tournamentId)
+                    val ownerTUById = tournamentUserRepository
+                        .findByIds(clones.map { it.ownerTournamentUserId }.toSet())
+                        .associateBy { it.getId() }
+                    // 본인이 소유한 CLONE 만 인정한다 (타인 CLONE 에 참여만 한 경우 제외).
+                    val myClone = clones.firstOrNull { ownerTUById[it.ownerTournamentUserId]?.userId == userId }
+                    // 옵션 A: 아직 본인 CLONE 을 시작하지 않은 참여자는 ROOT 가 COMPLETED 여도 403 대신
+                    // 시작 가능 상태(pending+ownerStarted)를 받아 본인 CLONE 을 만들어 진행할 수 있다.
+                        ?: return buildMemberPendingOnRoot(tournament)
+                    val myCloneOwnerTU = ownerTUById.getValue(myClone.ownerTournamentUserId)
+                    if (!myCloneOwnerTU.isCompleted()) throw TournamentException.forbiddenTournament()
                     val cloneHistories = tournamentRepository.findHistoriesByTournamentIdAndTournamentUserId(
-                        myClone.getId(), cloneTU.getId(),
+                        myClone.getId(), myCloneOwnerTU.getId(),
                     )
                     return buildCompleted(myClone, cloneHistories, computeHasGroupResult(tournament), false)
                 }
                 buildCompleted(tournament, histories, computeHasGroupResult(tournament), isOwner)
             }
         }
+    }
+
+    // 아직 본인 CLONE 을 시작하지 않은 멤버에게 내려주는 "시작 가능" 대기 응답.
+    // ROOT 가 IN_PROGRESS·COMPLETED 어느 쪽이든, 멤버는 ROOT 아이템·참여자를 보며 본인 플레이를 시작할 수 있다.
+    private fun buildMemberPendingOnRoot(root: Tournament): TournamentDetail.Pending {
+        val tournamentItems = tournamentItemRepository.findAllByTournamentId(root.getId())
+        val snapshotById = snapshotsOf(tournamentItems)
+        val tournamentUsers = tournamentUserRepository.findByTournamentId(root.getId())
+        val userById = userRepository
+            .findByIds(tournamentUsers.map { it.userId }.toSet())
+            .associateBy { it.id }
+        return TournamentDetail.Pending(
+            tournamentId = root.getId(),
+            name = root.name,
+            inviteCode = root.inviteCode,
+            inviteExpiresAt = root.inviteExpiresAt,
+            items = tournamentItems.map { toItemDetail(it, snapshotById) },
+            participants = tournamentUsers.mapNotNull { tu ->
+                userById[tu.userId]?.let { user ->
+                    TournamentDetail.ParticipantDetail(
+                        userId = user.id,
+                        nickname = user.nickname,
+                        profileImage = user.profileImage,
+                        isWithdrawn = !user.isActive(),
+                    )
+                }
+            },
+            isOwner = false,
+            isRoot = true,
+            ownerStarted = true,
+        )
     }
 
     @Transactional(readOnly = true)

--- a/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
@@ -966,6 +966,79 @@ class TournamentControllerTest : IntegrationTestSupport() {
     }
 
     @Test
+    fun `GET tournaments-id 는 CLONE 단건 조회 시 pending items 에 ROOT 아이템을 해소해 내려준다`() {
+        val mockMvc = buildMockMvc()
+        saveUser(otherUserId, "https://cdn.example.com/other.jpg", "다른유저")
+        val (tournamentId, _, _) = completeTournamentWith2Items(mockMvc)
+        mockMvc.perform(
+            post("/api/v1/tournaments/$tournamentId/play-link")
+                .header(HttpHeaders.AUTHORIZATION, authHeader(userId))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"),
+        )
+        val cloneResult = mockMvc
+            .perform(
+                post("/api/v1/tournaments/$tournamentId/from-play-link")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(otherUserId)),
+            ).andReturn()
+        val cloneId = objectMapper.readTree(cloneResult.response.contentAsString)["data"].asLong()
+
+        // CLONE 은 DB 아이템이 없지만 ROOT 의 2개 아이템을 해소해 내려줘야 한다.
+        mockMvc
+            .perform(
+                get("/api/v1/tournaments/$cloneId")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(otherUserId)),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.status").value("PENDING"))
+            .andExpect(jsonPath("$.data.pending.items.length()").value(2))
+    }
+
+    @Test
+    fun `GET tournaments-id 는 ROOT 가 COMPLETED 여도 아직 시작 안 한 참여자에게 403 대신 시작 가능 상태를 준다`() {
+        val mockMvc = buildMockMvc()
+        saveUser(otherUserId, "https://cdn.example.com/other.jpg", "다른유저")
+        val rootTournamentId = createTournament(mockMvc)
+        // otherUserId 가 멤버로 참여 (초대 코드 없이 링크 직접 접근)
+        mockMvc.perform(
+            post("/api/v1/tournaments/$rootTournamentId/join")
+                .header(HttpHeaders.AUTHORIZATION, authHeader(otherUserId))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"inviteCode":null}"""),
+        )
+        addItemsToTournament(mockMvc, rootTournamentId, userId, saveWishItem(name = "소셜1"), saveWishItem(name = "소셜2"))
+        mockMvc.perform(
+            post("/api/v1/tournaments/$rootTournamentId/start")
+                .header(HttpHeaders.AUTHORIZATION, authHeader(userId)),
+        )
+        val rootItems = tournamentItemJpaRepository.findAllByTournamentIdAndNotDeleted(rootTournamentId)
+        // owner 가 결승까지 끝내 ROOT 즉시 COMPLETED
+        mockMvc.perform(
+            post("/api/v1/tournaments/$rootTournamentId/matches")
+                .header(HttpHeaders.AUTHORIZATION, authHeader(userId))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """{"currentRound":2,"firstTournamentItemId":${rootItems[0].getId()},"secondTournamentItemId":${rootItems[1].getId()},"selectedTournamentItemId":${rootItems[0].getId()}}""",
+                ),
+        )
+
+        // 아직 본인 CLONE 을 시작 안 한 멤버가 ROOT 조회 → 403 아니라 시작 가능 상태(ownerStarted)
+        mockMvc
+            .perform(
+                get("/api/v1/tournaments/$rootTournamentId")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(otherUserId)),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.pending.ownerStarted").value(true))
+            .andExpect(jsonPath("$.data.pending.items.length()").value(2))
+
+        // 그리고 멤버는 본인 CLONE 을 만들어 진행할 수 있다 (ROOT 가 COMPLETED 여도)
+        mockMvc
+            .perform(
+                post("/api/v1/tournaments/$rootTournamentId/start")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(otherUserId)),
+            ).andExpect(status().isOk)
+    }
+
+    @Test
     fun `GET tournaments-id 에서 존재하지 않는 tournamentId 이면 404 를 반환한다`() {
         val mockMvc = buildMockMvc()
 


### PR DESCRIPTION
## Situation

프론트에서 소셜/플레이링크 토너먼트의 참여자 조회 흐름에서 두 가지 버그를 받았다.

- 플레이 링크로 들어온 게스트가 본인 복제 토너먼트의 담기 화면을 열면 아이템 목록이 빈 배열로 와서, 어떤 토너먼트인지 알 수 없었다.
- 주최자가 토너먼트를 먼저 끝내 버리면(완료 상태), 아직 본인 플레이를 시작도 안 한 참여자가 조회에서 권한 없음(403)을 받아 친구 초대로 같이 즐기는 흐름이 막혔다.

## Task

- 복제 토너먼트도 원본의 아이템을 보여주게 한다.
- 주최자가 먼저 끝내도 참여자가 본인 플레이를 시작할 수 있게 한다. 두 번째 건은 "완료됐으니 막는다" 와 "그래도 진행하게 한다" 가 갈려서, 참여자가 진행할 수 있게 하는 쪽으로 정했다.

## Action

### 복제 토너먼트 아이템 노출
- 단건 조회의 담기(PENDING) 분기가 DB 아이템을 직접 읽고 있었는데, 복제 토너먼트는 설계상 아이템을 자기 행으로 갖지 않아 항상 비어 있었다. 진행중 분기와 동일하게 원본 아이템을 해소해 내려주도록 바꿨다. 원본 토너먼트는 자기 아이템을 그대로 보므로 동작이 바뀌지 않는다.

### 완료된 원본에서 참여자 진행 허용
- 완료 분기는 "참여자는 본인 복제본의 결과로 응답한다" 를 전제로 짜여 있어, 아직 복제본이 없는 참여자는 권한 없음으로 떨어졌다. 이 경우 권한 없음 대신 시작 가능 상태로 응답해, 참여자가 본인 복제본을 만들어 진행할 수 있게 했다.
- 시작 API 자체는 원본이 완료 상태여도 이미 동작했다. 그래서 조회 응답만 고치면 흐름이 풀린다.
- "본인 복제본" 을 가리던 기준이 참여자 기준이라, 남의 복제본에 초대코드로 참여만 한 경우를 본인 것으로 오인할 수 있었다. 소유자 기준으로 바꿔 정확히 본인이 만든 복제본만 인정하도록 교정했다. (앞선 from-play-link 변경과 같은 원칙)
- 진행중 분기와 완료 분기가 같은 "시작 가능" 대기 응답을 쓰므로 한 곳으로 추출해 중복을 없앴다.

## Result

- 응답 코드 집합(200·401·403·404)은 그대로다. 권한 없음(403)은 "참여자가 아닌 사용자" 에만 남아 문서 설명과 정확히 맞게 됐다. 따라서 OpenAPI 문서는 손대지 않았다.
- 완료된 원본을 조회한 참여자 응답의 status 는 `ownerStarted=true` 매핑 규칙에 따라 진행중으로 내려간다(기존 DTO 규칙). 클라이언트는 이 값으로 시작 버튼을 활성화한다.
- 알려진 비대칭(이번 변경으로 생긴 것 아님): 참여자가 진행중인 복제본을 가진 채 원본을 조회하면 진행중 분기는 시작 가능, 완료 분기는 403 으로 갈린다. 둘 다 기존 동작이고 클라이언트 흐름상 도달하지 않아 이번 범위에서 제외했다.
- 검증: 복제본 담기 화면이 원본 2개 아이템을 받는지, 완료된 원본에서 미시작 참여자가 403 대신 시작 가능 상태를 받고 시작까지 되는지를 통합 테스트로 고정했다. 소유자 기준 교정 덕에 남의 복제본에 참여만 한 사용자는 본인 것으로 오인되지 않는다.

---
## 연관 이슈

- close #475


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 토너먼트 상태 전환에 따른 아이템 조회 로직 개선
  * 클론 토너먼트 조회 시 루트 토너먼트의 아이템이 정확히 반영되도록 수정
  * 완료된 토너먼트에서 미시작 참여자도 올바른 대기 상태를 표시하도록 수정

* **테스트**
  * 토너먼트 조회 엔드포인트 테스트 케이스 2개 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->