### PR TITLE
Auth·User·FCM·Notification 구조화 로깅 + userId 상관추적

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/auth/filter/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/filter/JwtAuthenticationFilter.kt
@@ -38,6 +38,9 @@ class JwtAuthenticationFilter(
                 // userId 를 단다 — traceId 가 요청 1건을 묶고, userId 가 그 유저의 여러 요청을 가로질러 묶는다.
                 // async 전파는 ContextPropagatingTaskDecorator(AsyncConfig)가 MDC 를 워커로 넘겨 보장한다.
                 MDC.put(LoggingKeys.USER_ID, payload.userId.toString())
+                // request attribute 에도 둔다 — AccessLogFilter(이 필터보다 바깥)는 자기 finally 시점에 아래 MDC.remove
+                // 가 이미 돈 뒤라 MDC 로는 userId 를 못 본다. attribute 는 요청 끝까지 살아있어 access log 가 그걸 읽는다.
+                request.setAttribute(LoggingKeys.USER_ID, payload.userId.toString())
             }
         try {
             filterChain.doFilter(request, response)

--- a/src/main/kotlin/com/depromeet/piki/auth/filter/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/filter/JwtAuthenticationFilter.kt
@@ -3,9 +3,11 @@ package com.depromeet.piki.auth.filter
 import com.depromeet.piki.auth.infrastructure.jwt.JwtProvider
 import com.depromeet.piki.auth.infrastructure.redis.WithdrawnTokenStore
 import com.depromeet.piki.auth.web.TokenCookieWriter
+import com.depromeet.piki.common.logging.LoggingKeys
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.MDC
 import org.springframework.http.HttpHeaders
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.context.SecurityContextHolder
@@ -32,8 +34,18 @@ class JwtAuthenticationFilter(
                 val authority = SimpleGrantedAuthority(payload.identityType.name)
                 SecurityContextHolder.getContext().authentication =
                     PreAuthenticatedAuthenticationToken(payload.userId, null, listOf(authority))
+                // 인증된 요청의 userId 를 MDC 에 실어 이 요청 이후 전 로그(컨트롤러·서비스·async 워커)가 같은
+                // userId 를 단다 — traceId 가 요청 1건을 묶고, userId 가 그 유저의 여러 요청을 가로질러 묶는다.
+                // async 전파는 ContextPropagatingTaskDecorator(AsyncConfig)가 MDC 를 워커로 넘겨 보장한다.
+                MDC.put(LoggingKeys.USER_ID, payload.userId.toString())
             }
-        filterChain.doFilter(request, response)
+        try {
+            filterChain.doFilter(request, response)
+        } finally {
+            // 톰캣 워커 스레드는 풀에서 재사용되므로 요청 끝에 반드시 지운다 — 안 지우면 다음 요청(미인증 포함)이
+            // 이전 요청의 userId 를 물려받아 오염된다. put 안 한 경우에도 remove 는 무해(no-op).
+            MDC.remove(LoggingKeys.USER_ID)
+        }
     }
 
     // 헤더(APP) 우선 → 없으면 access_token 쿠키(WEB). 둘 다 있으면 헤더가 이긴다.

--- a/src/main/kotlin/com/depromeet/piki/auth/service/AuthService.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/service/AuthService.kt
@@ -5,9 +5,11 @@ import com.depromeet.piki.auth.infrastructure.jwt.JwtProvider
 import com.depromeet.piki.auth.infrastructure.redis.RefreshTokenStore
 import com.depromeet.piki.auth.service.dto.SignupResult
 import com.depromeet.piki.auth.service.dto.TokenPair
+import com.depromeet.piki.common.logging.SensitiveData
 import com.depromeet.piki.user.domain.User
 import com.depromeet.piki.user.domain.UserException
 import com.depromeet.piki.user.service.UserService
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.util.UUID
 
