### PR TITLE
옛 depromeet 도메인 retire (piki.day 단독)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -194,6 +194,17 @@ jobs:
             [ -f /etc/nginx/team3-upstream.conf ] || echo "server localhost:8080;" | sudo tee /etc/nginx/team3-upstream.conf
             # 새 인스턴스(cloud-init nginx)는 stock default 사이트가 켜져 있어 catch-all 로 충돌 → 제거.
             sudo rm -f /etc/nginx/sites-enabled/default
+            # 환경당 conf 는 $DOMAIN 하나만 enabled 여야 한다. 도메인 rename(#488 depromeet retire 등) 후
+            # 옛 도메인의 잔존 conf 가 sites-enabled 에 남으면 limit_req_zone 중복으로 nginx -t 가 깨진다.
+            # $DOMAIN·default 외의 sites-enabled 항목과 그 sites-available 원본을 정리한다(멱등 — 정상 배포엔 no-op).
+            for old in /etc/nginx/sites-enabled/*; do
+              [ -e "$old" ] || continue   # sites-enabled 가 비어 glob 미확장 시 리터럴 '*' 보호
+              bn=$(basename "$old")
+              [ "$bn" = "$DOMAIN" ] && continue
+              [ "$bn" = "default" ] && continue
+              echo "[nginx] $DOMAIN 외 옛 conf 제거: $bn"
+              sudo rm -f "$old" "/etc/nginx/sites-available/$bn"
+            done
             # 현재 설정 백업 후 교체. nginx -t 검증 실패 시 이전 설정으로 롤백하고 배포를 중단한다.
             sudo cp "$DST" "${DST}.bak" 2>/dev/null || true
             sudo cp "$SRC" "$DST"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,12 +29,12 @@ jobs:
           REF="${{ github.event.workflow_run.head_sha || github.sha }}"
           if [ "$BRANCH" = "main" ]; then
             echo "environment=prod" >> "$GITHUB_OUTPUT"
-            echo "domain=api.depromeet18team3.cloud" >> "$GITHUB_OUTPUT"
-            echo "nginx_conf=api.depromeet18team3.cloud.conf" >> "$GITHUB_OUTPUT"
+            echo "domain=api.piki.day" >> "$GITHUB_OUTPUT"
+            echo "nginx_conf=api.piki.day.conf" >> "$GITHUB_OUTPUT"
           else
             echo "environment=dev" >> "$GITHUB_OUTPUT"
-            echo "domain=dev.api.depromeet18team3.cloud" >> "$GITHUB_OUTPUT"
-            echo "nginx_conf=dev.api.depromeet18team3.cloud.conf" >> "$GITHUB_OUTPUT"
+            echo "domain=dev.api.piki.day" >> "$GITHUB_OUTPUT"
+            echo "nginx_conf=dev.api.piki.day.conf" >> "$GITHUB_OUTPUT"
           fi
           echo "ref=$REF" >> "$GITHUB_OUTPUT"
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"

--- a/infra/nginx/api.piki.day.conf
+++ b/infra/nginx/api.piki.day.conf
@@ -1,20 +1,12 @@
-# dev.api.depromeet18team3.cloud nginx 설정 — dev EC2 전용
+# api.piki.day nginx 설정 — IaC 단일 진실(single source of truth)
 #
-# 이 파일이 배포 시 EC2 /etc/nginx/sites-available/dev.api.depromeet18team3.cloud 로 복사되고,
+# 이 파일이 배포 시 EC2 /etc/nginx/sites-available/api.piki.day 로 복사되고,
 # nginx -t 검증을 통과해야 reload 된다 (.github/workflows/deploy.yml).
-#
-# prod conf(api.depromeet18team3.cloud.conf)와 동일 구조를 유지한다 — 별도 파일이라 한쪽에만 설정이
-# 빠지는 드리프트가 생기기 쉽다. dev 가 prod 의 상위집합이 되도록(prod 에 있는 건 dev 에도 있게) 맞춘다.
-# 환경 고유 차이는 server_name 과 ssl_certificate 경로의 도메인 문자열뿐이다.
-# piki.day 도메인으로 전환 시 그 도메인 문자열만 교체하면 된다.
 #
 # 동적·서버 의존 요소는 이 레포가 관리하지 않고 경로로 참조만 한다:
 #   - /etc/nginx/team3-upstream.conf : deploy.yml 이 blue/green 전환 때 런타임에 생성하는 상태 파일
 #                                      (server localhost:8080 | 8081). IaC 대상 아님.
 #   - /etc/letsencrypt/*             : certbot 이 발급·자동 갱신하는 TLS 키·인증서 (비밀). git 금지.
-#
-# SSL 인증서 최초 발급 (dev EC2 접속 후):
-#   sudo certbot --nginx -d dev.api.depromeet18team3.cloud
 
 upstream team3 {
     include /etc/nginx/team3-upstream.conf;
@@ -51,10 +43,8 @@ limit_req_zone $binary_remote_addr zone=piki_general:10m rate=20r/s;   # 초당 
 limit_req_status 429;                                              # 초과 시 기본 503 대신 429 Too Many Requests (두 zone 공통)
 
 server {
-    # piki.day 도메인 이관(#488) — 듀얼런: dev.api.depromeet 와 dev.api.piki.day 를 한 server block 에서 함께 서빙한다.
-    # 인증서는 두 도메인을 SAN 으로 함께 커버하는 dev.api.piki.day cert(아래 ssl_certificate)를 쓴다.
-    # retire 시: server_name·아래 80 redirect 에서 dev.api.depromeet18team3.cloud 를 빼고, cert 를 piki.day 단독으로 재발급한다.
-    server_name dev.api.depromeet18team3.cloud dev.api.piki.day;
+    # piki.day 단독 (#488 retire 완료 — depromeet 도메인 제거). 인증서도 piki.day 단독(아래 ssl_certificate).
+    server_name api.piki.day;
 
     client_max_body_size 25M;
 
@@ -63,7 +53,12 @@ server {
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
-    # nginx 기본값(60s). 추출이 @Async 워커로 빠져 요청 스레드를 길게 잡는 동기 외부 호출이 없어 60s 로 충분하다 (prod conf 와 동일 근거).
+
+    # nginx 기본값(60s)을 의도적으로 명시한다. 과거엔 상품 추출(외부 fetch + Gemini)이 요청 스레드에서
+    # 동기로 돌아 최악 60s 가까이 걸렸고, 504(사유 없음)를 피하려 90s 로 늘렸었다. 이후 추출이 전부
+    # @Async 워커로 빠져(요청 스레드는 PROCESSING item 저장 후 즉시 응답, 결과는 SSE 알림으로 전달)
+    # 요청 스레드를 길게 잡는 동기 외부 호출은 사라졌다. 남은 최대 동기 외부 호출은 OAuth 로그인(read 10s)
+    # 과 recover 의 S3 이미지 1장 업로드(수초)뿐이라 60s 로 충분하다.
     proxy_read_timeout 60s;
 
     # actuator 엔드포인트는 외부에 노출하지 않는다. 메트릭(/actuator/prometheus)·health 는
@@ -137,21 +132,18 @@ server {
     # 형식 주의: nginx 1.25.1+ 는 `http2 on;` 지시어를 선호하나, 이 `listen ... http2` 파라미터 형식도 동작한다
     # (신버전은 deprecation 경고만, nginx -t 는 통과). 운영 nginx 버전에 맞춰 추후 `http2 on;` 으로 바꿔도 된다.
     listen 443 ssl http2;
-    # SAN 인증서 — dev.api.depromeet18team3.cloud + dev.api.piki.day 둘 다 커버 (#488 듀얼런). piki.day lineage 로 발급.
-    ssl_certificate /etc/letsencrypt/live/dev.api.piki.day/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/dev.api.piki.day/privkey.pem;
+    # 인증서 — api.piki.day 단독 (#488 retire). depromeet SAN 제거 후 piki.day 단독으로 재발급.
+    ssl_certificate /etc/letsencrypt/live/api.piki.day/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/api.piki.day/privkey.pem;
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 }
 
 server {
-    if ($host = dev.api.depromeet18team3.cloud) {
-        return 301 https://$host$request_uri;
-    }
-    if ($host = dev.api.piki.day) {
+    if ($host = api.piki.day) {
         return 301 https://$host$request_uri;
     }
     listen 80;
-    server_name dev.api.depromeet18team3.cloud dev.api.piki.day;
+    server_name api.piki.day;
     return 404;
 }

--- a/infra/nginx/dev.api.piki.day.conf
+++ b/infra/nginx/dev.api.piki.day.conf
@@ -1,12 +1,20 @@
-# api.depromeet18team3.cloud nginx 설정 — IaC 단일 진실(single source of truth)
+# dev.api.piki.day nginx 설정 — dev EC2 전용
 #
-# 이 파일이 배포 시 EC2 /etc/nginx/sites-available/api.depromeet18team3.cloud 로 복사되고,
+# 이 파일이 배포 시 EC2 /etc/nginx/sites-available/dev.api.piki.day 로 복사되고,
 # nginx -t 검증을 통과해야 reload 된다 (.github/workflows/deploy.yml).
+#
+# prod conf(api.piki.day.conf)와 동일 구조를 유지한다 — 별도 파일이라 한쪽에만 설정이
+# 빠지는 드리프트가 생기기 쉽다. dev 가 prod 의 상위집합이 되도록(prod 에 있는 건 dev 에도 있게) 맞춘다.
+# 환경 고유 차이는 server_name 과 ssl_certificate 경로의 도메인 문자열뿐이다.
+# piki.day 도메인으로 전환 시 그 도메인 문자열만 교체하면 된다.
 #
 # 동적·서버 의존 요소는 이 레포가 관리하지 않고 경로로 참조만 한다:
 #   - /etc/nginx/team3-upstream.conf : deploy.yml 이 blue/green 전환 때 런타임에 생성하는 상태 파일
 #                                      (server localhost:8080 | 8081). IaC 대상 아님.
 #   - /etc/letsencrypt/*             : certbot 이 발급·자동 갱신하는 TLS 키·인증서 (비밀). git 금지.
+#
+# SSL 인증서 최초 발급 (dev EC2 접속 후):
+#   sudo certbot --nginx -d dev.api.piki.day
 
 upstream team3 {
     include /etc/nginx/team3-upstream.conf;
@@ -43,10 +51,8 @@ limit_req_zone $binary_remote_addr zone=piki_general:10m rate=20r/s;   # 초당 
 limit_req_status 429;                                              # 초과 시 기본 503 대신 429 Too Many Requests (두 zone 공통)
 
 server {
-    # piki.day 도메인 이관(#488) — 듀얼런: api.depromeet 와 api.piki.day 를 한 server block 에서 함께 서빙한다.
-    # 인증서는 두 도메인을 SAN 으로 함께 커버하는 piki.day cert(아래 ssl_certificate)를 쓴다.
-    # retire 시: server_name·아래 80 redirect 에서 api.depromeet18team3.cloud 를 빼고, cert 를 piki.day 단독으로 재발급한다.
-    server_name api.depromeet18team3.cloud api.piki.day;
+    # dev.api.piki.day 단독 (#488 retire 완료 — depromeet 도메인 제거). 인증서도 piki.day 단독(아래 ssl_certificate).
+    server_name dev.api.piki.day;
 
     client_max_body_size 25M;
 
@@ -55,12 +61,7 @@ server {
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
-
-    # nginx 기본값(60s)을 의도적으로 명시한다. 과거엔 상품 추출(외부 fetch + Gemini)이 요청 스레드에서
-    # 동기로 돌아 최악 60s 가까이 걸렸고, 504(사유 없음)를 피하려 90s 로 늘렸었다. 이후 추출이 전부
-    # @Async 워커로 빠져(요청 스레드는 PROCESSING item 저장 후 즉시 응답, 결과는 SSE 알림으로 전달)
-    # 요청 스레드를 길게 잡는 동기 외부 호출은 사라졌다. 남은 최대 동기 외부 호출은 OAuth 로그인(read 10s)
-    # 과 recover 의 S3 이미지 1장 업로드(수초)뿐이라 60s 로 충분하다.
+    # nginx 기본값(60s). 추출이 @Async 워커로 빠져 요청 스레드를 길게 잡는 동기 외부 호출이 없어 60s 로 충분하다 (prod conf 와 동일 근거).
     proxy_read_timeout 60s;
 
     # actuator 엔드포인트는 외부에 노출하지 않는다. 메트릭(/actuator/prometheus)·health 는
@@ -134,21 +135,18 @@ server {
     # 형식 주의: nginx 1.25.1+ 는 `http2 on;` 지시어를 선호하나, 이 `listen ... http2` 파라미터 형식도 동작한다
     # (신버전은 deprecation 경고만, nginx -t 는 통과). 운영 nginx 버전에 맞춰 추후 `http2 on;` 으로 바꿔도 된다.
     listen 443 ssl http2;
-    # SAN 인증서 — api.depromeet18team3.cloud + api.piki.day 둘 다 커버 (#488 듀얼런). piki.day lineage 로 발급.
-    ssl_certificate /etc/letsencrypt/live/api.piki.day/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/api.piki.day/privkey.pem;
+    # 인증서 — dev.api.piki.day 단독 (#488 retire). depromeet SAN 제거 후 piki.day 단독으로 재발급.
+    ssl_certificate /etc/letsencrypt/live/dev.api.piki.day/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/dev.api.piki.day/privkey.pem;
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 }
 
 server {
-    if ($host = api.depromeet18team3.cloud) {
-        return 301 https://$host$request_uri;
-    }
-    if ($host = api.piki.day) {
+    if ($host = dev.api.piki.day) {
         return 301 https://$host$request_uri;
     }
     listen 80;
-    server_name api.depromeet18team3.cloud api.piki.day;
+    server_name dev.api.piki.day;
     return 404;
 }

--- a/src/main/kotlin/com/depromeet/piki/common/config/CorsConfig.kt
+++ b/src/main/kotlin/com/depromeet/piki/common/config/CorsConfig.kt
@@ -18,21 +18,11 @@ class CorsConfig {
             CorsConfiguration().apply {
                 allowedOrigins =
                     listOf(
-                        "https://depromeet18team3.cloud",
-                        "https://www.depromeet18team3.cloud",
+                        // Vercel 프로젝트 기본 URL — depromeet18team3.cloud 도메인과 별개라 retire 대상이 아니다.
                         "https://depromeet.vercel.app",
-                        // dev 프론트 — dev.api.depromeet18team3.cloud(dev 서버)를 호출하는 dev 프론트 origin.
-                        // (Apple 콜백이 www.dev 를 쓰는 등 호스트가 갈릴 수 있어 둘 다 허용)
-                        "https://dev.depromeet18team3.cloud",
-                        "https://www.dev.depromeet18team3.cloud",
-                        // 우리 서버 자체 origin — Stoplight UI (/docs/index.html) 의 try-it 이
-                        // 브라우저 fetch(mode=cors) 로 호출 시 same-origin 이어도 Origin 헤더가 박혀
-                        // CORS 검사를 거치므로 화이트리스트에 포함되어야 한다. (prod·dev API 둘 다)
-                        "https://api.depromeet18team3.cloud",
-                        "https://dev.api.depromeet18team3.cloud",
-                        // piki.day 도메인 이관(#488) — 옛 도메인과 듀얼런으로 병렬 허용한다. 프론트(Vercel:
-                        // piki.day·www·dev) + 우리 서버 self-origin(api·dev.api, Stoplight try-it). 옛 도메인
-                        // retire 시 위 depromeet18team3.cloud 블록을 제거한다.
+                        // piki.day — 프론트(Vercel: piki.day·www·dev) + 우리 서버 self-origin(api·dev.api 는
+                        // Stoplight UI(/docs/index.html) try-it 이 same-origin 이어도 Origin 헤더가 박혀 필요).
+                        // (#488 retire 로 옛 depromeet18team3.cloud 도메인 origin 은 제거됨.)
                         "https://piki.day",
                         "https://www.piki.day",
                         "https://dev.piki.day",

--- a/src/test/kotlin/com/depromeet/piki/common/config/CorsIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/common/config/CorsIntegrationTest.kt
@@ -54,9 +54,9 @@ class CorsIntegrationTest : IntegrationTestSupport() {
     }
 
     @Test
-    fun `dev 프론트 origin 의 preflight 도 허용된다`() {
-        // dev/prod 분리로 dev 프론트(dev.depromeet18team3.cloud)가 dev API 를 호출한다. 화이트리스트
-        // 누락 시 dev 에서 모든 인증/JSON 요청이 CORS 로 막힌다. 회귀 가드.
+    fun `retire 된 옛 depromeet origin 의 preflight 는 거부된다`() {
+        // #488 retire — 옛 dev.depromeet18team3.cloud 도메인 origin 은 화이트리스트에서 제거됐다.
+        // dev 프론트의 정상 경로는 dev.piki.day 로 옮겨갔고(아래 테스트), 옛 origin 은 이제 차단된다. 회귀 가드.
         val mockMvc =
             MockMvcBuilders
                 .webAppContextSetup(webApplicationContext)
@@ -68,9 +68,7 @@ class CorsIntegrationTest : IntegrationTestSupport() {
                 options("/api/v1/dev/users")
                     .header(HttpHeaders.ORIGIN, "https://dev.depromeet18team3.cloud")
                     .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "POST"),
-            ).andExpect(status().isOk)
-            .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "https://dev.depromeet18team3.cloud"))
-            .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS, "true"))
+            ).andExpect(status().isForbidden)
     }
 
     @Test


### PR DESCRIPTION
## Situation

- piki.day 이관(#488) 듀얼런으로 dev.piki.day와 piki.day가 안정화됐고, web 프론트가 piki.day로 완전히 이전됐다. 옛 depromeet18team3.cloud를 가리키는 클라이언트가 더 없다.
- 듀얼런을 유지하면 옛 도메인의 cert, DNS, conf가 계속 따라다닌다. 옛 도메인을 제거(retire)해 piki.day 단독으로 정리한다.

## Task

- dev와 prod의 nginx, CORS, 배포 설정에서 depromeet 도메인을 걷어내고 piki.day 단독으로 만든다.
- 핵심 결정: depromeet DNS를 제거한 뒤에도 배포가 안 깨지게 하는 것. 단순히 server_name만 빼면 배포 가드와 cert 갱신이 옛 도메인에 묶여 터진다.

## Action

### nginx (도메인 단독화 + 파일 rename)

- conf 2개를 piki.day 이름으로 rename (api.piki.day.conf, dev.api.piki.day.conf). server_name과 80 redirect를 piki.day 단독으로, cert 경로도 piki.day로.
- vercel.app은 유지: depromeet.vercel.app은 Vercel 프로젝트 기본 URL이라 retire 대상 도메인과 별개다. 제거하면 preview 접근이 깨질 수 있어 보존.

### deploy.yml (동적 도메인으로 가드, 알림, cert 정합)

- resolve의 prod/dev domain과 nginx_conf를 piki.day로 바꿨다. 이 domain output을 DNS 가드(getent), cert-ensure, Slack 알림이 공유하므로, depromeet DNS를 제거한 뒤에도 전부 piki.day 기준으로 동작한다. server_name만 빼면 DNS 제거 시 가드가 옛 도메인 resolve 실패로 배포를 멈춘다.
- 배포 nginx 스텝에 "현재 DOMAIN conf만 enabled" 정리를 추가했다. 도메인 rename으로 EC2 sites-enabled에 옛 conf가 남으면 limit_req_zone 중복으로 nginx -t가 깨진다. 수동 SSH나 다운타임 없이 배포가 멱등하게 옛 conf를 걷어낸다.

### CORS

- depromeet18team3.cloud origin 6개 제거. 통합테스트의 옛 origin 허용 단언을 "이제 403으로 거부됨"으로 뒤집어 retire 회귀 가드로 삼았다.

## Result

- 머지하면 dev 배포 시 dev.api.piki.day가 piki.day 단독으로 서빙되고 옛 도메인은 차단된다. prod는 dev에서 main 머지 때 동일하게 적용된다.
- 머지만으로 끝이 아니다. 옛 도메인 완전 제거에는 순서가 있다: 배포(옛 도메인 서빙 중단) 후 각 EC2 cert를 piki.day 단독으로 재발급(SAN에서 depromeet 제거) 후 마지막에 가비아 depromeet DNS 제거. cert 재발급을 DNS 제거보다 먼저 해야 certbot 갱신이 안 깨진다.
- dev와 prod 둘 다 retire 대상이다. prod도 듀얼런(SAN cert)이라 DNS만 빼면 prod cert 갱신이 약 60일 뒤 터진다.

---
## 연관 이슈

- #488 piki.day 도메인 이관 (이 PR로 옛 depromeet 도메인 retire, #488은 이미 closed라 close 키워드 미사용)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 프로덕션 API 도메인을 새로운 도메인으로 변경하고 배포 설정을 최적화했습니다.
  * 레거시 도메인에 대한 CORS 정책을 제거하고 새로운 도메인만 허용하도록 업데이트했습니다.
  * 배포 중 중복된 설정 제거 로직을 추가하여 안정성을 개선했습니다.

* **Tests**
  * 도메인 변경에 따른 CORS 테스트를 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->