### PR TITLE
Apple 서버-서버 알림 처리로 계정 상태 동기화

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/auth/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/config/SecurityConfig.kt
@@ -67,6 +67,10 @@ class SecurityConfig(
                     // 소셜 로그인 진입점 — 미인증으로 호출(게스트 토큰은 선택). 게스트 토큰을 보내면 필터가 principal 을 채워 게스트-연결로 동작.
                     .requestMatchers(HttpMethod.POST, "/api/v1/auth/login/*")
                     .permitAll()
+                    // Apple 서버-서버 알림 — Apple 이 직접 호출하는 외부 진입점이라 우리 JWT 인증이 없다.
+                    // 진위는 payload JWT 의 서명(Apple JWKS)으로 가린다(AppleNotificationVerifier). 위조는 401.
+                    .requestMatchers(HttpMethod.POST, "/api/v1/auth/apple/notifications")
+                    .permitAll()
                     .requestMatchers(HttpMethod.POST, "/api/v1/auth/token/refresh")
                     .permitAll()
                     .requestMatchers(HttpMethod.POST, "/api/v1/auth/logout")

--- a/src/main/kotlin/com/depromeet/piki/auth/controller/AppleNotificationApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/controller/AppleNotificationApi.kt
@@ -1,0 +1,64 @@
+package com.depromeet.piki.auth.controller
+
+import com.depromeet.piki.common.response.ApiResponseBody
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.security.SecurityRequirements
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.MediaType
+
+@Tag(name = "Auth", description = "인증 API")
+interface AppleNotificationApi {
+    @Operation(
+        summary = "Apple 서버-서버 알림 수신",
+        description =
+            "**Apple 이 직접 호출하는 서버-서버 엔드포인트다 (클라이언트 앱이 호출하지 않는다).**\n\n" +
+                "사용자가 Apple 쪽에서 \"Apple 로 로그인\" 연결을 끊거나 Apple ID 를 삭제하면, Apple 이 이 경로로 " +
+                "서명된 알림(JWT)을 보낸다. 우리는 서명을 검증한 뒤 계정 상태를 동기화한다. " +
+                "엔드포인트 URL 은 Apple Developer Console 의 Server-to-Server Notification Endpoint 에 등록해야 동작한다.\n\n" +
+                "요청은 `application/x-www-form-urlencoded` 의 `payload` 필드에 서명된 JWT 로 담겨 온다. " +
+                "진위는 오직 그 JWT 서명(Apple JWKS)·issuer·aud 로 가린다 (우리 JWT 인증 없음).\n\n" +
+                "**이벤트별 처리**\n\n" +
+                "| 이벤트 | 의미 | 처리 |\n" +
+                "|---|---|---|\n" +
+                "| `account-delete` | Apple ID 자체 삭제 | 회원 탈퇴 (데이터 파기) |\n" +
+                "| `consent-revoked` | 앱-Apple 연결 해제 | 세션 종료(로그아웃). 계정·데이터는 유지, 재로그인 시 복귀 |\n" +
+                "| `email-disabled` / `email-enabled` | Private Relay 전달 on/off | 로그만 (메일 발송 안 함) |\n\n" +
+                "- 대상 유저가 없거나(미가입·이미 탈퇴) 미지원 이벤트면 멱등하게 200 으로 흡수한다 " +
+                "(Apple 은 2xx 가 아니면 재시도하므로).",
+    )
+    // Apple 이 인증 없이 호출하는 진입점 (SecurityConfig 의 permitAll). 글로벌 Bearer 요구를 해제한다.
+    @SecurityRequirements
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "알림 처리 완료 (멱등 — 대상 유저 없음·이미 탈퇴·미지원 이벤트 포함)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "유효하지 않은 Apple 알림 (서명·issuer·aud 검증 실패 또는 payload 형식 오류 = 위조/비정상 호출)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun handle(
+        @Parameter(description = "Apple 이 보내는 서명된 알림 JWT (form 필드 payload)")
+        payload: String,
+    ): ApiResponseBody<Unit>
+}

--- a/src/main/kotlin/com/depromeet/piki/auth/controller/AppleNotificationApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/controller/AppleNotificationApi.kt
@@ -55,6 +55,16 @@ interface AppleNotificationApi {
                     ),
                 ],
             ),
+            ApiResponse(
+                responseCode = "502",
+                description = "외부 의존성 실패 (서명 검증에 필요한 Apple JWKS 조회 실패 — 재시도 가능)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
         ],
     )
     fun handle(

--- a/src/main/kotlin/com/depromeet/piki/auth/controller/AppleNotificationApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/controller/AppleNotificationApiExamples.kt
@@ -26,6 +26,8 @@ class AppleNotificationApiExamples(
                     )
                     // 서명/issuer/aud 검증 실패 → 401. detail·category 를 예외 정의에서 자동 추출(손으로 박지 않음).
                     add(AppleNotificationException.invalidSignature(), name = "유효하지 않은 Apple 알림")
+                    // JWKS 조회 실패 → 502. add(exception) 은 message·category·status 만 쓰므로 cause 는 더미.
+                    add(AppleNotificationException.providerError(RuntimeException()), name = "Apple 키 조회 실패 (재시도 가능)")
                 }
             }
             operation

--- a/src/main/kotlin/com/depromeet/piki/auth/controller/AppleNotificationApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/controller/AppleNotificationApiExamples.kt
@@ -1,0 +1,33 @@
+package com.depromeet.piki.auth.controller
+
+import com.depromeet.piki.auth.infrastructure.oauth.apple.AppleNotificationException
+import com.depromeet.piki.common.openapi.OpenApiObjectMapper
+import com.depromeet.piki.common.openapi.binds
+import com.depromeet.piki.common.openapi.examples
+import com.depromeet.piki.common.response.ApiResponseBody
+import org.springdoc.core.customizers.OperationCustomizer
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpStatus
+
+@Configuration
+class AppleNotificationApiExamples(
+    private val openApiObjectMapper: OpenApiObjectMapper,
+) {
+    @Bean
+    fun appleNotificationOpenApiExamples(): OperationCustomizer =
+        OperationCustomizer { operation, handlerMethod ->
+            if (handlerMethod.binds(AppleNotificationController::handle)) {
+                operation.examples(openApiObjectMapper.delegate) {
+                    add(
+                        status = HttpStatus.OK,
+                        name = "알림 처리 완료 (멱등)",
+                        payload = ApiResponseBody.ok<Unit>(),
+                    )
+                    // 서명/issuer/aud 검증 실패 → 401. detail·category 를 예외 정의에서 자동 추출(손으로 박지 않음).
+                    add(AppleNotificationException.invalidSignature(), name = "유효하지 않은 Apple 알림")
+                }
+            }
+            operation
+        }
+}

