### PR TITLE
알림 actor 아바타 snapshot · 활동/시스템 카테고리·탭별 안읽음 수

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/notification/controller/NotificationHistoryApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/controller/NotificationHistoryApi.kt
@@ -4,6 +4,7 @@ import com.depromeet.piki.common.response.ApiResponseBody
 import com.depromeet.piki.notification.controller.dto.NotificationHistoryResponse
 import com.depromeet.piki.notification.controller.dto.NotificationReadRequest
 import com.depromeet.piki.notification.controller.dto.NotificationReadResponse
+import com.depromeet.piki.notification.domain.NotificationCategory
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Content
@@ -24,8 +25,14 @@ interface NotificationHistoryApi {
                 "- 직전 응답의 `pageResponse.nextCursor` 를 다음 요청 `cursor` 로 그대로 전달한다.\n" +
                 "- 마지막 페이지면 `nextCursor` 는 `null`, `hasNext` 는 `false`.\n" +
                 "- `size` 는 미지정 시 20, 1~50 범위를 벗어나면 양 끝으로 보정된다.\n\n" +
+                "**카테고리 필터**\n\n" +
+                "- `category` 미지정 시 전체. `ACTIVITY`(활동: 토너먼트 소셜 알림) / `SYSTEM`(시스템: 파싱·공지)로 탭 필터.\n" +
+                "- `unreadCount` 는 category 와 무관하게 항상 전체 안읽음 수(앱 badge)다.\n" +
+                "- `unreadCountByCategory` 로 탭별 안읽음 수(탭 badge)를 함께 내려준다 — 모든 카테고리 키 포함, 없으면 0.\n\n" +
                 "**응답 활용**\n\n" +
-                "- 응답 `data` 의 `unreadCount` 로 안읽음 수(badge)를 함께 내려준다 (별도 카운트 API 없음).\n" +
+                "- 응답 `data` 의 `unreadCount`(앱 badge) · `unreadCountByCategory`(탭 badge)로 안읽음 수를 함께 내려준다 (별도 카운트 API 없음).\n" +
+                "- 각 항목의 `imageUrl` 은 항상 채워진다 — 사람 알림은 발송 시점 프사, 시스템 알림은 피키 로고. " +
+                "사람/시스템 구분은 `category`. 클라는 `imageUrl` 을 그대로 아바타로 렌더한다.\n" +
                 "- 각 항목 셰입은 SSE `notification` 이벤트 payload 와 동일하다 — `type` 으로 화면을, 파싱 알림은 " +
                 "`kind` 로 출처(위시/토너먼트)를 분기하고, `id` 로 단건 읽음 처리(`POST /read`)·딥링크 이동을 한다.",
     )
