### PR TITLE
refactor: SSE·FCM payload 단일 소스화 (NotificationSsePayload.from)

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/notification/fcm/service/FirebaseMessageSender.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/fcm/service/FirebaseMessageSender.kt
@@ -1,9 +1,7 @@
 package com.depromeet.piki.notification.fcm.service
 
+import com.depromeet.piki.notification.controller.dto.NotificationSsePayload
 import com.depromeet.piki.notification.domain.Notification
-import com.depromeet.piki.notification.domain.NotificationCategory
-import com.depromeet.piki.notification.domain.NotificationKind
-import com.depromeet.piki.notification.domain.NotificationRouting
 import com.depromeet.piki.notification.service.DefaultPushImage
 import com.google.firebase.FirebaseApp
 import com.google.firebase.messaging.AndroidConfig
@@ -61,24 +59,27 @@ class FirebaseMessageSender(
         return stale
     }
 
-    // 표시용 title/body + 클라 라우팅용 data(type·refId·라우팅 컨텍스트)를 실은 멀티캐스트 메시지.
-    // 백그라운드 수신 시 클라가 data 로 딥링크를 복원한다. data 키 구성은 buildDataPayload 가 결정한다.
+    // 표시용 title/body + 클라 라우팅용 data 를 실은 멀티캐스트 메시지. 백그라운드 수신 시 클라가 data 로 딥링크를 복원한다.
+    // 셰입의 단일 소스는 NotificationSsePayload.from() — SSE·히스토리와 같은 곳에서 title/body·category·imageUrl·라우팅 값을 만들어
+    // 채널이 달라도 내용이 어긋나지 않는다. FCM 은 그 payload 를 표시 블록(title/body)과 data(문자열 맵)로 인코딩만 한다(toFcmData).
     private fun buildMessage(
         tokens: List<String>,
         notification: Notification,
-    ): MulticastMessage =
-        MulticastMessage
+    ): MulticastMessage {
+        val payload = NotificationSsePayload.from(notification, defaultPushImage.url)
+        return MulticastMessage
             .builder()
             .addAllTokens(tokens)
             .setNotification(
                 FcmNotification
                     .builder()
-                    .setTitle(notification.title)
-                    .setBody(notification.body)
+                    .setTitle(payload.title)
+                    .setBody(payload.body)
                     .build(),
-            ).apply { buildDataPayload(notification, defaultPushImage.url).forEach { (key, value) -> putData(key, value) } }
+            ).apply { toFcmData(payload).forEach { (key, value) -> putData(key, value) } }
             .applyPlatformConfig()
             .build()
+    }
 
     // 플랫폼별 푸시 옵션을 한 메시지에 모두 싣는다 — FCM 이 각 토큰의 플랫폼에 맞는 config 만 적용하므로
     // (iOS 토큰엔 APNS, Android 토큰엔 Android, 웹 토큰엔 WebPush) 한 발송이 세 플랫폼을 다 커버한다.
