### PR TITLE
토너먼트 단건 조회 응답에 sourceTournamentId 추가

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
@@ -73,6 +73,7 @@ interface TournamentApi {
             토너먼트 ID로 상태에 따른 상세 정보를 조회한다.
             isOwner: 요청자가 해당 토너먼트 인스턴스(ROOT 또는 CLONE)의 소유자이면 true.
             isRoot: 소셜 토너먼트 원본(ROOT)이면 true, 멤버·플레이링크용 복사본(CLONE)이면 false. 솔로 토너먼트는 항상 true.
+            sourceTournamentId: CLONE 토너먼트이면 원본 ROOT의 id, ROOT이면 null. 게스트는 이 id로 GET /tournaments/{sourceTournamentId}/group-result를 호출한다.
             플레이 링크 공유는 isRoot && isOwner 일 때만 허용된다. isOwner 단독으로 분기하면 CLONE 소유자에게도 공유 버튼이 노출되어 시안 위반이다.
             응답의 status 필드에 따라 포함되는 데이터가 달라진다.
             - PENDING: pending 필드 (아이템 목록, 참여자 목록)

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApiExamples.kt
@@ -245,6 +245,7 @@ class TournamentApiExamples(
                                         status = TournamentStatus.PENDING,
                                         isOwner = true,
                                         isRoot = true,
+                                        sourceTournamentId = null,
                                         pending =
                                             TournamentDetailResponse.PendingData(
                                                 inviteCode = "ABC123",
@@ -299,6 +300,7 @@ class TournamentApiExamples(
                                         status = TournamentStatus.IN_PROGRESS,
                                         isOwner = false,
                                         isRoot = true,
+                                        sourceTournamentId = null,
                                         pending =
                                             TournamentDetailResponse.PendingData(
                                                 inviteCode = null,
@@ -348,15 +350,16 @@ class TournamentApiExamples(
                         )
                         add(
                             status = HttpStatus.OK,
-                            name = "IN_PROGRESS - 진행 중 복원",
+                            name = "IN_PROGRESS - 진행 중 복원 (CLONE)",
                             payload =
                                 ApiResponseBody.ok(
                                     TournamentDetailResponse(
-                                        tournamentId = 1,
+                                        tournamentId = 2,
                                         name = "내 토너먼트",
                                         status = TournamentStatus.IN_PROGRESS,
                                         isOwner = false,
                                         isRoot = false,
+                                        sourceTournamentId = 1,
                                         pending = null,
                                         inProgress =
                                             TournamentDetailResponse.InProgressData(
@@ -405,6 +408,7 @@ class TournamentApiExamples(
                                         status = TournamentStatus.COMPLETED,
                                         isOwner = true,
                                         isRoot = true,
+                                        sourceTournamentId = null,
                                         pending = null,
                                         inProgress = null,
                                         completed =

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/dto/TournamentDetailResponse.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/dto/TournamentDetailResponse.kt
@@ -16,6 +16,9 @@ data class TournamentDetailResponse(
     // ROOT(소셜 토너먼트 원본) 이면 true, CLONE(멤버·플레이링크용 복사본) 이면 false.
     // 플레이 링크 공유는 isRoot && isOwner 일 때만 허용된다.
     val isRoot: Boolean,
+    // CLONE 토너먼트이면 원본 ROOT id, ROOT 토너먼트이면 null.
+    // 게스트 클라이언트는 이 id 로 GET /tournaments/{sourceTournamentId}/group-result 를 호출한다.
+    val sourceTournamentId: Long?,
     val pending: PendingData?,
     val inProgress: InProgressData?,
     val completed: CompletedData?,
@@ -109,6 +112,7 @@ data class TournamentDetailResponse(
                         status = if (detail.ownerStarted) TournamentStatus.IN_PROGRESS else TournamentStatus.PENDING,
                         isOwner = detail.isOwner,
                         isRoot = detail.isRoot,
+                        sourceTournamentId = detail.sourceTournamentId,
                         pending =
                             PendingData(
                                 inviteCode = if (detail.ownerStarted) null else detail.inviteCode,
@@ -128,6 +132,7 @@ data class TournamentDetailResponse(
                         status = TournamentStatus.IN_PROGRESS,
                         isOwner = detail.isOwner,
                         isRoot = detail.isRoot,
+                        sourceTournamentId = detail.sourceTournamentId,
                         pending = null,
                         inProgress =
                             InProgressData(
@@ -145,6 +150,7 @@ data class TournamentDetailResponse(
                         status = TournamentStatus.COMPLETED,
                         isOwner = detail.isOwner,
                         isRoot = detail.isRoot,
+                        sourceTournamentId = detail.sourceTournamentId,
                         pending = null,
                         inProgress = null,
                         completed = CompletedData.from(detail),

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
@@ -321,6 +321,7 @@ class TournamentService(
                         },
                     isOwner = isOwner,
                     isRoot = isRoot,
+                    sourceTournamentId = tournament.sourceTournamentId,
                 )
             }
 
@@ -376,6 +377,7 @@ class TournamentService(
                     remainingItems = remainingItems,
                     isOwner = isOwner,
                     isRoot = isRoot,
+                    sourceTournamentId = tournament.sourceTournamentId,
                 )
             }
 
@@ -614,6 +616,7 @@ class TournamentService(
             isOwner = isOwner,
             isRoot = isRoot,
             playLinkExpiresAt = tournament.playLinkExpiresAt,
+            sourceTournamentId = tournament.sourceTournamentId,
         )
     }
 

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/dto/TournamentDetail.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/dto/TournamentDetail.kt
@@ -17,6 +17,7 @@ sealed class TournamentDetail {
         // ROOT 가 IN_PROGRESS 로 전환됐으나 이 멤버는 아직 매치를 시작하지 않은 상태.
         // true 이면 클라이언트가 "주최자가 시작했습니다, 지금 시작하세요" UI 를 보여야 한다.
         val ownerStarted: Boolean = false,
+        val sourceTournamentId: Long? = null,
     ) : TournamentDetail()
 
     data class InProgress(
@@ -27,6 +28,7 @@ sealed class TournamentDetail {
         val remainingItems: List<ItemDetail>,
         val isOwner: Boolean,
         val isRoot: Boolean,
+        val sourceTournamentId: Long? = null,
     ) : TournamentDetail()
 
     data class Completed(
@@ -37,6 +39,7 @@ sealed class TournamentDetail {
         val isOwner: Boolean,
         val isRoot: Boolean,
         val playLinkExpiresAt: java.time.LocalDateTime?,
+        val sourceTournamentId: Long? = null,
     ) : TournamentDetail()
 
     data class ItemDetail(

--- a/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
@@ -1050,6 +1050,44 @@ class TournamentControllerTest : IntegrationTestSupport() {
     }
 
     @Test
+    fun `GET tournaments-id 는 ROOT 토너먼트 응답에 sourceTournamentId 가 없다`() {
+        val mockMvc = buildMockMvc()
+        val tournamentId = createTournament(mockMvc)
+
+        mockMvc
+            .perform(
+                get("/api/v1/tournaments/$tournamentId")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(userId)),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.sourceTournamentId").doesNotExist())
+    }
+
+    @Test
+    fun `GET tournaments-id 는 CLONE 토너먼트 응답에 sourceTournamentId 로 ROOT id 를 내려준다`() {
+        val mockMvc = buildMockMvc()
+        saveUser(otherUserId, "https://cdn.example.com/guest.jpg", "게스트")
+        val (rootId) = completeTournamentWith2Items(mockMvc)
+        mockMvc.perform(
+            post("/api/v1/tournaments/$rootId/play-link")
+                .header(HttpHeaders.AUTHORIZATION, authHeader(userId))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"),
+        )
+        val cloneResult = mockMvc.perform(
+            post("/api/v1/tournaments/$rootId/from-play-link")
+                .header(HttpHeaders.AUTHORIZATION, authHeader(otherUserId)),
+        ).andReturn()
+        val cloneId = objectMapper.readTree(cloneResult.response.contentAsString)["data"].asLong()
+
+        mockMvc
+            .perform(
+                get("/api/v1/tournaments/$cloneId")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(otherUserId)),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.sourceTournamentId").value(rootId))
+    }
+
+    @Test
     fun `DELETE tournaments-id-items-itemId 는 PENDING 토너먼트에서 아이템을 삭제하고 200 을 반환한다`() {
         val mockMvc = buildMockMvc()
         val tournamentId = createTournament(mockMvc)


### PR DESCRIPTION
## Situation

- PR #482 에서 게스트(플레이링크 참여자)도 그룹 결과를 조회할 수 있도록 권한 게이트를 열었다.
- 그런데 게스트 결과 화면(`/tournament/{CLONE_id}/result`)은 CLONE id만 들고 있어, ROOT id를 알 방법이 없었다.
- `GET /tournaments/{id}` 응답에 `sourceTournamentId`가 없으므로, 클라이언트가 `GET /tournaments/{sourceTournamentId}/group-result`를 호출할 수 없는 상태였다.

## Task

- `GET /tournaments/{id}` 응답에 ROOT id를 노출해, 게스트가 결과 화면에서 그룹 결과를 바로 조회할 수 있게 한다.
- 구현 방향을 두 가지로 검토했다.
  - A) CLONE 응답에 `sourceTournamentId` 추가: 클라이언트가 그 id로 group-result를 호출한다.
  - B) CLONE id로 group-result 호출 시 서버가 자동으로 ROOT 결과를 반환: 클라이언트 코드 변경이 거의 없다.
- B는 엔드포인트 계약이 흐릿해지고(`{id}` group-result가 실제로는 다른 토너먼트 결과를 반환), 향후 CLONE 자체 결과가 필요한 시나리오에서 분기가 복잡해져 A를 선택했다.

## Action

- `TournamentDetailResponse`에 `sourceTournamentId: Long?` 필드를 추가한다.
- CLONE 토너먼트이면 ROOT id, ROOT 토너먼트이면 null을 반환한다.
- `@JsonInclude(NON_NULL)` 이 적용돼 있어 ROOT 응답에서는 필드 자체가 JSON에서 생략된다.
- Pending / InProgress / Completed 세 상태 모두 동일하게 포함했다. 서비스 레이어의 `TournamentDetail` 서브클래스에도 필드를 추가해 매핑 계층이 일관되게 흘러가도록 했다.
- OpenAPI 문서(description + example)를 함께 갱신했다. CLONE 예시(`isRoot=false`)에 `sourceTournamentId: 1`을 박아 계약을 명시했다.

## Result

- 게스트 클라이언트는 CLONE 응답의 `sourceTournamentId`를 들고 `GET /tournaments/{sourceTournamentId}/group-result`를 호출할 수 있게 된다.
- ROOT 응답(`sourceTournamentId: null`)과 CLONE 응답(`sourceTournamentId: <rootId>`) 두 케이스를 통합 테스트로 계약 고정했다.

---
## 연관 이슈

- close #485


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 토너먼트 상세 조회 API 응답에 소스 토너먼트 ID 필드 추가. CLONE 토너먼트는 원본 ROOT 토너먼트의 ID를, ROOT 토너먼트는 null 값을 반환합니다.

* **Documentation**
  * API 문서와 응답 예시에서 새 필드에 대한 설명 및 사용 사례 업데이트.

* **Tests**
  * 소스 토너먼트 ID 필드 반환 값 검증 테스트 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->