@@ -17,15 +19,20 @@ class AuthService(
     private val jwtProvider: JwtProvider,
     private val refreshTokenStore: RefreshTokenStore,
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
     fun createGuest(): SignupResult {
         val user = userService.createGuest()
         val tokenPair = issueTokenPair(user)
+        log.info("게스트 생성 userId={}", user.id)
         return SignupResult(tokenPair = tokenPair, user = user)
     }
 
     fun createMember(nickname: String): SignupResult {
+        // 닉네임 원문은 PII 라 싣지 않는다 — 생성 사실과 userId 만.
         val user = userService.createMember(nickname)
         val tokenPair = issueTokenPair(user)
+        log.info("회원 생성 userId={}", user.id)
         return SignupResult(tokenPair = tokenPair, user = user)
     }
 
@@ -38,16 +45,31 @@ class AuthService(
         return SignupResult(tokenPair = tokenPair, user = user)
     }
 
+    // 갱신 거부는 모두 클라이언트 계약 위반(만료·위조·재사용 토큰)이라 info 로 사유를 구분해 남긴다 —
+    // prod 401 디버깅의 핵심: "왜 거부됐나"(파싱 실패/탈퇴/저장 토큰 불일치)를 traceId·userId 와 함께 본다.
+    // refresh 토큰 원문은 크리덴셜이라 지문(maskToken)으로만 찍는다.
     fun refresh(refreshToken: String): TokenPair {
-        val userId = jwtProvider.parseRefreshToken(refreshToken) ?: throw AuthException.invalidToken()
+        val userId =
+            jwtProvider.parseRefreshToken(refreshToken) ?: run {
+                log.info("토큰 갱신 거부 사유=refresh 토큰 파싱 실패(만료·위조) token={}", SensitiveData.maskToken(refreshToken))
+                throw AuthException.invalidToken()
+            }
         val user = userService.findById(userId)
-        user.deletedAt?.let { throw AuthException.invalidToken() }
-        if (!refreshTokenStore.consumeIfMatches(userId, refreshToken)) throw AuthException.invalidToken()
+        user.deletedAt?.let {
+            log.info("토큰 갱신 거부 사유=탈퇴 유저 userId={}", userId)
+            throw AuthException.invalidToken()
+        }
+        if (!refreshTokenStore.consumeIfMatches(userId, refreshToken)) {
+            log.info("토큰 갱신 거부 사유=저장된 refresh 토큰 불일치(재사용·회전 후) userId={}", userId)
+            throw AuthException.invalidToken()
+        }
+        log.info("토큰 갱신 성공 userId={}", userId)
         return issueTokenPair(user)
     }
 
     fun logout(userId: UUID) {
         refreshTokenStore.delete(userId)
+        log.info("로그아웃 userId={}", userId)
     }
 
     fun createTokensForUser(user: User): TokenPair {

--- a/src/main/kotlin/com/depromeet/piki/auth/service/OAuthLoginService.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/service/OAuthLoginService.kt
@@ -8,6 +8,7 @@ import com.depromeet.piki.auth.infrastructure.oauth.OAuthUserInfo
 import com.depromeet.piki.auth.infrastructure.redis.OAuthStateStore
 import com.depromeet.piki.auth.service.dto.OAuthLoginCommand
 import com.depromeet.piki.auth.service.dto.SignupResult
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.util.UUID
 
@@ -20,20 +21,30 @@ class OAuthLoginService(
     private val authService: AuthService,
     private val oAuthStateStore: OAuthStateStore,
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
     fun login(
         provider: OAuthProvider,
         command: OAuthLoginCommand,
         currentUserId: UUID?,
     ): SignupResult {
+        // currentUserId 는 게스트가 소셜 연결을 시도하는 경우의 게스트 id(없으면 null=신규/재방문 로그인).
+        // 토큰·code 등 크리덴셜은 싣지 않는다 — provider 와 게스트연결 여부만 남긴다.
+        log.info("소셜 로그인 시도 provider={} currentUserId={}", provider, currentUserId)
         // state 가 있으면 Redis 에서 소비 검증. 없거나 만료된 state 는 401 — CSRF 방지.
         // state 를 보내지 않으면 검증 생략 (v2 SDK 흐름 · 과도기 호환).
         command.state?.ifBlank { null }?.let { state ->
-            if (!oAuthStateStore.consumeIfValid(state)) throw OAuthException.invalidState()
+            if (!oAuthStateStore.consumeIfValid(state)) {
+                // 클라이언트 계약 위반(만료·위조 state)이라 info — 서버 입장에선 정상 거부다.
+                log.info("소셜 로그인 거부 사유=state 검증 실패(CSRF 방지) provider={}", provider)
+                throw OAuthException.invalidState()
+            }
         }
         val client = oAuthClientRegistry.resolve(provider)
         val userInfo = fetchUserInfo(client, command) // 외부 호출, tx 밖
         val user = socialAccountService.resolveUser(userInfo, currentUserId) // 영속화, 짧은 tx
         val tokenPair = authService.createTokensForUser(user)
+        log.info("소셜 로그인 성공 provider={} userId={} identityType={}", provider, user.id, user.identityType)
         return SignupResult(tokenPair = tokenPair, user = user)
     }
 
@@ -58,6 +69,8 @@ class OAuthLoginService(
         } catch (e: OAuthException) {
             throw e
         } catch (e: Exception) {
+            // 외부 의존성(provider) 장애 → 502 매핑. warn + 스택으로 원인(네트워크·4xx/5xx·역직렬화)을 남긴다.
+            log.warn("OAuth provider 호출 실패 — 502 매핑", e)
             throw OAuthException.providerError(e)
         }
 }

--- a/src/main/kotlin/com/depromeet/piki/auth/service/OAuthLoginService.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/service/OAuthLoginService.kt
@@ -69,8 +69,9 @@ class OAuthLoginService(
         } catch (e: OAuthException) {
             throw e
         } catch (e: Exception) {
-            // 외부 의존성(provider) 장애 → 502 매핑. warn + 스택으로 원인(네트워크·4xx/5xx·역직렬화)을 남긴다.
-            log.warn("OAuth provider 호출 실패 — 502 매핑", e)
+            // provider 장애는 GlobalExceptionHandler 가 OAuthException(cause=e)을 category 기준 레벨로 남긴다
+            // (RETRYABLE=warn / SERVER_ERROR=error, 스택에 cause 포함). 여기서 raw e 를 또 찍으면 중복이고
+            // 원문 노출 표면만 늘어, 로깅은 핸들러에 일임하고 여기선 래핑만 한다.
             throw OAuthException.providerError(e)
         }
 }

--- a/src/main/kotlin/com/depromeet/piki/auth/service/SocialAccountService.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/service/SocialAccountService.kt
@@ -30,18 +30,26 @@ class SocialAccountService(
         // 2. 신규 소셜 + 현재 게스트면 → 게스트 계정에 연결 + 승격 (위시·토너먼트 데이터 이어줌)
         currentUserId?.let { guestId ->
             try {
-                socialAccountWriter.linkGuestAndPromote(guestId, userInfo)?.let { return it }
+                socialAccountWriter.linkGuestAndPromote(guestId, userInfo)?.let {
+                    // 계정 생애 이벤트(게스트→회원 승격) — 승격은 같은 userId 를 유지하므로 데이터 연속성이 보장된다.
+                    log.info("게스트 계정 소셜 연결·승격 userId={} provider={}", it.id, userInfo.provider)
+                    return it
+                }
             } catch (e: DataIntegrityViolationException) {
                 // 동시 충돌: 다른 요청이 이 소셜을 먼저 선점 → 그 계정으로 합류 (게스트 포기)
+                log.info("게스트 승격 중 소셜 선점 충돌 → 기존 계정 합류 guestId={} provider={}", guestId, userInfo.provider)
                 return loginExisting(userInfo) ?: throw e
             }
         }
 
         // 3. 순수 신규 가입 → MEMBER 생성 + 소셜 연결
         return try {
-            socialAccountWriter.createSocialUserAndLink(userInfo)
+            socialAccountWriter.createSocialUserAndLink(userInfo).also {
+                log.info("신규 소셜 회원 가입 userId={} provider={}", it.id, userInfo.provider)
+            }
         } catch (e: DataIntegrityViolationException) {
             // 동시 충돌: 다른 요청이 먼저 같은 소셜로 가입 → 그 user 로 합류 (내가 만든 user 는 REQUIRED tx 롤백으로 폐기)
+            log.info("신규 가입 중 소셜 선점 충돌 → 기존 계정 합류 provider={}", userInfo.provider)
             loginExisting(userInfo) ?: throw e
         }
     }

--- a/src/main/kotlin/com/depromeet/piki/auth/service/SocialAccountService.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/service/SocialAccountService.kt
@@ -36,8 +36,9 @@ class SocialAccountService(
                     return it
                 }
             } catch (e: DataIntegrityViolationException) {
-                // 동시 충돌: 다른 요청이 이 소셜을 먼저 선점 → 그 계정으로 합류 (게스트 포기)
-                log.info("게스트 승격 중 소셜 선점 충돌 → 기존 계정 합류 guestId={} provider={}", guestId, userInfo.provider)
+                // 동시 충돌: 다른 요청이 이 소셜을 먼저 선점 → 그 계정으로 합류 (게스트 포기).
+                // 방어적으로 복구한 비정상 경합이라 warn — 빈발하면 동시 로그인 경합 신호다.
+                log.warn("게스트 승격 중 소셜 선점 충돌 → 기존 계정 합류 guestId={} provider={}", guestId, userInfo.provider)
                 return loginExisting(userInfo) ?: throw e
             }
         }
