### PR TITLE
feat: 신규 알림 타입 4종 (플레이링크 플레이·완료·결과 + 공지 enum 선반영)

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/notification/domain/NotificationCategory.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/domain/NotificationCategory.kt
@@ -16,10 +16,14 @@ enum class NotificationCategory {
                 NotificationType.TOURNAMENT_JOINED,
                 NotificationType.TOURNAMENT_ITEM_ADDED,
                 NotificationType.TOURNAMENT_STARTED,
+                NotificationType.TOURNAMENT_PLAYED_FROM_LINK,
+                NotificationType.TOURNAMENT_COMPLETED,
+                NotificationType.TOURNAMENT_RESULT_READY,
                 -> ACTIVITY
 
                 NotificationType.ITEM_PARSING_COMPLETED,
                 NotificationType.ITEM_PARSING_FAILED,
+                NotificationType.ANNOUNCEMENT,
                 -> SYSTEM
             }
 

--- a/src/main/kotlin/com/depromeet/piki/notification/domain/NotificationType.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/domain/NotificationType.kt
@@ -6,6 +6,13 @@ enum class NotificationType {
     TOURNAMENT_JOINED,
     TOURNAMENT_ITEM_ADDED,
     TOURNAMENT_STARTED,
+    // 플레이링크로 내 토너먼트를 누군가 플레이/완료한 사실 — ROOT 주최자에게 간다(actor=플레이/완료한 사람).
+    TOURNAMENT_PLAYED_FROM_LINK,
+    TOURNAMENT_COMPLETED,
+    // 내가 참여한 토너먼트를 주최자가 완료해 결과가 나온 사실 — 참여자에게 간다(actor=주최자).
+    TOURNAMENT_RESULT_READY,
     ITEM_PARSING_COMPLETED,
     ITEM_PARSING_FAILED,
+    // 전체 공지(#391/#250). 트리거(admin 백오피스)·발행은 후속 — 지금은 분류/필터용 enum 만 선반영한다.
+    ANNOUNCEMENT,
 }

