### PR TITLE
piki.day 도메인 듀얼런 추가 (api.piki.day / dev.api.piki.day)

### DIFF
--- a/infra/nginx/api.depromeet18team3.cloud.conf
+++ b/infra/nginx/api.depromeet18team3.cloud.conf
@@ -43,7 +43,10 @@ limit_req_zone $binary_remote_addr zone=piki_general:10m rate=20r/s;   # 초당 
 limit_req_status 429;                                              # 초과 시 기본 503 대신 429 Too Many Requests (두 zone 공통)
 
 server {
-    server_name api.depromeet18team3.cloud;
+    # piki.day 도메인 이관(#488) — 듀얼런: api.depromeet 와 api.piki.day 를 한 server block 에서 함께 서빙한다.
+    # 인증서는 두 도메인을 SAN 으로 함께 커버하는 piki.day cert(아래 ssl_certificate)를 쓴다.
+    # retire 시: server_name·아래 80 redirect 에서 api.depromeet18team3.cloud 를 빼고, cert 를 piki.day 단독으로 재발급한다.
+    server_name api.depromeet18team3.cloud api.piki.day;
 
     client_max_body_size 25M;
 
@@ -131,8 +134,9 @@ server {
     # 형식 주의: nginx 1.25.1+ 는 `http2 on;` 지시어를 선호하나, 이 `listen ... http2` 파라미터 형식도 동작한다
     # (신버전은 deprecation 경고만, nginx -t 는 통과). 운영 nginx 버전에 맞춰 추후 `http2 on;` 으로 바꿔도 된다.
     listen 443 ssl http2;
-    ssl_certificate /etc/letsencrypt/live/api.depromeet18team3.cloud/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/api.depromeet18team3.cloud/privkey.pem;
+    # SAN 인증서 — api.depromeet18team3.cloud + api.piki.day 둘 다 커버 (#488 듀얼런). piki.day lineage 로 발급.
+    ssl_certificate /etc/letsencrypt/live/api.piki.day/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/api.piki.day/privkey.pem;
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 }
@@ -141,7 +145,10 @@ server {
     if ($host = api.depromeet18team3.cloud) {
         return 301 https://$host$request_uri;
     }
+    if ($host = api.piki.day) {
+        return 301 https://$host$request_uri;
+    }
     listen 80;
-    server_name api.depromeet18team3.cloud;
+    server_name api.depromeet18team3.cloud api.piki.day;
     return 404;
 }

--- a/infra/nginx/dev.api.depromeet18team3.cloud.conf
+++ b/infra/nginx/dev.api.depromeet18team3.cloud.conf
@@ -51,7 +51,10 @@ limit_req_zone $binary_remote_addr zone=piki_general:10m rate=20r/s;   # 초당 
 limit_req_status 429;                                              # 초과 시 기본 503 대신 429 Too Many Requests (두 zone 공통)
 
 server {
-    server_name dev.api.depromeet18team3.cloud;
+    # piki.day 도메인 이관(#488) — 듀얼런: dev.api.depromeet 와 dev.api.piki.day 를 한 server block 에서 함께 서빙한다.
+    # 인증서는 두 도메인을 SAN 으로 함께 커버하는 dev.api.piki.day cert(아래 ssl_certificate)를 쓴다.
+    # retire 시: server_name·아래 80 redirect 에서 dev.api.depromeet18team3.cloud 를 빼고, cert 를 piki.day 단독으로 재발급한다.
+    server_name dev.api.depromeet18team3.cloud dev.api.piki.day;
 
     client_max_body_size 25M;
 
@@ -134,8 +137,9 @@ server {
     # 형식 주의: nginx 1.25.1+ 는 `http2 on;` 지시어를 선호하나, 이 `listen ... http2` 파라미터 형식도 동작한다
     # (신버전은 deprecation 경고만, nginx -t 는 통과). 운영 nginx 버전에 맞춰 추후 `http2 on;` 으로 바꿔도 된다.
     listen 443 ssl http2;
-    ssl_certificate /etc/letsencrypt/live/dev.api.depromeet18team3.cloud/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/dev.api.depromeet18team3.cloud/privkey.pem;
+    # SAN 인증서 — dev.api.depromeet18team3.cloud + dev.api.piki.day 둘 다 커버 (#488 듀얼런). piki.day lineage 로 발급.
+    ssl_certificate /etc/letsencrypt/live/dev.api.piki.day/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/dev.api.piki.day/privkey.pem;
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 }
@@ -144,7 +148,10 @@ server {
     if ($host = dev.api.depromeet18team3.cloud) {
         return 301 https://$host$request_uri;
     }
+    if ($host = dev.api.piki.day) {
+        return 301 https://$host$request_uri;
+    }
     listen 80;
-    server_name dev.api.depromeet18team3.cloud;
+    server_name dev.api.depromeet18team3.cloud dev.api.piki.day;
     return 404;
 }

--- a/src/main/kotlin/com/depromeet/piki/common/config/CorsConfig.kt
+++ b/src/main/kotlin/com/depromeet/piki/common/config/CorsConfig.kt
@@ -30,6 +30,15 @@ class CorsConfig {
                         // CORS 검사를 거치므로 화이트리스트에 포함되어야 한다. (prod·dev API 둘 다)
                         "https://api.depromeet18team3.cloud",
                         "https://dev.api.depromeet18team3.cloud",
+                        // piki.day 도메인 이관(#488) — 옛 도메인과 듀얼런으로 병렬 허용한다. 프론트(Vercel:
+                        // piki.day·www·dev) + 우리 서버 self-origin(api·dev.api, Stoplight try-it). 옛 도메인
+                        // retire 시 위 depromeet18team3.cloud 블록을 제거한다.
+                        "https://piki.day",
+                        "https://www.piki.day",
+                        "https://dev.piki.day",
+                        "https://www.dev.piki.day",
+                        "https://api.piki.day",
+                        "https://dev.api.piki.day",
                         // 프론트엔드 로컬 개발 환경 (Next.js dev server) — 로컬에서 배포 서버 API 를
                         // 호출하며 통합 테스트할 때 Origin 헤더가 박혀 CORS 검사를 거치므로 허용한다.
                         // localhost 와 127.0.0.1 은 브라우저상 서로 다른 origin 이라 둘 다 명시한다.

--- a/src/main/kotlin/com/depromeet/piki/notification/fcm/service/FirebaseMessageSender.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/fcm/service/FirebaseMessageSender.kt
@@ -123,7 +123,8 @@ class FirebaseMessageSender(
         private const val ANDROID_CHANNEL_ID = "piki_default"
 
         // 웹 푸시 클릭 시 이동할 링크(https 필수) — 웹 프론트 붙을 때 실제 경로로 조정.
-        private const val WEB_CLICK_LINK = "https://depromeet18team3.cloud"
+        // piki.day 도메인 이관(#488): 웹 프론트 apex(Vercel)가 piki.day 로 이전됨.
+        private const val WEB_CLICK_LINK = "https://piki.day"
 
         // 발송 실패 토큰 중 "정리 대상(죽은 토큰)" 판정 — FirebaseMessaging 응답 구조와 무관한 순수 정책이라
         // companion 으로 분리해 단위 테스트로 분기를 망라한다(FirebaseApp 없이 검증).

--- a/src/test/kotlin/com/depromeet/piki/common/config/CorsIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/common/config/CorsIntegrationTest.kt
@@ -74,6 +74,26 @@ class CorsIntegrationTest : IntegrationTestSupport() {
     }
 
     @Test
+    fun `piki_day 프론트 origin 의 preflight 도 허용된다`() {
+        // 도메인 이관(#488) — piki.day 프론트가 API 를 호출한다. 옛 도메인과 듀얼런으로 함께 허용한다.
+        // 화이트리스트 누락 시 piki.day 에서 모든 인증/JSON 요청이 CORS 로 막힌다. 회귀 가드.
+        val mockMvc =
+            MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .apply<DefaultMockMvcBuilder>(springSecurity())
+                .build()
+
+        mockMvc
+            .perform(
+                options("/api/v1/dev/users")
+                    .header(HttpHeaders.ORIGIN, "https://dev.piki.day")
+                    .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "POST"),
+            ).andExpect(status().isOk)
+            .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "https://dev.piki.day"))
+            .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS, "true"))
+    }
+
+    @Test
     fun `화이트리스트에 없는 origin 의 preflight 는 403 으로 거부된다`() {
         // 허용 목록 검증이 실제로 동작함을 함께 단언해 테스트가 vacuous 하지 않도록 한다.
         val mockMvc =


### PR DESCRIPTION
## Situation

- piki.day 도메인을 구매해, 외부 도메인(depromeet18team3.cloud)에서 자체 브랜드 도메인으로 이관한다 (#488).
- 옛 도메인(api.depromeet)을 가리키는 클라이언트(현재 web 프론트)가 살아 있다. 하드 컷오버는 그 프론트를 깨뜨리므로 무중단 듀얼런이 필요하다.

## Task

- API 가 옛 도메인과 새 도메인(api.piki.day / dev.api.piki.day)을 **동시에** 받게 한다 (무중단).
- 결정 포인트 3개: (1) 듀얼런을 nginx 에서 어떻게 표현할지, (2) conf 파일명을 바꿀지, (3) 어떤 환경변수가 도메인에 묶여 있는지.

## Action

### nginx 듀얼런 (SAN 인증서, 파일명 유지)

- 한 server block 에 두 server_name(옛+새)을 두고, 두 도메인을 SAN 으로 함께 커버하는 인증서를 참조한다. (인증서 자체는 EC2 에서 certbot 으로 piki.day lineage 를 확장 발급해둠, 코드 밖.)
- **별도 server block 을 안 쓴 이유**: location 블록(레이트리밋·SSE·actuator)이 통째로 중복돼 drift 위험. SAN 한 블록이 단순하고 안전.
- **conf 파일명 유지**(api.depromeet...conf 가 두 도메인 서빙): 배포가 conf 를 `sites-available/$DOMAIN` 에 배치하는 구조라, 파일명을 바꾸면 옛 conf 가 EC2 에 남아 `limit_req_zone` 중복으로 nginx -t 가 깨진다. 그래서 in-place 편집 + **deploy.yml 무변경**.
- 80 redirect 도 두 호스트 모두 https 로.

### CORS / 푸시

- CorsConfig 허용 origin 에 piki.day(apex·www·dev·api·dev.api) 추가. additive 라 옛 도메인은 retire 전까지 유지. credentials 쓰는 API 라 wildcard 패턴 대신 explicit 열거를 유지(최소 권한).
- 웹 푸시 클릭 링크를 piki.day 로.
- CORS 통합테스트에 piki.day origin 허용 회귀 가드 1건 추가.

### 환경변수 영향도 (전수 확인)

| 구분 | 항목 |
|---|---|
| 바꿔야 함 | `APPLE_REDIRECT_URI` · `GOOGLE_REDIRECT_URI` · `KAKAO_REDIRECT_URI` (provider 콘솔과 한 쌍, **이 PR 범위 밖**) |
| 무관(확인) | DB·Redis 호스트, JWT, S3(amazonaws URL), Gemini, Admin, Firebase, 쿠키(host-only) |

## Result

- 머지 → dev 배포 시 `dev.api.piki.day` 가 라이브로 켜지고 옛 도메인은 그대로 서빙(무중단). prod 는 dev→main 때 동일. 배포 후 새 도메인이 실제 TLS·API 응답까지 도는지는 dev 에서 `curl https://dev.api.piki.day` 로 즉시 검증 가능(옛 도메인·유저 영향 0).
- 머지해도 piki.day 는 **"API 만 준비된" 반쪽 상태**다. 웹페이지는 Vercel 에 piki.day 등록이, 소셜로그인은 redirect_uri 갱신이 따라와야 완성된다. 유저는 아직 옛 도메인을 쓰므로 깨지는 사용자는 없다. 이게 의도된 점진 이관의 첫 조각.
- 주의(상세는 #488): 듀얼런 중 프론트와 API 도메인이 섞이면(piki.day 프론트가 api.depromeet 호출) `SameSite=Strict` 쿠키 미전송으로 web 로그인이 깨진다. 프론트와 API 는 같은 registrable domain 쌍으로 함께 이전할 것. retire 는 cert 를 piki.day 단독 재발급한 뒤 depromeet DNS 제거 순서(안 그러면 SAN 갱신 실패).

---
## 연관 이슈

- close #488