@@ -48,8 +49,9 @@ class SocialAccountService(
                 log.info("신규 소셜 회원 가입 userId={} provider={}", it.id, userInfo.provider)
             }
         } catch (e: DataIntegrityViolationException) {
-            // 동시 충돌: 다른 요청이 먼저 같은 소셜로 가입 → 그 user 로 합류 (내가 만든 user 는 REQUIRED tx 롤백으로 폐기)
-            log.info("신규 가입 중 소셜 선점 충돌 → 기존 계정 합류 provider={}", userInfo.provider)
+            // 동시 충돌: 다른 요청이 먼저 같은 소셜로 가입 → 그 user 로 합류 (내가 만든 user 는 REQUIRED tx 롤백으로 폐기).
+            // 방어적으로 복구한 비정상 경합이라 warn.
+            log.warn("신규 가입 중 소셜 선점 충돌 → 기존 계정 합류 provider={}", userInfo.provider)
             loginExisting(userInfo) ?: throw e
         }
     }

--- a/src/main/kotlin/com/depromeet/piki/common/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/depromeet/piki/common/exception/GlobalExceptionHandler.kt
@@ -25,14 +25,16 @@ class GlobalExceptionHandler : ResponseEntityExceptionHandler() {
     fun handleBaseException(e: BaseException): ResponseEntity<ApiResponseBody<Nothing>> {
         val status = if (e is HttpMappable) e.httpStatus else HttpStatus.INTERNAL_SERVER_ERROR
         val category = if (e is HttpMappable) e.category else ErrorCategory.SERVER_ERROR
-        // status 로 레벨을 가른다 (handleExceptionInternal 과 같은 기준). 전부 info 로 찍으면 서버 버그(5xx)가
-        // 스택 없이 묻히고, 외부 의존성 실패(502)가 정상 흐름처럼 보인다.
+        // 5xx 레벨은 HttpMappable 유무가 아니라 category 로 가른다 — 같은 502 라도 SERVER_ERROR(우리 설정·코드 버그:
+        // OAuth misconfigured·Gemini clientError)와 RETRYABLE(외부 일시 장애: provider 호출·Gemini callFailed)은
+        // 심각도가 다르다. HttpMappable 5xx 를 전부 warn 으로 묶으면 INTERNAL_SERVER_ERROR+SERVER_ERROR 인
+        // nicknameGenerationFailed 같은 진짜 서버 버그가 알림에서 누락된다.
         when {
-            // HttpMappable 아닌 5xx = 서버 버그·불변식 위반 → error + 스택. 정상 요청으로 닿을 수 없는 코드 결함.
-            status.is5xxServerError && e !is HttpMappable ->
+            // SERVER_ERROR(500/502) = 재시도해도 무의미한 우리 서버 문제 → error + 스택(알림 신호).
+            // HttpMappable 아닌 BaseException 도 category 가 SERVER_ERROR 라 여기로 와 스택과 함께 남는다.
+            status.is5xxServerError && category == ErrorCategory.SERVER_ERROR ->
                 log.error("[{}] {} -> {}", e.javaClass.simpleName, e.message, status.value(), e)
-            // HttpMappable 5xx = 외부 의존성 실패(502 등, OAuth provider·Gemini·Apple). 우리 밖의 장애라 warn,
-            // cause 추적 위해 예외 동봉. 클라이언트는 재시도로 대응 가능한 계약 응답이다.
+            // RETRYABLE 5xx(502) = 외부 의존성 일시 실패 → warn, cause 추적 위해 예외 동봉. 클라는 재시도로 대응 가능.
             status.is5xxServerError ->
                 log.warn("[{}] {} -> {}", e.javaClass.simpleName, e.message, status.value(), e)
             // 4xx = 클라이언트 계약 위반 → info. 서버 입장에선 정상 거부다.

--- a/src/main/kotlin/com/depromeet/piki/common/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/depromeet/piki/common/exception/GlobalExceptionHandler.kt
@@ -23,9 +23,22 @@ class GlobalExceptionHandler : ResponseEntityExceptionHandler() {
 
     @ExceptionHandler(BaseException::class)
     fun handleBaseException(e: BaseException): ResponseEntity<ApiResponseBody<Nothing>> {
-        log.info("[{}] {}", e.javaClass.simpleName, e.message)
         val status = if (e is HttpMappable) e.httpStatus else HttpStatus.INTERNAL_SERVER_ERROR
         val category = if (e is HttpMappable) e.category else ErrorCategory.SERVER_ERROR
+        // status 로 레벨을 가른다 (handleExceptionInternal 과 같은 기준). 전부 info 로 찍으면 서버 버그(5xx)가
+        // 스택 없이 묻히고, 외부 의존성 실패(502)가 정상 흐름처럼 보인다.
+        when {
+            // HttpMappable 아닌 5xx = 서버 버그·불변식 위반 → error + 스택. 정상 요청으로 닿을 수 없는 코드 결함.
+            status.is5xxServerError && e !is HttpMappable ->
+                log.error("[{}] {} -> {}", e.javaClass.simpleName, e.message, status.value(), e)
+            // HttpMappable 5xx = 외부 의존성 실패(502 등, OAuth provider·Gemini·Apple). 우리 밖의 장애라 warn,
+            // cause 추적 위해 예외 동봉. 클라이언트는 재시도로 대응 가능한 계약 응답이다.
+            status.is5xxServerError ->
+                log.warn("[{}] {} -> {}", e.javaClass.simpleName, e.message, status.value(), e)
+            // 4xx = 클라이언트 계약 위반 → info. 서버 입장에선 정상 거부다.
+            else ->
+                log.info("[{}] {} -> {}", e.javaClass.simpleName, e.message, status.value())
+        }
         return ResponseEntity
             .status(status)
             .body(ApiResponseBody.fail(category, e.message))

--- a/src/main/kotlin/com/depromeet/piki/common/logging/LoggingKeys.kt
+++ b/src/main/kotlin/com/depromeet/piki/common/logging/LoggingKeys.kt
@@ -1,0 +1,13 @@
+package com.depromeet.piki.common.logging
+
+// MDC 키 단일 출처. JwtAuthenticationFilter 가 인증된 요청에 userId 를 넣고, logback 콘솔 패턴(application.yml
+// 의 %X{userId})·ECS 구조화 출력이 같은 키로 값을 읽는다. 키 문자열을 바꾸면 application.yml 의 %X{userId} 도
+// 함께 바꿔야 한다(yaml 은 이 상수를 import 할 수 없어 리터럴이 양쪽에 존재 — 주석으로 연결).
+//
+// traceId/spanId 는 brave(Micrometer Tracing)가 자체 키로 MDC 에 넣으므로 여기서 정의하지 않는다.
+// userId 는 한 유저의 여러 요청을 가로질러 묶는 상관추적 키다 — traceId 가 요청 1건을 묶는다면 userId 는
+// 그 유저의 로그인→플레이→… 여정 전체를 grep 으로 잇는다. userId(UUID)는 크리덴셜이 아니고 내부 가명
+// 식별자라 마스킹 없이 그대로 싣는다(역추적은 DB join 이라는 별도 권한 경계를 거친다).
+object LoggingKeys {
+    const val USER_ID = "userId"
+}

--- a/src/main/kotlin/com/depromeet/piki/common/logging/SensitiveData.kt
+++ b/src/main/kotlin/com/depromeet/piki/common/logging/SensitiveData.kt
@@ -1,0 +1,33 @@
+package com.depromeet.piki.common.logging
+
+import java.security.MessageDigest
+
+// 로그·예외 message 에 남기는 민감값 마스킹 (CLAUDE.md "민감 정보는 마스킹해서 찍는다").
+// 원칙: 크리덴셜(토큰)·직접식별 PII(이메일·닉네임 원문)는 원문을 절대 싣지 않는다.
+//
+// userId(UUID)는 여기 대상이 아니다 — 크리덴셜이 아니고(알아도 권한 0) 내부 가명 식별자라, 상관추적 join 키로
+// 그대로 찍는다. 마스킹은 "비밀 노출" 차단이 목적이고, userId 는 비밀이 아니다([[LoggingKeys]]).
+object SensitiveData {
+    // 토큰(JWT access/refresh·FCM 기기 토큰 등) → 원문 대신 SHA-256 앞 8 hex 지문 + 길이.
+    // 같은 토큰은 같은 지문이라 "같은 토큰이 등록됐다 해제됐다"를 로그로 상관추적할 수 있고(예: FCM 등록/해제),
+    // 지문에서 원문 복원·재사용은 불가하다. 전량 노출(탈취)·무지문(상관추적 불가) 사이의 균형점.
+    fun maskToken(token: String?): String {
+        token ?: return "absent"
+        val fingerprint =
+            MessageDigest
+                .getInstance("SHA-256")
+                .digest(token.toByteArray())
+                .take(4)
+                .joinToString("") { "%02x".format(it) }
+        return "sha256:$fingerprint(len=${token.length})"
+    }
+
+    // 이메일 → 로컬파트 첫 글자 + 도메인 (a***@example.com). 원문은 직접식별 PII 라 저장 금지.
+    // 도메인은 남겨 provider 분포 등 운영 분석엔 쓰되, 개인 식별로는 못 잇게 로컬파트를 가린다.
+    fun maskEmail(email: String?): String {
+        email ?: return "absent"
+        val at = email.indexOf('@')
+        if (at <= 0) return "***"
+        return "${email.first()}***${email.substring(at)}"
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/common/web/AccessLogFilter.kt
+++ b/src/main/kotlin/com/depromeet/piki/common/web/AccessLogFilter.kt
@@ -1,0 +1,56 @@
+package com.depromeet.piki.common.web
+
+import com.depromeet.piki.common.logging.LoggingKeys
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.LoggerFactory
+import org.slf4j.MDC
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+
+// 모든 API 요청의 처리 결과를 한 줄로 남기는 access log — method·path·status·latency. 성공(2xx)·실패(4xx/5xx)를
+// 도메인 로깅 유무와 무관하게 균일하게 남겨 "이 API 가 무슨 status 로 얼마나 걸려 끝났나"를 빠짐없이 본다.
+// 실패 사유의 디테일(예외 클래스·메시지)은 GlobalExceptionHandler 가 담당하고, 여기선 결과 status 만 균일하게 찍는다.
+// path 만 남기고 쿼리스트링은 싣지 않는다 — 쿼리에 토큰이 실릴 수 있다(CLAUDE.md 민감정보 마스킹).
+//
+// order: 관측(observation, HIGHEST+1)·TraceIdHeaderFilter(+2) 안쪽(+3)이라 traceId 가 MDC 에 차 있고,
+// Security 필터(DEFAULT_FILTER_ORDER=-100)보다 바깥이라 인증 거부(401/403)로 컨트롤러에 닿기 전 끝난 요청도 잡는다.
+//
+// userId: 이 필터 finally 시점엔 JwtAuthenticationFilter(더 안쪽)가 자기 finally 에서 MDC userId 를 이미 지운 뒤다.
+// 그래서 JwtAuthenticationFilter 가 함께 심어둔 request attribute 에서 읽어, 이 로그 한 줄 동안만 MDC 에 얹는다 —
+// 콘솔 패턴 [user=...]·ECS userId 필드가 access log 에도 도메인 로그와 똑같이 찍힌다.
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE + 3)
+class AccessLogFilter : OncePerRequestFilter() {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        val start = System.currentTimeMillis()
+        try {
+            filterChain.doFilter(request, response)
+        } finally {
+            val latencyMs = System.currentTimeMillis() - start
+            (request.getAttribute(LoggingKeys.USER_ID) as? String)?.let { MDC.put(LoggingKeys.USER_ID, it) }
+            try {
+                log.info("{} {} -> {} ({}ms)", request.method, request.requestURI, response.status, latencyMs)
+            } finally {
+                // 미인증 요청이면 위에서 put 을 안 했어도 remove 는 무해(no-op). 이 한 줄 로그 범위로만 MDC 를 빌렸다 돌려준다.
+                MDC.remove(LoggingKeys.USER_ID)
+            }
+        }
+    }
+
+    // SSE 구독은 장시간 연결이라 finally(연결 종료)가 한참 뒤에 돌아 latency 가 비정상으로 크게 찍힌다.
+    // actuator 는 Alloy 가 자주 scrape 하는 노이즈다. 둘 다 access log 대상에서 제외한다.
+    override fun shouldNotFilter(request: HttpServletRequest): Boolean {
+        val uri = request.requestURI
+        return uri.startsWith("/actuator") || uri == "/api/v1/notifications/subscribe"
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/common/web/AccessLogFilter.kt
+++ b/src/main/kotlin/com/depromeet/piki/common/web/AccessLogFilter.kt
@@ -32,11 +32,13 @@ class AccessLogFilter : OncePerRequestFilter() {
         response: HttpServletResponse,
         filterChain: FilterChain,
     ) {
-        val start = System.currentTimeMillis()
+        // latency 는 monotonic clock(nanoTime)으로 잰다 — currentTimeMillis 는 NTP 시간 보정 때 음수·과대값으로
+        // 깨질 수 있어 관측 지표로 부적합하다. wall-clock 표시 시각은 로그 패턴의 %d 가 따로 담당한다.
+        val startNanos = System.nanoTime()
         try {
             filterChain.doFilter(request, response)
         } finally {
-            val latencyMs = System.currentTimeMillis() - start
+            val latencyMs = (System.nanoTime() - startNanos) / 1_000_000
             (request.getAttribute(LoggingKeys.USER_ID) as? String)?.let { MDC.put(LoggingKeys.USER_ID, it) }
             try {
                 log.info("{} {} -> {} ({}ms)", request.method, request.requestURI, response.status, latencyMs)

--- a/src/main/kotlin/com/depromeet/piki/notification/fcm/service/FirebaseMessageSender.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/fcm/service/FirebaseMessageSender.kt
@@ -1,7 +1,9 @@
 package com.depromeet.piki.notification.fcm.service
 
+import com.depromeet.piki.common.logging.SensitiveData
 import com.depromeet.piki.notification.controller.dto.NotificationSsePayload
 import com.depromeet.piki.notification.domain.Notification
+import com.depromeet.piki.notification.domain.NotificationCategory
 import com.depromeet.piki.notification.service.DefaultPushImage
 import com.google.firebase.FirebaseApp
 import com.google.firebase.messaging.AndroidConfig
@@ -37,25 +39,48 @@ class FirebaseMessageSender(
         notification: Notification,
     ): List<String> {
         val stale = mutableListOf<String>()
+        // 발송 결과 집계 — 성공 수와 실패 사유(FCM messagingErrorCode)별 분포를 모아 마지막에 한 줄로 요약한다.
+        // 토큰 원문은 크리덴셜이라 지문(maskToken)으로만 남긴다.
+        var success = 0
+        val failureCodes = mutableMapOf<String, Int>()
         tokens.chunked(MULTICAST_LIMIT).forEach { chunk ->
             val response =
                 runCatching { messaging.sendEachForMulticast(buildMessage(chunk, notification)) }
                     .getOrElse { e ->
-                        // 토큰은 민감 정보라 로그에 남기지 않는다 — 크기만.
-                        log.warn("FCM 멀티캐스트 발송 실패 chunkSize={}", chunk.size, e)
+                        // 토큰은 민감 정보라 로그에 남기지 않는다 — 크기만. 청크 통째 실패는 아래 요약에서 (실패=토큰−성공)으로 드러난다.
+                        log.warn("FCM 멀티캐스트 청크 발송 실패 chunkSize={}", chunk.size, e)
                         return@forEach
                     }
             response.responses.forEachIndexed { i, result ->
-                if (result.isSuccessful) return@forEachIndexed
+                if (result.isSuccessful) {
+                    success++
+                    return@forEachIndexed
+                }
                 val code = result.exception?.messagingErrorCode
+                failureCodes.merge(code?.name ?: "UNKNOWN", 1, Int::plus)
                 if (isStaleToken(code)) {
                     stale += chunk[i]
+                    log.info("FCM 죽은 토큰 감지 → 정리 대상 token={} code={}", SensitiveData.maskToken(chunk[i]), code)
                 } else {
-                    // 토큰 무관 실패(요청 오류·일시 오류 등)는 토큰을 지우지 않고 코드만 남긴다(토큰은 민감).
-                    log.warn("FCM 발송 실패(토큰 보존) code={}", code)
+                    // 토큰 무관 실패(요청 오류·일시 오류 등)는 토큰을 지우지 않고 코드만 남긴다(어떤 이슈로 실패했는지 = FCM 반환 코드).
+                    log.warn("FCM 발송 실패(토큰 보존) token={} code={}", SensitiveData.maskToken(chunk[i]), code)
                 }
             }
         }
+        // 어떤 페이로드(type·refId)를 몇 토큰에 보내 몇 건 성공/실패했고, 실패 사유(FCM code)별 분포 + 죽은 토큰 정리 수.
+        // 렌더된 title/body 는 닉네임 등 PII 를 담을 수 있어 싣지 않는다 — 라우팅 식별자(type·refId·category)만.
+        log.info(
+            "FCM 발송 결과 notificationId={} type={} category={} refId={} 토큰={} 성공={} 실패={} 실패사유={} 죽은토큰정리={}",
+            notification.getId(),
+            notification.type,
+            NotificationCategory.of(notification.type),
+            notification.refId,
+            tokens.size,
+            success,
+            tokens.size - success,
+            failureCodes,
+            stale.size,
+        )
         return stale
     }
 

--- a/src/main/kotlin/com/depromeet/piki/notification/fcm/service/UserDeviceService.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/fcm/service/UserDeviceService.kt
@@ -1,7 +1,9 @@
 package com.depromeet.piki.notification.fcm.service
 
+import com.depromeet.piki.common.logging.SensitiveData
 import com.depromeet.piki.notification.fcm.domain.UserDevice
 import com.depromeet.piki.notification.fcm.repository.UserDeviceRepository
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
@@ -13,6 +15,8 @@ import java.util.UUID
 class UserDeviceService(
     private val userDeviceRepository: UserDeviceRepository,
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
     // 토큰 등록/갱신(POST). upsert 다 — 앱 진입·토큰 회전 어느 경로로 와도 기기당 1 row 로 수렴한다.
     // 배달 정확성을 위해 같은 토큰을 들고 있던 다른 사용자 row 는 먼저 해제하고, 내 (user,device) row 가
     // 있으면 토큰만 교체, 없으면 신규 생성한다.
@@ -28,9 +32,12 @@ class UserDeviceService(
         val token = fcmToken.trim()
         val mine = userDeviceRepository.findByUserIdAndDeviceId(userId, device)
         releaseStaleTokenHolder(token, keep = mine)
-        mine ?: return userDeviceRepository.save(
-            UserDevice(userId = userId, deviceId = device, fcmToken = token),
-        )
+        // 토큰 원문은 크리덴셜이라 지문으로만. deviceId 는 기기 식별자라 그대로(같은 기기의 등록/해제 상관추적 키).
+        mine ?: run {
+            log.info("FCM 토큰 등록(신규) userId={} deviceId={} token={}", userId, device, SensitiveData.maskToken(token))
+            return userDeviceRepository.save(UserDevice(userId = userId, deviceId = device, fcmToken = token))
+        }
+        log.info("FCM 토큰 등록(갱신) userId={} deviceId={} token={}", userId, device, SensitiveData.maskToken(token))
         mine.refreshToken(token)
         return userDeviceRepository.save(mine)
     }
@@ -42,7 +49,9 @@ class UserDeviceService(
         deviceId: String,
     ) {
         // 등록과 같은 정규화 — 키 일치를 위해 trim.
-        userDeviceRepository.deleteByUserIdAndDeviceId(userId, deviceId.trim())
+        val device = deviceId.trim()
+        userDeviceRepository.deleteByUserIdAndDeviceId(userId, device)
+        log.info("FCM 토큰 해제 userId={} deviceId={}", userId, device)
     }
 
     // 발송(#245) — 한 사용자의 모든 기기 토큰을 모아 멀티캐스트 대상으로 넘긴다.

--- a/src/main/kotlin/com/depromeet/piki/notification/service/NotificationDispatcher.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/service/NotificationDispatcher.kt
@@ -35,6 +35,9 @@ class NotificationDispatcher(
                 ?: error("핸들러 미등록: ${event::class.simpleName}")
 
         val recipients = handler.resolveRecipients(event)
+        // 이벤트 수신 → 수신자 도출(인원). 디스패치는 async 워커라 MDC userId 는 이벤트를 유발한 actor 의 것이고,
+        // 수신자는 actor 와 다른 유저들이라 수신자 userId 는 아래 fan-out 에서 명시적으로 남긴다.
+        log.info("알림 디스패치 type={} event={} 수신자={}명", handler.notificationType, event::class.simpleName, recipients.size)
         if (recipients.isEmpty()) return
 
         val refId = handler.resolveRefId(event)
@@ -48,6 +51,7 @@ class NotificationDispatcher(
         val title = renderer.render(template.title, variables)
         val body = renderer.render(template.body, variables)
 
+        var delivered = 0
         recipients.forEach { userId ->
             // 한 수신자의 저장 실패가 나머지 수신자 fan-out 을 막지 않게 수신자 단위로 격리한다 (외부 전달은 트랜잭션 밖).
             runCatching {
@@ -69,6 +73,9 @@ class NotificationDispatcher(
                         .onFailure { e -> log.warn("채널 {} 전송 실패 userId={}", channel::class.simpleName, userId, e) }
                 }
             }.onFailure { e -> log.warn("알림 저장 실패로 수신자 건너뜀 userId={}", userId, e) }
+                .onSuccess { delivered++ }
         }
+        // fan-out 결과 요약 — 저장 실패로 누락된 수신자가 있으면 (수신자 인원 > 저장성공)으로 드러난다.
+        log.info("알림 fan-out 완료 type={} 수신자={}명 저장성공={}건", handler.notificationType, recipients.size, delivered)
     }
 }

--- a/src/main/kotlin/com/depromeet/piki/notification/service/NotificationService.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/service/NotificationService.kt
@@ -6,6 +6,7 @@ import com.depromeet.piki.notification.domain.NotificationHistorySize
 import com.depromeet.piki.notification.repository.NotificationRepository
 import com.depromeet.piki.notification.service.dto.NotificationHistoryPage
 import com.depromeet.piki.notification.service.dto.NotificationReadCommand
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
@@ -16,6 +17,8 @@ class NotificationService(
     private val notificationRepository: NotificationRepository,
     private val defaultPushImage: DefaultPushImage,
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
     // 본인 알림을 최신순으로 한 페이지 + 안읽음 수 동봉. hasNext 판단을 위해 한 건 더 조회하고 초과분은 잘라낸다.
     // category 가 있으면 그 카테고리의 type 집합으로 필터(활동/시스템 탭). unreadCount 는 category 무관 전체(앱 badge).
     @Transactional(readOnly = true)
@@ -58,10 +61,19 @@ class NotificationService(
         userId: UUID,
         command: NotificationReadCommand,
     ): Map<NotificationCategory, Long> {
-        when (command) {
-            NotificationReadCommand.All -> notificationRepository.markAllRead(userId)
-            is NotificationReadCommand.Ids -> notificationRepository.markRead(userId, command.ids)
-        }
-        return notificationRepository.countUnreadByCategory(userId)
+        val method =
+            when (command) {
+                NotificationReadCommand.All -> {
+                    notificationRepository.markAllRead(userId)
+                    "all"
+                }
+                is NotificationReadCommand.Ids -> {
+                    notificationRepository.markRead(userId, command.ids)
+                    "ids(${command.ids.size})"
+                }
+            }
+        val unread = notificationRepository.countUnreadByCategory(userId)
+        log.info("알림 읽음 처리 userId={} 방식={} 처리후안읽음={}", userId, method, unread.values.sum())
+        return unread
     }
 }

--- a/src/main/kotlin/com/depromeet/piki/user/service/UserService.kt
+++ b/src/main/kotlin/com/depromeet/piki/user/service/UserService.kt
@@ -6,6 +6,7 @@ import com.depromeet.piki.user.domain.UserException
 import com.depromeet.piki.user.repository.UserDetailRepository
 import com.depromeet.piki.user.repository.UserRepository
 import com.depromeet.piki.user.service.dto.UserProfile
+import org.slf4j.LoggerFactory
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -17,6 +18,8 @@ class UserService(
     private val userDetailRepository: UserDetailRepository,
     private val defaultProfileImages: DefaultProfileImages,
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
     companion object {
         // 형용사 32 × 동물 32 = 1024 조합. 모든 조합이 닉네임 10자 제한 이하가 되도록
         // 형용사는 5자 이하, 동물은 3자 이하로 유지한다(최대 5+1+3=9자).
@@ -186,19 +189,30 @@ class UserService(
     ): User {
         val user = findById(userId)
         user.deletedAt?.let { throw UserException.deletedUser(userId) }
-        nickname?.let {
-            if (userRepository.existsByNicknameAndIdNot(it, userId)) throw UserException.duplicateNickname()
-            user.updateNickname(it)
-        }
-        profileImageUrl?.let { user.updateProfileImage(it) }
+        // 무엇이 바뀌었는지만 남긴다 — 닉네임 원문은 PII 라 값이 아니라 "어떤 필드가 변경됐나"만 로깅한다.
+        val changedFields =
+            buildList {
+                nickname?.let {
+                    if (userRepository.existsByNicknameAndIdNot(it, userId)) throw UserException.duplicateNickname()
+                    user.updateNickname(it)
+                    add("nickname")
+                }
+                profileImageUrl?.let {
+                    user.updateProfileImage(it)
+                    add("profileImage")
+                }
+            }
         // existsByNicknameAndIdNot 체크와 save 사이에 다른 트랜잭션이 같은 nickname 으로 update / insert 하면
         // DB unique constraint (uq_users_nickname) 위반이 떠 race 케이스에서 500 이 새어나갈 수 있다.
         // createMember 와 같은 패턴으로 catch → 409 로 매핑.
-        return try {
-            userRepository.save(user)
-        } catch (e: DataIntegrityViolationException) {
-            throw UserException.duplicateNickname()
-        }
+        val saved =
+            try {
+                userRepository.save(user)
+            } catch (e: DataIntegrityViolationException) {
+                throw UserException.duplicateNickname()
+            }
+        log.info("내 정보 수정 userId={} 변경필드={}", userId, changedFields)
+        return saved
     }
 
     // 소셜 가입/연동 시 provider 가 준 프로필 이미지 URL 영속화만 담당하는 짧은 트랜잭션 (SocialAccountWriter 전용).

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -159,5 +159,8 @@ logging:
     #  - PID·--- ·application name([PIKI])을 뺀다. 단일 컨테이너라 PID 는 항상 1 이고, 서비스 구분은 Loki 의
     #    container 라벨(team3-blue/green)이 이미 한다 — 줄마다 반복할 가치가 없다.
     #  - traceId/spanId 는 한 요청의 전체 로그를 묶는 추적 키라 유지한다 (sampling 1.0 이라 항상 채워진다).
+    #  - userId(MDC, JwtAuthenticationFilter 가 인증 요청에 주입)는 한 유저의 여러 요청을 가로질러 묶는 키다 —
+    #    grep userId=<uuid> 로 로그인→플레이→… 여정 전체를 잇는다. 미인증 요청은 '-' 로 비워진다.
+    #    (prod ECS JSON 은 MDC 를 필드로 자동 출력하므로 이 평문 패턴에만 명시한다.)
     # 색상(%clr)은 쓰지 않는다 — non-TTY(컨테이너 stdout)에선 어차피 plain 이고, 로컬 콘솔 색상보다 패턴 단순함을 택한다.
-    console: "%d{yyyy-MM-dd HH:mm:ss.SSS, Asia/Seoul} %-5level [%thread] [%X{traceId:-},%X{spanId:-}] %logger{36} : %msg%n%wEx"
+    console: "%d{yyyy-MM-dd HH:mm:ss.SSS, Asia/Seoul} %-5level [%thread] [%X{traceId:-},%X{spanId:-}] [user=%X{userId:-}] %logger{36} : %msg%n%wEx"


### PR DESCRIPTION
## Situation
- 이번 prod 배포 사고에서 서버 로그가 401만 반복적으로 찍히고, 무슨 일이 일어났는지 로그만으로 파악하기 어려웠다.
- 현재 로깅이 매우 희소하다: User 도메인은 log 1개, Auth 는 로그인·갱신·로그아웃 미로깅, Notification 은 인프라 위주이고 요청 흐름·수신자 도출은 거의 안 찍힌다.
- traceId 는 한 요청을 묶어주지만, "어떤 유저가 로그인했고 그 다음 플레이를 어떻게 했나" 처럼 한 유저의 여러 요청을 가로질러 추적하려면 그것만으로는 부족하다.

## Task
- Auth·User·FCM·Notification 네 도메인의 의미있는 행동을 로그로 남겨, 로그만 읽고 한 요청과 한 유저의 여정을 재구성할 수 있게 한다.
- 동시에 개인정보 유출은 0 이어야 한다: 토큰·이메일·닉네임 원문은 절대 로그에 싣지 않는다.
- 결정 포인트: 유저 식별자를 로그에 어떻게 남길지. raw userId 그대로 vs 해시.

## Action

### 상관추적 2축 (요청 + 유저)
- 기존 traceId(요청 1건을 묶음)에 더해, 인증된 요청에 userId 를 MDC 로 실어 한 유저의 여러 요청을 가로질러 묶는다. `grep userId=<uuid>` 로 로그인 → 플레이 → 플레이 여정 전체가 이어진다.
- 인증 필터가 토큰을 검증한 직후 userId 를 MDC 에 넣고, 요청 끝에 반드시 지운다(톰캣 워커 재사용으로 다음 요청에 누수되지 않게).
- async 워커(알림 디스패치 등)에는 기존 ContextPropagatingTaskDecorator 가 MDC 를 전파하므로 userId 도 따라간다.
- 로컬 콘솔 패턴에 `[user=...]` 를 추가했다. prod 는 ECS JSON 구조화 로깅이라 MDC 가 자동으로 필드가 되어 Loki 에서 바로 필터된다(패턴 변경 불필요).

### userId 를 raw 로 남긴 결정 (보안 검토)
- userId 는 크리덴셜이 아니다(알아도 권한이 안 생긴다). 로그에 새도 계정 탈취로 이어지지 않으므로 보안상 안전하다.
- 프라이버시상으론 가명(pseudonymous) 식별자라 DB join 으로 역추적되지만, 로그는 내부 접근통제 대상이고 클라이언트엔 안 나가며 DB 접근은 별도 권한 경계다.
- 목적이 "사고를 로그만으로 재구성" 이라 즉시 역추적이 가능한 raw 가 맞다고 봤다. 해시는 상관추적은 되나 사고 때 "이 해시가 누구냐" 를 못 풀어 디버깅 마찰이 생긴다. 강한 규제 요건이 생기면 그때 해시로 올린다.

### 민감정보 마스킹
- 공용 마스킹 유틸을 두었다: 토큰은 SHA-256 앞 8자 지문 + 길이(같은 토큰은 같은 지문이라 등록/해제 상관추적은 되되 원문 복원·재사용 불가), 이메일은 첫 글자 + 도메인.
- 닉네임 원문은 값을 안 남긴다. 내 정보 수정 로그는 "어떤 필드가 바뀌었나"(nickname/profileImage)만 남긴다.

### 도메인별 로깅 (레벨: 계약 위반 info, 외부 호출 실패 warn)
| 도메인 | 남긴 것 |
|---|---|
| Auth | 소셜 로그인 시도·성공(provider·userId)·state 거부·provider 502, 토큰 갱신 거부를 사유별로(파싱 실패·탈퇴·재사용)·성공, 로그아웃, 게스트·회원 생성, 신규 가입·게스트 승격 |
| Notification | 디스패치(type·event·수신자 인원), fan-out 완료(저장 성공 건수), 읽음 처리(방식·처리 후 안읽음 수) |
| FCM | 발송 결과(type·category·refId·총 토큰·성공·실패·실패 사유 FCM 코드별 분포·죽은 토큰 정리 수), 토큰 등록(신규·갱신)·해제 |
| User | 내 정보 수정(변경 필드만). 탈퇴 cascade 범위·프로필 업로드는 기존 로그 유지 |

- 토큰 갱신 거부를 사유별로 나눈 게 prod 401 디버깅의 핵심: 왜 거부됐는지(만료·위조·탈퇴·재사용)를 traceId·userId 와 함께 본다.
- FCM 은 실패 토큰마다 FCM 반환 코드를 남기고, 마지막에 한 줄로 발송 결과를 요약한다. 렌더된 title/body 는 닉네임 같은 PII 를 담을 수 있어 싣지 않고 라우팅 식별자(type·refId·category)만 남긴다.

## Result
- 로그인 → 토큰 발급 → FCM 토큰 등록 → 알림 발송 → 읽음 처리 같은 대표 시나리오를 traceId 로 한 요청씩, userId 로 한 유저 여정으로 묶어 읽을 수 있다.
- 로그 어디에도 원문 토큰·이메일·닉네임은 노출되지 않는다(userId 는 의도적으로 raw).
- 후속: 전역 예외 핸들러의 API 성공/실패 로그가 정의된 Exception 대로 일관되게 남는지는 이 PR 범위 밖이라 별도로 점검한다.

---
## 연관 이슈

- close #497

## Updates

### 모든 API 성공·실패 로깅 — 전역 예외 레벨 분기 + access log (`f3f17cd`)
- Situation: 위 Result 의 후속(전역 예외 핸들러가 정의된 Exception 대로 일관되게 남는지)을 점검해 두 갭을 찾았다. 도메인 예외 핸들러가 status 무관 전부 info 로 찍었고, 모든 요청을 균일하게 남기는 access log 가 없었다.
- Action: 도메인 예외 핸들러를 status 로 분기했다. HttpMappable 아닌 5xx(서버 버그·불변식)는 error + 스택, 502 외부 의존성(OAuth provider·Gemini·Apple)은 warn, 4xx 는 info. 전부 info 면 서버 버그가 스택 없이 묻히고 외부 장애가 정상 흐름처럼 보였다.
- Action: 모든 요청을 한 줄로 남기는 access log 필터를 추가했다. method·path·status·latency 를 남기고, 인증 거부(401/403)도 컨트롤러 도달 전에 잡는다(Security 필터보다 바깥). SSE 구독·actuator 는 제외한다(장시간 연결로 latency 가 비정상·scrape 노이즈). path 만 남기고 쿼리스트링은 싣지 않는다(토큰 노출 방지).
- Action: access log 에도 userId 를 남기려고 인증 필터가 userId 를 request attribute 로도 심어, access log 필터가 그걸 읽어 로그 한 줄 동안만 MDC 에 얹는다. 필터 중첩 순서상 access log 시점엔 MDC userId 가 이미 지워진 뒤라 attribute 로 우회했다.
- Result: 도메인 로깅 유무와 무관하게 모든 API 요청이 status·latency·userId 와 함께 한 줄로 남고, 실패는 심각도(info·warn·error)대로 레벨이 갈린다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 시스템 로깅 및 모니터링 강화: 사용자 식별 추적, 민감 정보 마스킹, 접근 로그 기록 개선으로 운영 투명성 및 보안이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->