@@ -43,7 +50,7 @@ interface NotificationHistoryApi {
             ),
             ApiResponse(
                 responseCode = "400",
-                description = "유효하지 않은 cursor 값 (숫자로 변환 불가)",
+                description = "유효하지 않은 cursor 값 (숫자로 변환 불가) · 유효하지 않은 category 값 (ACTIVITY/SYSTEM 외)",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,
@@ -69,6 +76,8 @@ interface NotificationHistoryApi {
         cursor: String?,
         @Parameter(description = "페이지 크기 (기본 20, 최대 50)", example = "20")
         size: Int?,
+        @Parameter(description = "카테고리 필터 (미지정 시 전체). ACTIVITY(활동) / SYSTEM(시스템)", example = "ACTIVITY")
+        category: NotificationCategory?,
     ): ApiResponseBody<NotificationHistoryResponse>
 
     @Operation(
@@ -81,8 +90,8 @@ interface NotificationHistoryApi {
                 "| `ids=[...]` | 지정한 알림만 읽음 (단건 클릭은 `[id]` 1개, 클릭 후 FE 가 딥링크로 이동) |\n\n" +
                 "- 둘 다 보내거나 둘 다 비우면(빈 `ids` 포함) **400**.\n" +
                 "- `ids` 는 본인 소유만 반영되고 타인·없는 id 는 무시된다. **멱등**(이미 읽음도 성공).\n" +
-                "- 응답 `data` 의 `unreadCount` 로 처리 후 안읽음 수(badge)를 **서버 권위 값**으로 내려준다 — " +
-                "클라는 이 값을 그대로 badge 로 미러링한다(별도 카운트 조회 불필요).",
+                "- 응답 `data` 의 `unreadCount`(앱 badge) · `unreadCountByCategory`(탭 badge)로 처리 후 안읽음 수를 **서버 권위 값**으로 내려준다 — " +
+                "클라는 이 값들을 그대로 badge 로 미러링한다(별도 카운트 조회 불필요).",
     )
     @ApiResponses(
         value = [

--- a/src/main/kotlin/com/depromeet/piki/notification/controller/NotificationHistoryApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/controller/NotificationHistoryApiExamples.kt
@@ -10,6 +10,7 @@ import com.depromeet.piki.notification.controller.dto.NotificationHistoryRespons
 import com.depromeet.piki.notification.controller.dto.NotificationReadRequest
 import com.depromeet.piki.notification.controller.dto.NotificationReadResponse
 import com.depromeet.piki.notification.controller.dto.NotificationSsePayload
+import com.depromeet.piki.notification.domain.NotificationCategory
 import com.depromeet.piki.notification.domain.NotificationException
 import com.depromeet.piki.notification.domain.NotificationType
 import org.springdoc.core.customizers.OperationCustomizer
@@ -32,7 +33,12 @@ class NotificationHistoryApiExamples(
                         name = "조회 성공 (안읽음·읽음 혼재, 마지막 페이지)",
                         payload =
                             ApiResponseBody.ok(
-                                data = NotificationHistoryResponse(items = sampleItems, unreadCount = 2),
+                                data =
+                                    NotificationHistoryResponse(
+                                        items = sampleItems,
+                                        unreadCount = 2,
+                                        unreadCountByCategory = mapOf(NotificationCategory.ACTIVITY to 1L, NotificationCategory.SYSTEM to 1L),
+                                    ),
                                 pageResponse = PageResponse(nextCursor = null, hasNext = false),
                             ),
                     )
@@ -41,7 +47,12 @@ class NotificationHistoryApiExamples(
                         name = "조회 성공 (다음 페이지 있음)",
                         payload =
                             ApiResponseBody.ok(
-                                data = NotificationHistoryResponse(items = listOf(tournamentParsingItem), unreadCount = 1),
+                                data =
+                                    NotificationHistoryResponse(
+                                        items = listOf(tournamentParsingItem),
+                                        unreadCount = 1,
+                                        unreadCountByCategory = mapOf(NotificationCategory.ACTIVITY to 0L, NotificationCategory.SYSTEM to 1L),
+                                    ),
                                 pageResponse = PageResponse(nextCursor = "1024", hasNext = true),
                             ),
                     )
@@ -50,7 +61,12 @@ class NotificationHistoryApiExamples(
                         name = "빈 알림함",
                         payload =
                             ApiResponseBody.ok(
-                                data = NotificationHistoryResponse(items = emptyList(), unreadCount = 0),
+                                data =
+                                    NotificationHistoryResponse(
+                                        items = emptyList(),
+                                        unreadCount = 0,
+                                        unreadCountByCategory = mapOf(NotificationCategory.ACTIVITY to 0L, NotificationCategory.SYSTEM to 0L),
+                                    ),
                                 pageResponse = PageResponse(nextCursor = null, hasNext = false),
                             ),
                     )
@@ -63,7 +79,12 @@ class NotificationHistoryApiExamples(
                     add(
                         status = HttpStatus.OK,
                         name = "읽음 처리 성공 (처리 후 unreadCount 동봉)",
-                        payload = ApiResponseBody.ok(data = NotificationReadResponse.of(unreadCount = 2)),
+                        payload =
+                            ApiResponseBody.ok(
+                                data = NotificationReadResponse.of(
+                                    mapOf(NotificationCategory.ACTIVITY to 1L, NotificationCategory.SYSTEM to 1L),
+                                ),
+                            ),
                     )
                     add(
                         status = HttpStatus.BAD_REQUEST,
@@ -81,37 +102,43 @@ class NotificationHistoryApiExamples(
             operation
         }
 
-    // 토너먼트 알림 (라우팅 없음, refId 만) — 안읽음.
+    // 토너먼트 알림 (라우팅 없음, refId 만) — 활동, actor 있어 imageUrl=프사 snapshot, 안읽음.
     private val referenceItem =
         NotificationSsePayload.Reference(
             id = 1026,
             type = NotificationType.TOURNAMENT_JOINED,
+            category = NotificationCategory.ACTIVITY,
             title = "토너먼트에 참가했어요",
             body = "지금 바로 픽을 시작해보세요",
+            imageUrl = "https://images.piki/profiles/abc/3f7c.png",
             refId = 77,
             isRead = false,
             createdAt = LocalDateTime.of(2026, 6, 8, 10, 10, 0),
         )
 
-    // 위시 출처 파싱 완료 알림 (kind=WISH) — 읽음.
+    // 위시 출처 파싱 완료 알림 (kind=WISH) — 시스템, actor 없어 imageUrl=defaultPushImg(피키 로고), 읽음.
     private val wishParsingItem =
         NotificationSsePayload.WishParsing(
             id = 1025,
             type = NotificationType.ITEM_PARSING_COMPLETED,
+            category = NotificationCategory.SYSTEM,
             title = "상품 정보가 준비됐어요",
             body = "에어 조던 1 미드",
+            imageUrl = "https://images.piki/defaults/push-icon.svg",
             refId = 512,
             isRead = true,
             createdAt = LocalDateTime.of(2026, 6, 8, 10, 5, 0),
         )
 
-    // 토너먼트 출처 파싱 완료 알림 (kind=TOURNAMENT + 두 식별자) — 안읽음.
+    // 토너먼트 출처 파싱 완료 알림 (kind=TOURNAMENT + 두 식별자) — 시스템, imageUrl=defaultPushImg, 안읽음.
     private val tournamentParsingItem =
         NotificationSsePayload.TournamentParsing(
             id = 1024,
             type = NotificationType.ITEM_PARSING_COMPLETED,
+            category = NotificationCategory.SYSTEM,
             title = "토너먼트 아이템이 준비됐어요",
             body = "나이키 덩크 로우",
+            imageUrl = "https://images.piki/defaults/push-icon.svg",
             refId = 513,
             isRead = false,
             createdAt = LocalDateTime.of(2026, 6, 8, 10, 0, 0),

--- a/src/main/kotlin/com/depromeet/piki/notification/controller/NotificationHistoryController.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/controller/NotificationHistoryController.kt
@@ -6,7 +6,6 @@ import com.depromeet.piki.notification.controller.dto.NotificationHistoryRespons
 import com.depromeet.piki.notification.controller.dto.NotificationReadRequest
 import com.depromeet.piki.notification.controller.dto.NotificationReadResponse
 import com.depromeet.piki.notification.domain.NotificationCategory
-import com.depromeet.piki.notification.service.DefaultPushImage
 import com.depromeet.piki.notification.service.NotificationService
 import jakarta.validation.Valid
 import org.springframework.security.core.annotation.AuthenticationPrincipal
@@ -22,7 +21,6 @@ import java.util.UUID
 @RequestMapping("/api/v1/notifications")
 class NotificationHistoryController(
     private val notificationService: NotificationService,
-    private val defaultPushImage: DefaultPushImage,
 ) : NotificationHistoryApi {
     @GetMapping
     override fun getHistory(
@@ -33,7 +31,7 @@ class NotificationHistoryController(
     ): ApiResponseBody<NotificationHistoryResponse> {
         val page = notificationService.getHistory(userId = userId, rawCursor = cursor, rawSize = size, category = category)
         return ApiResponseBody.ok(
-            data = NotificationHistoryResponse.of(page.notifications, page.unreadCount, page.unreadCountByCategory, defaultPushImage.url),
+            data = NotificationHistoryResponse.of(page.notifications, page.unreadCount, page.unreadCountByCategory, page.defaultPushImageUrl),
             pageResponse = PageResponse(nextCursor = page.nextCursor, hasNext = page.hasNext),
         )
     }

--- a/src/main/kotlin/com/depromeet/piki/notification/controller/NotificationHistoryController.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/controller/NotificationHistoryController.kt
@@ -5,6 +5,8 @@ import com.depromeet.piki.common.response.PageResponse
 import com.depromeet.piki.notification.controller.dto.NotificationHistoryResponse
 import com.depromeet.piki.notification.controller.dto.NotificationReadRequest
 import com.depromeet.piki.notification.controller.dto.NotificationReadResponse
+import com.depromeet.piki.notification.domain.NotificationCategory
+import com.depromeet.piki.notification.service.DefaultPushImage
 import com.depromeet.piki.notification.service.NotificationService
 import jakarta.validation.Valid
 import org.springframework.security.core.annotation.AuthenticationPrincipal
@@ -20,16 +22,18 @@ import java.util.UUID
 @RequestMapping("/api/v1/notifications")
 class NotificationHistoryController(
     private val notificationService: NotificationService,
+    private val defaultPushImage: DefaultPushImage,
 ) : NotificationHistoryApi {
     @GetMapping
     override fun getHistory(
         @AuthenticationPrincipal userId: UUID,
         @RequestParam(required = false) cursor: String?,
         @RequestParam(required = false) size: Int?,
+        @RequestParam(required = false) category: NotificationCategory?,
     ): ApiResponseBody<NotificationHistoryResponse> {
-        val page = notificationService.getHistory(userId = userId, rawCursor = cursor, rawSize = size)
+        val page = notificationService.getHistory(userId = userId, rawCursor = cursor, rawSize = size, category = category)
         return ApiResponseBody.ok(
-            data = NotificationHistoryResponse.of(page.notifications, page.unreadCount),
+            data = NotificationHistoryResponse.of(page.notifications, page.unreadCount, page.unreadCountByCategory, defaultPushImage.url),
             pageResponse = PageResponse(nextCursor = page.nextCursor, hasNext = page.hasNext),
         )
     }
@@ -39,7 +43,7 @@ class NotificationHistoryController(
         @AuthenticationPrincipal userId: UUID,
         @Valid @RequestBody request: NotificationReadRequest,
     ): ApiResponseBody<NotificationReadResponse> {
-        val unreadCount = notificationService.read(userId = userId, command = request.toCommand())
-        return ApiResponseBody.ok(data = NotificationReadResponse.of(unreadCount))
+        val unreadByCategory = notificationService.read(userId = userId, command = request.toCommand())
+        return ApiResponseBody.ok(data = NotificationReadResponse.of(unreadByCategory))
     }
 }

--- a/src/main/kotlin/com/depromeet/piki/notification/controller/dto/NotificationHistoryResponse.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/controller/dto/NotificationHistoryResponse.kt
@@ -1,26 +1,33 @@
 package com.depromeet.piki.notification.controller.dto
 
 import com.depromeet.piki.notification.domain.Notification
+import com.depromeet.piki.notification.domain.NotificationCategory
 import io.swagger.v3.oas.annotations.media.Schema
 
 // 알림 히스토리 목록 응답. items 는 SSE 와 같은 셰입(NotificationSsePayload)을 그대로 재사용해, 클라가
 // SSE 로 받든 히스토리로 받든 동일한 객체로 다루게 한다(셰입 drift 방지 — 단일 소스). 페이징(nextCursor·hasNext)은
-// ApiResponseBody.pageResponse 가 싣고, 여기엔 안읽음 수(unreadCount)를 동봉한다(별도 카운트 API 없음, #246).
-@Schema(description = "알림 히스토리 목록 + 안읽음 수")
+// ApiResponseBody.pageResponse 가 싣고, 여기엔 전체 안읽음 수(unreadCount, 앱 badge)와 탭별(unreadCountByCategory)을 동봉한다.
+@Schema(description = "알림 히스토리 목록 + 안읽음 수(전체·탭별)")
 data class NotificationHistoryResponse(
     @field:Schema(description = "알림 목록 (최신순). 각 항목 셰입은 SSE notification 이벤트 payload 와 동일")
     val items: List<NotificationSsePayload>,
-    @field:Schema(description = "본인 안읽음 알림 수 (badge)", example = "3")
+    @field:Schema(description = "본인 전체 안읽음 알림 수 (앱 badge). category 필터와 무관하게 항상 전체", example = "3")
     val unreadCount: Long,
+    @field:Schema(description = "카테고리별 안읽음 수 (탭 badge). 모든 카테고리 키 포함, 없으면 0", example = "{\"ACTIVITY\":2,\"SYSTEM\":1}")
+    val unreadCountByCategory: Map<NotificationCategory, Long>,
 ) {
     companion object {
+        // defaultPushImageUrl 은 시스템 알림(actor 없음)의 imageUrl 을 채우는 기본 아바타 — 컨트롤러가 DefaultPushImage 에서 넘긴다.
         fun of(
             notifications: List<Notification>,
             unreadCount: Long,
+            unreadCountByCategory: Map<NotificationCategory, Long>,
+            defaultPushImageUrl: String,
         ): NotificationHistoryResponse =
             NotificationHistoryResponse(
-                items = notifications.map { NotificationSsePayload.from(it) },
+                items = notifications.map { NotificationSsePayload.from(it, defaultPushImageUrl) },
                 unreadCount = unreadCount,
+                unreadCountByCategory = unreadCountByCategory,
             )
     }
 }

--- a/src/main/kotlin/com/depromeet/piki/notification/controller/dto/NotificationReadResponse.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/controller/dto/NotificationReadResponse.kt
@@ -1,15 +1,24 @@
 package com.depromeet.piki.notification.controller.dto
 
+import com.depromeet.piki.notification.domain.NotificationCategory
 import io.swagger.v3.oas.annotations.media.Schema
 
-// 읽음 처리 응답 — 처리 후 본인 안읽음 수(badge)를 서버 권위 값으로 내려, 클라가 +1/-1 산수 없이 그대로 미러링하게 한다.
+// 읽음 처리 응답 — 처리 후 안읽음 수(전체·탭별)를 서버 권위 값으로 내려, 클라가 +1/-1 산수 없이 그대로 미러링하게 한다.
 // 멀티 디바이스에서도 읽은 기기는 추가 조회 없이 최신 badge 를 같은 왕복에서 받는다(다른 기기는 재진입 시 GET /notifications 로 보정).
-@Schema(description = "알림 읽음 처리 응답 — 처리 후 안읽음 수(badge)")
+// list 응답과 같은 셰입(unreadCount + unreadCountByCategory)이라, 읽음 후 앱 badge 와 활동/시스템 탭 badge 를 한 번에 갱신한다.
+@Schema(description = "알림 읽음 처리 응답 — 처리 후 안읽음 수(전체·탭별)")
 data class NotificationReadResponse(
-    @field:Schema(description = "처리 후 본인 안읽음 알림 수 (badge). 클라는 이 값을 그대로 badge 로 미러링한다", example = "2")
+    @field:Schema(description = "처리 후 본인 전체 안읽음 수 (앱 badge). 클라는 이 값을 그대로 badge 로 미러링한다", example = "2")
     val unreadCount: Long,
+    @field:Schema(description = "처리 후 카테고리별 안읽음 수 (탭 badge). 모든 카테고리 키 포함, 없으면 0", example = "{\"ACTIVITY\":1,\"SYSTEM\":1}")
+    val unreadCountByCategory: Map<NotificationCategory, Long>,
 ) {
     companion object {
-        fun of(unreadCount: Long): NotificationReadResponse = NotificationReadResponse(unreadCount)
+        // total 은 카테고리 합으로 도출 — 전체·탭별 두 수치가 어긋날 여지를 없앤다(getHistory 와 동일 규칙).
+        fun of(unreadCountByCategory: Map<NotificationCategory, Long>): NotificationReadResponse =
+            NotificationReadResponse(
+                unreadCount = unreadCountByCategory.values.sum(),
+                unreadCountByCategory = unreadCountByCategory,
+            )
     }
 }

--- a/src/main/kotlin/com/depromeet/piki/notification/controller/dto/NotificationSsePayload.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/controller/dto/NotificationSsePayload.kt
@@ -1,6 +1,7 @@
 package com.depromeet.piki.notification.controller.dto
 
 import com.depromeet.piki.notification.domain.Notification
+import com.depromeet.piki.notification.domain.NotificationCategory
 import com.depromeet.piki.notification.domain.NotificationKind
 import com.depromeet.piki.notification.domain.NotificationRouting
 import com.depromeet.piki.notification.domain.NotificationType
@@ -10,11 +11,17 @@ import java.time.LocalDateTime
 // 알림 종류별로 셰입이 다르다 — 라우팅 컨텍스트(#408)가 없는 알림은 refId 만, 파싱 알림은 출처(kind)별로 식별자가 갈린다.
 // nullable 잡탕 + NON_NULL 로 런타임에 가리는 대신, sealed 로 각 셰입을 타입에 고정한다(도메인 NotificationRouting 과 같은 결).
 // 클라이언트는 type 으로 화면을, 파싱 알림은 kind 로 출처를 분기한다. id 는 추후 읽음 처리(#246)의 키다.
+//
+// imageUrl·category(#473): imageUrl 은 항상 채워 내려간다 — 사람 알림은 발송 시점 actor 프사 snapshot,
+// 시스템 알림은 서버가 defaultPushImg(피키 로고)로 채운다. 클라는 null-check 없이 imageUrl 을 그대로 아바타로 렌더하고,
+// 사람/시스템 구분(탭·시각 차이)은 category(ACTIVITY/SYSTEM)로 한다. category 는 type 에서 파생한다(스키마 컬럼 없음).
 sealed interface NotificationSsePayload {
     val id: Long
     val type: NotificationType
+    val category: NotificationCategory
     val title: String
     val body: String
+    val imageUrl: String
     val refId: Long
     val isRead: Boolean
     val createdAt: LocalDateTime
@@ -23,8 +30,10 @@ sealed interface NotificationSsePayload {
     data class Reference(
         override val id: Long,
         override val type: NotificationType,
+        override val category: NotificationCategory,
         override val title: String,
         override val body: String,
+        override val imageUrl: String,
         override val refId: Long,
         override val isRead: Boolean,
         override val createdAt: LocalDateTime,
@@ -34,8 +43,10 @@ sealed interface NotificationSsePayload {
     data class WishParsing(
         override val id: Long,
         override val type: NotificationType,
+        override val category: NotificationCategory,
         override val title: String,
         override val body: String,
+        override val imageUrl: String,
         override val refId: Long,
         override val isRead: Boolean,
         override val createdAt: LocalDateTime,
@@ -47,8 +58,10 @@ sealed interface NotificationSsePayload {
     data class TournamentParsing(
         override val id: Long,
         override val type: NotificationType,
+        override val category: NotificationCategory,
         override val title: String,
         override val body: String,
+        override val imageUrl: String,
         override val refId: Long,
         override val isRead: Boolean,
         override val createdAt: LocalDateTime,
@@ -61,25 +74,32 @@ sealed interface NotificationSsePayload {
     companion object {
         // 채널에 도달한 Notification 은 dispatcher 가 이미 저장한 영속 엔티티라 id 가 보장된다(getId()).
         // 라우팅 컨텍스트(routing())로 셰입을 가른다 — 없으면 Reference, 위시/토너먼트면 각 파싱 payload.
-        fun from(notification: Notification): NotificationSsePayload {
+        // imageUrl = actor 스냅샷(actorImageUrl) 이 있으면 그것, 없으면(시스템) defaultPushImageUrl 로 채운다 — 항상 비지 않는다.
+        // category 는 type 에서 파생한다(NotificationCategory.of). defaultPushImageUrl 은 호출자(채널·응답)가 DefaultPushImage 에서 넘긴다.
+        fun from(
+            notification: Notification,
+            defaultPushImageUrl: String,
+        ): NotificationSsePayload {
             val id = notification.getId()
+            val category = NotificationCategory.of(notification.type)
+            val imageUrl = notification.actorImageUrl ?: defaultPushImageUrl
             return when (val routing = notification.routing()) {
                 null ->
                     Reference(
-                        id, notification.type, notification.title, notification.body,
-                        notification.refId, notification.isRead, notification.createdAt,
+                        id, notification.type, category, notification.title, notification.body,
+                        imageUrl, notification.refId, notification.isRead, notification.createdAt,
                     )
 
                 NotificationRouting.Wish ->
                     WishParsing(
-                        id, notification.type, notification.title, notification.body,
-                        notification.refId, notification.isRead, notification.createdAt,
+                        id, notification.type, category, notification.title, notification.body,
+                        imageUrl, notification.refId, notification.isRead, notification.createdAt,
                     )
 
                 is NotificationRouting.Tournament ->
                     TournamentParsing(
-                        id, notification.type, notification.title, notification.body,
-                        notification.refId, notification.isRead, notification.createdAt,
+                        id, notification.type, category, notification.title, notification.body,
+                        imageUrl, notification.refId, notification.isRead, notification.createdAt,
                         routing.tournamentId, routing.tournamentItemId,
                     )
             }

--- a/src/main/kotlin/com/depromeet/piki/notification/controller/dto/NotificationSsePayload.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/controller/dto/NotificationSsePayload.kt
@@ -86,21 +86,43 @@ sealed interface NotificationSsePayload {
             return when (val routing = notification.routing()) {
                 null ->
                     Reference(
-                        id, notification.type, category, notification.title, notification.body,
-                        imageUrl, notification.refId, notification.isRead, notification.createdAt,
+                        id = id,
+                        type = notification.type,
+                        category = category,
+                        title = notification.title,
+                        body = notification.body,
+                        imageUrl = imageUrl,
+                        refId = notification.refId,
+                        isRead = notification.isRead,
+                        createdAt = notification.createdAt,
                     )
 
                 NotificationRouting.Wish ->
                     WishParsing(
-                        id, notification.type, category, notification.title, notification.body,
-                        imageUrl, notification.refId, notification.isRead, notification.createdAt,
+                        id = id,
+                        type = notification.type,
+                        category = category,
+                        title = notification.title,
+                        body = notification.body,
+                        imageUrl = imageUrl,
+                        refId = notification.refId,
+                        isRead = notification.isRead,
+                        createdAt = notification.createdAt,
                     )
 
                 is NotificationRouting.Tournament ->
                     TournamentParsing(
-                        id, notification.type, category, notification.title, notification.body,
-                        imageUrl, notification.refId, notification.isRead, notification.createdAt,
-                        routing.tournamentId, routing.tournamentItemId,
+                        id = id,
+                        type = notification.type,
+                        category = category,
+                        title = notification.title,
+                        body = notification.body,
+                        imageUrl = imageUrl,
+                        refId = notification.refId,
+                        isRead = notification.isRead,
+                        createdAt = notification.createdAt,
+                        tournamentId = routing.tournamentId,
+                        tournamentItemId = routing.tournamentItemId,
                     )
             }
         }

--- a/src/main/kotlin/com/depromeet/piki/notification/domain/Notification.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/domain/Notification.kt
@@ -28,6 +28,11 @@ class Notification(
     // 파싱 알림 딥링크 라우팅 컨텍스트(#408) — 아래 kind·tournamentId·tournamentItemId 컬럼으로 평탄화해 저장한다.
     // 라우팅이 없는 알림(토너먼트 알림 등)은 null 을 넘겨 세 컬럼이 모두 비워진다. 생성자 끝의 default 라 기존 호출은 안 깨진다.
     routing: NotificationRouting? = null,
+    // 행위자(actor) 프로필 사진 snapshot(#473) — 발송 시점 actor 의 프사 URL 을 박아 고정한다. 이후 actor 가 프사를
+    // 바꿔도 과거 알림은 그 시점 사진 유지(title 의 닉네임 snapshot 과 같은 결). actor 없는 시스템 알림은 null —
+    // 직렬화 시 서버가 defaultPushImg 로 채운다(컬럼엔 저장 안 함). routing 뒤에 둬 기존 positional 호출(…,refId,routing)을 안 깬다.
+    @Column(name = "actor_image_url", length = MAX_IMAGE_URL_LENGTH)
+    val actorImageUrl: String? = null,
 ) : LongBaseEntity() {
     // 엔티티 불변식 — 최후의 보루. title/body 는 발송 시점에 렌더된 완성본이라, 정상 흐름에선
     // 입력 경계(닉네임 등 변수 길이 제한)가 먼저 걸러 VARCHAR(255) 안에 든다. 그래도 엔티티가
@@ -80,5 +85,8 @@ class Notification(
     companion object {
         // VARCHAR(255) 컬럼과 엔티티 불변식이 같은 상수를 공유한다.
         const val MAX_TEXT_LENGTH = 255
+
+        // actor_image_url 컬럼 길이 — users.profile_image(2048)와 정합. 발송 시점 그 값을 그대로 snapshot 하므로 같은 상한.
+        const val MAX_IMAGE_URL_LENGTH = 2048
     }
 }

--- a/src/main/kotlin/com/depromeet/piki/notification/domain/NotificationCategory.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/domain/NotificationCategory.kt
@@ -1,0 +1,30 @@
+package com.depromeet.piki.notification.domain
+
+// 알림센터 탭 구분(#473) — 활동(다른 사람의 행동) / 시스템(내 작업 결과·공지).
+// 카테고리는 type 에서 파생한다(스키마 컬럼 없음) — 저장하지 않고 조회·직렬화 때 type 으로 계산한다.
+// 주의: 카테고리(주제) ≠ 아바타(actor 유무). 예) 토너먼트 종료는 활동이지만 actor 가 없어 아바타는 피키 로고.
+enum class NotificationCategory {
+    ACTIVITY,
+    SYSTEM,
+    ;
+
+    companion object {
+        // type → category. when 이 NotificationType 전수라 else 가 없다 — 새 타입을 추가하면 여기서 컴파일이
+        // 깨져 카테고리 분류를 강제한다(누락 방지).
+        fun of(type: NotificationType): NotificationCategory =
+            when (type) {
+                NotificationType.TOURNAMENT_JOINED,
+                NotificationType.TOURNAMENT_ITEM_ADDED,
+                NotificationType.TOURNAMENT_STARTED,
+                -> ACTIVITY
+
+                NotificationType.ITEM_PARSING_COMPLETED,
+                NotificationType.ITEM_PARSING_FAILED,
+                -> SYSTEM
+            }
+
+        // 한 카테고리에 속한 type 들 — 목록 조회의 type-in 필터에 쓴다(?category=).
+        fun typesOf(category: NotificationCategory): List<NotificationType> =
+            NotificationType.entries.filter { of(it) == category }
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/notification/domain/NotificationCategory.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/domain/NotificationCategory.kt
@@ -24,7 +24,10 @@ enum class NotificationCategory {
             }
 
         // 한 카테고리에 속한 type 들 — 목록 조회의 type-in 필터에 쓴다(?category=).
-        fun typesOf(category: NotificationCategory): List<NotificationType> =
-            NotificationType.entries.filter { of(it) == category }
+        // type→category 가 고정이라 클래스 로딩 때 한 번 역색인해 두고(요청마다 entries 전수 순회 회피), 조회는 맵 lookup 으로 끝낸다.
+        private val typesByCategory: Map<NotificationCategory, List<NotificationType>> =
+            NotificationType.entries.groupBy { of(it) }
+
+        fun typesOf(category: NotificationCategory): List<NotificationType> = typesByCategory[category].orEmpty()
     }
 }

--- a/src/main/kotlin/com/depromeet/piki/notification/fcm/service/FirebaseMessageSender.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/fcm/service/FirebaseMessageSender.kt
@@ -1,8 +1,10 @@
 package com.depromeet.piki.notification.fcm.service
 
 import com.depromeet.piki.notification.domain.Notification
+import com.depromeet.piki.notification.domain.NotificationCategory
 import com.depromeet.piki.notification.domain.NotificationKind
 import com.depromeet.piki.notification.domain.NotificationRouting
+import com.depromeet.piki.notification.service.DefaultPushImage
 import com.google.firebase.FirebaseApp
 import com.google.firebase.messaging.AndroidConfig
 import com.google.firebase.messaging.AndroidNotification
@@ -25,6 +27,7 @@ import com.google.firebase.messaging.Notification as FcmNotification
 @ConditionalOnBean(FirebaseApp::class)
 class FirebaseMessageSender(
     firebaseApp: FirebaseApp,
+    private val defaultPushImage: DefaultPushImage,
 ) : FcmMessageSender {
     private val log = LoggerFactory.getLogger(javaClass)
     private val messaging = FirebaseMessaging.getInstance(firebaseApp)
@@ -73,7 +76,7 @@ class FirebaseMessageSender(
                     .setTitle(notification.title)
                     .setBody(notification.body)
                     .build(),
-            ).apply { buildDataPayload(notification).forEach { (key, value) -> putData(key, value) } }
+            ).apply { buildDataPayload(notification, defaultPushImage.url).forEach { (key, value) -> putData(key, value) } }
             .applyPlatformConfig()
             .build()
 
@@ -136,19 +139,27 @@ class FirebaseMessageSender(
         // id 는 채널 무관 dedup(SSE·FCM 중복 수신 시 같은 알림으로 합침)과 푸시 탭 → 읽음 처리(POST /read {ids:[id]})의 키다(#246).
         private const val DATA_KEY_ID = "id"
         private const val DATA_KEY_TYPE = "type"
+        private const val DATA_KEY_CATEGORY = "category"
+        private const val DATA_KEY_IMAGE_URL = "imageUrl"
         private const val DATA_KEY_REF_ID = "refId"
         private const val DATA_KEY_KIND = "kind"
         private const val DATA_KEY_TOURNAMENT_ID = "tournamentId"
         private const val DATA_KEY_TOURNAMENT_ITEM_ID = "tournamentItemId"
 
-        // FCM data payload(키→값) 구성 — id·type·refId 는 항상, 라우팅 컨텍스트(kind·tournamentId·tournamentItemId)는
+        // FCM data payload(키→값) 구성 — id·type·category·imageUrl·refId 는 항상, 라우팅 컨텍스트(kind·tournamentId·tournamentItemId)는
         // 있을 때만 싣는다. FCM data 는 값이 null 일 수 없어 null 키는 아예 넣지 않는다(#408). FirebaseMessaging
         // 호출과 무관한 순수 매핑이라 companion 으로 분리해 단위 테스트로 분기를 망라한다(FirebaseApp 없이 검증).
         // notification 은 dispatcher 가 이미 저장한 영속 엔티티라 getId() 가 보장된다(SsePayload.from 과 동일 전제).
-        internal fun buildDataPayload(notification: Notification): Map<String, String> =
+        // imageUrl 은 actor 스냅샷이 있으면 그것, 없으면(시스템) defaultPushImageUrl 로 채워 항상 비지 않게 한다(SsePayload.from 과 동일 규칙).
+        internal fun buildDataPayload(
+            notification: Notification,
+            defaultPushImageUrl: String,
+        ): Map<String, String> =
             buildMap {
                 put(DATA_KEY_ID, notification.getId().toString())
                 put(DATA_KEY_TYPE, notification.type.name)
+                put(DATA_KEY_CATEGORY, NotificationCategory.of(notification.type).name)
+                put(DATA_KEY_IMAGE_URL, notification.actorImageUrl ?: defaultPushImageUrl)
                 put(DATA_KEY_REF_ID, notification.refId.toString())
                 // SSE payload 와 같은 routing() sealed 를 분기해 두 채널이 한 소스를 쓴다. FCM data 는 값이 null 일 수 없어
                 // 라우팅이 없으면 키 자체를 안 넣고, TOURNAMENT 만 추가 식별자를 싣는다(#408).

--- a/src/main/kotlin/com/depromeet/piki/notification/handler/ActorNameResolver.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/handler/ActorNameResolver.kt
@@ -4,16 +4,19 @@ import com.depromeet.piki.user.repository.UserRepository
 import org.springframework.stereotype.Component
 import java.util.UUID
 
-// 알림 변수(actorName)용 — 행위자 userId 를 화면 표시용 닉네임으로 푼다.
-// 토너먼트 알림 템플릿("${actorName}님이 …")이 공유하는 단일 도출 지점이라, fallback 정책도 여기 한 곳에 둔다.
+// 알림 행위자(actor)의 화면 표시 속성(닉네임·프로필 사진)을 userId 로 푼다.
+// 토너먼트 알림 템플릿("${actorName}님이 …")과 아바타 snapshot(#473)이 공유하는 단일 도출 지점이라, fallback 정책도 여기 한 곳에 둔다.
 //
 // 행위자는 정상 흐름에선 방금 인증된 채로 행동한 유저라 항상 존재한다. 그래도 못 찾으면(데이터 불일치)
-// 던지지 않고 fallback 으로 채운다 — 알림은 best-effort 라, 닉네임 하나 때문에 알림 전체를 떨구지 않는다.
+// 던지지 않고 fallback(닉네임)·null(프사)로 채운다 — 알림은 best-effort 라, 속성 하나 때문에 알림 전체를 떨구지 않는다.
 @Component
 class ActorNameResolver(
     private val userRepository: UserRepository,
 ) {
     fun resolve(actorId: UUID): String = userRepository.findById(actorId)?.nickname ?: UNKNOWN_ACTOR
+
+    // 발송 시점 actor 프사 URL(#473). 못 찾으면 null → 직렬화 때 서버가 defaultPushImg 로 채운다.
+    fun resolveProfileImage(actorId: UUID): String? = userRepository.findById(actorId)?.profileImage
 
     companion object {
         const val UNKNOWN_ACTOR = "알 수 없는 사용자"

--- a/src/main/kotlin/com/depromeet/piki/notification/handler/ActorNameResolver.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/handler/ActorNameResolver.kt
@@ -13,12 +13,23 @@ import java.util.UUID
 class ActorNameResolver(
     private val userRepository: UserRepository,
 ) {
-    fun resolve(actorId: UUID): String = userRepository.findById(actorId)?.nickname ?: UNKNOWN_ACTOR
-
-    // 발송 시점 actor 프사 URL(#473). 못 찾으면 null → 직렬화 때 서버가 defaultPushImg 로 채운다.
-    fun resolveProfileImage(actorId: UUID): String? = userRepository.findById(actorId)?.profileImage
+    // 닉네임과 프사를 한 번의 findById 로 함께 푼다 — 둘을 따로 조회하면 같은 actor 에 쿼리가 두 번 나간다(#473).
+    // 못 찾으면(데이터 불일치) 닉네임은 fallback, 프사는 null(직렬화 때 서버가 defaultPushImg 로 채운다).
+    fun resolveAttributes(actorId: UUID): ActorAttributes {
+        val user = userRepository.findById(actorId)
+        return ActorAttributes(
+            name = user?.nickname ?: UNKNOWN_ACTOR,
+            profileImage = user?.profileImage,
+        )
+    }
 
     companion object {
         const val UNKNOWN_ACTOR = "알 수 없는 사용자"
     }
 }
+
+// actor 표시 속성 — 템플릿 변수(닉네임)와 프사 snapshot 의 단일 조회 결과.
+data class ActorAttributes(
+    val name: String,
+    val profileImage: String?,
+)

--- a/src/main/kotlin/com/depromeet/piki/notification/handler/ItemParsingCompletedHandler.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/handler/ItemParsingCompletedHandler.kt
@@ -8,7 +8,7 @@ import java.util.UUID
 
 // 아이템 파싱 완료 알림. 위시·토너먼트 어느 쪽으로 올린 아이템이든 동일하게 "파싱 완료" 를 알린다 —
 // 수신자는 itemId 를 역조회해 위시 주인 ∪ 토너먼트 참가자로 모은다(ItemParsingRecipientResolver, 실패 알림과 공유).
-// 변수 없는 고정 문구라 resolveVariables 는 베이스 기본값(emptyMap)을 그대로 쓴다.
+// 변수 없는 고정 문구 + actor 없음이라 resolveActorContext 는 베이스 기본값(빈 컨텍스트)을 그대로 쓴다.
 @Component
 class ItemParsingCompletedHandler(
     private val recipientResolver: ItemParsingRecipientResolver,

--- a/src/main/kotlin/com/depromeet/piki/notification/handler/NotificationEventHandler.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/handler/NotificationEventHandler.kt
@@ -38,6 +38,11 @@ abstract class NotificationEventHandler<E : Any>(
     // 기본값 null 을 그대로 쓰고, 그러면 Notification 의 라우팅 컬럼이 비워진다(채널에서 키가 생략된다).
     open fun resolveRouting(event: E): NotificationRouting? = null
 
+    // 행위자(actor) 프로필 사진 URL — 발송 시점에 snapshot 해 Notification.actorImageUrl 에 저장한다(#473).
+    // actor 가 있는 알림(TOURNAMENT_* 등 "OO님이 …")만 override 해 actorId 의 현재 프사 URL 을 돌려준다.
+    // actor 없는 시스템 알림(파싱·공지)은 기본값 null — 직렬화 때 서버가 defaultPushImg(피키 로고)로 채운다.
+    open fun resolveActorImageUrl(event: E): String? = null
+
     // 타입 인자 E 를 Spring 의 제네릭 추출 헬퍼로 풀어낸다. 서브클래스 생성 시 javaClass 는 실제 구현체라,
     // 그 슈퍼타입 NotificationEventHandler<E> 의 첫 타입 인자가 E 다. (private 라 가상 호출이 아니므로 init 안전)
     @Suppress("UNCHECKED_CAST")

--- a/src/main/kotlin/com/depromeet/piki/notification/handler/NotificationEventHandler.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/handler/NotificationEventHandler.kt
@@ -30,18 +30,16 @@ abstract class NotificationEventHandler<E : Any>(
     // 알림 row 가 중복 저장되지 않는다(#236 fan-out 안전).
     abstract fun resolveRecipients(event: E): Set<UUID>
 
-    // 템플릿 변수 (예: actorName). 변수 없는 알림은 기본값 emptyMap 을 그대로 쓰고 override 하지 않는다.
-    open fun resolveVariables(event: E): Map<String, String> = emptyMap()
-
     // 딥링크 라우팅 컨텍스트(#408). 파싱 알림처럼 출처(위시/토너먼트)별로 이동 화면이 갈리는 알림은 이를 override 해
     // 도메인 식별자(kind·tournamentId·tournamentItemId)를 싣는다. refId 만으로 충분한 알림(토너먼트 알림 등)은
     // 기본값 null 을 그대로 쓰고, 그러면 Notification 의 라우팅 컬럼이 비워진다(채널에서 키가 생략된다).
     open fun resolveRouting(event: E): NotificationRouting? = null
 
-    // 행위자(actor) 프로필 사진 URL — 발송 시점에 snapshot 해 Notification.actorImageUrl 에 저장한다(#473).
-    // actor 가 있는 알림(TOURNAMENT_* 등 "OO님이 …")만 override 해 actorId 의 현재 프사 URL 을 돌려준다.
-    // actor 없는 시스템 알림(파싱·공지)은 기본값 null — 직렬화 때 서버가 defaultPushImg(피키 로고)로 채운다.
-    open fun resolveActorImageUrl(event: E): String? = null
+    // 행위자(actor) 표시 컨텍스트 — 템플릿 변수(actorName)와 발송 시점 프사 snapshot 을 한 번에 해석한다(#473).
+    // 변수와 프사를 따로 hook 으로 두면 같은 actor 에 findById 가 두 번 나가므로, 한 조회로 합쳐 돌려준다.
+    // actor 가 있는 알림(TOURNAMENT_* 등 "OO님이 …")만 override 한다. actor 없는 시스템 알림(파싱·공지)은
+    // 기본값(빈 컨텍스트): 변수 없음 + imageUrl null → 직렬화 때 서버가 defaultPushImg(피키 로고)로 채운다.
+    open fun resolveActorContext(event: E): ActorContext = ActorContext()
 
     // 타입 인자 E 를 Spring 의 제네릭 추출 헬퍼로 풀어낸다. 서브클래스 생성 시 javaClass 는 실제 구현체라,
     // 그 슈퍼타입 NotificationEventHandler<E> 의 첫 타입 인자가 E 다. (private 라 가상 호출이 아니므로 init 안전)
@@ -52,3 +50,11 @@ abstract class NotificationEventHandler<E : Any>(
                 ?: error("${javaClass.simpleName} 의 이벤트 타입 인자(E)를 해석할 수 없습니다")
         ).kotlin as KClass<E>
 }
+
+// actor 알림이 actor 1명에서 함께 끌어내는 표시 컨텍스트 — 템플릿 변수(예: actorName)와 프사 snapshot(imageUrl).
+// 둘을 한 hook(resolveActorContext)으로 묶어 actorId→User 조회를 한 번으로 합친다(#473).
+// 기본값(빈 컨텍스트)은 actor 없는 알림(파싱·공지)이 쓴다 — 변수 없음 + imageUrl null.
+data class ActorContext(
+    val variables: Map<String, String> = emptyMap(),
+    val imageUrl: String? = null,
+)

--- a/src/main/kotlin/com/depromeet/piki/notification/handler/TournamentItemAddedHandler.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/handler/TournamentItemAddedHandler.kt
@@ -18,8 +18,8 @@ class TournamentItemAddedHandler(
     override fun resolveRecipients(event: TournamentItemAdded): Set<UUID> =
         tournamentUserRepository.findByTournamentId(event.tournamentId).map { it.userId }.toSet() - event.actorId
 
-    override fun resolveVariables(event: TournamentItemAdded): Map<String, String> =
-        mapOf("actorName" to actorNameResolver.resolve(event.actorId))
-
-    override fun resolveActorImageUrl(event: TournamentItemAdded): String? = actorNameResolver.resolveProfileImage(event.actorId)
+    override fun resolveActorContext(event: TournamentItemAdded): ActorContext {
+        val actor = actorNameResolver.resolveAttributes(event.actorId)
+        return ActorContext(variables = mapOf("actorName" to actor.name), imageUrl = actor.profileImage)
+    }
 }

--- a/src/main/kotlin/com/depromeet/piki/notification/handler/TournamentItemAddedHandler.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/handler/TournamentItemAddedHandler.kt
@@ -20,4 +20,6 @@ class TournamentItemAddedHandler(
 
     override fun resolveVariables(event: TournamentItemAdded): Map<String, String> =
         mapOf("actorName" to actorNameResolver.resolve(event.actorId))
+
+    override fun resolveActorImageUrl(event: TournamentItemAdded): String? = actorNameResolver.resolveProfileImage(event.actorId)
 }

--- a/src/main/kotlin/com/depromeet/piki/notification/handler/TournamentJoinedHandler.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/handler/TournamentJoinedHandler.kt
@@ -20,8 +20,8 @@ class TournamentJoinedHandler(
     override fun resolveRecipients(event: TournamentJoined): Set<UUID> =
         tournamentUserRepository.findByTournamentId(event.tournamentId).map { it.userId }.toSet() - event.actorId
 
-    override fun resolveVariables(event: TournamentJoined): Map<String, String> =
-        mapOf("actorName" to actorNameResolver.resolve(event.actorId))
-
-    override fun resolveActorImageUrl(event: TournamentJoined): String? = actorNameResolver.resolveProfileImage(event.actorId)
+    override fun resolveActorContext(event: TournamentJoined): ActorContext {
+        val actor = actorNameResolver.resolveAttributes(event.actorId)
+        return ActorContext(variables = mapOf("actorName" to actor.name), imageUrl = actor.profileImage)
+    }
 }

--- a/src/main/kotlin/com/depromeet/piki/notification/handler/TournamentJoinedHandler.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/handler/TournamentJoinedHandler.kt
@@ -22,4 +22,6 @@ class TournamentJoinedHandler(
 
     override fun resolveVariables(event: TournamentJoined): Map<String, String> =
         mapOf("actorName" to actorNameResolver.resolve(event.actorId))
+
+    override fun resolveActorImageUrl(event: TournamentJoined): String? = actorNameResolver.resolveProfileImage(event.actorId)
 }

--- a/src/main/kotlin/com/depromeet/piki/notification/handler/TournamentStartedHandler.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/handler/TournamentStartedHandler.kt
@@ -18,8 +18,8 @@ class TournamentStartedHandler(
     override fun resolveRecipients(event: TournamentStarted): Set<UUID> =
         tournamentUserRepository.findByTournamentId(event.tournamentId).map { it.userId }.toSet() - event.actorId
 
-    override fun resolveVariables(event: TournamentStarted): Map<String, String> =
-        mapOf("actorName" to actorNameResolver.resolve(event.actorId))
-
-    override fun resolveActorImageUrl(event: TournamentStarted): String? = actorNameResolver.resolveProfileImage(event.actorId)
+    override fun resolveActorContext(event: TournamentStarted): ActorContext {
+        val actor = actorNameResolver.resolveAttributes(event.actorId)
+        return ActorContext(variables = mapOf("actorName" to actor.name), imageUrl = actor.profileImage)
+    }
 }

--- a/src/main/kotlin/com/depromeet/piki/notification/handler/TournamentStartedHandler.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/handler/TournamentStartedHandler.kt
@@ -20,4 +20,6 @@ class TournamentStartedHandler(
 
     override fun resolveVariables(event: TournamentStarted): Map<String, String> =
         mapOf("actorName" to actorNameResolver.resolve(event.actorId))
+
+    override fun resolveActorImageUrl(event: TournamentStarted): String? = actorNameResolver.resolveProfileImage(event.actorId)
 }

--- a/src/main/kotlin/com/depromeet/piki/notification/repository/NotificationJpaRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/repository/NotificationJpaRepository.kt
@@ -45,9 +45,6 @@ interface NotificationJpaRepository : JpaRepository<Notification, Long> {
         limit: Limit,
     ): List<Notification>
 
-    // 안읽음 수(badge). (idx_notifications_user_id_is_read 가 그대로 커버)
-    fun countByUserIdAndIsReadFalse(userId: UUID): Long
-
     // type 별 안읽음 수 — 전체 badge + 탭별(활동/시스템) badge 를 한 쿼리(group by)로 집계한다.
     // closed projection(type·count alias)으로 받아 RepositoryImpl 이 카테고리로 접는다. (idx (user_id, is_read) 커버)
     @Query(

--- a/src/main/kotlin/com/depromeet/piki/notification/repository/NotificationJpaRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/repository/NotificationJpaRepository.kt
@@ -1,6 +1,7 @@
 package com.depromeet.piki.notification.repository
 
 import com.depromeet.piki.notification.domain.Notification
+import com.depromeet.piki.notification.domain.NotificationType
 import org.springframework.data.domain.Limit
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
@@ -29,8 +30,39 @@ interface NotificationJpaRepository : JpaRepository<Notification, Long> {
         limit: Limit,
     ): List<Notification>
 
+    // 카테고리 탭 첫 페이지 — 본인 알림 중 그 카테고리 type 집합만 최신순 limit 건. (idx (user_id, id) 가 정렬을 받치고 type 은 필터)
+    fun findByUserIdAndTypeInOrderByIdDesc(
+        userId: UUID,
+        types: List<NotificationType>,
+        limit: Limit,
+    ): List<Notification>
+
+    // 카테고리 탭 다음 페이지 — 커서 미만 + 그 카테고리 type 집합만 최신순 limit 건.
+    fun findByUserIdAndIdLessThanAndTypeInOrderByIdDesc(
+        userId: UUID,
+        id: Long,
+        types: List<NotificationType>,
+        limit: Limit,
+    ): List<Notification>
+
     // 안읽음 수(badge). (idx_notifications_user_id_is_read 가 그대로 커버)
     fun countByUserIdAndIsReadFalse(userId: UUID): Long
+
+    // type 별 안읽음 수 — 전체 badge + 탭별(활동/시스템) badge 를 한 쿼리(group by)로 집계한다.
+    // closed projection(type·count alias)으로 받아 RepositoryImpl 이 카테고리로 접는다. (idx (user_id, is_read) 커버)
+    @Query(
+        "SELECT n.type AS type, COUNT(n) AS count FROM Notification n " +
+            "WHERE n.userId = :userId AND n.isRead = false GROUP BY n.type",
+    )
+    fun countUnreadByType(
+        @Param("userId") userId: UUID,
+    ): List<TypeUnreadCount>
+
+    // group by 결과 한 행 — type 과 그 안읽음 수. Spring Data closed projection(SELECT alias 와 게터명 일치).
+    interface TypeUnreadCount {
+        val type: NotificationType
+        val count: Long
+    }
 
     // 본인 소유(user_id) + 지정 id + 아직 안읽음만 read 로. user_id 가 WHERE 에 있어 타인/없는 id 는 무영향(소유 검증 겸용).
     // 영향 건수를 돌려준다. 멱등(이미 읽음·없는 id 는 0건).

--- a/src/main/kotlin/com/depromeet/piki/notification/repository/NotificationRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/repository/NotificationRepository.kt
@@ -21,10 +21,8 @@ interface NotificationRepository {
         types: List<NotificationType>?,
     ): List<Notification>
 
-    // 본인 안읽음 수(badge).
-    fun countUnread(userId: UUID): Long
-
     // 카테고리별 안읽음 수(탭별 badge). 모든 카테고리를 키로 포함하며 해당 없는 카테고리는 0 이다.
+    // 전체 안읽음 수(앱 badge)는 이 맵의 값 합으로 도출한다 — 두 수치가 어긋날 여지를 없앤다.
     fun countUnreadByCategory(userId: UUID): Map<NotificationCategory, Long>
 
     // 지정 id 중 본인 소유 + 안읽음만 read 로 (타인/없는 id 무영향). 영향 건수 반환. 멱등.

--- a/src/main/kotlin/com/depromeet/piki/notification/repository/NotificationRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/repository/NotificationRepository.kt
@@ -1,7 +1,9 @@
 package com.depromeet.piki.notification.repository
 
 import com.depromeet.piki.notification.domain.Notification
+import com.depromeet.piki.notification.domain.NotificationCategory
 import com.depromeet.piki.notification.domain.NotificationCursor
+import com.depromeet.piki.notification.domain.NotificationType
 import java.util.UUID
 
 interface NotificationRepository {
@@ -11,14 +13,19 @@ interface NotificationRepository {
     fun hardDeleteAllByUserId(userId: UUID): Int
 
     // 본인 알림을 최신순(id desc)으로 최대 limit 건. cursor 가 있으면 그 id 미만만(다음 페이지).
+    // types 가 있으면 그 type 집합만(카테고리 탭 필터), null 이면 전체.
     fun findPage(
         userId: UUID,
         cursor: NotificationCursor?,
         limit: Int,
+        types: List<NotificationType>?,
     ): List<Notification>
 
     // 본인 안읽음 수(badge).
     fun countUnread(userId: UUID): Long
+
+    // 카테고리별 안읽음 수(탭별 badge). 모든 카테고리를 키로 포함하며 해당 없는 카테고리는 0 이다.
+    fun countUnreadByCategory(userId: UUID): Map<NotificationCategory, Long>
 
     // 지정 id 중 본인 소유 + 안읽음만 read 로 (타인/없는 id 무영향). 영향 건수 반환. 멱등.
     fun markRead(

--- a/src/main/kotlin/com/depromeet/piki/notification/repository/NotificationRepositoryImpl.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/repository/NotificationRepositoryImpl.kt
@@ -1,7 +1,9 @@
 package com.depromeet.piki.notification.repository
 
 import com.depromeet.piki.notification.domain.Notification
+import com.depromeet.piki.notification.domain.NotificationCategory
 import com.depromeet.piki.notification.domain.NotificationCursor
+import com.depromeet.piki.notification.domain.NotificationType
 import org.springframework.data.domain.Limit
 import org.springframework.stereotype.Repository
 import java.util.UUID
@@ -14,17 +16,50 @@ class NotificationRepositoryImpl(
 
     override fun hardDeleteAllByUserId(userId: UUID): Int = notificationJpaRepository.hardDeleteAllByUserId(userId)
 
+    // cursor(다음 페이지) × types(카테고리 필터) 분기. types 가 없으면 전체, 있으면 type-in 변형. 각 분기는 cursor 유무로 다시 갈린다.
     override fun findPage(
         userId: UUID,
         cursor: NotificationCursor?,
         limit: Int,
+        types: List<NotificationType>?,
     ): List<Notification> {
         val limited = Limit.of(limit)
+        types ?: return findPageAllTypes(userId, cursor, limited)
+        return findPageInTypes(userId, cursor, types, limited)
+    }
+
+    private fun findPageAllTypes(
+        userId: UUID,
+        cursor: NotificationCursor?,
+        limited: Limit,
+    ): List<Notification> {
         cursor ?: return notificationJpaRepository.findByUserIdOrderByIdDesc(userId, limited)
         return notificationJpaRepository.findByUserIdAndIdLessThanOrderByIdDesc(userId, cursor.lastNotificationId, limited)
     }
 
+    private fun findPageInTypes(
+        userId: UUID,
+        cursor: NotificationCursor?,
+        types: List<NotificationType>,
+        limited: Limit,
+    ): List<Notification> {
+        cursor ?: return notificationJpaRepository.findByUserIdAndTypeInOrderByIdDesc(userId, types, limited)
+        return notificationJpaRepository.findByUserIdAndIdLessThanAndTypeInOrderByIdDesc(userId, cursor.lastNotificationId, types, limited)
+    }
+
     override fun countUnread(userId: UUID): Long = notificationJpaRepository.countByUserIdAndIsReadFalse(userId)
+
+    // type 별 group-by 결과를 카테고리로 접는다. 모든 카테고리를 0 으로 깔고 해당 type 의 수를 카테고리에 누적해,
+    // 안읽음이 없는 카테고리도 키로 0 을 보장한다(FE 가 탭 badge 를 항상 읽을 수 있게).
+    override fun countUnreadByCategory(userId: UUID): Map<NotificationCategory, Long> {
+        val base = NotificationCategory.entries.associateWith { 0L }
+        return notificationJpaRepository
+            .countUnreadByType(userId)
+            .fold(base) { acc, row ->
+                val category = NotificationCategory.of(row.type)
+                acc + (category to (acc.getValue(category) + row.count))
+            }
+    }
 
     override fun markRead(
         userId: UUID,

--- a/src/main/kotlin/com/depromeet/piki/notification/repository/NotificationRepositoryImpl.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/repository/NotificationRepositoryImpl.kt
@@ -47,18 +47,14 @@ class NotificationRepositoryImpl(
         return notificationJpaRepository.findByUserIdAndIdLessThanAndTypeInOrderByIdDesc(userId, cursor.lastNotificationId, types, limited)
     }
 
-    override fun countUnread(userId: UUID): Long = notificationJpaRepository.countByUserIdAndIsReadFalse(userId)
-
     // type 별 group-by 결과를 카테고리로 접는다. 모든 카테고리를 0 으로 깔고 해당 type 의 수를 카테고리에 누적해,
     // 안읽음이 없는 카테고리도 키로 0 을 보장한다(FE 가 탭 badge 를 항상 읽을 수 있게).
     override fun countUnreadByCategory(userId: UUID): Map<NotificationCategory, Long> {
-        val base = NotificationCategory.entries.associateWith { 0L }
-        return notificationJpaRepository
-            .countUnreadByType(userId)
-            .fold(base) { acc, row ->
-                val category = NotificationCategory.of(row.type)
-                acc + (category to (acc.getValue(category) + row.count))
-            }
+        val result = NotificationCategory.entries.associateWithTo(mutableMapOf()) { 0L }
+        notificationJpaRepository.countUnreadByType(userId).forEach { row ->
+            result.merge(NotificationCategory.of(row.type), row.count, Long::plus)
+        }
+        return result
     }
 
     override fun markRead(

--- a/src/main/kotlin/com/depromeet/piki/notification/service/DefaultPushImage.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/service/DefaultPushImage.kt
@@ -1,0 +1,19 @@
+package com.depromeet.piki.notification.service
+
+import com.depromeet.piki.common.storage.S3Properties
+import org.springframework.stereotype.Component
+
+// 시스템 알림(actor 없음)의 기본 아바타 URL 발급(#473). 아이콘 파일은 이미지 버킷의 `defaults/push-icon.svg` 로
+// 사전 업로드돼 있고(랜덤 기본 프사와 같은 공개 `defaults/` 경로), 여기선 그 공개 URL 만 조립한다.
+// publicBaseUrl 로 조립하므로 dev/prod 버킷 차이를 흡수한다(DefaultProfileImages 와 같은 방식 — 주소를 박지 않는다).
+// payload imageUrl 은 actor 스냅샷이 있으면 그것을, 없으면(시스템) 이 URL 을 채워 항상 비지 않게 한다.
+@Component
+class DefaultPushImage(
+    s3Properties: S3Properties,
+) {
+    val url: String = "${s3Properties.publicBaseUrl.trimEnd('/')}/$KEY"
+
+    companion object {
+        const val KEY = "defaults/push-icon.svg"
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/notification/service/NotificationDispatcher.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/service/NotificationDispatcher.kt
@@ -39,10 +39,12 @@ class NotificationDispatcher(
 
         val refId = handler.resolveRefId(event)
         val routing = handler.resolveRouting(event)
-        // actor 프사는 한 이벤트에 한 명이라 수신자 루프 밖에서 한 번만 해석해 모든 수신자 알림에 같은 값을 박는다(#473).
-        val actorImageUrl = handler.resolveActorImageUrl(event)
+        // actor 는 한 이벤트에 한 명이라 수신자 루프 밖에서 한 번만 해석해(actorId 조회 1회) 모든 수신자 알림에 같은 값을 박는다(#473).
+        // 변수(actorName)와 프사 snapshot 을 한 컨텍스트로 함께 받는다.
+        val actorContext = handler.resolveActorContext(event)
+        val actorImageUrl = actorContext.imageUrl
         val template = templateProvider.find(handler.notificationType)
-        val variables = handler.resolveVariables(event)
+        val variables = actorContext.variables
         val title = renderer.render(template.title, variables)
         val body = renderer.render(template.body, variables)
 

--- a/src/main/kotlin/com/depromeet/piki/notification/service/NotificationDispatcher.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/service/NotificationDispatcher.kt
@@ -39,6 +39,8 @@ class NotificationDispatcher(
 
         val refId = handler.resolveRefId(event)
         val routing = handler.resolveRouting(event)
+        // actor 프사는 한 이벤트에 한 명이라 수신자 루프 밖에서 한 번만 해석해 모든 수신자 알림에 같은 값을 박는다(#473).
+        val actorImageUrl = handler.resolveActorImageUrl(event)
         val template = templateProvider.find(handler.notificationType)
         val variables = handler.resolveVariables(event)
         val title = renderer.render(template.title, variables)
@@ -56,6 +58,7 @@ class NotificationDispatcher(
                             body = body,
                             refId = refId,
                             routing = routing,
+                            actorImageUrl = actorImageUrl,
                         ),
                     )
                 // 한 채널의 실패도 다른 채널 전달을 막지 않게 추가로 격리한다.

--- a/src/main/kotlin/com/depromeet/piki/notification/service/NotificationService.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/service/NotificationService.kt
@@ -1,5 +1,6 @@
 package com.depromeet.piki.notification.service
 
+import com.depromeet.piki.notification.domain.NotificationCategory
 import com.depromeet.piki.notification.domain.NotificationCursor
 import com.depromeet.piki.notification.domain.NotificationHistorySize
 import com.depromeet.piki.notification.repository.NotificationRepository
@@ -15,38 +16,50 @@ class NotificationService(
     private val notificationRepository: NotificationRepository,
 ) {
     // 본인 알림을 최신순으로 한 페이지 + 안읽음 수 동봉. hasNext 판단을 위해 한 건 더 조회하고 초과분은 잘라낸다.
+    // category 가 있으면 그 카테고리의 type 집합으로 필터(활동/시스템 탭). unreadCount 는 category 무관 전체(앱 badge).
     @Transactional(readOnly = true)
     fun getHistory(
         userId: UUID,
         rawCursor: String?,
         rawSize: Int?,
+        category: NotificationCategory?,
     ): NotificationHistoryPage {
         val cursor = NotificationCursor.parse(rawCursor)
         val size = NotificationHistorySize.of(rawSize).value
-        val fetched = notificationRepository.findPage(userId, cursor, size + 1)
+        val types = category?.let { NotificationCategory.typesOf(it) }
+        val fetched = notificationRepository.findPage(userId, cursor, size + 1, types)
         val hasNext = fetched.size > size
         val page = fetched.take(size)
-        val unreadCount = notificationRepository.countUnread(userId)
+        // 전체(badge) + 카테고리별(탭 badge)을 한 번에. total 은 카테고리 합으로 도출해 두 수치가 어긋날 여지를 없앤다.
+        val unreadByCategory = notificationRepository.countUnreadByCategory(userId)
+        val unreadCount = unreadByCategory.values.sum()
         val nextCursor =
             page
                 .lastOrNull()
                 ?.getId()
                 ?.toString()
                 .takeIf { hasNext }
-        return NotificationHistoryPage(notifications = page, unreadCount = unreadCount, nextCursor = nextCursor, hasNext = hasNext)
+        return NotificationHistoryPage(
+            notifications = page,
+            unreadCount = unreadCount,
+            unreadCountByCategory = unreadByCategory,
+            nextCursor = nextCursor,
+            hasNext = hasNext,
+        )
     }
 
     // 읽음 처리 — 명령(All/Ids)별 벌크 UPDATE. 본인 소유만 반영(소유 검증은 쿼리의 user_id 조건이 겸한다). 멱등.
-    // 처리 후 안읽음 수를 같은 트랜잭션에서 세어 반환한다 — 클라가 badge 를 서버 권위 값으로 미러링하게 해 +1/-1 산수 drift 를 없앤다.
+    // 처리 후 카테고리별 안읽음 수를 같은 트랜잭션에서 세어 반환한다 — 클라가 앱 badge·탭 badge 를 서버 권위 값으로
+    // 미러링하게 해 +1/-1 산수 drift 를 없앤다(전체는 응답 DTO 가 카테고리 합으로 도출).
     @Transactional
     fun read(
         userId: UUID,
         command: NotificationReadCommand,
-    ): Long {
+    ): Map<NotificationCategory, Long> {
         when (command) {
             NotificationReadCommand.All -> notificationRepository.markAllRead(userId)
             is NotificationReadCommand.Ids -> notificationRepository.markRead(userId, command.ids)
         }
-        return notificationRepository.countUnread(userId)
+        return notificationRepository.countUnreadByCategory(userId)
     }
 }

--- a/src/main/kotlin/com/depromeet/piki/notification/service/NotificationService.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/service/NotificationService.kt
@@ -14,6 +14,7 @@ import java.util.UUID
 @Service
 class NotificationService(
     private val notificationRepository: NotificationRepository,
+    private val defaultPushImage: DefaultPushImage,
 ) {
     // 본인 알림을 최신순으로 한 페이지 + 안읽음 수 동봉. hasNext 판단을 위해 한 건 더 조회하고 초과분은 잘라낸다.
     // category 가 있으면 그 카테고리의 type 집합으로 필터(활동/시스템 탭). unreadCount 는 category 무관 전체(앱 badge).
@@ -45,6 +46,7 @@ class NotificationService(
             unreadCountByCategory = unreadByCategory,
             nextCursor = nextCursor,
             hasNext = hasNext,
+            defaultPushImageUrl = defaultPushImage.url,
         )
     }
 

--- a/src/main/kotlin/com/depromeet/piki/notification/service/dto/NotificationHistoryPage.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/service/dto/NotificationHistoryPage.kt
@@ -1,13 +1,15 @@
 package com.depromeet.piki.notification.service.dto
 
 import com.depromeet.piki.notification.domain.Notification
+import com.depromeet.piki.notification.domain.NotificationCategory
 
 // 알림 히스토리 cursor 페이지네이션 한 페이지의 결과.
-// notifications 는 응답 매핑 전 도메인 엔티티, unreadCount 는 목록과 함께 내려보낼 안읽음 수(별도 카운트 API 없음).
+// notifications 는 응답 매핑 전 도메인 엔티티, unreadCount 는 전체 안읽음 수(앱 badge), unreadCountByCategory 는 탭별 badge.
 // nextCursor 는 다음 요청에 그대로 돌려보낼 커서(마지막 항목 id 문자열), 마지막 페이지면 null.
 data class NotificationHistoryPage(
     val notifications: List<Notification>,
     val unreadCount: Long,
+    val unreadCountByCategory: Map<NotificationCategory, Long>,
     val nextCursor: String?,
     val hasNext: Boolean,
 )

--- a/src/main/kotlin/com/depromeet/piki/notification/service/dto/NotificationHistoryPage.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/service/dto/NotificationHistoryPage.kt
@@ -6,10 +6,12 @@ import com.depromeet.piki.notification.domain.NotificationCategory
 // 알림 히스토리 cursor 페이지네이션 한 페이지의 결과.
 // notifications 는 응답 매핑 전 도메인 엔티티, unreadCount 는 전체 안읽음 수(앱 badge), unreadCountByCategory 는 탭별 badge.
 // nextCursor 는 다음 요청에 그대로 돌려보낼 커서(마지막 항목 id 문자열), 마지막 페이지면 null.
+// defaultPushImageUrl 은 시스템 알림(actor 없음)의 imageUrl 을 채우는 기본 아바타 — 서비스가 채워, 컨트롤러는 매핑에 그대로 넘긴다.
 data class NotificationHistoryPage(
     val notifications: List<Notification>,
     val unreadCount: Long,
     val unreadCountByCategory: Map<NotificationCategory, Long>,
     val nextCursor: String?,
     val hasNext: Boolean,
+    val defaultPushImageUrl: String,
 )

--- a/src/main/kotlin/com/depromeet/piki/notification/sse/LocalSseDelivery.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/sse/LocalSseDelivery.kt
@@ -2,6 +2,7 @@ package com.depromeet.piki.notification.sse
 
 import com.depromeet.piki.notification.controller.dto.NotificationSsePayload
 import com.depromeet.piki.notification.domain.Notification
+import com.depromeet.piki.notification.service.DefaultPushImage
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
@@ -16,6 +17,7 @@ import java.util.UUID
 @Component
 class LocalSseDelivery(
     private val registry: SseEmitterRegistry,
+    private val defaultPushImage: DefaultPushImage,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -28,7 +30,7 @@ class LocalSseDelivery(
             SseEmitter
                 .event()
                 .name(EVENT_NOTIFICATION)
-                .data(NotificationSsePayload.from(notification))
+                .data(NotificationSsePayload.from(notification, defaultPushImage.url))
         registry.emittersOf(userId).forEach { sendOrEvict(userId, it, event) }
     }
 

--- a/src/main/resources/db/migration/V20260610011418__add_actor_image_url_to_notifications.sql
+++ b/src/main/resources/db/migration/V20260610011418__add_actor_image_url_to_notifications.sql
@@ -1,0 +1,8 @@
+-- 알림 행위자(actor) 프로필 사진 snapshot 컬럼 (#473).
+-- 사람 알림(TOURNAMENT_* 등 actor 있는 알림)은 발송 시점 actor 의 프로필 이미지 URL 을 여기 박아 고정한다.
+-- 이후 actor 가 프사를 바꿔도 과거 알림은 그 시점 사진 그대로 유지된다(title 의 닉네임 snapshot 과 같은 결).
+-- 프로필 이미지 URL 은 업로드마다 새 키(immutable)라 옛 URL 이 옛 이미지를 계속 가리켜 snapshot 이 안전하다.
+-- 시스템 알림(actor 없음)은 NULL — 직렬화 시 서버가 defaultPushImg(피키 로고)로 채운다(컬럼엔 저장 안 함).
+-- length 2048 은 users.profile_image 와 정합. additive 라 out-of-order 무해. FK 없음(프로젝트 정책).
+ALTER TABLE notifications
+    ADD COLUMN actor_image_url VARCHAR(2048) NULL;

--- a/src/test/kotlin/com/depromeet/piki/notification/controller/NotificationHistoryControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/notification/controller/NotificationHistoryControllerIntegrationTest.kt
@@ -7,6 +7,7 @@ import com.depromeet.piki.notification.domain.NotificationRouting
 import com.depromeet.piki.notification.domain.NotificationType
 import com.depromeet.piki.notification.repository.NotificationJpaRepository
 import com.depromeet.piki.notification.repository.NotificationRepository
+import com.depromeet.piki.notification.service.DefaultPushImage
 import com.depromeet.piki.support.IntegrationTestSupport
 import com.depromeet.piki.user.domain.IdentityType
 import org.hamcrest.Matchers.notNullValue
@@ -40,6 +41,8 @@ class NotificationHistoryControllerIntegrationTest : IntegrationTestSupport() {
 
     @Autowired private lateinit var notificationJpaRepository: NotificationJpaRepository
 
+    @Autowired private lateinit var defaultPushImage: DefaultPushImage
+
     private fun authHeader(userId: UUID): String = "Bearer ${jwtProvider.generateAccessToken(userId, IdentityType.MEMBER)}"
 
     private fun buildMockMvc(): MockMvc =
@@ -63,6 +66,16 @@ class NotificationHistoryControllerIntegrationTest : IntegrationTestSupport() {
         }
         return saved.getId()
     }
+
+    // 타입·actor 프사 snapshot 을 지정해 저장 — 카테고리 필터·imageUrl 검증용.
+    private fun seedTyped(
+        userId: UUID,
+        type: NotificationType,
+        actorImageUrl: String? = null,
+    ): Long =
+        notificationRepository
+            .save(Notification(userId, type, "제목", "본문", 11L, routing = null, actorImageUrl = actorImageUrl))
+            .getId()
 
     @Test
     fun `본인 알림만 최신순으로 unreadCount 와 함께 조회된다`() {
@@ -89,6 +102,113 @@ class NotificationHistoryControllerIntegrationTest : IntegrationTestSupport() {
             .andExpect(jsonPath("$.data.unreadCount").value(2))
             .andExpect(jsonPath("$.pageResponse.hasNext").value(false))
             .andExpect(jsonPath("$.pageResponse.nextCursor").value(nullValue()))
+    }
+
+    @Test
+    fun `category=ACTIVITY 면 토너먼트 알림만, category=SYSTEM 이면 파싱 알림만 조회된다`() {
+        val userId = UUID.randomUUID()
+        val activity = seedTyped(userId, NotificationType.TOURNAMENT_STARTED)
+        val system = seedTyped(userId, NotificationType.ITEM_PARSING_COMPLETED)
+        val mockMvc = buildMockMvc()
+
+        mockMvc
+            .perform(get("/api/v1/notifications").param("category", "ACTIVITY").header(HttpHeaders.AUTHORIZATION, authHeader(userId)))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.items.length()").value(1))
+            .andExpect(jsonPath("$.data.items[0].id").value(activity))
+            .andExpect(jsonPath("$.data.items[0].category").value("ACTIVITY"))
+
+        mockMvc
+            .perform(get("/api/v1/notifications").param("category", "SYSTEM").header(HttpHeaders.AUTHORIZATION, authHeader(userId)))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.items.length()").value(1))
+            .andExpect(jsonPath("$.data.items[0].id").value(system))
+            .andExpect(jsonPath("$.data.items[0].category").value("SYSTEM"))
+    }
+
+    @Test
+    fun `category 필터도 커서로 페이지를 나누고 다음 페이지를 잇는다`() {
+        val userId = UUID.randomUUID()
+        val a1 = seedTyped(userId, NotificationType.TOURNAMENT_JOINED)
+        val a2 = seedTyped(userId, NotificationType.TOURNAMENT_ITEM_ADDED)
+        val a3 = seedTyped(userId, NotificationType.TOURNAMENT_STARTED)
+        seedTyped(userId, NotificationType.ITEM_PARSING_COMPLETED) // 시스템 — ACTIVITY 페이징에 섞이면 안 됨
+        val mockMvc = buildMockMvc()
+
+        // 1페이지: ACTIVITY size=2 → 최신 2건(a3, a2), 다음 페이지 있음, 커서=a2 (type-in 커서 변형 검증)
+        mockMvc
+            .perform(
+                get("/api/v1/notifications")
+                    .param("category", "ACTIVITY")
+                    .param("size", "2")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(userId)),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.items.length()").value(2))
+            .andExpect(jsonPath("$.data.items[0].id").value(a3))
+            .andExpect(jsonPath("$.data.items[1].id").value(a2))
+            .andExpect(jsonPath("$.pageResponse.hasNext").value(true))
+            .andExpect(jsonPath("$.pageResponse.nextCursor").value(a2.toString()))
+
+        // 2페이지: cursor=a2 + ACTIVITY → 남은 활동 1건(a1)만, 시스템 알림은 안 섞임
+        mockMvc
+            .perform(
+                get("/api/v1/notifications")
+                    .param("category", "ACTIVITY")
+                    .param("size", "2")
+                    .param("cursor", a2.toString())
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(userId)),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.items.length()").value(1))
+            .andExpect(jsonPath("$.data.items[0].id").value(a1))
+            .andExpect(jsonPath("$.pageResponse.hasNext").value(false))
+            .andExpect(jsonPath("$.pageResponse.nextCursor").value(nullValue()))
+    }
+
+    @Test
+    fun `category 로 걸러도 unreadCount 는 전체이고 탭별 카운트를 함께 내려준다`() {
+        val userId = UUID.randomUUID()
+        seedTyped(userId, NotificationType.TOURNAMENT_STARTED) // 활동 1
+        seedTyped(userId, NotificationType.ITEM_PARSING_COMPLETED) // 시스템 1
+        seedTyped(userId, NotificationType.ITEM_PARSING_FAILED) // 시스템 1
+
+        // category=ACTIVITY 로 목록은 1건만 걸러지지만, unreadCount(앱 badge)는 전체 3, 탭별은 활동1·시스템2.
+        buildMockMvc()
+            .perform(get("/api/v1/notifications").param("category", "ACTIVITY").header(HttpHeaders.AUTHORIZATION, authHeader(userId)))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.items.length()").value(1))
+            .andExpect(jsonPath("$.data.unreadCount").value(3))
+            .andExpect(jsonPath("$.data.unreadCountByCategory.ACTIVITY").value(1))
+            .andExpect(jsonPath("$.data.unreadCountByCategory.SYSTEM").value(2))
+    }
+
+    @Test
+    fun `유효하지 않은 category 는 400 으로 거른다`() {
+        buildMockMvc()
+            .perform(
+                get("/api/v1/notifications")
+                    .param("category", "NOPE")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(UUID.randomUUID())),
+            ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.detail", notNullValue()))
+    }
+
+    @Test
+    fun `actor 알림은 imageUrl 이 프사 snapshot, 시스템 알림은 defaultPushImg 로 채워진다`() {
+        val userId = UUID.randomUUID()
+        val actorImage = "https://img.test/profiles/actor.png"
+        val activity = seedTyped(userId, NotificationType.TOURNAMENT_JOINED, actorImageUrl = actorImage)
+        val system = seedTyped(userId, NotificationType.ITEM_PARSING_COMPLETED, actorImageUrl = null)
+
+        buildMockMvc()
+            .perform(get("/api/v1/notifications").header(HttpHeaders.AUTHORIZATION, authHeader(userId)))
+            .andExpect(status().isOk)
+            // 최신순(id desc): system → activity
+            .andExpect(jsonPath("$.data.items[0].id").value(system))
+            .andExpect(jsonPath("$.data.items[0].imageUrl").value(defaultPushImage.url)) // actor 없음 → 서버가 채운 기본 아바타
+            .andExpect(jsonPath("$.data.items[0].category").value("SYSTEM"))
+            .andExpect(jsonPath("$.data.items[1].id").value(activity))
+            .andExpect(jsonPath("$.data.items[1].imageUrl").value(actorImage)) // 발송 시점 프사 snapshot 그대로
+            .andExpect(jsonPath("$.data.items[1].category").value("ACTIVITY"))
     }
 
     @Test
@@ -162,8 +282,10 @@ class NotificationHistoryControllerIntegrationTest : IntegrationTestSupport() {
                     .content("""{"all":true}""")
                     .header(HttpHeaders.AUTHORIZATION, authHeader(userId)),
             ).andExpect(status().isOk)
-            // 처리 후 안읽음 수를 응답으로 바로 내려준다(badge 미러링용) — 별도 GET 불필요.
+            // 처리 후 안읽음 수(전체·탭별)를 응답으로 바로 내려준다(badge 미러링용) — 별도 GET 불필요.
             .andExpect(jsonPath("$.data.unreadCount").value(0))
+            .andExpect(jsonPath("$.data.unreadCountByCategory.ACTIVITY").value(0))
+            .andExpect(jsonPath("$.data.unreadCountByCategory.SYSTEM").value(0))
 
         mockMvc
             .perform(get("/api/v1/notifications").header(HttpHeaders.AUTHORIZATION, authHeader(userId)))
@@ -192,7 +314,10 @@ class NotificationHistoryControllerIntegrationTest : IntegrationTestSupport() {
                     .header(HttpHeaders.AUTHORIZATION, authHeader(userId)),
             ).andExpect(status().isOk)
             // target 만 본인 소유라 읽힘 → 본인 안읽음은 untouched 1건 남는다(others 는 타인이라 무영향).
+            // seed 는 ITEM_PARSING_COMPLETED(시스템)라 남은 1건은 SYSTEM 탭.
             .andExpect(jsonPath("$.data.unreadCount").value(1))
+            .andExpect(jsonPath("$.data.unreadCountByCategory.SYSTEM").value(1))
+            .andExpect(jsonPath("$.data.unreadCountByCategory.ACTIVITY").value(0))
 
         // 지정 + 본인 소유만 read. 미지정 본인 것·타인 것은 그대로(소유 검증은 쿼리 user_id 가 겸한다).
         assertTrue(notificationJpaRepository.findById(target).get().isRead)

--- a/src/test/kotlin/com/depromeet/piki/notification/domain/NotificationCategoryTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/notification/domain/NotificationCategoryTest.kt
@@ -1,0 +1,49 @@
+package com.depromeet.piki.notification.domain
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import kotlin.test.assertEquals
+
+class NotificationCategoryTest {
+    // type → category 매핑 전수. TOURNAMENT_* 는 활동, ITEM_PARSING_* 는 시스템.
+    @ParameterizedTest
+    @CsvSource(
+        "TOURNAMENT_JOINED, ACTIVITY",
+        "TOURNAMENT_ITEM_ADDED, ACTIVITY",
+        "TOURNAMENT_STARTED, ACTIVITY",
+        "ITEM_PARSING_COMPLETED, SYSTEM",
+        "ITEM_PARSING_FAILED, SYSTEM",
+    )
+    fun `type 별 카테고리 매핑`(
+        type: NotificationType,
+        expected: NotificationCategory,
+    ) {
+        assertEquals(expected, NotificationCategory.of(type))
+    }
+
+    @Test
+    fun `모든 NotificationType 은 카테고리로 분류된다`() {
+        // of 가 when 전수라 누락 시 컴파일이 깨지지만, 분류 자체가 비어있지 않은지도 런타임으로 확인한다.
+        NotificationType.entries.forEach { NotificationCategory.of(it) }
+    }
+
+    @Test
+    fun `typesOf 는 그 카테고리에 속한 type 만 돌려준다`() {
+        assertEquals(
+            listOf(NotificationType.TOURNAMENT_JOINED, NotificationType.TOURNAMENT_ITEM_ADDED, NotificationType.TOURNAMENT_STARTED),
+            NotificationCategory.typesOf(NotificationCategory.ACTIVITY),
+        )
+        assertEquals(
+            listOf(NotificationType.ITEM_PARSING_COMPLETED, NotificationType.ITEM_PARSING_FAILED),
+            NotificationCategory.typesOf(NotificationCategory.SYSTEM),
+        )
+    }
+
+    @Test
+    fun `두 카테고리의 type 집합은 전체를 빠짐없이 나눈다`() {
+        val all = NotificationCategory.entries.flatMap { NotificationCategory.typesOf(it) }
+        assertEquals(NotificationType.entries.toSet(), all.toSet())
+        assertEquals(NotificationType.entries.size, all.size) // 중복 없이 분할(partition)
+    }
+}

--- a/src/test/kotlin/com/depromeet/piki/notification/fcm/service/FirebaseMessageSenderTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/notification/fcm/service/FirebaseMessageSenderTest.kt
@@ -17,6 +17,9 @@ import kotlin.test.assertTrue
 // (멀티캐스트 chunk 루프·발송 실패 스킵은 FirebaseMessaging 호출에 강결합이라 여기서 다루지 않는다 —
 //  채널 레벨 fan-out·정리는 PushNotificationChannelIntegrationTest 가 stub 으로 덮는다.)
 class FirebaseMessageSenderTest {
+    // 시스템 알림(actor 없음)의 imageUrl 을 채우는 기본 아바타 — 운영에선 DefaultPushImage 가 publicBaseUrl 로 조립한다.
+    private val defaultPushImageUrl = "https://img.test/defaults/push-icon.svg"
+
     @Test
     fun `UNREGISTERED 만 정리 대상이다`() {
         assertTrue(FirebaseMessageSender.isStaleToken(MessagingErrorCode.UNREGISTERED))
@@ -42,12 +45,28 @@ class FirebaseMessageSenderTest {
     // buildDataPayload 는 FCM data(키→값) 구성 정책 — 라우팅 컨텍스트 유무에 따른 키 셋 분기를 단위로 망라한다(#408).
     // id 는 항상 실린다(채널 무관 dedup·푸시 탭→읽음의 키, #246) — 미영속 엔티티엔 withId 로 부여한다.
     @Test
-    fun `라우팅 없는 알림은 id·type·refId 만 data 에 싣는다`() {
+    fun `라우팅 없는 알림은 id·type·category·imageUrl·refId 를 data 에 싣는다`() {
         val notification = Notification(UUID.randomUUID(), NotificationType.TOURNAMENT_JOINED, "제목", "본문", 7L).withId(42L)
 
-        val data = FirebaseMessageSender.buildDataPayload(notification)
+        val data = FirebaseMessageSender.buildDataPayload(notification, defaultPushImageUrl)
 
-        assertEquals(mapOf("id" to "42", "type" to "TOURNAMENT_JOINED", "refId" to "7"), data)
+        // actor 스냅샷 없음 → imageUrl 은 defaultPushImageUrl 로 채워진다. TOURNAMENT_JOINED → category=ACTIVITY.
+        assertEquals(
+            mapOf("id" to "42", "type" to "TOURNAMENT_JOINED", "category" to "ACTIVITY", "imageUrl" to defaultPushImageUrl, "refId" to "7"),
+            data,
+        )
+    }
+
+    @Test
+    fun `actor 스냅샷이 있으면 imageUrl 은 그 프사 URL 이다`() {
+        val notification =
+            Notification(UUID.randomUUID(), NotificationType.TOURNAMENT_ITEM_ADDED, "제목", "본문", 7L, actorImageUrl = "https://img.test/profiles/a.png")
+                .withId(45L)
+
+        val data = FirebaseMessageSender.buildDataPayload(notification, defaultPushImageUrl)
+
+        assertEquals("https://img.test/profiles/a.png", data["imageUrl"])
+        assertEquals("ACTIVITY", data["category"])
     }
 
     @Test
@@ -56,9 +75,20 @@ class FirebaseMessageSenderTest {
             Notification(UUID.randomUUID(), NotificationType.ITEM_PARSING_COMPLETED, "제목", "본문", 11L, NotificationRouting.Wish)
                 .withId(43L)
 
-        val data = FirebaseMessageSender.buildDataPayload(notification)
+        val data = FirebaseMessageSender.buildDataPayload(notification, defaultPushImageUrl)
 
-        assertEquals(mapOf("id" to "43", "type" to "ITEM_PARSING_COMPLETED", "refId" to "11", "kind" to "WISH"), data)
+        // ITEM_PARSING_* → category=SYSTEM. actor 없어 imageUrl=default.
+        assertEquals(
+            mapOf(
+                "id" to "43",
+                "type" to "ITEM_PARSING_COMPLETED",
+                "category" to "SYSTEM",
+                "imageUrl" to defaultPushImageUrl,
+                "refId" to "11",
+                "kind" to "WISH",
+            ),
+            data,
+        )
     }
 
     @Test
@@ -73,12 +103,14 @@ class FirebaseMessageSenderTest {
                 NotificationRouting.Tournament(tournamentId = 99L, tournamentItemId = 555L),
             ).withId(44L)
 
-        val data = FirebaseMessageSender.buildDataPayload(notification)
+        val data = FirebaseMessageSender.buildDataPayload(notification, defaultPushImageUrl)
 
         assertEquals(
             mapOf(
                 "id" to "44",
                 "type" to "ITEM_PARSING_COMPLETED",
+                "category" to "SYSTEM",
+                "imageUrl" to defaultPushImageUrl,
                 "refId" to "11",
                 "kind" to "TOURNAMENT",
                 "tournamentId" to "99",

--- a/src/test/kotlin/com/depromeet/piki/notification/handler/NotificationRecipientResolutionIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/notification/handler/NotificationRecipientResolutionIntegrationTest.kt
@@ -25,7 +25,7 @@ import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-// 핸들러의 수신자(resolveRecipients)·변수(resolveVariables) 도출은 DB 역조회에 의존하므로 통합으로 검증한다.
+// 핸들러의 수신자(resolveRecipients)·actor 컨텍스트(resolveActorContext) 도출은 DB 역조회에 의존하므로 통합으로 검증한다.
 // 영속 fixture(참가자·위시·토너먼트 아이템·유저)를 깔고 실제 빈으로 도출 결과를 단언한다. @Transactional 자동 롤백.
 @Transactional
 class NotificationRecipientResolutionIntegrationTest : IntegrationTestSupport() {
@@ -98,7 +98,7 @@ class NotificationRecipientResolutionIntegrationTest : IntegrationTestSupport() 
         val owner = UUID.randomUUID()
         userRepository.save(User(id = owner, nickname = "주최자", profileImage = "https://x/p.jpg", identityType = IdentityType.GUEST))
 
-        val variables = startedHandler.resolveVariables(TournamentStarted(tournamentId, owner))
+        val variables = startedHandler.resolveActorContext(TournamentStarted(tournamentId, owner)).variables
 
         assertEquals(mapOf("actorName" to "주최자"), variables)
     }
@@ -109,14 +109,14 @@ class NotificationRecipientResolutionIntegrationTest : IntegrationTestSupport() 
         val actor = UUID.randomUUID()
         userRepository.save(User(id = actor, nickname = "홍길동", profileImage = "https://x/p.jpg", identityType = IdentityType.GUEST))
 
-        val variables = itemAddedHandler.resolveVariables(TournamentItemAdded(tournamentId, actor))
+        val variables = itemAddedHandler.resolveActorContext(TournamentItemAdded(tournamentId, actor)).variables
 
         assertEquals(mapOf("actorName" to "홍길동"), variables)
     }
 
     @Test
     fun `행위자 유저를 못 찾으면 actorName 은 fallback 으로 채운다`() {
-        val variables = itemAddedHandler.resolveVariables(TournamentItemAdded(1004L, UUID.randomUUID()))
+        val variables = itemAddedHandler.resolveActorContext(TournamentItemAdded(1004L, UUID.randomUUID())).variables
 
         assertEquals(mapOf("actorName" to ActorNameResolver.UNKNOWN_ACTOR), variables)
     }
@@ -127,37 +127,39 @@ class NotificationRecipientResolutionIntegrationTest : IntegrationTestSupport() 
         userRepository.save(User(id = actor, nickname = "홍길동", profileImage = "https://x/actor-now.png", identityType = IdentityType.GUEST))
 
         // 핸들러가 actorId 로 현재 프사 URL 을 뽑아 온다(이 값이 dispatcher 를 통해 Notification.actorImageUrl 로 박힌다).
-        assertEquals("https://x/actor-now.png", joinedHandler.resolveActorImageUrl(TournamentJoined(1009L, actor)))
-        assertEquals("https://x/actor-now.png", itemAddedHandler.resolveActorImageUrl(TournamentItemAdded(1009L, actor)))
-        assertEquals("https://x/actor-now.png", startedHandler.resolveActorImageUrl(TournamentStarted(1009L, actor)))
+        assertEquals("https://x/actor-now.png", joinedHandler.resolveActorContext(TournamentJoined(1009L, actor)).imageUrl)
+        assertEquals("https://x/actor-now.png", itemAddedHandler.resolveActorContext(TournamentItemAdded(1009L, actor)).imageUrl)
+        assertEquals("https://x/actor-now.png", startedHandler.resolveActorContext(TournamentStarted(1009L, actor)).imageUrl)
     }
 
     @Test
     fun `행위자 유저를 못 찾으면 actorImageUrl 은 null 이다 (직렬화 때 defaultPushImg 로 채워짐)`() {
-        assertEquals(null, joinedHandler.resolveActorImageUrl(TournamentJoined(1010L, UUID.randomUUID())))
+        assertEquals(null, joinedHandler.resolveActorContext(TournamentJoined(1010L, UUID.randomUUID())).imageUrl)
     }
 
     @Test
     fun `시스템 알림(파싱)은 actor 가 없어 actorImageUrl 이 null 이다 - negative control`() {
-        // 파싱 핸들러는 resolveActorImageUrl 을 override 하지 않는다 → 기본 null → 직렬화 때 피키 로고로 채워진다.
-        assertEquals(null, parsingCompletedHandler.resolveActorImageUrl(ItemParsingCompleted(2099L)))
-        assertEquals(null, parsingFailedHandler.resolveActorImageUrl(ItemParsingFailed(2099L)))
+        // 파싱 핸들러는 resolveActorContext 를 override 하지 않는다 → 기본 빈 컨텍스트 imageUrl null → 직렬화 때 피키 로고로 채워진다.
+        assertEquals(null, parsingCompletedHandler.resolveActorContext(ItemParsingCompleted(2099L)).imageUrl)
+        assertEquals(null, parsingFailedHandler.resolveActorContext(ItemParsingFailed(2099L)).imageUrl)
     }
 
     @Test
-    fun `dispatch 가 actor 이벤트의 프사를 수신자 알림에 snapshot 으로 저장한다 - end-to-end`() {
+    fun `dispatch 가 actor 이벤트의 프사와 닉네임을 한 컨텍스트에서 수신자 알림에 박는다 - end-to-end`() {
         val tournamentId = 1011L
         val actor = UUID.randomUUID()
         val recipient = UUID.randomUUID()
         listOf(actor, recipient).forEach { tournamentUserRepository.save(TournamentUser(tournamentId, it)) }
         userRepository.save(User(id = actor, nickname = "행위자", profileImage = "https://x/snap.png", identityType = IdentityType.GUEST))
 
-        // 이벤트 발행 → dispatch → 핸들러 resolveActorImageUrl → Notification.actorImageUrl 까지 실제 체인을 탄다.
+        // 이벤트 발행 → dispatch → 핸들러 resolveActorContext(한 번의 actor 조회) → 변수(actorName) 렌더 + 프사 snapshot 까지 실제 체인을 탄다.
         notificationDispatcher.dispatch(TournamentItemAdded(tournamentId, actor))
 
         val saved = notificationRepository.findPage(recipient, cursor = null, limit = 10, types = null)
         assertEquals(1, saved.size)
         assertEquals("https://x/snap.png", saved.first().actorImageUrl) // 발송 시점 actor 프사가 그대로 박혔다
+        // 같은 컨텍스트의 변수(actorName)가 템플릿에 렌더돼 제목에 박힌다 — 변수·프사가 한 조회에서 함께 흐르는지 end-to-end 로 가드한다.
+        assertEquals("행위자님이 아이템을 추가했어요", saved.first().title)
     }
 
     @Test

--- a/src/test/kotlin/com/depromeet/piki/notification/handler/NotificationRecipientResolutionIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/notification/handler/NotificationRecipientResolutionIntegrationTest.kt
@@ -3,6 +3,8 @@ package com.depromeet.piki.notification.handler
 import com.depromeet.piki.item.event.ItemParsingCompleted
 import com.depromeet.piki.item.event.ItemParsingFailed
 import com.depromeet.piki.notification.domain.NotificationRouting
+import com.depromeet.piki.notification.repository.NotificationRepository
+import com.depromeet.piki.notification.service.NotificationDispatcher
 import com.depromeet.piki.support.IntegrationTestSupport
 import com.depromeet.piki.tournament.domain.TournamentItem
 import com.depromeet.piki.tournament.domain.TournamentUser
@@ -44,6 +46,10 @@ class NotificationRecipientResolutionIntegrationTest : IntegrationTestSupport() 
     @Autowired private lateinit var wishRepository: WishRepository
 
     @Autowired private lateinit var userRepository: UserRepository
+
+    @Autowired private lateinit var notificationDispatcher: NotificationDispatcher
+
+    @Autowired private lateinit var notificationRepository: NotificationRepository
 
     @Test
     fun `토너먼트 아이템 추가 수신자는 참가자에서 추가한 본인을 뺀 집합이다`() {
@@ -113,6 +119,45 @@ class NotificationRecipientResolutionIntegrationTest : IntegrationTestSupport() 
         val variables = itemAddedHandler.resolveVariables(TournamentItemAdded(1004L, UUID.randomUUID()))
 
         assertEquals(mapOf("actorName" to ActorNameResolver.UNKNOWN_ACTOR), variables)
+    }
+
+    @Test
+    fun `actor 알림은 발송 시점 행위자 프로필 이미지를 snapshot 한다`() {
+        val actor = UUID.randomUUID()
+        userRepository.save(User(id = actor, nickname = "홍길동", profileImage = "https://x/actor-now.png", identityType = IdentityType.GUEST))
+
+        // 핸들러가 actorId 로 현재 프사 URL 을 뽑아 온다(이 값이 dispatcher 를 통해 Notification.actorImageUrl 로 박힌다).
+        assertEquals("https://x/actor-now.png", joinedHandler.resolveActorImageUrl(TournamentJoined(1009L, actor)))
+        assertEquals("https://x/actor-now.png", itemAddedHandler.resolveActorImageUrl(TournamentItemAdded(1009L, actor)))
+        assertEquals("https://x/actor-now.png", startedHandler.resolveActorImageUrl(TournamentStarted(1009L, actor)))
+    }
+
+    @Test
+    fun `행위자 유저를 못 찾으면 actorImageUrl 은 null 이다 (직렬화 때 defaultPushImg 로 채워짐)`() {
+        assertEquals(null, joinedHandler.resolveActorImageUrl(TournamentJoined(1010L, UUID.randomUUID())))
+    }
+
+    @Test
+    fun `시스템 알림(파싱)은 actor 가 없어 actorImageUrl 이 null 이다 - negative control`() {
+        // 파싱 핸들러는 resolveActorImageUrl 을 override 하지 않는다 → 기본 null → 직렬화 때 피키 로고로 채워진다.
+        assertEquals(null, parsingCompletedHandler.resolveActorImageUrl(ItemParsingCompleted(2099L)))
+        assertEquals(null, parsingFailedHandler.resolveActorImageUrl(ItemParsingFailed(2099L)))
+    }
+
+    @Test
+    fun `dispatch 가 actor 이벤트의 프사를 수신자 알림에 snapshot 으로 저장한다 - end-to-end`() {
+        val tournamentId = 1011L
+        val actor = UUID.randomUUID()
+        val recipient = UUID.randomUUID()
+        listOf(actor, recipient).forEach { tournamentUserRepository.save(TournamentUser(tournamentId, it)) }
+        userRepository.save(User(id = actor, nickname = "행위자", profileImage = "https://x/snap.png", identityType = IdentityType.GUEST))
+
+        // 이벤트 발행 → dispatch → 핸들러 resolveActorImageUrl → Notification.actorImageUrl 까지 실제 체인을 탄다.
+        notificationDispatcher.dispatch(TournamentItemAdded(tournamentId, actor))
+
+        val saved = notificationRepository.findPage(recipient, cursor = null, limit = 10, types = null)
+        assertEquals(1, saved.size)
+        assertEquals("https://x/snap.png", saved.first().actorImageUrl) // 발송 시점 actor 프사가 그대로 박혔다
     }
 
     @Test

--- a/src/test/kotlin/com/depromeet/piki/notification/service/DefaultPushImageTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/notification/service/DefaultPushImageTest.kt
@@ -1,0 +1,26 @@
+package com.depromeet.piki.notification.service
+
+import com.depromeet.piki.common.storage.S3Properties
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import kotlin.test.assertEquals
+
+// 시스템 알림 기본 아바타 URL 조립 — publicBaseUrl + defaults/push-icon.svg. Spring 없이 순수 조립 로직만 검증.
+class DefaultPushImageTest {
+    @Test
+    fun `publicBaseUrl 에 defaults push-icon 경로를 붙인다`() {
+        val pushImage = DefaultPushImage(S3Properties(bucket = "b", publicBaseUrl = "https://cdn.example"))
+
+        assertEquals("https://cdn.example/defaults/push-icon.svg", pushImage.url)
+    }
+
+    // publicBaseUrl 끝 슬래시는 무시한다(// 중복 방지) — DefaultProfileImages 와 동일 규칙.
+    @ParameterizedTest
+    @ValueSource(strings = ["https://cdn.example", "https://cdn.example/"])
+    fun `끝 슬래시 유무와 무관하게 슬래시 하나로 이어붙인다`(base: String) {
+        val pushImage = DefaultPushImage(S3Properties(bucket = "b", publicBaseUrl = base))
+
+        assertEquals("https://cdn.example/defaults/push-icon.svg", pushImage.url)
+    }
+}

--- a/src/test/kotlin/com/depromeet/piki/notification/sse/NotificationSseIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/notification/sse/NotificationSseIntegrationTest.kt
@@ -3,6 +3,7 @@ package com.depromeet.piki.notification.sse
 import com.depromeet.piki.auth.infrastructure.jwt.JwtProvider
 import com.depromeet.piki.notification.controller.dto.NotificationSsePayload
 import com.depromeet.piki.notification.domain.Notification
+import com.depromeet.piki.notification.domain.NotificationCategory
 import com.depromeet.piki.notification.domain.NotificationKind
 import com.depromeet.piki.notification.domain.NotificationRouting
 import com.depromeet.piki.notification.domain.NotificationType
@@ -34,6 +35,9 @@ import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
+
+// 시스템 알림(actor 없음)의 imageUrl 을 채우는 기본 아바타 — 운영에선 DefaultPushImage 가 publicBaseUrl 로 조립한다.
+private const val DEFAULT_PUSH_IMAGE_URL = "https://img.test/defaults/push-icon.svg"
 
 // 구독 엔드포인트 contract 와 채널 전달을 실제 빈으로 검증한다.
 // 도메인 publish -> AFTER_COMMIT -> dispatcher -> 채널 리스트 순회는 토대(PR #288)의 통합 테스트가 이미 덮으므로,
@@ -212,10 +216,13 @@ class NotificationSseIntegrationTest : IntegrationTestSupport() {
                 ),
             )
 
-        val payload = NotificationSsePayload.from(notification)
+        val payload = NotificationSsePayload.from(notification, DEFAULT_PUSH_IMAGE_URL)
         val wish = assertIs<NotificationSsePayload.WishParsing>(payload)
         assertEquals(NotificationKind.WISH, wish.kind)
         assertEquals(11L, wish.refId)
+        // 시스템 알림(파싱·actor 없음) → category=SYSTEM, imageUrl 은 defaultPushImg 로 채워진다.
+        assertEquals(NotificationCategory.SYSTEM, wish.category)
+        assertEquals(DEFAULT_PUSH_IMAGE_URL, wish.imageUrl)
     }
 
     @Test
@@ -237,7 +244,7 @@ class NotificationSseIntegrationTest : IntegrationTestSupport() {
         entityManager.clear()
         val reloaded = notificationJpaRepository.findById(saved.getId()).orElseThrow()
 
-        val payload = NotificationSsePayload.from(reloaded)
+        val payload = NotificationSsePayload.from(reloaded, DEFAULT_PUSH_IMAGE_URL)
         val tournament = assertIs<NotificationSsePayload.TournamentParsing>(payload)
         assertEquals(NotificationKind.TOURNAMENT, tournament.kind)
         assertEquals(99L, tournament.tournamentId)
@@ -249,6 +256,9 @@ class NotificationSseIntegrationTest : IntegrationTestSupport() {
         assertEquals("TOURNAMENT", node.get("kind").asString())
         assertEquals(99L, node.get("tournamentId").asLong())
         assertEquals(555L, node.get("tournamentItemId").asLong())
+        // imageUrl·category 도 와이어에 실린다 — 시스템 알림이라 category=SYSTEM, imageUrl=defaultPushImg.
+        assertEquals("SYSTEM", node.get("category").asString())
+        assertEquals(DEFAULT_PUSH_IMAGE_URL, node.get("imageUrl").asString())
         // Jackson3+kotlin module 은 isRead 필드명으로 직렬화한다(모듈 없는 Jackson2 였으면 "read" 라 이 키가 없다).
         assertTrue(node.has("isRead"))
     }


### PR DESCRIPTION
## Situation

- 알림 히스토리·읽음·badge API(#471)는 머지됐지만, 디자이너와 합의한 알림센터의 **행위자 아바타**와 **활동/시스템 탭**이 아직 없어 FE 가 화면을 못 만든다.
- 후속 이슈 #473 은 (아바타 · 카테고리 · 신규 알림 타입 · 공지)를 한 덩어리로 담고 있는데, 그 중 **FE 가 당장 기다리는 부분(아바타 · 카테고리/탭 카운트)** 만 먼저 떼어 구현했다.
- 어드민(템플릿 백오피스 #250 · 전체공지 #391)과 신규 알림 타입, 공지 fan-out 은 데이터/운영 의존이라 이 PR 에서 제외했다.

## Task

- 사람 알림은 **행위자 프로필 사진**, 시스템 알림은 **피키 로고**로 아바타를 가른다. 단, 과거 알림은 발생 당시 사진으로 고정한다.
- 알림센터를 **활동 / 시스템** 탭으로 거른다. 앱 전체 badge 와 탭별 badge 를 둘 다 내려준다.
- 결정 포인트: 아바타를 발송 시점에 박을지(snapshot) 행위자 id 로 매번 조회할지, 카테고리를 스키마에 둘지 타입에서 파생할지, badge 를 서버가 줄지 클라가 계산할지.

## Action

### 아바타: 발송 시점 프로필 사진 snapshot

- 알림에 `actor_image_url` 컬럼을 더하고, 발송 시점 행위자의 프로필 사진 URL 을 그 행에 박는다. 이후 그 사람이 프사를 바꿔도 과거 알림은 그 시점 사진을 그대로 보여준다.
- 행위자 id 로 매번 조회(live)하지 않고 snapshot 으로 간 이유:
  - 알림 제목("세빈님이 ...")이 이미 발송 시점 닉네임을 박아 굳힌 값이다. 이미지만 live 로 조회하면 옛 이름에 새 얼굴이 붙어 어긋난다. 아바타도 굳혀야 이름과 짝이 맞는다.
  - 히스토리 목록은 단일 테이블 읽기인데, live 조회는 페이지당 행위자 수만큼 사용자 조인을 다시 들여 그 설계를 깬다.
  - 프로필 이미지는 업로드마다 새 키(immutable)라, snapshot 한 URL 이 옛 이미지를 계속 가리켜 안전하다(프사 변경 시 옛 객체를 지우지 않음을 코드로 확인).

### imageUrl 은 서버가 항상 채운다

- 응답 `imageUrl` 은 비지 않는다. 행위자가 있으면 그 프사, 없으면(시스템) 서버가 기본 이미지를 채운다. 클라는 null 분기 없이 그대로 아바타로 렌더하고, 사람/시스템 구분은 `category` 로 한다.
- 기본 이미지 URL 은 코드에 박지 않고 `publicBaseUrl` 에 `defaults/push-icon.svg` 를 이어 붙여 만든다(랜덤 기본 프사와 같은 방식). dev/prod 버킷 차이는 환경변수가 흡수한다.

### 카테고리: 타입에서 파생, 스키마 변경 없음

| 카테고리 | 타입 |
|---|---|
| 활동(ACTIVITY) | `TOURNAMENT_JOINED` · `TOURNAMENT_ITEM_ADDED` · `TOURNAMENT_STARTED` |
| 시스템(SYSTEM) | `ITEM_PARSING_COMPLETED` · `ITEM_PARSING_FAILED` |

- 카테고리는 저장하지 않고 타입에서 계산한다. 매핑 분기는 타입 전수라, 나중에 새 타입을 더하면 컴파일이 깨져 분류를 강제한다.
- `GET /notifications?category=` 로 거른다(미지정 시 전체). 커서 페이지네이션도 카테고리 필터와 함께 동작한다.
- 주의: 카테고리(주제)와 아바타(행위자 유무)는 별개 축이다. 예를 들어 토너먼트 종료는 활동이지만 행위자가 없어 아바타는 피키 로고다.

### badge: 서버 권위 값, 전체 + 탭별

- 목록·읽음 응답이 전체 안읽음 수(앱 badge)와 카테고리별 안읽음 수(탭 badge)를 함께 내려준다. 클라는 더하고 빼는 산수 대신 서버 값을 그대로 미러링한다.
- 한 번의 group-by 집계로 전체·탭별을 모두 구하고, 전체는 카테고리 합으로 도출해 두 수치가 어긋날 여지를 없앴다. 전체 badge 는 탭 필터와 무관하게 항상 전체다.
- 읽음 응답도 같은 셰입으로 줘서, 읽고 나면 앱 badge 와 탭 badge 를 한 왕복에서 같이 갱신한다.

### 세 채널 일관

- 목록(REST) · 실시간(SSE) · 푸시(FCM) 가 같은 규칙으로 `imageUrl` · `category` 를 싣는다. 클라가 어느 채널로 받든 같은 셰입으로 다룬다.

## Result

- FE 가 지금 API 로 **사람/시스템 아바타 + 활동/시스템 탭 + 탭별 badge** 까지 알림센터를 만들 수 있다.
- 검증에서 비자명한 부분: 행위자 프사를 발송 시점에 뽑아 저장하는 핵심 경로를 손으로 넣은 값이 아니라 실제 이벤트→발송→저장 체인으로 확인했고, 시스템 알림은 행위자가 없어 기본 이미지로 채워지는지 negative control 로 함께 검증했다.
- 한계: FCM 의 실제 기기 도착은 Firebase 자격증명·실 디바이스 토큰이 필요해 자동 테스트 밖이며, dev 의 자가 발송 엔드포인트로 스모크한다(이 PR 변경은 푸시 data 에 키 2개를 더한 것이라 위험은 낮다).
- 남은 후속(이 PR 범위 밖): 신규 알림 타입(토너먼트 종료 등), 공지(ANNOUNCEMENT)와 fan-out 모델, 어드민 백오피스, 사용자 공지사항 페이지.

---
## 연관 이슈

- 관련 #473 (이 PR 은 #473 중 아바타 · 카테고리/탭 카운트만 다룬다. 신규 타입 · 공지 · 어드민은 후속이라 close 하지 않는다.)


---
## Updates

리뷰 피드백 반영 (`0ab8278`):

**🔴 중요**
- **actor 조회 1회로 축소** — `ActorNameResolver.resolveAttributes` 단일 조회 + `NotificationEventHandler` 의 변수·프사 훅을 `resolveActorContext` 하나로 병합. actor 당 `findById` 2회 → 1회.
- **dead code 제거** — `NotificationRepository.countUnread` 및 유일 호출처였던 `countByUserIdAndIsReadFalse` 삭제(현재 전 경로가 `countUnreadByCategory` 사용).

**🟡 개선**
- **레이어 위반 해소** — `DefaultPushImage` 를 컨트롤러에서 서비스로 이동(`NotificationHistoryPage.defaultPushImageUrl` 경유). 컨트롤러는 더 이상 기본 아바타 조립을 모름.
- `NotificationSsePayload.from` 위치 인자 → 이름 인자(8~9개 인자 순서 실수 방지).
- `countUnreadByCategory` fold → `mutable merge`(매 row Map 재생성 제거).
- `NotificationCategory.typesOf` 결과를 클래스 로딩 시 1회 역색인 캐싱(요청마다 전수 순회 제거).

**테스트**
- dispatch end-to-end 테스트에 `actorName` 제목 렌더 단언 추가 — 병합한 `resolveActorContext` 의 변수·프사가 한 조회에서 함께 흐르는지 가드.
- notification 스위트 전체 그린(JDK 25 컴파일·테스트 확인).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 알림 히스토리 조회에 카테고리 필터링 추가 - 활동/시스템별로 알림을 구분하여 조회 가능
  * 미확인 알림 수 정보 확대 - 앱 배지(전체)와 탭별 배지(카테고리별)를 함께 제공

* **Improvements**
  * 알림 아이콘 및 이미지 스냅샷 저장으로 시간 경과 후에도 일관된 이미지 표시

<!-- end of auto-generated comment: release notes by coderabbit.ai -->