### PR TITLE
게스트(플레이링크 참여자)도 친구 토너먼트 결과 조회 허용

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
@@ -791,15 +791,24 @@ class TournamentService(
             tournamentRepository.findTournamentById(tournamentId)
                 ?: throw TournamentException.notFoundTournament()
         tournament.sourceTournamentId?.let { throw TournamentException.clonedTournamentCannotViewGroupResult() }
-        val requesterRootTU = tournamentUserRepository.findByTournamentIdAndUserId(tournamentId, userId)
-            ?: throw TournamentException.forbiddenTournament()
         val allClones = tournamentRepository.findBySourceTournamentId(tournamentId)
-        // Progressive gate: 요청자 본인이 완료했고 전체 완료 인원 ≥2 일 때 그룹 결과를 조회할 수 있다.
-        val requesterHasCompleted = if (requesterRootTU.getId() == tournament.ownerTournamentUserId) {
-            requesterRootTU.isCompleted()
+        val requesterRootTU = tournamentUserRepository.findByTournamentIdAndUserId(tournamentId, userId)
+        val cloneOwnerTUById = tournamentUserRepository
+            .findByIds(allClones.map { it.ownerTournamentUserId }.toSet())
+            .associateBy { it.getId() }
+        // 본인이 소유한 CLONE (멤버·게스트). 게스트는 ROOT TU 없이 본인 CLONE 만 가진다.
+        val requesterOwnedClone = allClones.firstOrNull { cloneOwnerTUById[it.ownerTournamentUserId]?.userId == userId }
+        // 참여자(ROOT TU 또는 ROOT 클론 소유자)가 아니면 조회 불가.
+        // 정책 변경: 게스트(완료된 플레이링크 CLONE 소유자)도 그룹 결과를 조회할 수 있다.
+        requesterRootTU ?: requesterOwnedClone ?: throw TournamentException.forbiddenTournament()
+
+        // Progressive gate: 본인 플레이가 완료됐고 전체 완료 인원 ≥2 일 때만 조회 가능하다.
+        // 주최자는 ROOT 진행, 멤버·게스트는 본인 CLONE 진행이 완료 기준이다.
+        val requesterIsOwner = requesterRootTU?.getId() == tournament.ownerTournamentUserId
+        val requesterHasCompleted = if (requesterIsOwner) {
+            requesterRootTU?.isCompleted() ?: false
         } else {
-            val cloneTUs = tournamentUserRepository.findByTournamentIds(allClones.map { it.getId() })
-            cloneTUs.any { it.userId == userId && it.isCompleted() }
+            requesterOwnedClone?.isCompleted() ?: false
         }
         if (!requesterHasCompleted || !computeHasGroupResult(tournament)) {
             throw TournamentException.groupResultNotAvailable()
@@ -811,8 +820,7 @@ class TournamentService(
 
         val completedRootTUs = tournamentUserRepository.findCompletedByTournamentId(tournamentId)
         val completedClones = allClones.filter { it.isCompleted() }
-        val cloneOwnerTUs = tournamentUserRepository.findByIds(completedClones.map { it.ownerTournamentUserId }.toSet())
-        val cloneOwnerTUById = cloneOwnerTUs.associateBy { it.getId() }
+        // cloneOwnerTUById 는 위 권한 게이트에서 allClones 전체로 구해 재사용한다 (completedClones ⊆ allClones).
 
         val plays = buildList {
             completedRootTUs.forEach { tu -> add(Play(tournamentId, tu.getId(), tu.userId)) }

--- a/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
@@ -2373,6 +2373,65 @@ class TournamentControllerTest : IntegrationTestSupport() {
             ).andExpect(status().isConflict)
     }
 
+    @Test
+    fun `GET group-result 는 게스트(플레이링크 참여자)도 본인 완료 후 ROOT id 로 조회할 수 있다`() {
+        val mockMvc = buildMockMvc()
+        saveUser(userId, userProfileImage, "주최자")
+        saveUser(otherUserId, "https://cdn.example.com/guest.jpg", "게스트")
+        // 주최자가 ROOT 생성·시작·완료
+        val (rootId, ti1, ti2) = completeTournamentWith2Items(mockMvc)
+        // 주최자가 플레이링크 생성
+        mockMvc.perform(
+            post("/api/v1/tournaments/$rootId/play-link")
+                .header(HttpHeaders.AUTHORIZATION, authHeader(userId))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"),
+        )
+        // 게스트가 플레이링크로 본인 CLONE 생성 → 시작 → 완료
+        val cloneResult = mockMvc
+            .perform(
+                post("/api/v1/tournaments/$rootId/from-play-link")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(otherUserId)),
+            ).andReturn()
+        val cloneId = objectMapper.readTree(cloneResult.response.contentAsString)["data"].asLong()
+        mockMvc.perform(
+            post("/api/v1/tournaments/$cloneId/start")
+                .header(HttpHeaders.AUTHORIZATION, authHeader(otherUserId)),
+        )
+        mockMvc.perform(
+            post("/api/v1/tournaments/$cloneId/matches")
+                .header(HttpHeaders.AUTHORIZATION, authHeader(otherUserId))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """{"currentRound":2,"firstTournamentItemId":$ti1,"secondTournamentItemId":$ti2,"selectedTournamentItemId":$ti1}""",
+                ),
+        )
+
+        // 게스트(ROOT TU 아님, 본인 CLONE 소유자)가 ROOT id 로 그룹 결과 조회 → 200
+        mockMvc
+            .perform(
+                get("/api/v1/tournaments/$rootId/group-result")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(otherUserId)),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.items").isArray)
+    }
+
+    @Test
+    fun `GET group-result 는 ROOT 참여자도 본인 CLONE 소유자도 아니면 403 을 반환한다`() {
+        val mockMvc = buildMockMvc()
+        saveUser(userId, userProfileImage, "주최자")
+        val outsiderId = UUID.randomUUID()
+        saveUser(outsiderId, "https://cdn.example.com/outsider.jpg", "외부인")
+        val rootId = completeSocialTournamentWith2Players(mockMvc)
+
+        // outsiderId 는 ROOT 의 TournamentUser 도, ROOT 클론의 소유자도 아니다.
+        mockMvc
+            .perform(
+                get("/api/v1/tournaments/$rootId/group-result")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(outsiderId)),
+            ).andExpect(status().isForbidden)
+    }
+
     private fun completeTournamentWith2Items(mockMvc: MockMvc): TournamentStart {
         val tournamentId = createTournament(mockMvc)
         val item1Id = saveWishItem(name = "아이템1")


### PR DESCRIPTION
## Situation

결과 보기 정책이 바뀌었다. 기존에는 게스트(플레이 링크로만 참여한 사용자)가 친구 전체 결과를 볼 수 없었는데, 이제 볼 수 있어야 한다.

## Task

게스트도 본인 플레이를 끝냈으면 친구 전체 결과를 조회할 수 있게 한다. 누가 결과를 볼 수 있는지(권한)만 바꾸는 일이고, 결과 자체의 집계 방식은 건드리지 않는다.

## Action

- 그룹 결과 조회는 요청자가 원본 토너먼트의 참여자(주최자·멤버)일 때만 허용하고 있었다. 게스트는 원본의 참여자가 아니라 본인 플레이 링크 복제본의 소유자라서 권한 없음으로 막혔다.
- 권한 기준을 "원본 참여자 또는 원본의 복제본 소유자" 로 넓혀 게스트를 포함시켰다. 본인 플레이 완료 판정도 같은 결로 맞췄다: 주최자는 원본 진행 완료, 멤버와 게스트는 본인 복제본 진행 완료가 기준이다.
- 집계에는 원래부터 게스트의 복제본이 들어가 있었다. 그래서 "2명 이상 완료" 같은 노출 조건은 손대지 않았고, 바뀐 건 접근 권한뿐이다.
- "본인 복제본" 을 가리는 기준은 참여자가 아니라 소유자로 잡았다. 남의 복제본에 끼어 있던 경우를 본인 것으로 오인하지 않게 하기 위함이다.
- 권한 확인을 위해 이미 조회한 복제본 소유자 정보를, 뒤쪽 결과 집계 구간에서 다시 조회하던 부분을 재사용으로 바꿔 중복 조회를 없앴다.

## Result

- 응답 코드 구성(200·401·403·404·409)은 그대로다. 권한 없음(403)은 이제 "원본 참여자도, 원본 복제본 소유자도 아닌 사용자" 에만 남는다. 기존 문서 설명과 어긋나지 않아 OpenAPI 문서는 그대로 두었다.
- 검증: 게스트가 본인 플레이를 끝낸 뒤 원본 id 로 조회하면 200 으로 결과를 받는지, 아무 관련 없는 사용자는 403 인지를 통합 테스트로 고정했다.

### 프론트 연동 계약
- 게스트 클라이언트는 그룹 결과를 원본 토너먼트 id 로 호출해야 한다. 이 id 는 플레이 링크에 담겨 들어온 그 id(복제 생성 시 쓴 source 토너먼트 id)다.
- 본인 복제본 id 로 호출하면 기존과 동일하게 409(복제 토너먼트에서는 그룹 결과 조회 불가)다.
- 만약 게스트의 결과 화면이 원본 id 를 들고 있지 않다면, 복제본 id 호출 허용이나 응답에 source id 노출 같은 후속이 필요하다.

---
## 연관 이슈

- close #481


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 토너먼트 그룹 결과 조회 권한 로직을 개선했습니다. 플레이링크 참여를 완료한 게스트 사용자도 자신의 그룹 결과를 조회할 수 있도록 확대되었습니다.

* **Tests**
  * 토너먼트 그룹 결과 권한 검증 관련 테스트 2개가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->