### PR TITLE
Notification API 문서 설명 마크다운 정비

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/notification/controller/NotificationHistoryApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/controller/NotificationHistoryApi.kt
@@ -18,14 +18,16 @@ import java.util.UUID
 interface NotificationHistoryApi {
     @Operation(
         summary = "알림 히스토리 조회",
-        description = """
-            로그인한 유저 본인의 알림을 최신순(id desc)으로 조회한다 (GUEST·MEMBER 모두).
-            cursor 페이지네이션: 직전 응답의 pageResponse.nextCursor 를 다음 요청 cursor 로 그대로 전달한다.
-            마지막 페이지면 nextCursor 는 null, hasNext 는 false. size 는 미지정 시 20, 1~50 범위를 벗어나면 양 끝으로 보정된다.
-            응답 data 의 unreadCount 로 안읽음 수(badge)를 함께 내려준다 (별도 카운트 API 없음).
-            각 항목 셰입은 SSE notification 이벤트 payload 와 동일하다 — type 으로 화면을, 파싱 알림은 kind 로 출처(위시/토너먼트)를 분기하고,
-            id 로 단건 읽음 처리(POST /read)·딥링크 이동을 한다.
-        """,
+        description =
+            "로그인한 유저 본인의 알림을 **최신순(`id` desc)** 으로 조회한다 (**GUEST·MEMBER 모두**).\n\n" +
+                "**커서 페이지네이션**\n\n" +
+                "- 직전 응답의 `pageResponse.nextCursor` 를 다음 요청 `cursor` 로 그대로 전달한다.\n" +
+                "- 마지막 페이지면 `nextCursor` 는 `null`, `hasNext` 는 `false`.\n" +
+                "- `size` 는 미지정 시 20, 1~50 범위를 벗어나면 양 끝으로 보정된다.\n\n" +
+                "**응답 활용**\n\n" +
+                "- 응답 `data` 의 `unreadCount` 로 안읽음 수(badge)를 함께 내려준다 (별도 카운트 API 없음).\n" +
+                "- 각 항목 셰입은 SSE `notification` 이벤트 payload 와 동일하다 — `type` 으로 화면을, 파싱 알림은 " +
+                "`kind` 로 출처(위시/토너먼트)를 분기하고, `id` 로 단건 읽음 처리(`POST /read`)·딥링크 이동을 한다.",
     )
     @ApiResponses(
         value = [
@@ -71,13 +73,16 @@ interface NotificationHistoryApi {
 
     @Operation(
         summary = "알림 읽음 처리",
-        description = """
-            알림을 읽음 처리한다 (GUEST·MEMBER 모두, 본인 알림만). 요청 body 는 두 방식 중 정확히 하나:
-            - all=true → 본인 안읽음 알림 전부 읽음 (전체 읽음 버튼, 화면 이동 없음)
-            - ids=[...] → 지정한 알림만 읽음 (단건 클릭은 [id] 1개, 클릭 후 FE 가 딥링크로 이동)
-            둘 다 보내거나 둘 다 비우면(빈 ids 포함) 400. ids 는 본인 소유만 반영되고 타인·없는 id 는 무시된다. 멱등(이미 읽음도 성공).
-            응답 data 의 unreadCount 로 처리 후 안읽음 수(badge)를 서버 권위 값으로 내려준다 — 클라는 이 값을 그대로 badge 로 미러링한다(별도 카운트 조회 불필요).
-        """,
+        description =
+            "알림을 읽음 처리한다 (**GUEST·MEMBER 모두, 본인 알림만**). 요청 body 는 두 방식 중 **정확히 하나**:\n\n" +
+                "| 방식 | 동작 |\n" +
+                "|---|---|\n" +
+                "| `all=true` | 본인 안읽음 알림 전부 읽음 (전체 읽음 버튼, 화면 이동 없음) |\n" +
+                "| `ids=[...]` | 지정한 알림만 읽음 (단건 클릭은 `[id]` 1개, 클릭 후 FE 가 딥링크로 이동) |\n\n" +
+                "- 둘 다 보내거나 둘 다 비우면(빈 `ids` 포함) **400**.\n" +
+                "- `ids` 는 본인 소유만 반영되고 타인·없는 id 는 무시된다. **멱등**(이미 읽음도 성공).\n" +
+                "- 응답 `data` 의 `unreadCount` 로 처리 후 안읽음 수(badge)를 **서버 권위 값**으로 내려준다 — " +
+                "클라는 이 값을 그대로 badge 로 미러링한다(별도 카운트 조회 불필요).",
     )
     @ApiResponses(
         value = [

--- a/src/main/kotlin/com/depromeet/piki/notification/controller/NotificationSseApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/controller/NotificationSseApi.kt
@@ -16,24 +16,26 @@ import java.util.UUID
 interface NotificationSseApi {
     @Operation(
         summary = "알림 실시간 구독 (SSE)",
-        description = """
-            인증 유저의 알림을 실시간으로 받는 SSE(Server-Sent Events) 스트림을 연다.
-            응답은 ApiResponseBody JSON 래퍼가 아니라 text/event-stream 스트림이며, 다음 이벤트가 흘러온다.
-            - connect: 구독 직후 1회. data="connected". 연결 성립 신호.
-            - notification: 알림 1건. type 으로 화면을, 파싱 알림은 kind 로 출처(위시/토너먼트)를 분기한다. 출처별 payload 셰입과 라우팅 필드(kind·tournamentId·tournamentItemId)는 notification-sse-spec.md 참조.
-            - (주석 ping): 약 30초 간격 하트비트. 연결 유지용이며 data 이벤트가 아니다.
-            토너먼트 알림은 해당 토너먼트 참여자에게만 fan-out 되므로, 자기 스트림 1개만 구독하면 토너먼트·개인 알림이 모두 도착한다.
-            연결은 30분 후 타임아웃되며, 클라이언트는 끊기면 재연결한다.
-        """,
+        description =
+            "인증 유저의 알림을 실시간으로 받는 **SSE(Server-Sent Events)** 스트림을 연다.\n\n" +
+                "응답은 `ApiResponseBody` JSON 래퍼가 아니라 `text/event-stream` 스트림이며, 다음 이벤트가 흘러온다.\n\n" +
+                "| 이벤트 | 시점 | 내용 |\n" +
+                "|---|---|---|\n" +
+                "| `connect` | 구독 직후 1회 | `data=\"connected\"`. 연결 성립 신호 |\n" +
+                "| `notification` | 알림 1건마다 | `type` 으로 화면을, 파싱 알림은 `kind` 로 출처(위시/토너먼트)를 분기. " +
+                "출처별 payload 셰입과 라우팅 필드(`kind`·`tournamentId`·`tournamentItemId`)는 `notification-sse-spec.md` 참조 |\n" +
+                "| `(주석 ping)` | 약 30초 간격 | 하트비트. 연결 유지용이며 data 이벤트가 아니다 |\n\n" +
+                "- 토너먼트 알림은 해당 토너먼트 참여자에게만 fan-out 되므로, **자기 스트림 1개만 구독**하면 토너먼트·개인 알림이 모두 도착한다.\n" +
+                "- 연결은 **30분 후 타임아웃**되며, 클라이언트는 끊기면 재연결한다.",
     )
     @ApiResponses(
         value = [
             ApiResponse(
                 responseCode = "200",
                 description =
-                    "SSE 스트림 시작 (text/event-stream). notification 이벤트 data payload 는 알림 종류별로 셰입이 다르고" +
-                        "(파싱 알림은 출처별 kind·tournamentId·tournamentItemId), 스트림·다형 구조라 OpenAPI 로 표현이 어려워" +
-                        " notification-sse-spec.md 로 문서화한다.",
+                    "SSE 스트림 시작 (`text/event-stream`). `notification` 이벤트 data payload 는 알림 종류별로 셰입이 다르고" +
+                        "(파싱 알림은 출처별 `kind`·`tournamentId`·`tournamentItemId`), 스트림·다형 구조라 OpenAPI 로 표현이 어려워" +
+                        " `notification-sse-spec.md` 로 문서화한다.",
             ),
             ApiResponse(
                 responseCode = "401",


### PR DESCRIPTION
## Situation

- PR #464 에서 Auth·User·FCM·Dev API 문서 설명을 마크다운 스타일로 정비했는데, 알림(`/notifications`) API 는 그 정비에서 빠져 있었다.
- 알림 API 설명은 여전히 트리플 quote 줄글이라, Swagger UI 에서 줄바꿈·리스트가 살지 않고 한 문단으로 뭉쳐 보였다. 같은 docs 페이지 안에서 도메인마다 가독성이 들쭉날쭉했다.

## Task

- `/notifications` 경로 API 설명을 User·FCM 과 같은 마크다운 스타일로 통일해 가독성을 맞춘다.
- 문서 표현만 손대고, 응답 코드·시그니처 등 API contract 는 건드리지 않는다.

## Action

- SSE 실시간 구독(`NotificationSseApi`)과 히스토리 조회·읽음 처리(`NotificationHistoryApi`) 설명을 트리플 quote 줄글에서 문자열 연결 + 마크다운으로 전환했다.
- 분기·종류가 갈리는 부분은 표로 정리했다.

| 다듬은 곳 | 표로 바꾼 내용 |
|---|---|
| SSE 구독 | 스트림 이벤트 3종(`connect` / `notification` / 주석 ping)을 시점·내용으로 |
| 읽음 처리 | 요청 두 방식(`all=true` / `ids=[...]`)을 동작으로 |

- 식별자(`type`·`kind`·`cursor` 등)는 인라인 코드로, 핵심 동작(멱등, fan-out, 30분 타임아웃, 서버 권위 badge 값)은 굵게 강조했다.
- 문단은 빈 줄로 나눠 Swagger UI 에서 실제로 분리되어 렌더되게 했다.

## Result

- 같은 docs 페이지에서 알림 API 설명이 User·FCM 과 같은 결로 읽힌다. 표·불릿·문단이 렌더되어 클라이언트가 스트림 이벤트와 읽음 방식을 빠르게 파악할 수 있다.
- contract 변경이 없어 실제 응답·동작에는 영향이 없다.

## 스코프

- 알림(`/notifications`) 외 다른 엔드포인트는 이 PR 에서 건드리지 않는다. 내 작업 영역이 아니기도 하고, 문서 표현은 각 개발자의 개성을 존중해 담당자 재량으로 남긴다.

---
## 연관 이슈

- 
