### PR TITLE
알림 타입 9종 카탈로그를 api-docs에 추가

### DIFF
--- a/notification-sse-spec.md
+++ b/notification-sse-spec.md
@@ -65,7 +65,7 @@ data: connected
 
 ```text
 event: notification
-data: {"id":123,"type":"TOURNAMENT_JOINED","title":"홍길동님이 참가했어요","body":"","refId":45,"isRead":false,"createdAt":"2026-06-06T14:32:10"}
+data: {"id":123,"type":"TOURNAMENT_JOINED","category":"ACTIVITY","title":"홍길동님이 참가했어요","body":"","imageUrl":"https://.../profiles/{uid}.png","refId":45,"isRead":false,"createdAt":"2026-06-06T14:32:10"}
 ```
 
 ### (3) 하트비트 (주석 ping)
@@ -86,8 +86,10 @@ data: {"id":123,"type":"TOURNAMENT_JOINED","title":"홍길동님이 참가했어
 |---|---|---|
 | `id` | number (long) | 알림 식별자. 추후 읽음 처리 API 의 키. |
 | `type` | string (enum) | 알림 종류. 딥링크 분기 키. (아래 표) |
+| `category` | string (enum) | 알림센터 탭 구분. `ACTIVITY`(활동) \| `SYSTEM`(시스템). `type` 에서 파생. |
 | `title` | string | 표시용 제목. 발송 시점에 변수 치환이 끝난 완성본. |
 | `body` | string | 표시용 본문. **현재는 전 타입 빈 문자열(`""`)** (후속 템플릿 작업에서 채워질 예정). |
+| `imageUrl` | string | 아바타 URL. **항상 채워짐** — 사람 알림은 발송 시점 actor 프사 snapshot, 시스템 알림은 피키 로고(서버가 `defaultPushImg` 채움). 클라는 null-check 없이 렌더. |
 | `refId` | number (long) | 딥링크 대상 식별자. `type` 에 따라 가리키는 대상이 다름 (아래 표). |
 | `isRead` | boolean | 읽음 여부. SSE 로 즉시 도착하는 알림은 사실상 `false`. |
 | `createdAt` | string (ISO-8601 LocalDateTime) | 생성 시각. 예: `2026-06-06T14:32:10`. 타임존 오프셋 없음(서버 로컬). |
@@ -103,12 +105,17 @@ data: {"id":123,"type":"TOURNAMENT_JOINED","title":"홍길동님이 참가했어
 
 클라이언트는 `type` 으로 화면을 분기하고 `refId` 로 이동 대상을 정한다.
 
-| `type` | 의미 | `title` (현재 문구) | `refId` 가 가리키는 것 | 수신자 |
-|---|---|---|---|---|
-| `TOURNAMENT_JOINED` | 누군가 내 토너먼트에 참가 | `{참가자}님이 참가했어요` | **tournamentId** | 해당 토너먼트 참여자 (행위자 제외) |
-| `TOURNAMENT_ITEM_ADDED` | 누군가 토너먼트에 아이템 추가 | `{참가자}님이 아이템을 추가했어요` | **tournamentId** | 해당 토너먼트 참여자 (행위자 제외) |
-| `ITEM_PARSING_COMPLETED` | 내 상품 정보 추출 성공 | `상품 정보가 저장됐어요` | **itemId** | 본인 |
-| `ITEM_PARSING_FAILED` | 내 상품 정보 추출 실패 | `상품 정보를 가져오지 못했어요` | **itemId** | 본인 |
+| `type` | 카테고리 | 의미 | `title` (현재 문구) | `refId` | 수신자 |
+|---|---|---|---|---|---|
+| `TOURNAMENT_JOINED` | ACTIVITY | 누군가 토너먼트에 참가 | `{참가자}님이 참가했어요` | **tournamentId** | 참여자 (행위자 제외) |
+| `TOURNAMENT_ITEM_ADDED` | ACTIVITY | 누군가 아이템 추가 | `{참가자}님이 아이템을 추가했어요` | **tournamentId** | 참여자 (행위자 제외) |
+| `TOURNAMENT_STARTED` | ACTIVITY | 주최자가 토너먼트 시작 | `{주최자}님이 토너먼트를 시작했어요` | **tournamentId** | 참여자 (주최자 제외) |
+| `TOURNAMENT_PLAYED_FROM_LINK` | ACTIVITY | 플레이링크로 내 토너먼트 플레이 시작 | `{플레이어}님이 회원님 토너먼트를 플레이했어요` | **ROOT 토너먼트 id** | ROOT 주최자 |
+| `TOURNAMENT_COMPLETED` | ACTIVITY | 멤버/게스트가 클론 완료 | `{멤버}님이 회원님 토너먼트를 완료했어요` | **ROOT 토너먼트 id** | ROOT 주최자 |
+| `TOURNAMENT_RESULT_READY` | ACTIVITY | 주최자가 ROOT 완료(결과 나옴) | `참여하신 {주최자}님의 토너먼트 결과가 나왔어요` | **ROOT 토너먼트 id** | 참여자 (주최자 제외) |
+| `ITEM_PARSING_COMPLETED` | SYSTEM | 내 상품 정보 추출 성공 | `상품 정보가 저장됐어요` | **itemId** | 본인(위시 주인/등록자) |
+| `ITEM_PARSING_FAILED` | SYSTEM | 내 상품 정보 추출 실패 | `상품 정보를 가져오지 못했어요` | **itemId** | 본인(위시 주인/등록자) |
+| `ANNOUNCEMENT` | SYSTEM | 전체 공지(관리자, 후속) | (관리자 입력) | **공지 id/0** | 토큰 보유 유저(후속) |
 
 > `title` 문구는 서버 템플릿에서 렌더된 값이라 바뀔 수 있다. 클라이언트는 **문구가 아니라 `type` 으로 분기**할 것.
 

--- a/src/main/kotlin/com/depromeet/piki/notification/controller/NotificationHistoryApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/controller/NotificationHistoryApi.kt
@@ -33,8 +33,23 @@ interface NotificationHistoryApi {
                 "- 응답 `data` 의 `unreadCount`(앱 badge) · `unreadCountByCategory`(탭 badge)로 안읽음 수를 함께 내려준다 (별도 카운트 API 없음).\n" +
                 "- 각 항목의 `imageUrl` 은 항상 채워진다 — 사람 알림은 발송 시점 프사, 시스템 알림은 피키 로고. " +
                 "사람/시스템 구분은 `category`. 클라는 `imageUrl` 을 그대로 아바타로 렌더한다.\n" +
-                "- 각 항목 셰입은 SSE `notification` 이벤트 payload 와 동일하다 — `type` 으로 화면을, 파싱 알림은 " +
-                "`kind` 로 출처(위시/토너먼트)를 분기하고, `id` 로 단건 읽음 처리(`POST /read`)·딥링크 이동을 한다.",
+                "- 각 항목 셰입은 SSE `notification` 이벤트 payload 와 동일하다 — `type` 으로 화면을, " +
+                "`refId` 로 딥링크 이동을, 파싱 알림은 `kind` 로 출처(위시/토너먼트)를 분기하고, `id` 로 단건 읽음 처리(`POST /read`)를 한다.\n\n" +
+                "**알림 타입 카탈로그 (전 9종)**\n\n" +
+                "`type` 으로 화면을 분기하고 `refId` 로 이동 대상을 정한다. `body` 는 현재 전 타입 빈 문자열(`\"\"`).\n\n" +
+                "| `type` | 트리거 | 카테고리 | `refId` | `title` 예시 | 아바타(`imageUrl`) |\n" +
+                "|---|---|---|---|---|---|\n" +
+                "| `TOURNAMENT_JOINED` | 토너먼트 참가 | ACTIVITY | tournamentId | {참가자}님이 참가했어요 | 행위자 프사 |\n" +
+                "| `TOURNAMENT_ITEM_ADDED` | 아이템 추가 | ACTIVITY | tournamentId | {참가자}님이 아이템을 추가했어요 | 행위자 프사 |\n" +
+                "| `TOURNAMENT_STARTED` | 토너먼트 시작 | ACTIVITY | tournamentId | {주최자}님이 토너먼트를 시작했어요 | 행위자 프사 |\n" +
+                "| `TOURNAMENT_PLAYED_FROM_LINK` | 플레이링크로 플레이 시작 | ACTIVITY | ROOT 토너먼트 id | {플레이어}님이 회원님 토너먼트를 플레이했어요 | 행위자 프사 |\n" +
+                "| `TOURNAMENT_COMPLETED` | 멤버가 클론 완료 | ACTIVITY | ROOT 토너먼트 id | {멤버}님이 회원님 토너먼트를 완료했어요 | 행위자 프사 |\n" +
+                "| `TOURNAMENT_RESULT_READY` | 주최자가 ROOT 완료 | ACTIVITY | ROOT 토너먼트 id | 참여하신 {주최자}님의 토너먼트 결과가 나왔어요 | 주최자 프사 |\n" +
+                "| `ITEM_PARSING_COMPLETED` | 상품 추출 성공 | SYSTEM | itemId | 상품 정보가 저장됐어요 | 피키 로고 |\n" +
+                "| `ITEM_PARSING_FAILED` | 상품 추출 실패 | SYSTEM | itemId | 상품 정보를 가져오지 못했어요 | 피키 로고 |\n" +
+                "| `ANNOUNCEMENT` | 관리자 공지(후속) | SYSTEM | 공지 id/0 | (관리자 입력) | 피키 로고 |\n\n" +
+                "> 파싱 알림(`ITEM_PARSING_*`)만 출처별 `kind`(WISH/TOURNAMENT)·`tournamentId`·`tournamentItemId` 가 추가로 실린다. " +
+                "나머지 타입엔 그 키가 없다. `title` 은 발송 시점 렌더 값이라 클라는 문구가 아니라 `type` 으로 분기한다.",
     )
     @ApiResponses(
         value = [


### PR DESCRIPTION
## Situation
- 알림 타입이 9종으로 늘었지만(#490 에서 4종 추가), api-docs 에는 각 타입이 어떤 트리거로 어떤 화면으로 가는지 정리된 표가 없었다.
- 프론트는 알림을 받으면 `type` 으로 화면을, `refId` 로 이동 대상을 정해야 하는데, 9종 각각의 `refId` 가 무엇을 가리키는지(특히 토너먼트 ROOT/CLONE 모델에서 `refId` 가 ROOT 토너먼트 id 라는 점)가 문서에 없어 클라가 딥링크를 설계할 근거가 부족했다.

## Task
- 9종 알림 전부의 예시(`type`·트리거·카테고리·`refId`·`title` 예시·아바타)를 한 표로 정리해 클라가 docs 만 보고 화면 분기·딥링크를 설계할 수 있게 한다.
- localhost Stoplight 에 실제로 노출되는 자리에 표를 넣는다. repo 전용 문서(`.md`)는 앱이 서빙하지 않아 Stoplight 엔 안 뜨므로, 노출 자리와 동기화 자리를 구분한다.

## Action
- 알림 히스토리 조회 엔드포인트 설명에 "알림 타입 카탈로그(전 9종)" 표를 추가했다. 이게 Stoplight(localhost)에 실제로 렌더되는 자리다.
- 표는 타입별로 트리거, 카테고리(활동/시스템), `refId` 가 가리키는 대상, `title` 예시, 아바타 출처(행위자 프사 / 피키 로고)를 한 줄로 정리한다.
- 토너먼트 소셜 알림 3종(플레이링크 플레이·완료·결과)의 `refId` 는 CLONE 이 아니라 ROOT 토너먼트 id 임을 표에 명시했다. ROOT/CLONE 모델에서 클라가 이동해야 하는 건 항상 ROOT 토너먼트라서다.
- 파싱 알림(`ITEM_PARSING_*`)만 출처별 `kind`·`tournamentId`·`tournamentItemId` 가 추가로 실리고 나머지 타입엔 없다는 점을 표 아래 주석으로 남겼다.
- repo 문서 `notification-sse-spec.md` 도 같은 9종으로 동기화했다: payload 스키마에 `category`·`imageUrl` 필드를 추가하고, 예시 JSON 을 갱신하고, 4종이던 딥링크 표를 9종(+카테고리 컬럼)으로 교체했다. 앱이 서빙하진 않지만 repo 안 단일 출처가 실제 타입과 어긋나지 않게 맞춘다.

## Result
- 문서 전용 변경이라 런타임/스키마 영향 없음. Stoplight 에서 알림 히스토리 조회 description 에 9종 표가 노출된다.
- 표의 `title` 은 발송 시점 렌더 값 예시일 뿐이라, 클라는 문구가 아니라 `type` 으로 분기해야 한다는 점을 주석으로 못박았다.
- `ANNOUNCEMENT` 는 관리자 기능이 붙는 후속 작업 대상이라 `refId` 를 "공지 id/0" 으로 잠정 표기했다.

---
## 연관 이슈

- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * 알림 이벤트 스키마에 카테고리(ACTIVITY/SYSTEM) 필드 추가
  * 알림 타입별 상세 정보(카테고리, 의미, 제목, 수신자) 문서 업데이트
  * API 문서에 알림 타입 설명 보강

<!-- end of auto-generated comment: release notes by coderabbit.ai -->