--- a/src/main/kotlin/com/depromeet/piki/auth/controller/AppleNotificationController.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/controller/AppleNotificationController.kt
@@ -1,0 +1,24 @@
+package com.depromeet.piki.auth.controller
+
+import com.depromeet.piki.auth.service.AppleNotificationService
+import com.depromeet.piki.common.response.ApiResponseBody
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/auth/apple")
+class AppleNotificationController(
+    private val appleNotificationService: AppleNotificationService,
+) : AppleNotificationApi {
+    // Apple 은 application/x-www-form-urlencoded 의 payload 필드에 서명된 JWT 를 담아 POST 한다.
+    @PostMapping("/notifications", consumes = [MediaType.APPLICATION_FORM_URLENCODED_VALUE])
+    override fun handle(
+        @RequestParam("payload") payload: String,
+    ): ApiResponseBody<Unit> {
+        appleNotificationService.handle(payload)
+        return ApiResponseBody.ok()
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthClientConfig.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/OAuthClientConfig.kt
@@ -22,6 +22,9 @@ class OAuthClientConfig {
     @Bean
     fun kakaoOAuthClient(kakaoProperties: KakaoProperties): OAuthClient = KakaoOAuthClient(kakaoProperties)
 
+    // 반환 타입을 AppleOAuthClient 로 노출한다 — OAuthClient(소셜 로그인) 와 AppleNotificationVerifier
+    // (서버-서버 알림 검증)를 한 인스턴스가 모두 구현하므로, 두 주입 지점에 같은 빈이 쓰여 JWKS 캐시를 공유한다.
+    // 여전히 OAuthClient 구현이라 List<OAuthClient> 주입(소셜 로그인 registry)과도 호환된다.
     @Bean
-    fun appleOAuthClient(appleProperties: AppleProperties): OAuthClient = AppleOAuthClient(appleProperties)
+    fun appleOAuthClient(appleProperties: AppleProperties): AppleOAuthClient = AppleOAuthClient(appleProperties)
 }

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/apple/AppleNotificationEvent.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/apple/AppleNotificationEvent.kt
@@ -1,0 +1,24 @@
+package com.depromeet.piki.auth.infrastructure.oauth.apple
+
+import tools.jackson.databind.json.JsonMapper
+
+// Apple 서버-서버 알림 JWT 의 events 클레임을 파싱한 결과. events 는 payload JWT 안에 JSON 이
+// 문자열로 한 번 더 인코딩되어 들어온다 (예: "{\"type\":\"account-delete\",\"sub\":\"00..\",\"event_time\":1700..}").
+// 서명 검증과 분리된 순수 파싱이라 단위 테스트로 분기를 망라한다.
+data class AppleNotificationEvent(
+    val type: AppleNotificationEventType,
+    val sub: String?,
+) {
+    companion object {
+        private val jsonMapper = JsonMapper.builder().build()
+
+        // events 클레임(JSON 문자열)을 파싱한다. type 은 enum 으로 정규화하고, sub 는 공백이면 null 로 둔다.
+        // 우리가 보는 필드는 type·sub 뿐이라 나머지(email·event_time 등)는 무시한다.
+        fun parse(eventsJson: String): AppleNotificationEvent {
+            val node = jsonMapper.readTree(eventsJson)
+            val type = AppleNotificationEventType.from(node.get("type")?.asString())
+            val sub = node.get("sub")?.asString()?.ifBlank { null }
+            return AppleNotificationEvent(type = type, sub = sub)
+        }
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/apple/AppleNotificationEvent.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/apple/AppleNotificationEvent.kt
@@ -14,11 +14,19 @@ data class AppleNotificationEvent(
 
         // events 클레임(JSON 문자열)을 파싱한다. type 은 enum 으로 정규화하고, sub 는 공백이면 null 로 둔다.
         // 우리가 보는 필드는 type·sub 뿐이라 나머지(email·event_time 등)는 무시한다.
+        //
+        // 탈퇴·세션 종료는 대상 유저를 sub 로 특정해야 한다. 그 두 타입의 sub 누락은 비정상 payload(형식 오류)이므로
+        // 예외로 막는다 — 여기서 멱등 무시(200)로 흡수하면 실제 처리 없이 200 이 나가 Apple 상태와 어긋난다.
+        // (호출자 verify 가 이 예외를 invalidSignature 401 로 변환한다.) email·unknown 은 sub 없이도 로그만 남기므로 허용.
         fun parse(eventsJson: String): AppleNotificationEvent {
             val node = jsonMapper.readTree(eventsJson)
             val type = AppleNotificationEventType.from(node.get("type")?.asString())
-            val sub = node.get("sub")?.asString()?.ifBlank { null }
-            return AppleNotificationEvent(type = type, sub = sub)
+            val sub = node.get("sub")?.asString()?.trim()?.ifBlank { null }
+            return when (type) {
+                AppleNotificationEventType.ACCOUNT_DELETE, AppleNotificationEventType.CONSENT_REVOKED ->
+                    AppleNotificationEvent(type, sub ?: throw IllegalArgumentException("sub is required for $type"))
+                else -> AppleNotificationEvent(type, sub)
+            }
         }
     }
 }

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/apple/AppleNotificationEventType.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/apple/AppleNotificationEventType.kt
@@ -1,0 +1,26 @@
+package com.depromeet.piki.auth.infrastructure.oauth.apple
+
+// Apple 서버-서버 알림(events)의 type. Apple 이 보내는 원문 문자열을 우리 enum 으로 정규화한다.
+// 모르는 타입은 UNKNOWN 으로 흡수해 (Apple 이 타입을 늘려도) 처리를 깨뜨리지 않고 로그만 남긴다.
+enum class AppleNotificationEventType {
+    ACCOUNT_DELETE, // Apple ID 자체 삭제 → 회원 탈퇴
+    CONSENT_REVOKED, // 앱-Apple 연결 해제 → 세션 종료(로그아웃), 계정·데이터는 유지
+    EMAIL_DISABLED, // Private Relay 이메일 전달 중단 → 로그만 (우리는 메일 발송 안 함)
+    EMAIL_ENABLED, // Private Relay 이메일 전달 재개 → 로그만
+    UNKNOWN, // 미지원/미상 타입 → 로그만
+    ;
+
+    companion object {
+        // Apple 원문(예: "account-delete")을 enum 으로. 미상·null 은 UNKNOWN.
+        fun from(raw: String?): AppleNotificationEventType {
+            val normalized = raw?.trim()?.lowercase() ?: return UNKNOWN
+            return when (normalized) {
+                "account-delete" -> ACCOUNT_DELETE
+                "consent-revoked" -> CONSENT_REVOKED
+                "email-disabled" -> EMAIL_DISABLED
+                "email-enabled" -> EMAIL_ENABLED
+                else -> UNKNOWN
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/apple/AppleNotificationException.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/apple/AppleNotificationException.kt
@@ -1,0 +1,29 @@
+package com.depromeet.piki.auth.infrastructure.oauth.apple
+
+import com.depromeet.piki.common.exception.BaseException
+import com.depromeet.piki.common.exception.ErrorCategory
+import com.depromeet.piki.common.exception.HttpMappable
+import org.springframework.http.HttpStatus
+
+// Apple 서버-서버 알림 처리 예외. 이 엔드포인트는 우리 JWT 인증 없이(permitAll) 열려 있고,
+// 진위는 오직 payload JWT 의 서명으로 가린다. 서명·issuer·aud 검증이 깨지거나 payload 가 우리가
+// 아는 형식이 아니면 = Apple 이 보낸 정상 알림이 아니므로 401 로 거부한다 (위조 호출 차단의 핵심 방어선).
+// 디버깅용 원인은 cause 로만 남기고 message 는 고정 문구로 둔다(원문 비노출).
+class AppleNotificationException private constructor(
+    message: String,
+    override val category: ErrorCategory,
+    override val httpStatus: HttpStatus,
+    cause: Throwable? = null,
+) : BaseException(message, cause),
+    HttpMappable {
+    companion object {
+        // 서명/issuer/aud 검증 실패 또는 payload 형식 오류 — Apple 이 보낸 게 아니거나 위조된 호출 → 401.
+        fun invalidSignature(cause: Throwable? = null): AppleNotificationException =
+            AppleNotificationException(
+                "유효하지 않은 Apple 서버 알림입니다.",
+                ErrorCategory.UNAUTHORIZED,
+                HttpStatus.UNAUTHORIZED,
+                cause,
+            )
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/apple/AppleNotificationException.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/apple/AppleNotificationException.kt
@@ -25,5 +25,15 @@ class AppleNotificationException private constructor(
                 HttpStatus.UNAUTHORIZED,
                 cause,
             )
+
+        // 서명 검증에 필요한 Apple JWKS(/auth/keys) 조회 실패 — 우리 밖 의존성 장애라 위조와 구분해 502 로 올린다.
+        // 위조(invalidSignature, 401)와 한데 묶으면 JWKS 일시 장애가 위조 공격으로 오진돼 운영 알람·재시도 해석이 어긋난다.
+        fun providerError(cause: Throwable): AppleNotificationException =
+            AppleNotificationException(
+                "Apple 알림 검증 중 외부 키 조회에 실패했습니다.",
+                ErrorCategory.RETRYABLE,
+                HttpStatus.BAD_GATEWAY,
+                cause,
+            )
     }
 }

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/apple/AppleNotificationVerifier.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/apple/AppleNotificationVerifier.kt
@@ -1,0 +1,10 @@
+package com.depromeet.piki.auth.infrastructure.oauth.apple
+
+// Apple 서버-서버 알림 payload(JWT)의 서명·issuer·aud 를 검증하고 events 를 파싱해 돌려준다.
+// Apple JWKS(/auth/keys)를 가져오는 외부 호출 경계이므로 인터페이스로 분리한다 — 통합 테스트는
+// 이 경계를 stub 로 격리한다(모킹 정책: 외부 호출 경계만 격리). 운영 구현은 AppleOAuthClient 가
+// 맡아 id_token 검증과 JWKS 캐시를 한 인스턴스에서 공유한다(/auth/keys 중복 호출 방지).
+interface AppleNotificationVerifier {
+    // 검증 성공 시 파싱된 이벤트를 반환한다. 서명/issuer/aud 실패·형식 오류면 AppleNotificationException(401).
+    fun verify(payloadJwt: String): AppleNotificationEvent
+}

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/apple/AppleOAuthClient.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/apple/AppleOAuthClient.kt
@@ -27,7 +27,8 @@ import java.util.Date
 
 class AppleOAuthClient(
     private val props: AppleProperties,
-) : OAuthClient {
+) : OAuthClient,
+    AppleNotificationVerifier {
     override val provider = OAuthProvider.APPLE
 
     private val log = LoggerFactory.getLogger(javaClass)
@@ -90,6 +91,37 @@ class AppleOAuthClient(
     // v2: iOS SDK 가 발급한 identityToken(JWT)을 직접 검증. aud = bundleId (Bundle ID).
     override fun fetchUserInfoByAccessToken(accessToken: String): OAuthUserInfo =
         verifyIdTokenAndExtract(accessToken, expectedAud = props.bundleId)
+
+    // Apple 서버-서버 알림 검증. id_token 과 같은 JWKS·issuer·kid 회전 인프라(parseWithKidRotationRetry)를
+    // 재사용해 JWKS 캐시를 한 인스턴스에서 공유한다. 알림 JWT 는 aud 가 우리 client_id(Services ID) 또는
+    // bundleId 이고, payload 의 events 클레임을 들고 온다. 검증·파싱 실패는 모두 AppleNotificationException(401)로
+    // 변환한다 — 이 엔드포인트는 permitAll 이라 서명이 유일한 진위 방어선이고, 위조/비정상 호출은 401 로 거부한다.
+    override fun verify(payloadJwt: String): AppleNotificationEvent {
+        val claims =
+            try {
+                parseWithKidRotationRetry(payloadJwt)
+            } catch (e: Exception) {
+                throw AppleNotificationException.invalidSignature(e)
+            }
+        return toNotificationEvent(claims)
+    }
+
+    // 서명·issuer 검증이 끝난 claims 에서 aud 를 확인하고 events 를 파싱한다. 외부 호출(JWKS) 없는 순수 검증이라
+    // 단위 테스트가 직접 호출한다 — aud 위조·events 누락 같은 보안 경로를 stub 없이 망라한다.
+    // aud 는 우리 client_id(Services ID) 또는 bundleId 여야 한다. 불일치·형식 오류는 AppleNotificationException(401).
+    internal fun toNotificationEvent(claims: Claims): AppleNotificationEvent {
+        val aud = claims.audience ?: emptySet()
+        if (aud.none { it == props.clientId || it == props.bundleId }) {
+            log.warn("Apple 알림 aud 불일치: actual={}", aud)
+            throw AppleNotificationException.invalidSignature()
+        }
+        val eventsJson = claims["events"] as? String ?: throw AppleNotificationException.invalidSignature()
+        return try {
+            AppleNotificationEvent.parse(eventsJson)
+        } catch (e: Exception) {
+            throw AppleNotificationException.invalidSignature(e)
+        }
+    }
 
     private fun verifyIdTokenAndExtract(
         idToken: String,

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/apple/AppleOAuthClient.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/apple/AppleOAuthClient.kt
@@ -96,14 +96,36 @@ class AppleOAuthClient(
     // 재사용해 JWKS 캐시를 한 인스턴스에서 공유한다. 알림 JWT 는 aud 가 우리 client_id(Services ID) 또는
     // bundleId 이고, payload 의 events 클레임을 들고 온다. 검증·파싱 실패는 모두 AppleNotificationException(401)로
     // 변환한다 — 이 엔드포인트는 permitAll 이라 서명이 유일한 진위 방어선이고, 위조/비정상 호출은 401 로 거부한다.
-    override fun verify(payloadJwt: String): AppleNotificationEvent {
-        val claims =
+    override fun verify(payloadJwt: String): AppleNotificationEvent = toNotificationEvent(parseNotificationClaims(payloadJwt))
+
+    // 알림 JWT 파싱. id_token 경로(parseWithKidRotationRetry)와 같은 JWKS·kid 회전 로직을 따르되 예외 매핑이 다르다 —
+    // JWKS fetch 실패(외부 의존성)는 providerError(502)로, 서명·claims 파싱 실패(위조)는 invalidSignature(401)로 분기한다.
+    // parseWithKidRotationRetry 를 그대로 쓰면 둘 다 OAuthException.providerError 로 뭉쳐 구분이 불가능해 따로 둔다.
+    private fun parseNotificationClaims(payloadJwt: String): Claims {
+        val jwks =
             try {
-                parseWithKidRotationRetry(payloadJwt)
+                getJwks()
             } catch (e: Exception) {
-                throw AppleNotificationException.invalidSignature(e)
+                throw AppleNotificationException.providerError(e)
             }
-        return toNotificationEvent(claims)
+        return try {
+            parseIdToken(payloadJwt, jwks)
+        } catch (e: Exception) {
+            // 캐시 JWKS 에 없는 kid = Apple 키 회전 가능성 → 캐시 무효화 후 1회 재시도. 그 외(서명 위조·exp·issuer)는 401.
+            if (!isKidRotation(e)) throw AppleNotificationException.invalidSignature(e)
+            jwksCachedAt = 0L
+            val refreshed =
+                try {
+                    getJwks()
+                } catch (re: Exception) {
+                    throw AppleNotificationException.providerError(re)
+                }
+            try {
+                parseIdToken(payloadJwt, refreshed)
+            } catch (retry: Exception) {
+                throw AppleNotificationException.invalidSignature(retry)
+            }
+        }
     }
 
     // 서명·issuer 검증이 끝난 claims 에서 aud 를 확인하고 events 를 파싱한다. 외부 호출(JWKS) 없는 순수 검증이라

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/apple/AppleOAuthClient.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/oauth/apple/AppleOAuthClient.kt
@@ -102,24 +102,14 @@ class AppleOAuthClient(
     // JWKS fetch 실패(외부 의존성)는 providerError(502)로, 서명·claims 파싱 실패(위조)는 invalidSignature(401)로 분기한다.
     // parseWithKidRotationRetry 를 그대로 쓰면 둘 다 OAuthException.providerError 로 뭉쳐 구분이 불가능해 따로 둔다.
     private fun parseNotificationClaims(payloadJwt: String): Claims {
-        val jwks =
-            try {
-                getJwks()
-            } catch (e: Exception) {
-                throw AppleNotificationException.providerError(e)
-            }
+        val jwks = fetchJwksForNotification()
         return try {
             parseIdToken(payloadJwt, jwks)
         } catch (e: Exception) {
             // 캐시 JWKS 에 없는 kid = Apple 키 회전 가능성 → 캐시 무효화 후 1회 재시도. 그 외(서명 위조·exp·issuer)는 401.
             if (!isKidRotation(e)) throw AppleNotificationException.invalidSignature(e)
             jwksCachedAt = 0L
-            val refreshed =
-                try {
-                    getJwks()
-                } catch (re: Exception) {
-                    throw AppleNotificationException.providerError(re)
-                }
+            val refreshed = fetchJwksForNotification()
             try {
                 parseIdToken(payloadJwt, refreshed)
             } catch (retry: Exception) {
@@ -127,6 +117,16 @@ class AppleOAuthClient(
             }
         }
     }
+
+    // JWKS 조회는 외부 호출이므로 실패 시 warn 으로 남긴다(CLAUDE.md: 외부 호출 실패 = warn). providerError 는
+    // GlobalExceptionHandler 에서 info 로만 요약되므로, 외부 의존성 장애를 운영에서 놓치지 않게 호출 지점에 warn + 스택을 남긴다.
+    private fun fetchJwksForNotification(): String =
+        try {
+            getJwks()
+        } catch (e: Exception) {
+            log.warn("Apple JWKS 조회 실패로 알림 검증 불가 (재시도 가능)", e)
+            throw AppleNotificationException.providerError(e)
+        }
 
     // 서명·issuer 검증이 끝난 claims 에서 aud 를 확인하고 events 를 파싱한다. 외부 호출(JWKS) 없는 순수 검증이라
     // 단위 테스트가 직접 호출한다 — aud 위조·events 누락 같은 보안 경로를 stub 없이 망라한다.

--- a/src/main/kotlin/com/depromeet/piki/auth/service/AppleNotificationService.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/service/AppleNotificationService.kt
@@ -46,11 +46,11 @@ class AppleNotificationService(
     }
 
     // sub(Apple subject = socialId) → 우리 userId. 못 찾으면(미가입·이미 탈퇴로 user_detail 파기됨) 멱등하게 무시한다.
+    // sub 는 호출 시점에 이미 non-null 이다 — account-delete·consent-revoked 는 AppleNotificationEvent.parse 가
+    // sub 를 보장하고(누락은 401 로 차단됨), 이 메서드는 그 둘에서만 호출된다. 여기 null 이 닿으면 parse 를 안 거친
+    // 내부 버그이므로 불변식(requireNotNull)으로 막는다(500).
     private fun resolveUserId(sub: String?): UUID? {
-        sub ?: run {
-            log.info("Apple 알림 sub 누락 — 무시")
-            return null
-        }
+        requireNotNull(sub) { "account-delete·consent-revoked 는 parse 가 sub 를 보장하므로 여기 닿으면 안 된다" }
         val userId = userDetailRepository.findByProviderAndSocialId(OAuthProvider.APPLE.name, sub)?.getIdOrNull()
         userId ?: log.info("Apple 알림 대상 유저 없음 — 멱등 무시 (미가입 또는 이미 탈퇴)")
         return userId

--- a/src/main/kotlin/com/depromeet/piki/auth/service/AppleNotificationService.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/service/AppleNotificationService.kt
@@ -1,0 +1,67 @@
+package com.depromeet.piki.auth.service
+
+import com.depromeet.piki.auth.infrastructure.oauth.OAuthProvider
+import com.depromeet.piki.auth.infrastructure.oauth.apple.AppleNotificationEventType
+import com.depromeet.piki.auth.infrastructure.oauth.apple.AppleNotificationVerifier
+import com.depromeet.piki.auth.infrastructure.redis.RefreshTokenStore
+import com.depromeet.piki.notification.sse.LocalSseDelivery
+import com.depromeet.piki.user.repository.UserDetailRepository
+import com.depromeet.piki.user.service.WithdrawalService
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import java.util.UUID
+
+// Apple 서버-서버 알림 처리. 사용자가 Apple 쪽에서 연결을 끊거나(consent-revoked) Apple ID 를
+// 삭제(account-delete)하면 Apple 이 이 경로로 알림을 보내고, 그에 맞춰 우리 계정 상태를 동기화한다.
+//
+// 트랜잭션을 걸지 않는다 — 서명 검증(verify)이 Apple JWKS 를 가져오는 외부 호출이라, 그 latency 동안
+// DB 커넥션을 잡으면 안 된다(트랜잭션 경계 규약). 실제 영속화는 WithdrawalService 가 자기 트랜잭션으로 처리한다.
+@Service
+class AppleNotificationService(
+    private val verifier: AppleNotificationVerifier,
+    private val userDetailRepository: UserDetailRepository,
+    private val withdrawalService: WithdrawalService,
+    private val refreshTokenStore: RefreshTokenStore,
+    private val localSseDelivery: LocalSseDelivery,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    fun handle(payloadJwt: String) {
+        // 검증 실패(서명·issuer·aud·형식)는 AppleNotificationException(401)로 던져 위조 호출을 거부한다.
+        val event = verifier.verify(payloadJwt)
+        when (event.type) {
+            // Apple ID 삭제 → 주인이 사라진 계정이므로 데이터까지 파기(탈퇴).
+            AppleNotificationEventType.ACCOUNT_DELETE ->
+                resolveUserId(event.sub)?.let { withdrawalService.withdraw(it) }
+            // 앱-Apple 연결 해제 → 세션만 종료(계정·데이터 유지). 재로그인하면 같은 sub 로 기존 계정 복귀.
+            AppleNotificationEventType.CONSENT_REVOKED ->
+                resolveUserId(event.sub)?.let { terminateSession(it) }
+            // Private Relay 이메일 전달 on/off — 우리는 메일을 발송하지 않아 반영할 동작이 없다(로그만).
+            AppleNotificationEventType.EMAIL_DISABLED, AppleNotificationEventType.EMAIL_ENABLED ->
+                log.info("Apple 이메일 릴레이 상태 변경 이벤트 수신 type={}", event.type)
+            // Apple 이 타입을 늘려도 깨지지 않게 흡수(로그만).
+            AppleNotificationEventType.UNKNOWN ->
+                log.info("미지원 Apple 알림 이벤트 수신 — 무시")
+        }
+    }
+
+    // sub(Apple subject = socialId) → 우리 userId. 못 찾으면(미가입·이미 탈퇴로 user_detail 파기됨) 멱등하게 무시한다.
+    private fun resolveUserId(sub: String?): UUID? {
+        sub ?: run {
+            log.info("Apple 알림 sub 누락 — 무시")
+            return null
+        }
+        val userId = userDetailRepository.findByProviderAndSocialId(OAuthProvider.APPLE.name, sub)?.getIdOrNull()
+        userId ?: log.info("Apple 알림 대상 유저 없음 — 멱등 무시 (미가입 또는 이미 탈퇴)")
+        return userId
+    }
+
+    // consent-revoked 세션 종료: refresh token 삭제(재발급 차단) + SSE 연결 즉시 종료.
+    // access token denylist 는 쓰지 않는다 — userId 단위라 마킹하면 재로그인으로 받은 새 access token 까지
+    // 거부되어 "재로그인 시 기존 계정 복귀"가 깨진다. access token 은 짧은 수명으로 자연 만료에 맡긴다.
+    private fun terminateSession(userId: UUID) {
+        refreshTokenStore.delete(userId)
+        localSseDelivery.closeAll(userId)
+        log.info("Apple consent-revoked 세션 종료 userId={}", userId)
+    }
+}

--- a/src/test/kotlin/com/depromeet/piki/auth/controller/AppleNotificationControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/controller/AppleNotificationControllerIntegrationTest.kt
@@ -1,0 +1,217 @@
+package com.depromeet.piki.auth.controller
+
+import com.depromeet.piki.auth.infrastructure.oauth.apple.AppleNotificationEvent
+import com.depromeet.piki.auth.infrastructure.oauth.apple.AppleNotificationEventType
+import com.depromeet.piki.auth.infrastructure.oauth.apple.AppleNotificationException
+import com.depromeet.piki.support.IntegrationTestSupport
+import com.depromeet.piki.support.StubAppleNotificationVerifier
+import com.depromeet.piki.support.StubRefreshTokenStore
+import com.depromeet.piki.support.uuidToBytes
+import com.depromeet.piki.user.domain.IdentityType
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.context.WebApplicationContext
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+@Transactional
+class AppleNotificationControllerIntegrationTest : IntegrationTestSupport() {
+    @Autowired
+    private lateinit var webApplicationContext: WebApplicationContext
+
+    @Autowired
+    private lateinit var jdbcTemplate: JdbcTemplate
+
+    @Autowired
+    private lateinit var stubAppleNotificationVerifier: StubAppleNotificationVerifier
+
+    @Autowired
+    private lateinit var stubRefreshTokenStore: StubRefreshTokenStore
+
+    @PersistenceContext
+    private lateinit var entityManager: EntityManager
+
+    private fun mockMvc(): MockMvc =
+        MockMvcBuilders
+            .webAppContextSetup(webApplicationContext)
+            .apply<DefaultMockMvcBuilder>(springSecurity())
+            .build()
+
+    // Apple 로 가입한 MEMBER 1명 생성 (users + user_details provider=APPLE). socialId 가 알림의 sub 와 매칭된다.
+    private fun insertAppleUser(
+        userId: UUID,
+        socialId: String,
+        nickname: String = "애플유저",
+    ) {
+        jdbcTemplate.update(
+            "INSERT INTO users (id, nickname, profile_image, identity_type, created_at, updated_at) " +
+                "VALUES (?, ?, ?, ?, NOW(6), NOW(6))",
+            uuidToBytes(userId),
+            nickname,
+            "https://example.com/img.png",
+            IdentityType.MEMBER.name,
+        )
+        jdbcTemplate.update(
+            "INSERT INTO user_details (user_id, provider, social_id, created_at, updated_at) " +
+                "VALUES (?, ?, ?, NOW(6), NOW(6))",
+            uuidToBytes(userId),
+            "APPLE",
+            socialId,
+        )
+    }
+
+    private fun postNotification(): org.springframework.test.web.servlet.ResultActions =
+        mockMvc().perform(
+            post("/api/v1/auth/apple/notifications")
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .param("payload", "signed-jwt-payload"),
+        )
+
+    @Test
+    fun `account-delete 알림이면 해당 유저가 탈퇴(tombstone)되고 200 이 반환된다`() {
+        val userId = UUID.randomUUID()
+        val socialId = "apple_sub_${userId.toString().take(8)}"
+        insertAppleUser(userId, socialId, nickname = "애플멤버")
+        stubAppleNotificationVerifier.verifyStub = {
+            AppleNotificationEvent(AppleNotificationEventType.ACCOUNT_DELETE, socialId)
+        }
+
+        postNotification()
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.data").value(null))
+            .andExpect(jsonPath("$.detail").value("정상적으로 처리되었습니다."))
+
+        entityManager.flush()
+        entityManager.clear()
+
+        // users tombstone — 닉네임 익명화 + deleted_at set
+        val nickname =
+            jdbcTemplate.queryForObject(
+                "SELECT nickname FROM users WHERE id = ?",
+                String::class.java,
+                uuidToBytes(userId),
+            )
+        assertNotEquals("애플멤버", nickname)
+        val deletedAt =
+            jdbcTemplate.queryForObject(
+                "SELECT deleted_at FROM users WHERE id = ?",
+                java.sql.Timestamp::class.java,
+                uuidToBytes(userId),
+            )
+        assertNotNull(deletedAt, "account-delete 면 user 가 tombstone 으로 탈퇴되어야 한다")
+
+        // user_details(PII) 하드삭제
+        val detailCount =
+            jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM user_details WHERE user_id = ?",
+                Long::class.java,
+                uuidToBytes(userId),
+            )
+        assertEquals(0L, detailCount)
+    }
+
+    @Test
+    fun `consent-revoked 알림이면 refresh token 만 삭제되고 계정·데이터는 유지된다`() {
+        val userId = UUID.randomUUID()
+        val socialId = "apple_sub_${userId.toString().take(8)}"
+        insertAppleUser(userId, socialId, nickname = "애플멤버")
+        stubRefreshTokenStore.save(userId, "refresh-token-value")
+        stubAppleNotificationVerifier.verifyStub = {
+            AppleNotificationEvent(AppleNotificationEventType.CONSENT_REVOKED, socialId)
+        }
+
+        postNotification()
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.data").value(null))
+
+        entityManager.flush()
+        entityManager.clear()
+
+        // refresh token 은 삭제(재발급 차단)
+        assertNull(stubRefreshTokenStore.get(userId), "consent-revoked 면 refresh token 이 삭제되어야 한다")
+
+        // 계정은 살아있음 — tombstone 되지 않고 닉네임·user_detail 유지(재로그인 복귀 보장)
+        val nickname =
+            jdbcTemplate.queryForObject(
+                "SELECT nickname FROM users WHERE id = ?",
+                String::class.java,
+                uuidToBytes(userId),
+            )
+        assertEquals("애플멤버", nickname)
+        val deletedAt =
+            jdbcTemplate.queryForObject(
+                "SELECT deleted_at FROM users WHERE id = ?",
+                java.sql.Timestamp::class.java,
+                uuidToBytes(userId),
+            )
+        assertNull(deletedAt, "consent-revoked 면 계정은 유지되어야 한다")
+        val detailCount =
+            jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM user_details WHERE user_id = ?",
+                Long::class.java,
+                uuidToBytes(userId),
+            )
+        assertEquals(1L, detailCount, "consent-revoked 면 user_detail 이 유지되어야 한다")
+    }
+
+    @Test
+    fun `대상 유저가 없으면 멱등하게 200 으로 흡수한다`() {
+        // 매칭되는 user_detail 이 없는 sub (미가입 또는 이미 탈퇴로 파기됨)
+        stubAppleNotificationVerifier.verifyStub = {
+            AppleNotificationEvent(AppleNotificationEventType.ACCOUNT_DELETE, "not_exist_sub")
+        }
+
+        postNotification()
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.data").value(null))
+    }
+
+    @Test
+    fun `서명 검증에 실패하면 401 이 반환된다`() {
+        stubAppleNotificationVerifier.verifyStub = { throw AppleNotificationException.invalidSignature() }
+
+        postNotification()
+            .andExpect(status().isUnauthorized)
+            .andExpect(jsonPath("$.detail").value("유효하지 않은 Apple 서버 알림입니다."))
+            .andExpect(jsonPath("$.data").value(null))
+    }
+
+    @Test
+    fun `email 릴레이 이벤트는 아무 상태 변경 없이 200 이 반환된다`() {
+        val userId = UUID.randomUUID()
+        val socialId = "apple_sub_${userId.toString().take(8)}"
+        insertAppleUser(userId, socialId, nickname = "애플멤버")
+        stubAppleNotificationVerifier.verifyStub = {
+            AppleNotificationEvent(AppleNotificationEventType.EMAIL_DISABLED, socialId)
+        }
+
+        postNotification().andExpect(status().isOk)
+
+        entityManager.flush()
+        entityManager.clear()
+
+        // 계정 그대로
+        val deletedAt =
+            jdbcTemplate.queryForObject(
+                "SELECT deleted_at FROM users WHERE id = ?",
+                java.sql.Timestamp::class.java,
+                uuidToBytes(userId),
+            )
+        assertNull(deletedAt, "email 이벤트는 계정 상태를 바꾸지 않는다")
+    }
+}

--- a/src/test/kotlin/com/depromeet/piki/auth/controller/AppleNotificationControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/controller/AppleNotificationControllerIntegrationTest.kt
@@ -11,6 +11,8 @@ import com.depromeet.piki.user.domain.IdentityType
 import jakarta.persistence.EntityManager
 import jakarta.persistence.PersistenceContext
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
 import org.springframework.jdbc.core.JdbcTemplate
@@ -191,27 +193,29 @@ class AppleNotificationControllerIntegrationTest : IntegrationTestSupport() {
             .andExpect(jsonPath("$.data").value(null))
     }
 
-    @Test
-    fun `email 릴레이 이벤트는 아무 상태 변경 없이 200 이 반환된다`() {
+    @ParameterizedTest
+    @EnumSource(
+        value = AppleNotificationEventType::class,
+        names = ["EMAIL_DISABLED", "EMAIL_ENABLED", "UNKNOWN"],
+    )
+    fun `상태 변경 없는 이벤트는 계정을 건드리지 않고 200 으로 흡수한다`(type: AppleNotificationEventType) {
+        // no-op 계열(email 릴레이 on·off, 미지원 타입). UNKNOWN→200 계약이 깨지면 Apple 재시도로 운영 부담이 커지므로 함께 고정한다.
         val userId = UUID.randomUUID()
         val socialId = "apple_sub_${userId.toString().take(8)}"
         insertAppleUser(userId, socialId, nickname = "애플멤버")
-        stubAppleNotificationVerifier.verifyStub = {
-            AppleNotificationEvent(AppleNotificationEventType.EMAIL_DISABLED, socialId)
-        }
+        stubAppleNotificationVerifier.verifyStub = { AppleNotificationEvent(type, socialId) }
 
         postNotification().andExpect(status().isOk)
 
         entityManager.flush()
         entityManager.clear()
 
-        // 계정 그대로
         val deletedAt =
             jdbcTemplate.queryForObject(
                 "SELECT deleted_at FROM users WHERE id = ?",
                 java.sql.Timestamp::class.java,
                 uuidToBytes(userId),
             )
-        assertNull(deletedAt, "email 이벤트는 계정 상태를 바꾸지 않는다")
+        assertNull(deletedAt, "$type 이벤트는 계정 상태를 바꾸지 않는다")
     }
 }

--- a/src/test/kotlin/com/depromeet/piki/auth/infrastructure/oauth/apple/AppleNotificationEventTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/infrastructure/oauth/apple/AppleNotificationEventTest.kt
@@ -1,7 +1,10 @@
 package com.depromeet.piki.auth.infrastructure.oauth.apple
 
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 
 class AppleNotificationEventTest {
@@ -22,21 +25,28 @@ class AppleNotificationEventTest {
         assertEquals(AppleNotificationEventType.UNKNOWN, AppleNotificationEvent.parse(json).type)
     }
 
-    @Test
-    fun `sub 가 없으면 null 이다`() {
-        val json = """{"type":"consent-revoked","event_time":1}"""
+    @ParameterizedTest
+    @ValueSource(strings = ["account-delete", "consent-revoked"])
+    fun `탈퇴·세션종료 이벤트는 sub 가 없으면 예외를 던진다`(type: String) {
+        // sub 누락은 비정상 payload — 멱등 무시(200)로 삼키지 않고 형식 오류로 막아 호출자가 401 로 거부하게 한다.
+        val json = """{"type":"$type","event_time":1}"""
 
-        val event = AppleNotificationEvent.parse(json)
+        assertFailsWith<IllegalArgumentException> { AppleNotificationEvent.parse(json) }
+    }
 
-        assertEquals(AppleNotificationEventType.CONSENT_REVOKED, event.type)
-        assertNull(event.sub)
+    @ParameterizedTest
+    @ValueSource(strings = ["account-delete", "consent-revoked"])
+    fun `탈퇴·세션종료 이벤트는 sub 가 공백이면 예외를 던진다`(type: String) {
+        val json = """{"type":"$type","sub":"   "}"""
+
+        assertFailsWith<IllegalArgumentException> { AppleNotificationEvent.parse(json) }
     }
 
     @Test
-    fun `sub 가 공백이면 null 로 정규화한다`() {
-        val json = """{"type":"account-delete","sub":"   "}"""
-
-        assertNull(AppleNotificationEvent.parse(json).sub)
+    fun `email·unknown 이벤트는 sub 가 없어도 허용한다 (로그만 하므로 대상 유저 불필요)`() {
+        assertNull(AppleNotificationEvent.parse("""{"type":"email-disabled"}""").sub)
+        assertNull(AppleNotificationEvent.parse("""{"type":"email-enabled"}""").sub)
+        assertNull(AppleNotificationEvent.parse("""{"type":"foo-bar"}""").sub)
     }
 
     @Test

--- a/src/test/kotlin/com/depromeet/piki/auth/infrastructure/oauth/apple/AppleNotificationEventTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/infrastructure/oauth/apple/AppleNotificationEventTest.kt
@@ -1,0 +1,52 @@
+package com.depromeet.piki.auth.infrastructure.oauth.apple
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class AppleNotificationEventTest {
+    @Test
+    fun `events JSON 에서 type 과 sub 를 추출한다`() {
+        val json = """{"type":"account-delete","sub":"001234.abcdef","event_time":1700000000000}"""
+
+        val event = AppleNotificationEvent.parse(json)
+
+        assertEquals(AppleNotificationEventType.ACCOUNT_DELETE, event.type)
+        assertEquals("001234.abcdef", event.sub)
+    }
+
+    @Test
+    fun `미지원 type 은 UNKNOWN 으로 파싱한다`() {
+        val json = """{"type":"foo-bar","sub":"001"}"""
+
+        assertEquals(AppleNotificationEventType.UNKNOWN, AppleNotificationEvent.parse(json).type)
+    }
+
+    @Test
+    fun `sub 가 없으면 null 이다`() {
+        val json = """{"type":"consent-revoked","event_time":1}"""
+
+        val event = AppleNotificationEvent.parse(json)
+
+        assertEquals(AppleNotificationEventType.CONSENT_REVOKED, event.type)
+        assertNull(event.sub)
+    }
+
+    @Test
+    fun `sub 가 공백이면 null 로 정규화한다`() {
+        val json = """{"type":"account-delete","sub":"   "}"""
+
+        assertNull(AppleNotificationEvent.parse(json).sub)
+    }
+
+    @Test
+    fun `우리가 보지 않는 필드(email 등)는 무시한다`() {
+        val json =
+            """{"type":"email-disabled","sub":"001","email":"x@privaterelay.appleid.com","is_private_email":"true"}"""
+
+        val event = AppleNotificationEvent.parse(json)
+
+        assertEquals(AppleNotificationEventType.EMAIL_DISABLED, event.type)
+        assertEquals("001", event.sub)
+    }
+}

--- a/src/test/kotlin/com/depromeet/piki/auth/infrastructure/oauth/apple/AppleNotificationEventTypeTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/infrastructure/oauth/apple/AppleNotificationEventTypeTest.kt
@@ -1,0 +1,39 @@
+package com.depromeet.piki.auth.infrastructure.oauth.apple
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.ValueSource
+import kotlin.test.assertEquals
+
+class AppleNotificationEventTypeTest {
+    @ParameterizedTest
+    @CsvSource(
+        "account-delete, ACCOUNT_DELETE",
+        "consent-revoked, CONSENT_REVOKED",
+        "email-disabled, EMAIL_DISABLED",
+        "email-enabled, EMAIL_ENABLED",
+    )
+    fun `Apple 원문 타입을 enum 으로 매핑한다`(
+        raw: String,
+        expected: AppleNotificationEventType,
+    ) {
+        assertEquals(expected, AppleNotificationEventType.from(raw))
+    }
+
+    @Test
+    fun `대소문자와 앞뒤 공백이 섞여도 정규화해 매핑한다`() {
+        assertEquals(AppleNotificationEventType.ACCOUNT_DELETE, AppleNotificationEventType.from("  Account-Delete "))
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["", "unknown-type", "delete", "consent_revoked"])
+    fun `미상 타입은 UNKNOWN 으로 흡수한다`(raw: String) {
+        assertEquals(AppleNotificationEventType.UNKNOWN, AppleNotificationEventType.from(raw))
+    }
+
+    @Test
+    fun `null 은 UNKNOWN 으로 흡수한다`() {
+        assertEquals(AppleNotificationEventType.UNKNOWN, AppleNotificationEventType.from(null))
+    }
+}

--- a/src/test/kotlin/com/depromeet/piki/auth/infrastructure/oauth/apple/AppleOAuthClientTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/infrastructure/oauth/apple/AppleOAuthClientTest.kt
@@ -407,6 +407,15 @@ class AppleOAuthClientTest {
             val ex = assertFailsWith<AppleNotificationException> { client.toNotificationEvent(claims) }
             assertEquals(401, ex.httpStatus.value())
         }
+
+        @Test
+        fun `events JSON 이 손상되면 401 로 거부한다`() {
+            val client = AppleOAuthClient(props())
+            val claims = eventClaims(audience = "com.test.service", eventsJson = "{not-json")
+
+            val ex = assertFailsWith<AppleNotificationException> { client.toNotificationEvent(claims) }
+            assertEquals(401, ex.httpStatus.value())
+        }
     }
 
     // ---- helpers ----

--- a/src/test/kotlin/com/depromeet/piki/auth/infrastructure/oauth/apple/AppleOAuthClientTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/infrastructure/oauth/apple/AppleOAuthClientTest.kt
@@ -328,6 +328,87 @@ class AppleOAuthClientTest {
         }
     }
 
+    @Nested
+    inner class VerifyNotification {
+        // 서버-서버 알림 검증의 순수 부분(aud 검증 + events 파싱)을 외부 호출(JWKS) 없이 망라한다.
+        // 서명·issuer·kid 검증은 id_token 과 같은 parseIdToken 경로라 위 VerifyIdToken·KidRotation 테스트가 커버한다.
+
+        private fun eventClaims(
+            audience: String,
+            eventsJson: String?,
+        ): io.jsonwebtoken.Claims {
+            val client = AppleOAuthClient(props())
+            val now = Date()
+            val builder =
+                Jwts
+                    .builder()
+                    .header()
+                    .add("kid", testKid)
+                    .and()
+                    .issuer("https://appleid.apple.com")
+                    .audience()
+                    .add(audience)
+                    .and()
+                    .issuedAt(now)
+                    .expiration(Date(now.time + 60_000))
+            eventsJson?.let { builder.claim("events", it) }
+            val token = builder.signWith(testKeyPair.private).compact()
+            return client.parseIdToken(token, testJwksJson)
+        }
+
+        @Test
+        fun `aud 가 clientId 와 일치하면 events 를 파싱해 반환한다`() {
+            val client = AppleOAuthClient(props())
+            val claims =
+                eventClaims(
+                    audience = "com.test.service",
+                    eventsJson = """{"type":"account-delete","sub":"001234.abc","event_time":1700000000000}""",
+                )
+
+            val event = client.toNotificationEvent(claims)
+
+            assertEquals(AppleNotificationEventType.ACCOUNT_DELETE, event.type)
+            assertEquals("001234.abc", event.sub)
+        }
+
+        @Test
+        fun `aud 가 bundleId 와 일치해도 통과한다`() {
+            val client = AppleOAuthClient(props())
+            val claims =
+                eventClaims(
+                    audience = "com.test.app",
+                    eventsJson = """{"type":"consent-revoked","sub":"002.def"}""",
+                )
+
+            val event = client.toNotificationEvent(claims)
+
+            assertEquals(AppleNotificationEventType.CONSENT_REVOKED, event.type)
+            assertEquals("002.def", event.sub)
+        }
+
+        @Test
+        fun `aud 가 우리 client_id 가 아니면 401 로 거부한다 (위조 방어)`() {
+            val client = AppleOAuthClient(props())
+            val claims =
+                eventClaims(
+                    audience = "com.attacker.service",
+                    eventsJson = """{"type":"account-delete","sub":"001"}""",
+                )
+
+            val ex = assertFailsWith<AppleNotificationException> { client.toNotificationEvent(claims) }
+            assertEquals(401, ex.httpStatus.value())
+        }
+
+        @Test
+        fun `events 클레임이 없으면 401 로 거부한다`() {
+            val client = AppleOAuthClient(props())
+            val claims = eventClaims(audience = "com.test.service", eventsJson = null)
+
+            val ex = assertFailsWith<AppleNotificationException> { client.toNotificationEvent(claims) }
+            assertEquals(401, ex.httpStatus.value())
+        }
+    }
+
     // ---- helpers ----
 
     private fun signAppleIdToken(

--- a/src/test/kotlin/com/depromeet/piki/support/IntegrationStubs.kt
+++ b/src/test/kotlin/com/depromeet/piki/support/IntegrationStubs.kt
@@ -81,4 +81,9 @@ class IntegrationStubs {
 
     @Bean
     fun appleOAuthClient(): StubOAuthClient = StubOAuthClient(OAuthProvider.APPLE)
+
+    // Apple 서버-서버 알림 서명 검증(외부 JWKS 호출) 격리. 운영 AppleOAuthClient 가 AppleNotificationVerifier 를
+    // 구현하지만 oauth.client.enabled=false 로 꺼지므로, 이 stub 이 유일한 AppleNotificationVerifier 라 @Primary 불필요.
+    @Bean
+    fun appleNotificationVerifier(): StubAppleNotificationVerifier = StubAppleNotificationVerifier()
 }

--- a/src/test/kotlin/com/depromeet/piki/support/StubAppleNotificationVerifier.kt
+++ b/src/test/kotlin/com/depromeet/piki/support/StubAppleNotificationVerifier.kt
@@ -1,0 +1,16 @@
+package com.depromeet.piki.support
+
+import com.depromeet.piki.auth.infrastructure.oauth.apple.AppleNotificationEvent
+import com.depromeet.piki.auth.infrastructure.oauth.apple.AppleNotificationVerifier
+
+// Apple JWKS 검증(외부 호출 경계) 격리용 programmable stub. 운영 구현(AppleOAuthClient)은
+// oauth.client.enabled=false 로 꺼져 있어 이 stub 이 유일한 AppleNotificationVerifier 다.
+// default 람다는 throw — 명시 세팅을 빠뜨리면 호출 시점에 즉시 깨지도록 강제한다.
+// 서명 실패(401) 시나리오는 verifyStub 에 throw 를 세팅해 재현한다.
+class StubAppleNotificationVerifier : AppleNotificationVerifier {
+    var verifyStub: (String) -> AppleNotificationEvent = {
+        error("stub.verifyStub 를 테스트 본문에서 명시 세팅해야 한다.")
+    }
+
+    override fun verify(payloadJwt: String): AppleNotificationEvent = verifyStub(payloadJwt)
+}


### PR DESCRIPTION
## Situation

- Apple 은 사용자가 "Apple 로 로그인" 연결을 끊거나 Apple ID 를 삭제하면, 우리가 등록한 서버 엔드포인트로 서명된 알림(JWT)을 보낸다. 이걸 받지 않으면 Apple 쪽에서 떠난 사용자가 우리 서비스에는 그대로 남아 계정 상태가 어긋난다.
- 인앱 계정 삭제(Apple 5.1.1(v))는 이미 `DELETE /api/v1/users/me`(#416)로 충족됐다. 이 작업은 그 위에 얹는 계정 정합성 보강이다.

## Task

- Apple 서버-서버 알림 엔드포인트를 신설하고, 이벤트별로 우리 계정 상태를 동기화한다.
- 핵심 결정 포인트: (1) 연결 해제와 계정 삭제를 같게 볼 것인가, (2) 이 외부 엔드포인트의 진위를 어떻게 가릴 것인가, (3) 통합 테스트에서 외부 검증을 어떻게 격리할 것인가.

## Action

### 이벤트별 처리 방향

| 이벤트 | 의미 | 처리 |
|---|---|---|
| `account-delete` | Apple ID 자체 삭제 | 회원 탈퇴 (데이터 파기, 기존 탈퇴 로직 재사용) |
| `consent-revoked` | 앱-Apple 연결만 해제 | 세션 종료(로그아웃). 계정·데이터는 유지 |
| `email-disabled` / `email-enabled` | Private Relay 전달 on/off | 로그만 |
| 그 외/미지원 | - | 로그만 |

- 처음엔 이슈 스펙대로 `consent-revoked` 도 탈퇴로 잡았으나, 연결 해제는 탈퇴 의사로 보기 어렵다고 판단해 분리했다. 사용자가 나중에 다시 "Apple 로 로그인"하면 같은 식별자로 기존 계정에 복귀하므로, 데이터를 파기하면 멀쩡한 계정을 잃는다. 그래서 연결 해제는 세션만 끊는다.
- 세션 종료는 refresh token 삭제(재발급 차단)와 실시간 연결(SSE) 종료까지다. 남은 access token 을 즉시 막는 denylist 는 일부러 쓰지 않았다. denylist 가 사용자 단위라, 연결 해제로 마킹하면 재로그인으로 받은 새 토큰까지 거부돼 복귀가 깨지기 때문이다. access token 은 수명이 짧아 자연 만료에 맡긴다. (denylist 는 기존 설계대로 탈퇴 전용으로 둔다.)
- 이메일 릴레이 on/off 는 로그만 남긴다. 우리는 사용자에게 메일을 보내지 않아 반영할 동작이 없다. 메일 발송이 생기면 그때 처리한다.

### 서명 검증과 격리

- 이 엔드포인트는 Apple 이 직접 호출하므로 우리 로그인 인증이 없다(permitAll). 진위는 오직 payload JWT 의 서명(Apple JWKS)·issuer·aud 로 가린다. 위조·비정상 호출은 401 로 거부한다.
- 서명 검증을 `AppleNotificationVerifier` 인터페이스로 분리했다. 운영 구현은 기존 `AppleOAuthClient` 가 맡아, 로그인 토큰 검증과 JWKS 캐시를 한 인스턴스에서 공유한다(Apple 키 엔드포인트 중복 호출 방지). 검증은 외부 호출 경계라, 통합 테스트는 이 인터페이스를 stub 으로 격리한다(모킹 정책: 외부 호출 경계만 stub).
- 정상이지만 처리할 게 없는 경우(미가입·이미 탈퇴·미지원 이벤트)는 멱등하게 200 으로 흡수한다. Apple 은 응답이 2xx 가 아니면 재시도하므로, "처리할 게 없음"을 에러로 응답하지 않는다.

## Result

- 위조 방어의 핵심인 aud 검증과 events 파싱을 외부 호출 없는 순수 함수로 빼, 단위 테스트로 망라했다. aud 가 우리 식별자가 아니면 401 로 떨어지는지(가짜 발신자 차단), events 누락·미지원 타입 흡수까지 케이스로 고정했다. 통합 테스트가 검증을 stub 으로 대체하는 만큼, 이 보안 경로는 단위에서 실제 서명·클레임으로 검증된다.
- 후속: 이 엔드포인트 URL 을 Apple Developer Console 의 Server-to-Server Notification Endpoint 에 등록해야 Apple 이 실제로 호출한다 (코드와 별개의 콘솔 설정).

---
## 연관 이슈

- close #348


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * Apple 계정 삭제 시 자동으로 앱 계정이 탈퇴되도록 지원
  * Apple 동의 철회 시 세션이 즉시 종료되도록 개선
  * Apple 이메일 활성화/비활성화 알림 수신 및 로깅 기능 추가

* **Tests**
  * Apple 알림 처리에 대한 통합 테스트 추가
  * 서명 검증 및 이벤트 파싱 테스트 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->