--- a/src/main/kotlin/com/depromeet/piki/notification/handler/TournamentCompletedHandler.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/handler/TournamentCompletedHandler.kt
@@ -1,0 +1,24 @@
+package com.depromeet.piki.notification.handler
+
+import com.depromeet.piki.notification.domain.NotificationType
+import com.depromeet.piki.tournament.event.TournamentCompleted
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+// 멤버/게스트가 자기 클론(=내 토너먼트의 클론)을 완료하면 ROOT 주최자에게 "OO님이 회원님 토너먼트를 완료했어요" 를 보낸다.
+// 수신자 = 원본(ROOT) 주최자. actor(완료한 사람)가 곧 주최자면 제외(− actorId). (ROOT 자체 완료는 TournamentResultReady 가 담당)
+@Component
+class TournamentCompletedHandler(
+    private val recipientResolver: TournamentNotificationRecipientResolver,
+    private val actorNameResolver: ActorNameResolver,
+) : NotificationEventHandler<TournamentCompleted>(NotificationType.TOURNAMENT_COMPLETED) {
+    override fun resolveRefId(event: TournamentCompleted): Long = event.rootTournamentId
+
+    override fun resolveRecipients(event: TournamentCompleted): Set<UUID> =
+        recipientResolver.rootOwner(event.rootTournamentId) - event.actorId
+
+    override fun resolveActorContext(event: TournamentCompleted): ActorContext {
+        val actor = actorNameResolver.resolveAttributes(event.actorId)
+        return ActorContext(variables = mapOf("actorName" to actor.name), imageUrl = actor.profileImage)
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/notification/handler/TournamentNotificationRecipientResolver.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/handler/TournamentNotificationRecipientResolver.kt
@@ -1,0 +1,36 @@
+package com.depromeet.piki.notification.handler
+
+import com.depromeet.piki.tournament.repository.TournamentRepository
+import com.depromeet.piki.tournament.repository.TournamentUserRepository
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+// 플레이링크/완료/결과 알림의 수신자를 ROOT 토너먼트 기준으로 역조회한다. 세 핸들러가 공유하는 단일 도출 지점이라
+// "ROOT 주최자가 누구냐 / 결과 참여자가 누구냐" 규칙을 여기 한 곳에 둔다 (ItemParsingRecipientResolver 와 같은 결).
+//
+// 못 찾으면(데이터 불일치) 빈 집합을 돌려 알림을 떨군다 — 알림은 best-effort 라 수신자 한 명을 못 풀었다고 던지지 않는다.
+// actor(주최자 본인) 제외는 호출하는 핸들러가 `- event.actorId` 로 적용한다(수신자 규칙과 제외 규칙을 한 곳에 묶지 않는다).
+@Component
+class TournamentNotificationRecipientResolver(
+    private val tournamentRepository: TournamentRepository,
+    private val tournamentUserRepository: TournamentUserRepository,
+) {
+    // 플레이/완료 알림 수신자 = ROOT 주최자 1명. ROOT 의 ownerTournamentUserId → 그 TournamentUser 의 userId.
+    fun rootOwner(rootTournamentId: Long): Set<UUID> {
+        val root = tournamentRepository.findTournamentById(rootTournamentId) ?: return emptySet()
+        return tournamentUserRepository
+            .findByIds(setOf(root.ownerTournamentUserId))
+            .firstOrNull()
+            ?.let { setOf(it.userId) }
+            ?: emptySet()
+    }
+
+    // 결과 알림 수신자 = ROOT 참가자(아이템 등록·합류) ∪ 플레이링크 클론 소유자(게스트 포함).
+    // 토큰 있는 사람에게만 푸시가 가고, 없으면 히스토리에만 적재된다(#473 — GUEST 도 토너먼트 푸시 대상).
+    fun resultParticipants(rootTournamentId: Long): Set<UUID> {
+        val rootParticipants = tournamentUserRepository.findByTournamentId(rootTournamentId).map { it.userId }
+        val cloneOwnerTuIds = tournamentRepository.findBySourceTournamentId(rootTournamentId).map { it.ownerTournamentUserId }
+        val cloneOwners = tournamentUserRepository.findByIds(cloneOwnerTuIds.toSet()).map { it.userId }
+        return (rootParticipants + cloneOwners).toSet()
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/notification/handler/TournamentPlayedFromLinkHandler.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/handler/TournamentPlayedFromLinkHandler.kt
@@ -1,0 +1,24 @@
+package com.depromeet.piki.notification.handler
+
+import com.depromeet.piki.notification.domain.NotificationType
+import com.depromeet.piki.tournament.event.TournamentPlayedFromLink
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+// 플레이링크로 누군가 내 토너먼트를 플레이하기 시작하면 ROOT 주최자에게 "OO님이 회원님 토너먼트를 플레이했어요" 를 보낸다.
+// 수신자 = 원본(ROOT) 주최자. actor(플레이한 사람)가 곧 주최자면 제외(− actorId)해 자기 알림을 막는다.
+@Component
+class TournamentPlayedFromLinkHandler(
+    private val recipientResolver: TournamentNotificationRecipientResolver,
+    private val actorNameResolver: ActorNameResolver,
+) : NotificationEventHandler<TournamentPlayedFromLink>(NotificationType.TOURNAMENT_PLAYED_FROM_LINK) {
+    override fun resolveRefId(event: TournamentPlayedFromLink): Long = event.rootTournamentId
+
+    override fun resolveRecipients(event: TournamentPlayedFromLink): Set<UUID> =
+        recipientResolver.rootOwner(event.rootTournamentId) - event.actorId
+
+    override fun resolveActorContext(event: TournamentPlayedFromLink): ActorContext {
+        val actor = actorNameResolver.resolveAttributes(event.actorId)
+        return ActorContext(variables = mapOf("actorName" to actor.name), imageUrl = actor.profileImage)
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/notification/handler/TournamentResultReadyHandler.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/handler/TournamentResultReadyHandler.kt
@@ -1,0 +1,24 @@
+package com.depromeet.piki.notification.handler
+
+import com.depromeet.piki.notification.domain.NotificationType
+import com.depromeet.piki.tournament.event.TournamentResultReady
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+// 주최자가 자기 토너먼트(ROOT)를 완료하면 참여자에게 "참여하신 OO님의 토너먼트 결과가 나왔어요" 를 보낸다.
+// 수신자 = ROOT 참가자 ∪ 플레이링크 클론 소유자(게스트 포함) − 주최자 본인(actor). actor=주최자라 문구의 OO 는 주최자 이름·프사다.
+@Component
+class TournamentResultReadyHandler(
+    private val recipientResolver: TournamentNotificationRecipientResolver,
+    private val actorNameResolver: ActorNameResolver,
+) : NotificationEventHandler<TournamentResultReady>(NotificationType.TOURNAMENT_RESULT_READY) {
+    override fun resolveRefId(event: TournamentResultReady): Long = event.rootTournamentId
+
+    override fun resolveRecipients(event: TournamentResultReady): Set<UUID> =
+        recipientResolver.resultParticipants(event.rootTournamentId) - event.actorId
+
+    override fun resolveActorContext(event: TournamentResultReady): ActorContext {
+        val actor = actorNameResolver.resolveAttributes(event.actorId)
+        return ActorContext(variables = mapOf("actorName" to actor.name), imageUrl = actor.profileImage)
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/notification/service/InMemoryNotificationTemplateProvider.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/service/InMemoryNotificationTemplateProvider.kt
@@ -15,10 +15,19 @@ class InMemoryNotificationTemplateProvider : NotificationTemplateProvider {
                 NotificationTemplate(title = "\${actorName}님이 아이템을 추가했어요", body = ""),
             NotificationType.TOURNAMENT_STARTED to
                 NotificationTemplate(title = "\${actorName}님이 토너먼트를 시작했어요", body = ""),
+            NotificationType.TOURNAMENT_PLAYED_FROM_LINK to
+                NotificationTemplate(title = "\${actorName}님이 회원님 토너먼트를 플레이했어요", body = ""),
+            NotificationType.TOURNAMENT_COMPLETED to
+                NotificationTemplate(title = "\${actorName}님이 회원님 토너먼트를 완료했어요", body = ""),
+            NotificationType.TOURNAMENT_RESULT_READY to
+                NotificationTemplate(title = "참여하신 \${actorName}님의 토너먼트 결과가 나왔어요", body = ""),
             NotificationType.ITEM_PARSING_COMPLETED to
                 NotificationTemplate(title = "상품 정보가 저장됐어요", body = ""),
             NotificationType.ITEM_PARSING_FAILED to
                 NotificationTemplate(title = "상품 정보를 가져오지 못했어요", body = ""),
+            // 공지 본문은 추후 admin 백오피스가 변수(title·body)로 채운다(#391/#250). 트리거 전까진 발송되지 않는 placeholder.
+            NotificationType.ANNOUNCEMENT to
+                NotificationTemplate(title = "\${title}", body = "\${body}"),
         )
 
     // 시작 시점 전수 검증 — enum 에 새 타입을 추가하고 여기 시드를 빠뜨리면, 첫 발송(런타임)이 아니라

--- a/src/main/kotlin/com/depromeet/piki/tournament/event/TournamentCompleted.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/event/TournamentCompleted.kt
@@ -1,0 +1,11 @@
+package com.depromeet.piki.tournament.event
+
+import java.util.UUID
+
+// 멤버/게스트가 자기 클론(=내 토너먼트의 클론)을 끝까지 플레이해 완료한 사실 — 도메인 사실. recordMatch 결승 → complete() 시점이며,
+// 완료된 토너먼트가 CLONE(sourceTournamentId 있음)일 때만 발행한다. rootTournamentId 는 원본(ROOT), actorId 는 완료한 사람.
+// 수신자(ROOT 주최자)에게 "OO님이 완료했어요" 를 알린다. (ROOT 자체 완료=주최자 본인 완료는 TournamentResultReady 로 간다.)
+data class TournamentCompleted(
+    val rootTournamentId: Long,
+    val actorId: UUID,
+)

--- a/src/main/kotlin/com/depromeet/piki/tournament/event/TournamentPlayedFromLink.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/event/TournamentPlayedFromLink.kt
@@ -1,0 +1,11 @@
+package com.depromeet.piki.tournament.event
+
+import java.util.UUID
+
+// 플레이링크로 누군가 내 토너먼트를 플레이하기 시작한 사실 — 도메인 사실. createFromPlayLink 의 신규 클론 생성 시점이다.
+// rootTournamentId 는 원본(ROOT) 토너먼트, actorId 는 링크로 플레이를 시작한 사람. 수신자(ROOT 주최자)에게 알려,
+// 링크를 뿌린 주최자가 누가 참여했는지 앱을 일일이 안 열어봐도 알게 한다.
+data class TournamentPlayedFromLink(
+    val rootTournamentId: Long,
+    val actorId: UUID,
+)

--- a/src/main/kotlin/com/depromeet/piki/tournament/event/TournamentResultReady.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/event/TournamentResultReady.kt
@@ -1,0 +1,11 @@
+package com.depromeet.piki.tournament.event
+
+import java.util.UUID
+
+// 주최자가 자기 토너먼트(ROOT)를 완료해 결과가 나온 사실 — 도메인 사실. recordMatch 결승 → complete() 시점이며,
+// 완료된 토너먼트가 ROOT(sourceTournamentId 없음=주최자 본인 진행)일 때만 발행한다. rootTournamentId 는 그 ROOT, actorId 는 주최자.
+// 수신자(참여자 − 주최자: ROOT 참가자 + 플레이링크 클론 소유자)에게 "참여하신 OO님의 토너먼트 결과가 나왔어요" 를 알린다.
+data class TournamentResultReady(
+    val rootTournamentId: Long,
+    val actorId: UUID,
+)

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
@@ -8,8 +8,11 @@ import com.depromeet.piki.tournament.domain.TournamentHistory
 import com.depromeet.piki.tournament.domain.TournamentItem
 import com.depromeet.piki.tournament.domain.TournamentStatus
 import com.depromeet.piki.tournament.domain.TournamentUser
+import com.depromeet.piki.tournament.event.TournamentCompleted
 import com.depromeet.piki.tournament.event.TournamentItemAdded
 import com.depromeet.piki.tournament.event.TournamentJoined
+import com.depromeet.piki.tournament.event.TournamentPlayedFromLink
+import com.depromeet.piki.tournament.event.TournamentResultReady
 import com.depromeet.piki.tournament.event.TournamentStarted
 import com.depromeet.piki.tournament.repository.TournamentItemRepository
 import com.depromeet.piki.tournament.repository.TournamentRepository
@@ -572,6 +575,15 @@ class TournamentService(
         tournamentUser.complete()
         tournament.complete()
 
+        // 완료 알림 발행(#473). CLONE 완료(멤버/게스트) → ROOT 주최자에게 "완료했어요",
+        // ROOT 완료(주최자 본인 진행) → 참여자에게 "결과 나왔어요". rootId 는 클론이면 원본, ROOT 면 자기 자신.
+        val rootTournamentId = tournament.sourceTournamentId ?: tournament.getId()
+        if (tournament.sourceTournamentId != null) {
+            eventPublisher.publishEvent(TournamentCompleted(rootTournamentId = rootTournamentId, actorId = userId))
+        } else {
+            eventPublisher.publishEvent(TournamentResultReady(rootTournamentId = rootTournamentId, actorId = userId))
+        }
+
         val isOwner = tournamentUser.getId() == tournament.ownerTournamentUserId
         return buildCompleted(tournament, histories + newHistory, computeHasGroupResult(tournament), isOwner)
     }
@@ -781,6 +793,8 @@ class TournamentService(
             TournamentUser(tournamentId = newTournament.getId(), userId = userId),
         )
         newTournament.assignOwner(tournamentUser.getId())
+        // 플레이링크로 새 클론을 만들어 플레이를 시작한 사실을 ROOT 주최자에게 알린다(#473). get-or-create 의 신규 생성 분기에서만 발행한다.
+        eventPublisher.publishEvent(TournamentPlayedFromLink(rootTournamentId = sourceTournamentId, actorId = userId))
         // CLONE 은 DB 에 아이템 행을 두지 않는다. getEffectiveTournamentItems 가 sourceTournamentId 경유로 원본 아이템을 해소한다.
         return newTournament.getId()
     }

--- a/src/test/kotlin/com/depromeet/piki/notification/domain/NotificationCategoryTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/notification/domain/NotificationCategoryTest.kt
@@ -12,8 +12,12 @@ class NotificationCategoryTest {
         "TOURNAMENT_JOINED, ACTIVITY",
         "TOURNAMENT_ITEM_ADDED, ACTIVITY",
         "TOURNAMENT_STARTED, ACTIVITY",
+        "TOURNAMENT_PLAYED_FROM_LINK, ACTIVITY",
+        "TOURNAMENT_COMPLETED, ACTIVITY",
+        "TOURNAMENT_RESULT_READY, ACTIVITY",
         "ITEM_PARSING_COMPLETED, SYSTEM",
         "ITEM_PARSING_FAILED, SYSTEM",
+        "ANNOUNCEMENT, SYSTEM",
     )
     fun `type 별 카테고리 매핑`(
         type: NotificationType,
@@ -31,11 +35,22 @@ class NotificationCategoryTest {
     @Test
     fun `typesOf 는 그 카테고리에 속한 type 만 돌려준다`() {
         assertEquals(
-            listOf(NotificationType.TOURNAMENT_JOINED, NotificationType.TOURNAMENT_ITEM_ADDED, NotificationType.TOURNAMENT_STARTED),
+            listOf(
+                NotificationType.TOURNAMENT_JOINED,
+                NotificationType.TOURNAMENT_ITEM_ADDED,
+                NotificationType.TOURNAMENT_STARTED,
+                NotificationType.TOURNAMENT_PLAYED_FROM_LINK,
+                NotificationType.TOURNAMENT_COMPLETED,
+                NotificationType.TOURNAMENT_RESULT_READY,
+            ),
             NotificationCategory.typesOf(NotificationCategory.ACTIVITY),
         )
         assertEquals(
-            listOf(NotificationType.ITEM_PARSING_COMPLETED, NotificationType.ITEM_PARSING_FAILED),
+            listOf(
+                NotificationType.ITEM_PARSING_COMPLETED,
+                NotificationType.ITEM_PARSING_FAILED,
+                NotificationType.ANNOUNCEMENT,
+            ),
             NotificationCategory.typesOf(NotificationCategory.SYSTEM),
         )
     }

--- a/src/test/kotlin/com/depromeet/piki/notification/flow/NotificationTournamentFlowIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/notification/flow/NotificationTournamentFlowIntegrationTest.kt
@@ -1,0 +1,156 @@
+package com.depromeet.piki.notification.flow
+
+import com.depromeet.piki.auth.infrastructure.jwt.JwtProvider
+import com.depromeet.piki.notification.fcm.service.UserDeviceService
+import com.depromeet.piki.notification.repository.NotificationRepository
+import com.depromeet.piki.notification.service.DefaultPushImage
+import com.depromeet.piki.notification.service.NotificationDispatcher
+import com.depromeet.piki.support.IntegrationTestSupport
+import com.depromeet.piki.tournament.domain.Tournament
+import com.depromeet.piki.tournament.domain.TournamentUser
+import com.depromeet.piki.tournament.event.TournamentCompleted
+import com.depromeet.piki.tournament.event.TournamentResultReady
+import com.depromeet.piki.tournament.repository.TournamentRepository
+import com.depromeet.piki.tournament.repository.TournamentUserRepository
+import com.depromeet.piki.user.domain.IdentityType
+import com.depromeet.piki.user.domain.User
+import com.depromeet.piki.user.repository.UserRepository
+import org.hamcrest.Matchers.containsString
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.context.WebApplicationContext
+import java.time.LocalDateTime
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+// 신규 토너먼트 알림(#473)의 전체 flow 통합 검증:
+// 유저 진입(회원·게스트 생성) → FCM 토큰 등록 → 토너먼트 결과 발송(dispatch) → 수신자 히스토리 조회 → 읽음 처리.
+// @Transactional 테스트는 AFTER_COMMIT 리스너가 안 뜨므로, 발송은 dispatcher 로 직접 구동한다
+// (recordMatch/createFromPlayLink → 이벤트 발행은 TournamentServiceTest 가 단위로 커버).
+@Transactional
+class NotificationTournamentFlowIntegrationTest : IntegrationTestSupport() {
+    @Autowired private lateinit var webApplicationContext: WebApplicationContext
+
+    @Autowired private lateinit var jwtProvider: JwtProvider
+
+    @Autowired private lateinit var userRepository: UserRepository
+
+    @Autowired private lateinit var userDeviceService: UserDeviceService
+
+    @Autowired private lateinit var tournamentRepository: TournamentRepository
+
+    @Autowired private lateinit var tournamentUserRepository: TournamentUserRepository
+
+    @Autowired private lateinit var notificationDispatcher: NotificationDispatcher
+
+    @Autowired private lateinit var notificationRepository: NotificationRepository
+
+    @Autowired private lateinit var defaultPushImage: DefaultPushImage
+
+    private fun mockMvc(): MockMvc =
+        MockMvcBuilders
+            .webAppContextSetup(webApplicationContext)
+            .apply<DefaultMockMvcBuilder>(springSecurity())
+            .build()
+
+    private fun authHeader(userId: UUID): String = "Bearer ${jwtProvider.generateAccessToken(userId, IdentityType.MEMBER)}"
+
+    @Test
+    fun `유저 진입 → 토큰 등록 → 토너먼트 결과 발송 → 히스토리 조회 → 읽음 까지 전체 flow`() {
+        // 1) 유저 진입 — 주최자(회원) · 참여자(회원)
+        val owner = saveUser("주최자", "https://img/owner.png", IdentityType.MEMBER)
+        val participant = saveUser("참여자", "https://img/part.png", IdentityType.MEMBER)
+        val rootId = createRootWithOwnerAndParticipant(owner, participant)
+
+        // 2) 참여자가 앱 진입 시 FCM 토큰 등록 (게스트·회원 모두 가능 — 푸시 전달 경로 확보)
+        userDeviceService.register(participant, deviceId = "device-1", fcmToken = "fcm-token-1")
+        assertEquals(listOf("fcm-token-1"), userDeviceService.findTokens(participant))
+
+        // 3) 주최자가 ROOT 를 완료 → 결과 알림 발송(참여자 − 주최자 에게). actor=주최자.
+        notificationDispatcher.dispatch(TournamentResultReady(rootTournamentId = rootId, actorId = owner))
+
+        // 4) 발송 결과 — 참여자에게 RESULT_READY 1건이 actor(주최자) 프사 snapshot 과 함께 저장된다.
+        val saved = notificationRepository.findPage(participant, cursor = null, limit = 10, types = null)
+        assertEquals(1, saved.size)
+        assertEquals("https://img/owner.png", saved.first().actorImageUrl) // 주최자 프사 snapshot
+
+        // 5) 참여자 히스토리 조회 (GET /notifications) — type·category·imageUrl·title 이 셰입대로 내려온다.
+        val mvc = mockMvc()
+        mvc
+            .perform(get("/api/v1/notifications").header(HttpHeaders.AUTHORIZATION, authHeader(participant)))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.items.length()").value(1))
+            .andExpect(jsonPath("$.data.items[0].type").value("TOURNAMENT_RESULT_READY"))
+            .andExpect(jsonPath("$.data.items[0].category").value("ACTIVITY"))
+            .andExpect(jsonPath("$.data.items[0].imageUrl").value("https://img/owner.png"))
+            .andExpect(jsonPath("$.data.items[0].title", containsString("주최자")))
+            .andExpect(jsonPath("$.data.items[0].isRead").value(false))
+            .andExpect(jsonPath("$.data.unreadCount").value(1))
+            .andExpect(jsonPath("$.data.unreadCountByCategory.ACTIVITY").value(1))
+            .andExpect(jsonPath("$.data.unreadCountByCategory.SYSTEM").value(0))
+
+        // 6) 참여자가 읽음 처리 (POST /read all) — 처리 후 안읽음 수 0 을 서버 권위값으로 돌려준다.
+        mvc
+            .perform(
+                post("/api/v1/notifications/read")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"all":true}""")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(participant)),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.unreadCount").value(0))
+            .andExpect(jsonPath("$.data.unreadCountByCategory.ACTIVITY").value(0))
+    }
+
+    @Test
+    fun `클론 완료 발송은 ROOT 주최자에게만 가고 참여자에겐 안 간다`() {
+        val owner = saveUser("주최자", "https://img/owner.png", IdentityType.MEMBER)
+        val member = saveUser("멤버", "https://img/member.png", IdentityType.MEMBER)
+        val rootId = createRootWithOwnerAndParticipant(owner, member)
+
+        // 멤버가 자기 클론을 완료 → ROOT 주최자에게 "멤버님이 완료했어요". (actor=멤버)
+        notificationDispatcher.dispatch(TournamentCompleted(rootTournamentId = rootId, actorId = member))
+
+        // 주최자는 1건 받고(actor=멤버 프사), 멤버 본인(actor)은 0건.
+        val ownerInbox = notificationRepository.findPage(owner, cursor = null, limit = 10, types = null)
+        assertEquals(1, ownerInbox.size)
+        assertEquals("https://img/member.png", ownerInbox.first().actorImageUrl)
+        assertTrue(notificationRepository.findPage(member, cursor = null, limit = 10, types = null).isEmpty())
+    }
+
+    private fun saveUser(
+        nickname: String,
+        profileImage: String,
+        identityType: IdentityType,
+    ): UUID {
+        val id = UUID.randomUUID()
+        userRepository.save(User(id = id, nickname = nickname, profileImage = profileImage, identityType = identityType))
+        return id
+    }
+
+    // ROOT 토너먼트 + 주최자(ownerTU) + 참여자(TU) fixture. 결과 알림 수신자 해석(참여자 − 주최자)이 동작하도록 깐다.
+    private fun createRootWithOwnerAndParticipant(
+        ownerUserId: UUID,
+        participantUserId: UUID,
+    ): Long {
+        val root = tournamentRepository.saveTournament(
+            Tournament(ownerTournamentUserId = 0L, name = "t", inviteCode = "ROOT01", inviteExpiresAt = LocalDateTime.now().plusDays(1)),
+        )
+        val ownerTu = tournamentUserRepository.save(TournamentUser(root.getId(), ownerUserId))
+        root.assignOwner(ownerTu.getId())
+        tournamentRepository.saveTournament(root)
+        tournamentUserRepository.save(TournamentUser(root.getId(), participantUserId))
+        return root.getId()
+    }
+}

--- a/src/test/kotlin/com/depromeet/piki/notification/handler/NotificationRecipientResolutionIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/notification/handler/NotificationRecipientResolutionIntegrationTest.kt
@@ -6,12 +6,17 @@ import com.depromeet.piki.notification.domain.NotificationRouting
 import com.depromeet.piki.notification.repository.NotificationRepository
 import com.depromeet.piki.notification.service.NotificationDispatcher
 import com.depromeet.piki.support.IntegrationTestSupport
+import com.depromeet.piki.tournament.domain.Tournament
 import com.depromeet.piki.tournament.domain.TournamentItem
 import com.depromeet.piki.tournament.domain.TournamentUser
+import com.depromeet.piki.tournament.event.TournamentCompleted
 import com.depromeet.piki.tournament.event.TournamentItemAdded
 import com.depromeet.piki.tournament.event.TournamentJoined
+import com.depromeet.piki.tournament.event.TournamentPlayedFromLink
+import com.depromeet.piki.tournament.event.TournamentResultReady
 import com.depromeet.piki.tournament.event.TournamentStarted
 import com.depromeet.piki.tournament.repository.TournamentItemRepository
+import com.depromeet.piki.tournament.repository.TournamentRepository
 import com.depromeet.piki.tournament.repository.TournamentUserRepository
 import com.depromeet.piki.user.domain.IdentityType
 import com.depromeet.piki.user.domain.User
@@ -21,6 +26,7 @@ import com.depromeet.piki.wishlist.repository.WishRepository
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
 import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -34,6 +40,14 @@ class NotificationRecipientResolutionIntegrationTest : IntegrationTestSupport() 
     @Autowired private lateinit var joinedHandler: TournamentJoinedHandler
 
     @Autowired private lateinit var startedHandler: TournamentStartedHandler
+
+    @Autowired private lateinit var playedFromLinkHandler: TournamentPlayedFromLinkHandler
+
+    @Autowired private lateinit var completedHandler: TournamentCompletedHandler
+
+    @Autowired private lateinit var resultReadyHandler: TournamentResultReadyHandler
+
+    @Autowired private lateinit var tournamentRepository: TournamentRepository
 
     @Autowired private lateinit var parsingCompletedHandler: ItemParsingCompletedHandler
 
@@ -267,4 +281,98 @@ class NotificationRecipientResolutionIntegrationTest : IntegrationTestSupport() 
 
         assertEquals(NotificationRouting.Wish, routing)
     }
+
+    // ── 신규 토너먼트 알림(#473): 플레이링크 플레이 · 완료 · 결과 ──────────────────────────
+
+    @Test
+    fun `플레이링크 플레이 알림 수신자는 ROOT 주최자다`() {
+        val owner = UUID.randomUUID()
+        val player = UUID.randomUUID()
+        val rootId = createRootWithOwner(owner)
+
+        val recipients = playedFromLinkHandler.resolveRecipients(TournamentPlayedFromLink(rootId, player))
+
+        assertEquals(setOf(owner), recipients)
+    }
+
+    @Test
+    fun `완료 알림 수신자는 ROOT 주최자이고, 완료자가 곧 주최자면 제외된다`() {
+        val owner = UUID.randomUUID()
+        val member = UUID.randomUUID()
+        val rootId = createRootWithOwner(owner)
+
+        assertEquals(setOf(owner), completedHandler.resolveRecipients(TournamentCompleted(rootId, member)))
+        // actor(완료자)가 주최자 본인이면 자기 알림을 막는다 → 빈 집합.
+        assertTrue(completedHandler.resolveRecipients(TournamentCompleted(rootId, owner)).isEmpty())
+    }
+
+    @Test
+    fun `결과 알림 수신자는 ROOT 참가자와 플레이링크 클론 소유자 합집합에서 주최자를 뺀 집합이다`() {
+        val owner = UUID.randomUUID()
+        val participant = UUID.randomUUID()
+        val guest = UUID.randomUUID()
+        val rootId = createRootWithOwner(owner)
+        tournamentUserRepository.save(TournamentUser(rootId, participant)) // ROOT 참가자(아이템 등록·합류)
+        createClone(rootId, guest) // 플레이링크 클론 소유자(게스트)
+
+        val recipients = resultReadyHandler.resolveRecipients(TournamentResultReady(rootId, owner))
+
+        // 주최자(actor)는 빠지고, ROOT 참가자 + 클론 소유자만 남는다.
+        assertEquals(setOf(participant, guest), recipients)
+    }
+
+    @Test
+    fun `존재하지 않는 ROOT 면 플레이·완료 알림 수신자는 빈 집합이다 (resolver not-found 분기)`() {
+        val absentRootId = 987_654L
+        assertTrue(playedFromLinkHandler.resolveRecipients(TournamentPlayedFromLink(absentRootId, UUID.randomUUID())).isEmpty())
+        assertTrue(completedHandler.resolveRecipients(TournamentCompleted(absentRootId, UUID.randomUUID())).isEmpty())
+        // 결과 알림도 참여자·클론이 하나도 없으면 빈 집합 → dispatch 가 early return 으로 떨군다.
+        assertTrue(resultReadyHandler.resolveRecipients(TournamentResultReady(absentRootId, UUID.randomUUID())).isEmpty())
+    }
+
+    @Test
+    fun `완료 알림 actor 컨텍스트는 완료한 사람의 닉네임과 프사다`() {
+        val actor = UUID.randomUUID()
+        userRepository.save(User(id = actor, nickname = "행위자", profileImage = "https://x/p.png", identityType = IdentityType.GUEST))
+
+        val context = completedHandler.resolveActorContext(TournamentCompleted(1234L, actor))
+
+        assertEquals(mapOf("actorName" to "행위자"), context.variables)
+        assertEquals("https://x/p.png", context.imageUrl)
+    }
+
+    // ROOT 토너먼트 + 주최자(TournamentUser) fixture. ownerTournamentUserId 를 실제 TU id 로 연결한다.
+    private fun createRootWithOwner(ownerUserId: UUID): Long {
+        val root = tournamentRepository.saveTournament(
+            Tournament(ownerTournamentUserId = 0L, name = "t", inviteCode = nextInviteCode(), inviteExpiresAt = LocalDateTime.now().plusDays(1)),
+        )
+        val ownerTu = tournamentUserRepository.save(TournamentUser(root.getId(), ownerUserId))
+        root.assignOwner(ownerTu.getId())
+        tournamentRepository.saveTournament(root)
+        return root.getId()
+    }
+
+    // ROOT 의 CLONE(sourceTournamentId 연결) + 그 소유자(TournamentUser) fixture.
+    private fun createClone(
+        rootId: Long,
+        ownerUserId: UUID,
+    ): Long {
+        val clone = tournamentRepository.saveTournament(
+            Tournament(
+                ownerTournamentUserId = 0L,
+                name = "t",
+                inviteCode = nextInviteCode(),
+                inviteExpiresAt = LocalDateTime.now().plusDays(1),
+                sourceTournamentId = rootId,
+            ),
+        )
+        val tu = tournamentUserRepository.save(TournamentUser(clone.getId(), ownerUserId))
+        clone.assignOwner(tu.getId())
+        tournamentRepository.saveTournament(clone)
+        return clone.getId()
+    }
+
+    private var inviteSeq = 0
+
+    private fun nextInviteCode(): String = "T%05d".format(inviteSeq++)
 }

--- a/src/test/kotlin/com/depromeet/piki/tournament/service/TournamentServiceTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/service/TournamentServiceTest.kt
@@ -11,8 +11,11 @@ import com.depromeet.piki.tournament.domain.TournamentHistory
 import com.depromeet.piki.tournament.domain.TournamentItem
 import com.depromeet.piki.tournament.domain.TournamentStatus
 import com.depromeet.piki.tournament.domain.TournamentUser
+import com.depromeet.piki.tournament.event.TournamentCompleted
 import com.depromeet.piki.tournament.event.TournamentItemAdded
 import com.depromeet.piki.tournament.event.TournamentJoined
+import com.depromeet.piki.tournament.event.TournamentPlayedFromLink
+import com.depromeet.piki.tournament.event.TournamentResultReady
 import com.depromeet.piki.tournament.event.TournamentStarted
 import com.depromeet.piki.tournament.repository.TournamentItemRepository
 import com.depromeet.piki.tournament.repository.TournamentItemRoutingView
@@ -842,6 +845,63 @@ class TournamentServiceTest {
         )
 
         assertEquals(TournamentStatus.COMPLETED, repository.tournaments[tournamentId]!!.status)
+    }
+
+    @Test
+    fun `recordMatch 결승 완료 시 ROOT(주최자 본인 진행)면 TournamentResultReady 를 발행한다`() {
+        val tournamentId = createAndStart(listOf(10L, 20L))
+        val items = tournamentItemRepository.findAllByTournamentId(tournamentId)
+        val first = items.find { it.itemId == 10L }!!
+        val second = items.find { it.itemId == 20L }!!
+        publishedEvents.clear() // create·addItems·start 발행분 제거 — 완료 발행만 단언한다.
+
+        service.recordMatch(userId, RecordMatch(tournamentId, 2, first.getId(), second.getId(), first.getId()))
+
+        assertEquals(listOf<Any>(TournamentResultReady(rootTournamentId = tournamentId, actorId = userId)), publishedEvents)
+    }
+
+    @Test
+    fun `recordMatch 결승 완료 시 CLONE(멤버 진행)이면 TournamentCompleted 를 발행한다`() {
+        val rootId = service.create(userId, CreateTournament("t")).tournamentId
+        testWishRepository.addWish(userId, 10L, 20L)
+        service.addItemsFromWish(userId, AddTournamentItemsFromWish(rootId, listOf(10L, 20L)))
+        val inviteCode = repository.tournaments[rootId]!!.inviteCode
+        service.join(otherUserId, rootId, inviteCode) // 멤버 합류(PENDING)
+        service.start(userId, rootId) // 주최자가 시작 → ROOT IN_PROGRESS
+        val cloneId = service.start(otherUserId, rootId).tournamentId // 멤버가 본인 클론 시작
+        val items = tournamentItemRepository.findAllByTournamentId(rootId) // 클론은 ROOT 아이템을 쓴다
+        publishedEvents.clear()
+
+        service.recordMatch(otherUserId, RecordMatch(cloneId, 2, items[0].getId(), items[1].getId(), items[0].getId()))
+
+        assertEquals(listOf<Any>(TournamentCompleted(rootTournamentId = rootId, actorId = otherUserId)), publishedEvents)
+    }
+
+    @Test
+    fun `createFromPlayLink 신규 클론 생성 시 TournamentPlayedFromLink 를 발행한다`() {
+        val rootId = createAndStart(listOf(10L, 20L))
+        val items = tournamentItemRepository.findAllByTournamentId(rootId)
+        service.recordMatch(userId, RecordMatch(rootId, 2, items[0].getId(), items[1].getId(), items[0].getId())) // ROOT 완료
+        service.createPlayLink(userId, rootId) // 주최자가 플레이링크 생성
+        publishedEvents.clear()
+
+        service.createFromPlayLink(otherUserId, rootId) // 링크로 신규 클론 생성·플레이 시작
+
+        assertEquals(listOf<Any>(TournamentPlayedFromLink(rootTournamentId = rootId, actorId = otherUserId)), publishedEvents)
+    }
+
+    @Test
+    fun `createFromPlayLink 가 기존 클론을 돌려주는 경우(get-or-create)엔 발행하지 않는다`() {
+        val rootId = createAndStart(listOf(10L, 20L))
+        val items = tournamentItemRepository.findAllByTournamentId(rootId)
+        service.recordMatch(userId, RecordMatch(rootId, 2, items[0].getId(), items[1].getId(), items[0].getId()))
+        service.createPlayLink(userId, rootId)
+        service.createFromPlayLink(otherUserId, rootId) // 1회차 — 신규 클론(발행 O)
+        publishedEvents.clear()
+
+        service.createFromPlayLink(otherUserId, rootId) // 2회차 — 본인 클론 이어하기(발행 X)
+
+        assertTrue(publishedEvents.isEmpty())
     }
 
     @Test


### PR DESCRIPTION
## Situation
알림센터(#473)에 토너먼트 소셜 알림이 3종(입장·아이템 추가·시작)뿐이라, "누가 내 토너먼트를 플레이/완료했는지", "내가 참여한 토너먼트 결과가 나왔는지"를 알 수 없었다. 공지(ANNOUNCEMENT) 타입도 분류 체계에 없었다.

## Task
플레이링크 플레이·완료·결과 알림 3종을 도메인 이벤트에 태워 발행하고, 공지 타입은 enum 만 선반영한다. 새 카테고리 신설 없이 기존 ACTIVITY/SYSTEM 에 매핑한다.

## Action
**신규 타입 4종**

| Type | 트리거(발행 지점) | 수신자 | actor | 카테고리 |
|---|---|---|---|---|
| `TOURNAMENT_PLAYED_FROM_LINK` | `createFromPlayLink` 신규 클론 분기 | ROOT 주최자 | 플레이한 사람 | ACTIVITY |
| `TOURNAMENT_COMPLETED` | `recordMatch` 완료 **[CLONE]** | ROOT 주최자 | 완료한 멤버 | ACTIVITY |
| `TOURNAMENT_RESULT_READY` | `recordMatch` 완료 **[ROOT]** | 참여자(ROOT 참가자 ∪ 클론 소유자) − 주최자 | 주최자 | ACTIVITY |
| `ANNOUNCEMENT` | 없음(enum·카테고리·placeholder 템플릿만 선반영) | 후속(#489) | 없음 | SYSTEM |

- `recordMatch` 완료 시 `sourceTournamentId` 유무로 **CLONE→COMPLETED / ROOT→RESULT_READY** 자연 분기
- 수신자 역조회는 `TournamentNotificationRecipientResolver` 로 공유(`ItemParsingRecipientResolver` 패턴)
- 3 핸들러는 `resolveActorContext` 단일 훅으로 actor 1회 조회
- 컴파일 가드(`NotificationCategory.of()` exhaustive)·부팅 가드(템플릿 require) 모두 충족
- 게스트도 토큰 보유 시 수신 대상(인프라가 GUEST 푸시 허용) — `RESULT_READY` 는 클론 소유 게스트 포함

## Result
- 발송 단위(`TournamentServiceTest`): ROOT→ResultReady, CLONE→Completed, PlayLink→PlayedFromLink, get-or-create 재방문 미발행
- 핸들러 수신자/actor + not-found 엣지(`NotificationRecipientResolutionIntegrationTest`)
- 전체 flow 통합(`NotificationTournamentFlowIntegrationTest`): 유저 진입 → FCM 토큰 등록 → 결과 발송 → 히스토리(GET, type·category·imageUrl·title) → 읽음(POST /read)
- `NotificationCategoryTest` 9개 타입 전수 매핑
- main·test 컴파일 + `notification.*`·`tournament.*` 전체 그린 (JDK 25)

> ANNOUNCEMENT 실발행(prod 어드민 + 토큰 보유자 fan-out)은 별도 #489.

관련 #473
