### PR TITLE
상품 추출 HTML 절단 순서를 바꿔 절단선 밖 가격 누락 해소

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/product/service/gemini/GeminiHtmlExtractor.kt
+++ b/src/main/kotlin/com/depromeet/piki/product/service/gemini/GeminiHtmlExtractor.kt
@@ -22,19 +22,25 @@ class GeminiHtmlExtractor(
         return result.toProductSnapshot(link)
     }
 
-    // LLM 입력에서 토큰 낭비·오판 요소(<script>/<style>/주석)를 제거한다.
+    // LLM 입력에서 토큰 낭비·오판 요소(<script>/<style>/주석)를 제거하고, 토큰 비용 상한(MAX_LLM_CHARS)으로 자른다.
     // <script type="application/ld+json"> 은 product schema 라 보존하며, ld+json 판별을 jsoup(파싱된 attr 기준)으로 해
     // type 변형(charset 파라미터·공백 등)에도 정확하다 — 구조화 파서의 select 와 같은 기준이라 두 경로가 일관된다.
+    // 절단은 fetch 단계(원본 앞부분)가 아니라 여기서 정리된 HTML 에 적용한다 — script/style 을 걷어낸 뒤라 같은
+    // 길이 안에 실제 상품 정보(가격 span 등)가 훨씬 더 담긴다. fetch 단계는 구조화 추출을 위해 전체를 보존한다.
     private fun sanitize(document: Document): String {
         document
             .select("script")
             .filter { !it.attr("type").trim().startsWith("application/ld+json", ignoreCase = true) }
             .forEach { it.remove() }
         document.select("style").remove()
-        return document.outerHtml().replace(COMMENT_PATTERN, "")
+        val cleaned = document.outerHtml().replace(COMMENT_PATTERN, "")
+        return if (cleaned.length > MAX_LLM_CHARS) cleaned.substring(0, MAX_LLM_CHARS) else cleaned
     }
 
     companion object {
+        // Gemini 입력의 토큰 비용 상한. fetch 단계가 아니라 sanitize 직후 정리된 HTML 에 적용한다.
+        private const val MAX_LLM_CHARS = 200_000
+
         private val COMMENT_PATTERN =
             Regex(
                 "<!--.*?-->",

--- a/src/main/kotlin/com/depromeet/piki/product/service/http/HttpPageFetcher.kt
+++ b/src/main/kotlin/com/depromeet/piki/product/service/http/HttpPageFetcher.kt
@@ -72,7 +72,7 @@ class HttpPageFetcher(
                 throw PageFetchException.emptyBody()
             }
 
-        val truncated = if (body.length > MAX_HTML_CHARS) body.substring(0, MAX_HTML_CHARS) else body
+        val truncated = if (body.length > MAX_FETCH_CHARS) body.substring(0, MAX_FETCH_CHARS) else body
         return PageContent(link = link, html = truncated)
     }
 
@@ -111,8 +111,13 @@ class HttpPageFetcher(
         private const val CONNECT_TIMEOUT_MS = 5_000
         private const val READ_TIMEOUT_MS = 15_000
 
-        // LLM 토큰 비용 상한. 대형 쇼핑몰(쿠팡 등)은 1MB 가 넘는 경우도 있음.
-        private const val MAX_HTML_CHARS = 200_000
+        // fetch 본문의 보관·파싱 비용을 막는 안전 상한이다. LLM 토큰 상한이 아니다 — 그건 Gemini 입력 직전
+        // GeminiHtmlExtractor 가 정리(sanitize)된 HTML 에 따로 적용한다. 이 상한을 넉넉히 둬야 구조화 추출
+        // (JSON-LD/OpenGraph)이 페이지 전체를 본다: JSON-LD·가격이 본문 뒤쪽에 있는 사이트(아마존 약 1.65MB,
+        // 나이키 약 0.75MB 실측)는 앞부분만 보면 가격을 놓친다. 동시 파싱(워커 풀) 시 메모리(상한 x 동시 수)를
+        // 감안해 무제한이 아니라 3MB 로 바운드한다. 무거운 한국 메이저 몰(쿠팡·G마켓·옥션)은 403 으로 막혀
+        // 애초에 fetch 되지 않으므로 이 상한과 무관하다.
+        private const val MAX_FETCH_CHARS = 3_000_000
 
         // 기본 RestClient UA 는 일부 사이트에서 차단되므로 실제 브라우저 UA 로 위장.
         private const val USER_AGENT =

--- a/src/test/kotlin/com/depromeet/piki/product/service/StructuredFirstExtractionIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/product/service/StructuredFirstExtractionIntegrationTest.kt
@@ -104,6 +104,42 @@ class StructuredFirstExtractionIntegrationTest : IntegrationTestSupport() {
         assertFalse(sentHtml.contains("제거대상주석"), "주석은 제거돼야 한다")
     }
 
+    @Test
+    fun `구조화 데이터가 과거 절단선(200KB) 뒤쪽에 있어도 추출하고 LLM 을 호출하지 않는다`() {
+        stubGeminiClient.reset()
+        stubGeminiClient.build = { error("절단선 밖 JSON-LD 도 구조화로 잡혀 LLM 이 호출되면 안 된다") }
+        // 과거엔 fetch 가 앞 200KB 만 남겨 뒤쪽 JSON-LD 를 놓쳤다(#476). 절단을 fetch 가 아니라 Gemini 입력 직전으로
+        // 옮겼으므로, 240KB 필러 뒤에 있는 JSON-LD 도 구조화가 잡아 LLM 없이 추출해야 한다.
+        val filler = "<div>x</div>".repeat(20_000) // 약 240KB
+        val html =
+            "<html><head></head><body>$filler" +
+                """<script type="application/ld+json">{"@type":"Product","name":"뒤쪽상품","offers":{"price":"77000","priceCurrency":"KRW"}}</script>""" +
+                "</body></html>"
+        stubPageFetcher.build = { PageContent(it, html) }
+
+        val snapshot = extractor.extract(link)
+
+        assertEquals("뒤쪽상품", snapshot.name)
+        assertEquals(77_000, snapshot.currentPrice)
+        assertEquals(0, stubGeminiClient.invocations)
+    }
+
+    @Test
+    fun `fallback 시 LLM 입력 HTML 은 정리 후 200KB 상한으로 잘린다`() {
+        stubGeminiClient.reset()
+        stubGeminiClient.build = { GeminiExtractionResult(isProductPage = true, name = "엘엘엠상품", currentPrice = 1_000) }
+        // 구조화 데이터 없는 대용량 페이지 → fallback. sanitize 후에도 200KB 를 넘으면 앞쪽(HEAD)은 남고 200KB 뒤(TAIL)는 잘려야 한다.
+        val filler = "<p>filler line content here</p>".repeat(20_000) // 약 620KB
+        val html = "<html><head></head><body><p>HEAD_MARKER</p>$filler<p>TAIL_MARKER</p></body></html>"
+        stubPageFetcher.build = { PageContent(it, html) }
+
+        extractor.extract(link)
+
+        val sentHtml = llmInputHtmlOf(stubGeminiClient.lastRequest)
+        assertTrue(sentHtml.contains("HEAD_MARKER"), "앞부분은 LLM 입력에 포함돼야 한다")
+        assertFalse(sentHtml.contains("TAIL_MARKER"), "200KB 뒤(MAX_LLM_CHARS 초과)는 잘려 LLM 입력에서 빠져야 한다")
+    }
+
     // GeminiExtractionRequest 의 HTML part(마지막 Part)에서 sanitize 된 LLM 입력 HTML 을 꺼낸다.
     private fun llmInputHtmlOf(request: Any?): String {
         val extractionRequest = request as GeminiExtractionRequest


### PR DESCRIPTION
## Situation

- 일부 상품 페이지에서 이름은 나오는데 가격이 비어 추출됐다(아마존·나이키 등). 실제 URL로 원본 HTML을 떠보니 가격은 페이지에 분명히 있었다.
- 원인은 추출기가 HTML을 fetch하자마자 앞부분(약 200KB)만 남기고 잘라낸 것이었다. 가격이 든 구조화 데이터(JSON-LD)나 가격 표시가 페이지 뒤쪽에 있는 사이트는 그 부분이 통째로 버려져, 구조화 추출도 LLM도 가격을 못 봤다. 자바스크립트 렌더 문제가 아니라 우리 절단 처리 문제였다.

## Task

- 절단 때문에 잃던 가격을 회수하되, LLM 토큰 비용 상한은 그대로 유지한다.
- 메모리·파싱 비용이 폭주하지 않게 fetch 보관량에는 안전 상한을 둔다.

## Action

- 절단 "시점"을 옮겼다. fetch는 페이지 전체를 넘겨 구조화 추출이 전체를 보게 하고, LLM 입력 절단은 정리(script·style 제거) 직후의 HTML에 적용한다. 같은 200KB라도 정리된 본문이라 실제 상품 정보(가격 표시)가 훨씬 많이 담긴다.
- fetch 보관 상한은 실측으로 정했다. fetch 가능한 페이지 중 최대는 아마존 약 1.65MB였고(쿠팡·G마켓·옥션 등 무거운 한국 몰은 403으로 차단돼 fetch 자체가 안 됨), 여기에 헤드룸을 둬 3MB로 잡았다. 동시 파싱(워커 풀)에서 메모리는 상한 곱하기 동시 수라 무제한 대신 바운드한다.

### 구현

- `HttpPageFetcher`: fetch 절단 상한을 200KB(`MAX_HTML_CHARS`, LLM 상한 목적)에서 3MB(`MAX_FETCH_CHARS`, 보관·파싱 안전 바운드)로 변경.
- `GeminiHtmlExtractor`: 정리(sanitize) 직후의 HTML을 LLM 토큰 상한 200KB(`MAX_LLM_CHARS`)로 절단.

## Result

- 절단선 밖에 있던 가격이 두 경로로 회수된다(실제 Gemini E2E 측정):

| 사이트 | 경로 | 이번 결과 | 이전 |
|---|---|---|---|
| 나이키 | 구조화(JSON-LD) | 199,000 KRW | 누락 |
| 아마존(텀블러) | LLM | 144,409 KRW | 누락 |
| 아마존(스트랩) | LLM | 38,079 KRW | 누락 |
| 무신사(앵커) | 구조화 | 35,100 KRW | 정상(회귀 없음) |

- LLM 입력 토큰은 여전히 200KB로 바운드된다(절단 위치만 fetch에서 정리 후로 이동). fetch 상한 3MB는 LLM으로 보내는 양이 아니라 구조화 추출·정리 단계가 보는 원본 범위만 키운다.
- 나이키는 우리 파서(JSON-LD)로, 아마존은 가격을 표준 포맷(JSON-LD/OpenGraph)에 안 넣고 자체 마크업에만 둬서 LLM으로 갈린다. 아마존을 파서로 잡으려면 사이트별 셀렉터 하드코딩이 필요해(host 무관 원칙 위배) LLM fallback에 맡긴다.
- 한계: fetch 상한을 넘는 페이지는 그 위가 잘린다(절벽이 아니라 꼬리 데이터 손실). 응답 body는 상한 적용 전 전부 메모리로 읽히므로 진짜 거대 응답 방어(Content-Length 기반 스트리밍 제한)는 별도 후속이다. 이번 변경으로 추출 HTML 길이가 full로 로깅되어, 운영 분포를 보고 3MB를 사후 조정할 수 있다.

---
## 연관 이슈

- close #476


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * HTML 정리 시 script(style 제외)와 style 제거, 주석 제거 및 JSON-LD 보존 로직 강화
  * LLM 입력은 정리 후 최대 200,000자(MAX_LLM_CHARS)로 앞부분(HEAD)만 잘라 전달하여 토큰/비용 상한 보장
  * 페이지 페칭 시 내부 버퍼 상한을 3,000,000자(MAX_FETCH_CHARS)로 조정해 메모리 사용 제어

* **Tests**
  * 구조화 추출과 LLM 폴백 시의 JSON-LD 보존 및 입력 잘림 동작을 검증하는 통합 테스트 2건 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Updates

### dev 머지 — #454와 충돌 해소 (`d7fd23a`)

- 분기 후 #454(`HttpPageFetcher` same-domain redirect 재작성)가 dev에 머지되며 같은 파일에서 충돌. dev의 #454 변경을 통째로 유지하고, 그 새 구조(`fetchFollowingRedirects`) 위에 절단 변경(`MAX_HTML_CHARS` 200KB → `MAX_FETCH_CHARS` 3MB)만 재적용. GeminiHtmlExtractor·통합 테스트는 충돌 없이 그대로.
- origin/dev 대비 순변경은 여전히 본 3개 파일뿐(+52/-5). 머지 후 전체 단위+통합 테스트 통과(#454의 redirect·SSRF 테스트 포함).