@@ -133,9 +134,7 @@ class FirebaseMessageSender(
         internal fun isStaleToken(code: MessagingErrorCode?): Boolean = code == MessagingErrorCode.UNREGISTERED
 
         // 백그라운드 수신 시 클라가 딥링크를 복원하려고 읽는 data 키 — FE 와 공유하는 contract.
-        // 값은 NotificationSsePayload 의 필드명(id·type·refId·kind·tournamentId·tournamentItemId)과 일치시켜,
-        // 클라가 SSE/FCM 어느 채널로 받든 같은 키로 같은 알림을 다루게 한다. (SSE 는 data class 프로퍼티명을 Jackson 이
-        //  직렬화하므로 그 쪽은 같은 문자열을 상수로 빼지 못한다 — 이 상수의 값으로 일치를 맞춘다.)
+        // 키 이름은 NotificationSsePayload 의 필드명과 일치시켜, 클라가 SSE/FCM 어느 채널로 받든 같은 키로 같은 알림을 다루게 한다.
         // id 는 채널 무관 dedup(SSE·FCM 중복 수신 시 같은 알림으로 합침)과 푸시 탭 → 읽음 처리(POST /read {ids:[id]})의 키다(#246).
         private const val DATA_KEY_ID = "id"
         private const val DATA_KEY_TYPE = "type"
@@ -146,30 +145,25 @@ class FirebaseMessageSender(
         private const val DATA_KEY_TOURNAMENT_ID = "tournamentId"
         private const val DATA_KEY_TOURNAMENT_ITEM_ID = "tournamentItemId"
 
-        // FCM data payload(키→값) 구성 — id·type·category·imageUrl·refId 는 항상, 라우팅 컨텍스트(kind·tournamentId·tournamentItemId)는
-        // 있을 때만 싣는다. FCM data 는 값이 null 일 수 없어 null 키는 아예 넣지 않는다(#408). FirebaseMessaging
-        // 호출과 무관한 순수 매핑이라 companion 으로 분리해 단위 테스트로 분기를 망라한다(FirebaseApp 없이 검증).
-        // notification 은 dispatcher 가 이미 저장한 영속 엔티티라 getId() 가 보장된다(SsePayload.from 과 동일 전제).
-        // imageUrl 은 actor 스냅샷이 있으면 그것, 없으면(시스템) defaultPushImageUrl 로 채워 항상 비지 않게 한다(SsePayload.from 과 동일 규칙).
-        internal fun buildDataPayload(
-            notification: Notification,
-            defaultPushImageUrl: String,
-        ): Map<String, String> =
+        // NotificationSsePayload 를 FCM data(키→값 문자열 맵)로 인코딩한다. 값은 payload(=from())가 이미 만든 것을 읽기만 하고
+        // (category·imageUrl·refId·라우팅 재계산 없음 — SSE 와 단일 소스), 여기선 문자열 평탄화만 한다. FCM data 는 값이 null 일 수 없어
+        // 라우팅 없는 알림(Reference)은 kind 계열 키를 아예 넣지 않는다(#408). title/body 는 표시 블록(setNotification)이 담당해 data 에
+        // 중복하지 않고, isRead(항상 false)·createdAt(수신시점)도 딥링크 복원에 불필요해 싣지 않는다(lean contract).
+        // FirebaseMessaging 호출과 무관한 순수 매핑이라 companion 으로 분리해 단위 테스트로 분기를 망라한다(FirebaseApp 없이 검증).
+        internal fun toFcmData(payload: NotificationSsePayload): Map<String, String> =
             buildMap {
-                put(DATA_KEY_ID, notification.getId().toString())
-                put(DATA_KEY_TYPE, notification.type.name)
-                put(DATA_KEY_CATEGORY, NotificationCategory.of(notification.type).name)
-                put(DATA_KEY_IMAGE_URL, notification.actorImageUrl ?: defaultPushImageUrl)
-                put(DATA_KEY_REF_ID, notification.refId.toString())
-                // SSE payload 와 같은 routing() sealed 를 분기해 두 채널이 한 소스를 쓴다. FCM data 는 값이 null 일 수 없어
-                // 라우팅이 없으면 키 자체를 안 넣고, TOURNAMENT 만 추가 식별자를 싣는다(#408).
-                when (val routing = notification.routing()) {
-                    null -> Unit
-                    NotificationRouting.Wish -> put(DATA_KEY_KIND, NotificationKind.WISH.name)
-                    is NotificationRouting.Tournament -> {
-                        put(DATA_KEY_KIND, NotificationKind.TOURNAMENT.name)
-                        put(DATA_KEY_TOURNAMENT_ID, routing.tournamentId.toString())
-                        put(DATA_KEY_TOURNAMENT_ITEM_ID, routing.tournamentItemId.toString())
+                put(DATA_KEY_ID, payload.id.toString())
+                put(DATA_KEY_TYPE, payload.type.name)
+                put(DATA_KEY_CATEGORY, payload.category.name)
+                put(DATA_KEY_IMAGE_URL, payload.imageUrl)
+                put(DATA_KEY_REF_ID, payload.refId.toString())
+                when (payload) {
+                    is NotificationSsePayload.Reference -> Unit
+                    is NotificationSsePayload.WishParsing -> put(DATA_KEY_KIND, payload.kind.name)
+                    is NotificationSsePayload.TournamentParsing -> {
+                        put(DATA_KEY_KIND, payload.kind.name)
+                        put(DATA_KEY_TOURNAMENT_ID, payload.tournamentId.toString())
+                        put(DATA_KEY_TOURNAMENT_ITEM_ID, payload.tournamentItemId.toString())
                     }
                 }
             }

--- a/src/test/kotlin/com/depromeet/piki/notification/fcm/service/FirebaseMessageSenderTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/notification/fcm/service/FirebaseMessageSenderTest.kt
@@ -1,5 +1,6 @@
 package com.depromeet.piki.notification.fcm.service
 
+import com.depromeet.piki.notification.controller.dto.NotificationSsePayload
 import com.depromeet.piki.notification.domain.Notification
 import com.depromeet.piki.notification.domain.NotificationRouting
 import com.depromeet.piki.notification.domain.NotificationType
@@ -42,13 +43,13 @@ class FirebaseMessageSenderTest {
         assertFalse(FirebaseMessageSender.isStaleToken(null))
     }
 
-    // buildDataPayload 는 FCM data(키→값) 구성 정책 — 라우팅 컨텍스트 유무에 따른 키 셋 분기를 단위로 망라한다(#408).
-    // id 는 항상 실린다(채널 무관 dedup·푸시 탭→읽음의 키, #246) — 미영속 엔티티엔 withId 로 부여한다.
+    // toFcmData 는 NotificationSsePayload(=from(), SSE 와 단일 소스)를 FCM data 로 인코딩 — 라우팅 유무에 따른 키 셋 분기를 단위로 망라한다(#408).
+    // 값은 payload 에서 읽기만 하므로 category·imageUrl 파생이 SSE 와 어긋날 수 없다. id 는 항상 실린다(#246) — 미영속 엔티티엔 withId 로 부여한다.
     @Test
     fun `라우팅 없는 알림은 id·type·category·imageUrl·refId 를 data 에 싣는다`() {
         val notification = Notification(UUID.randomUUID(), NotificationType.TOURNAMENT_JOINED, "제목", "본문", 7L).withId(42L)
 
-        val data = FirebaseMessageSender.buildDataPayload(notification, defaultPushImageUrl)
+        val data = FirebaseMessageSender.toFcmData(NotificationSsePayload.from(notification, defaultPushImageUrl))
 
         // actor 스냅샷 없음 → imageUrl 은 defaultPushImageUrl 로 채워진다. TOURNAMENT_JOINED → category=ACTIVITY.
         assertEquals(
@@ -63,7 +64,7 @@ class FirebaseMessageSenderTest {
             Notification(UUID.randomUUID(), NotificationType.TOURNAMENT_ITEM_ADDED, "제목", "본문", 7L, actorImageUrl = "https://img.test/profiles/a.png")
                 .withId(45L)
 
-        val data = FirebaseMessageSender.buildDataPayload(notification, defaultPushImageUrl)
+        val data = FirebaseMessageSender.toFcmData(NotificationSsePayload.from(notification, defaultPushImageUrl))
 
         assertEquals("https://img.test/profiles/a.png", data["imageUrl"])
         assertEquals("ACTIVITY", data["category"])
@@ -75,7 +76,7 @@ class FirebaseMessageSenderTest {
             Notification(UUID.randomUUID(), NotificationType.ITEM_PARSING_COMPLETED, "제목", "본문", 11L, NotificationRouting.Wish)
                 .withId(43L)
 
-        val data = FirebaseMessageSender.buildDataPayload(notification, defaultPushImageUrl)
+        val data = FirebaseMessageSender.toFcmData(NotificationSsePayload.from(notification, defaultPushImageUrl))
 
         // ITEM_PARSING_* → category=SYSTEM. actor 없어 imageUrl=default.
         assertEquals(
@@ -103,7 +104,7 @@ class FirebaseMessageSenderTest {
                 NotificationRouting.Tournament(tournamentId = 99L, tournamentItemId = 555L),
             ).withId(44L)
 
-        val data = FirebaseMessageSender.buildDataPayload(notification, defaultPushImageUrl)
+        val data = FirebaseMessageSender.toFcmData(NotificationSsePayload.from(notification, defaultPushImageUrl))
 
         assertEquals(
             mapOf(


### PR DESCRIPTION
## Situation
알림 payload를 SSE는 `NotificationSsePayload.from()`, FCM은 `FirebaseMessageSender.buildDataPayload()`로 **각자** 만들고 있었다. `category = NotificationCategory.of(type)`, `imageUrl = actorImageUrl ?: default`, 라우팅 분기 같은 **값 파생 로직이 두 곳에 중복**돼, 한쪽만 고치면 채널 간 내용이 어긋날 수 있었다.

## Task
값을 만드는 곳을 하나로 합쳐 SSE·FCM·히스토리가 **단일 소스**를 쓰게 한다. FCM 출력은 바꾸지 않는다(behavior-preserving).

## Action
- `FirebaseMessageSender`가 `NotificationSsePayload.from()`으로 payload를 **1번** 만들고:
  - 표시 블록: `setNotification(payload.title, payload.body)`
  - data: `toFcmData(payload)` — payload 필드를 **읽어서 문자열로 평탄화만** (category·imageUrl·refId·routing 재계산 제거)
- `buildDataPayload(notification, …)` → `toFcmData(payload)` 로 교체. 값 파생이 `from()` 단일 소스라 채널 간 drift 불가.
- FCM data는 **기존과 동일**하게 lean 유지: `id·type·category·imageUrl·refId` (+ 파싱 알림 `kind·tournamentId·tournamentItemId`). `title/body`는 표시 블록, `isRead`(항상 false)·`createdAt`(수신시점)은 딥링크 복원에 불필요해 제외.

## Result
- FCM data 맵·SSE payload **출력 불변** — 단위 테스트 기대값 그대로 통과(`toFcmData(from(...))`로 전환).
- `notification.*` FCM·SSE·controller 테스트 전부 그린 (JDK 25).
- 이후 알림 payload 필드/문구 변경은 `NotificationSsePayload.from()`(값)·템플릿(문구) 한 곳만 고치면 SSE·FCM·히스토리 3곳 자동 반영.

> 참고: payload 클래스가 `controller/dto`에 있어 FCM(infra)이 이를 의존한다(기존 SSE 채널도 동일). 더 엄격한 레이어 분리를 원하면 `notification/dto`로 이동 + 이름 변경(`NotificationPayload`)을 후속으로 검토 가능.
