### PR TITLE
staging 환경 구축 (dev → staging → prod 3단 파이프라인)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,10 @@ name: CI
 
 on:
   push:
-    branches: [dev, main]
+    branches: [dev, staging, main]
   pull_request:
     types: [opened, synchronize]
-    branches: [dev, main]
+    branches: [dev, staging, main]
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy
 on:
   workflow_run:
     workflows: [CI]
-    branches: [dev, main]
+    branches: [dev, staging, main]
     types: [completed]
   workflow_dispatch:
 
@@ -31,6 +31,10 @@ jobs:
             echo "environment=prod" >> "$GITHUB_OUTPUT"
             echo "domain=api.piki.day" >> "$GITHUB_OUTPUT"
             echo "nginx_conf=api.piki.day.conf" >> "$GITHUB_OUTPUT"
+          elif [ "$BRANCH" = "staging" ]; then
+            echo "environment=staging" >> "$GITHUB_OUTPUT"
+            echo "domain=staging.api.piki.day" >> "$GITHUB_OUTPUT"
+            echo "nginx_conf=staging.api.piki.day.conf" >> "$GITHUB_OUTPUT"
           else
             echo "environment=dev" >> "$GITHUB_OUTPUT"
             echo "domain=dev.api.piki.day" >> "$GITHUB_OUTPUT"
@@ -305,9 +309,9 @@ jobs:
           # FCM 푸시(#242) — Firebase 서비스계정 키(JSON base64). dev/prod 가 같은 piki 프로젝트를 공유해 공통 secret.
           # 미설정이면 FirebaseConfig 가 안 떠 발송이 no-op (부팅은 정상, 토큰 수집 API 는 계속 동작).
           FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
-          # Spring 프로파일 — prod 에서만 'prod' 활성. @Profile("!prod") 의 dev 전용 빈(admin·DevAuth 등)이
-          # prod 에서 안 뜨게 하는 핵심. dev 는 'dev'(=!prod)라 그 빈들이 정상 로드된다.
-          SPRING_PROFILES_ACTIVE: ${{ needs.resolve.outputs.environment == 'prod' && 'prod' || 'dev' }}
+          # Spring 프로파일 — prod·staging 에서 'prod' 활성. @Profile("!prod") 의 dev 전용 빈(admin·DevAuth 등)이
+          # prod·staging 에서 안 뜨게 하는 핵심. staging 은 진짜 pre-prod 라 prod 와 동일 동작(#498). dev 만 'dev'(=!prod).
+          SPRING_PROFILES_ACTIVE: ${{ (needs.resolve.outputs.environment == 'prod' || needs.resolve.outputs.environment == 'staging') && 'prod' || 'dev' }}
           # admin 백오피스 — dev 전용. prod 는 false(프로파일 게이팅과 이중 방어).
           ADMIN_ENABLED: ${{ needs.resolve.outputs.environment == 'dev' && 'true' || 'false' }}
           ADMIN_USERNAME: ${{ secrets.ADMIN_USERNAME }}

--- a/infra/nginx/staging.api.piki.day.conf
+++ b/infra/nginx/staging.api.piki.day.conf
@@ -1,0 +1,151 @@
+# staging.api.piki.day nginx 설정 — staging EC2 전용 (#498)
+#
+# 이 파일이 배포 시 EC2 /etc/nginx/sites-available/staging.api.piki.day 로 복사되고,
+# nginx -t 검증을 통과해야 reload 된다 (.github/workflows/deploy.yml).
+#
+# prod conf(api.depromeet18team3.cloud.conf)와 동일 구조를 유지한다 — 별도 파일이라 한쪽에만 설정이
+# 빠지는 드리프트가 생기기 쉽다. dev 가 prod 의 상위집합이 되도록(prod 에 있는 건 dev 에도 있게) 맞춘다.
+# 환경 고유 차이는 server_name 과 ssl_certificate 경로의 도메인 문자열뿐이다.
+# piki.day 도메인으로 전환 시 그 도메인 문자열만 교체하면 된다.
+#
+# 동적·서버 의존 요소는 이 레포가 관리하지 않고 경로로 참조만 한다:
+#   - /etc/nginx/team3-upstream.conf : deploy.yml 이 blue/green 전환 때 런타임에 생성하는 상태 파일
+#                                      (server localhost:8080 | 8081). IaC 대상 아님.
+#   - /etc/letsencrypt/*             : certbot 이 발급·자동 갱신하는 TLS 키·인증서 (비밀). git 금지.
+#
+# SSL 인증서 최초 발급 (dev EC2 접속 후):
+#   sudo certbot --nginx -d staging.api.piki.day  (또는 deploy 의 cert-ensure 가 자동 발급)
+
+upstream team3 {
+    include /etc/nginx/team3-upstream.conf;
+}
+
+# --- 레이트리밋(1/2): 비싼 Gemini 호출(링크 추출·이미지 OCR)을 IP별로 타이트하게 제한한다 ---
+# 목적은 Gemini 호출 폭주로 인한 비용·자원(톰캣 스레드·DB 커넥션) 고갈 방어다. (일반 경로의 느슨한 전역 그물은 2/2 참고.)
+#
+# 이건 거친 1차 그물이다 — 일부러 느슨하게 둬서 정상 유저 오탐(CGNAT·공유망)을 0 으로 하고 명백한 flood 만 막는다.
+# 정밀한 비용·공정성 제어(인증 사용자별 "하루 N회" quota)는 앱 레이어 후속 작업(userId + Redis)이 맡는다.
+# 둘은 대체가 아니라 보완이다: IP 는 미인증·flood 1차 차단, userId 는 인증 후 정밀 quota.
+#
+# POST 만 카운트 키에 담는다 — 비싼 경로는 전부 POST 이고, 같은 경로의 GET(위시 목록 조회)·기타 메서드는
+# 빈 키가 되어 limit_req 가 카운트에서 제외한다(nginx 는 키가 빈 문자열인 요청을 세지 않는다).
+# 그래서 location 을 메서드별로 쪼개지 않고도 POST 만 정확히 잡는다.
+#
+# $binary_remote_addr 을 키로 쓴다 — EIP 직결(앞단에 ALB/CloudFront 없음)이라 이게 진짜 클라이언트 IP 다.
+# 단일 노드(blue/green 도 한 박스)라 shared memory zone 카운터가 IP 별로 정확하다.
+# (앞단 LB 를 도입하면 $remote_addr 이 LB IP 로 바뀌어 전 요청이 한 버킷에 묶이므로, 그때 real_ip 모듈 +
+#  X-Forwarded-For 로 키를 바꿔야 한다.)
+map $request_method $piki_llm_limit_key {
+    POST    $binary_remote_addr;
+    default "";
+}
+limit_req_zone $piki_llm_limit_key zone=piki_llm:10m rate=30r/m;   # 분당 30회 / IP(느슨), zone 10m ≈ IP 16만 개 추적
+
+# --- 레이트리밋(2/2): 전역 — 모든 경로(메서드 무관)에 아주 느슨한 IP별 그물 ---
+# 일반 조회·CRUD 도 무제한이면 스크래핑·flood 에 노출된다. 다만 일반 경로는 정상 트래픽이 비싼 경로보다
+# 훨씬 잦아(화면 1개에 GET 여럿 동시 호출·무한스크롤) 같은 강도면 정상 사용자가 막힌다. 그래서 1/2 보다
+# 훨씬 느슨하게 둬 명백한 폭주만 컷한다. 키는 raw $binary_remote_addr(메서드·경로 무관 전부 카운트).
+# 비싼 경로는 piki_llm(초당 0.5)이 이보다 훨씬 타이트해 지배하므로, 그쪽 location 엔 이 zone 을 겹치지 않는다.
+limit_req_zone $binary_remote_addr zone=piki_general:10m rate=20r/s;   # 초당 20회 / IP(아주 느슨)
+
+limit_req_status 429;                                              # 초과 시 기본 503 대신 429 Too Many Requests (두 zone 공통)
+
+server {
+    # staging 신규 도메인 — 단일 server_name (듀얼런 불필요). 인증서는 deploy 의 cert-ensure 가 발급한다.
+    server_name staging.api.piki.day;
+
+    client_max_body_size 25M;
+
+    # 공통 proxy 설정 — 아래 proxy_pass location 들이 상속한다(actuator 403 location 은 프록시하지 않아 무관).
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    # nginx 기본값(60s). 추출이 @Async 워커로 빠져 요청 스레드를 길게 잡는 동기 외부 호출이 없어 60s 로 충분하다 (prod conf 와 동일 근거).
+    proxy_read_timeout 60s;
+
+    # actuator 엔드포인트는 외부에 노출하지 않는다. 메트릭(/actuator/prometheus)·health 는
+    # EC2 내부의 Grafana Alloy 가 localhost 컨테이너 포트로 직접 scrape 하므로 nginx 를 거치지 않는다.
+    # ^~ 접두어 매칭이 아래 정규/일반 `location /` 보다 우선해, /actuator/* 외부 요청은 앱까지 가지 않고 여기서 끊긴다.
+    # `^~ /actuator/` 는 슬래시로 끝나는 prefix 라 슬래시 없는 부모 경로 `/actuator`(actuator 인덱스)는
+    # 안 잡혀 location / 로 새어 나간다. `= /actuator` 정확 매칭을 따로 둬 그 구멍을 막는다.
+    location = /actuator {
+        return 403;
+    }
+    location ^~ /actuator/ {
+        return 403;
+    }
+
+    # 레이트리밋 초과(429)를 ApiResponseBody 모양 JSON 으로 내린다 (위 limit_req_status 429 와 짝).
+    # nginx 가 앱 앞에서 끊어 GlobalExceptionHandler 를 못 거치므로, 클라이언트가 "모든 응답=ApiResponseBody"
+    # 로 파싱해도 깨지지 않게 같은 스키마({data, detail, pageResponse})를 고정 JSON 으로 흉내낸다.
+    # 주의: ApiResponseBody 필드가 바뀌면 이 JSON 도 손으로 맞춰야 한다(컴파일러가 못 잡는 drift).
+    # 완전한 해법은 후속 userId 앱 레이어 레이트리밋(GlobalExceptionHandler 가 진짜 ApiResponseBody 를 만든다).
+    error_page 429 = @rate_limited;
+    location @rate_limited {
+        default_type application/json;
+        add_header Retry-After 1 always;
+        return 429 '{"data":null,"detail":"요청이 너무 잦습니다. 잠시 후 다시 시도해 주세요.","pageResponse":{"nextCursor":null,"hasNext":false}}';
+    }
+
+    # --- 비싼 Gemini 경로: IP별 레이트리밋 적용 ---
+    # burst=20 nodelay: 순간 연타·모바일 CGNAT(여러 사용자가 한 공인 IP 뒤에 묶임)는 흡수하되,
+    # 지속적인 폭주만 429 로 막는다. nodelay 라 burst 분은 지연 없이 즉시 통과한다.
+    #
+    # 토너먼트 아이템 추가 — /{tournamentId}/items/link(링크 추출) · /items/images(이미지 추출). 둘 다 POST 전용 경로.
+    # /?$ : trailing slash 변형(.../link/)도 같은 비싼 경로로 묶어 piki_llm 우회를 막는다.
+    location ~ ^/api/v1/tournaments/[^/]+/items/(link|images)/?$ {
+        limit_req zone=piki_llm burst=20 nodelay;
+        proxy_pass http://team3;
+    }
+    # 위시 등록(POST = 링크 추출). 같은 경로의 GET(목록 조회)은 map 의 빈 키로 제한에서 제외된다.
+    # /?$ : trailing slash 변형(/api/v1/wishlists/)도 같은 경로로 묶어 piki_llm 우회를 막는다.
+    location ~ ^/api/v1/wishlists/?$ {
+        limit_req zone=piki_llm burst=20 nodelay;
+        proxy_pass http://team3;
+    }
+    # 위시 이미지 등록(POST = 이미지 추출).
+    location ~ ^/api/v1/wishlists/images/?$ {
+        limit_req zone=piki_llm burst=20 nodelay;
+        proxy_pass http://team3;
+    }
+
+    # SSE 실시간 알림 구독 — text/event-stream 스트림이라 전용 설정이 필요하다(앱: GET /api/v1/notifications/subscribe).
+    # - proxy_http_version 1.1: nginx 가 백엔드에 붙는 기본값은 1.0 인데, 1.0 은 chunked 스트리밍이 안 돼
+    #   SSE 가 버퍼링되거나 끊긴다. 1.1 로 올린다. 다른 경로 동작을 안 건드리도록 server 전역이 아니라 이 location 한정으로 둔다.
+    # - proxy_buffering off: nginx 가 응답을 모았다 내보내면 실시간성이 깨진다. 이벤트를 받는 즉시 클라이언트로 흘려보낸다.
+    # 공통 proxy_set_header / proxy_read_timeout 60s 는 server 레벨에서 상속한다(앱 하트비트가 30s 라 60s read_timeout 은 안 끊긴다).
+    # 정확매칭(=)이라 catch-all(location /)보다 우선한다. 레이트리밋은 일반 그물(piki_general) 유지 — 구독은 오래 열린 1요청이라 카운트 1로 무해하다.
+    location = /api/v1/notifications/subscribe {
+        limit_req zone=piki_general burst=40 nodelay;
+        proxy_pass http://team3;
+        proxy_http_version 1.1;
+        proxy_buffering off;
+    }
+
+    # 그 외 모든 경로 — 전역 느슨한 그물(piki_general). 정상 화면 로딩·무한스크롤은 무영향, 명백한 폭주만 429.
+    location / {
+        limit_req zone=piki_general burst=40 nodelay;
+        proxy_pass http://team3;
+    }
+
+    # http2: 브라우저는 origin 당 커넥션을 약 6개로 제한하는데, SSE 가 그 중 1개를 계속 점유한다.
+    # 멀티탭·요청 많은 화면에서 HTTP/2 의 스트림 multiplexing 이 이 제한을 풀어 SSE 가 다른 요청을 굶기지 않게 한다
+    # (백엔드 leg 와 무관한 클라이언트↔nginx leg 최적화). 단일 탭 해피케이스에선 이득이 작지만 켜는 비용도 0 에 가깝다.
+    # 형식 주의: nginx 1.25.1+ 는 `http2 on;` 지시어를 선호하나, 이 `listen ... http2` 파라미터 형식도 동작한다
+    # (신버전은 deprecation 경고만, nginx -t 는 통과). 운영 nginx 버전에 맞춰 추후 `http2 on;` 으로 바꿔도 된다.
+    listen 443 ssl http2;
+    ssl_certificate /etc/letsencrypt/live/staging.api.piki.day/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/staging.api.piki.day/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+}
+
+server {
+    if ($host = staging.api.piki.day) {
+        return 301 https://$host$request_uri;
+    }
+    listen 80;
+    server_name staging.api.piki.day;
+    return 404;
+}

--- a/infra/scripts/provision-runtime.sh
+++ b/infra/scripts/provision-runtime.sh
@@ -60,10 +60,10 @@ else
     redis:7-alpine
 fi
 
-# 3) mysql (dev 전용) — prod 는 RDS 를 쓰므로 ENVIRONMENT=dev 일 때만 기동.
+# 3) mysql (dev·staging 전용) — prod 는 RDS 를 쓰므로 dev/staging 일 때만 로컬 컨테이너로 기동.
 #    redis 와 동일하게 named 볼륨 + 있으면 skip 패턴. 앱의 DB_* 환경변수와 같은 값으로 초기화.
 #    포트는 172.17.0.1:3306 바인딩 — 앱 컨테이너가 docker bridge 를 통해 접근하고 외부엔 노출 안 함.
-if [ "${ENVIRONMENT:-}" = "dev" ]; then
+if [ "${ENVIRONMENT:-}" = "dev" ] || [ "${ENVIRONMENT:-}" = "staging" ]; then
   if docker ps -a --format '{{.Names}}' | grep -qx 'team3-mysql'; then
     echo "[mysql] team3-mysql 이미 존재 — skip"
   else

--- a/src/main/kotlin/com/depromeet/piki/common/config/CorsConfig.kt
+++ b/src/main/kotlin/com/depromeet/piki/common/config/CorsConfig.kt
@@ -29,6 +29,10 @@ class CorsConfig {
                         "https://www.dev.piki.day",
                         "https://api.piki.day",
                         "https://dev.api.piki.day",
+                        // staging 환경(#498) — staging.piki.day 프론트 + staging.api self-origin(Stoplight try-it).
+                        "https://staging.piki.day",
+                        "https://www.staging.piki.day",
+                        "https://staging.api.piki.day",
                         // 프론트엔드 로컬 개발 환경 (Next.js dev server) — 로컬에서 배포 서버 API 를
                         // 호출하며 통합 테스트할 때 Origin 헤더가 박혀 CORS 검사를 거치므로 허용한다.
                         // localhost 와 127.0.0.1 은 브라우저상 서로 다른 origin 이라 둘 다 명시한다.

--- a/src/test/kotlin/com/depromeet/piki/common/config/CorsIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/common/config/CorsIntegrationTest.kt
@@ -92,6 +92,26 @@ class CorsIntegrationTest : IntegrationTestSupport() {
     }
 
     @Test
+    fun `staging 프론트 origin 의 preflight 도 허용된다`() {
+        // staging 환경(#498) — staging.piki.day 프론트가 API 를 호출한다. 화이트리스트 누락 시
+        // staging 에서 모든 인증/JSON 요청이 CORS 로 막힌다. 회귀 가드.
+        val mockMvc =
+            MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .apply<DefaultMockMvcBuilder>(springSecurity())
+                .build()
+
+        mockMvc
+            .perform(
+                options("/api/v1/dev/users")
+                    .header(HttpHeaders.ORIGIN, "https://staging.piki.day")
+                    .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "POST"),
+            ).andExpect(status().isOk)
+            .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "https://staging.piki.day"))
+            .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS, "true"))
+    }
+
+    @Test
     fun `화이트리스트에 없는 origin 의 preflight 는 403 으로 거부된다`() {
         // 허용 목록 검증이 실제로 동작함을 함께 단언해 테스트가 vacuous 하지 않도록 한다.
         val mockMvc =

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -118,3 +118,54 @@ resource "aws_instance" "dev_app" {
     Name = "team3-dev-app"
   }
 }
+
+# -----------------------------------------------------------------------------
+# 스테이징(staging) EC2 — dev 와 동일 경량 구성(로컬 MySQL/Redis), prod 프로파일로 동작.
+# 동일 VPC/서브넷/SG/instance role 공유. 별도 EIP·도메인(staging.api.piki.day).
+# 신규 인스턴스라 cloud-init 로 docker·nginx·certbot 설치(dev_app 과 동일).
+# user_data 는 첫 부팅에만 실행되므로, 기존 인스턴스엔 -replace 로 적용한다.
+# -----------------------------------------------------------------------------
+resource "aws_instance" "staging_app" {
+  ami                    = var.ec2_ami_id != null ? var.ec2_ami_id : data.aws_ami.ubuntu_2404_arm64[0].id
+  instance_type          = var.ec2_instance_type
+  subnet_id              = aws_subnet.public.id
+  availability_zone      = var.azs[0]
+  vpc_security_group_ids = [aws_security_group.ec2.id]
+  # staging 전용 키페어 — AWS 콘솔에서 미리 생성(.pem). 개인키는 staging env EC2_SSH_KEY 로 주입.
+  key_name             = "team3-staging-SE-1"
+  iam_instance_profile = aws_iam_instance_profile.app.name
+
+  user_data = <<-EOF
+    #!/bin/bash
+    set -eux
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update
+    apt-get install -y ca-certificates curl nginx certbot python3-certbot-nginx
+    install -m 0755 -d /etc/apt/keyrings
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+    chmod a+r /etc/apt/keyrings/docker.asc
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" > /etc/apt/sources.list.d/docker.list
+    apt-get update
+    apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+    usermod -aG docker ubuntu
+    systemctl enable --now docker
+    systemctl enable --now nginx
+  EOF
+
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2
+  }
+
+  root_block_device {
+    volume_size           = 20
+    volume_type           = "gp3"
+    encrypted             = true
+    delete_on_termination = true
+  }
+
+  tags = {
+    Name = "team3-staging-app"
+  }
+}

--- a/terraform/eip.tf
+++ b/terraform/eip.tf
@@ -41,3 +41,19 @@ resource "aws_eip_association" "dev_app" {
   instance_id   = aws_instance.dev_app.id
   allocation_id = aws_eip.dev_app.id
 }
+
+# -----------------------------------------------------------------------------
+# 스테이징(staging) EC2 용 EIP — apply 후 staging_ec2_public_ip 를 가비아 staging.api 에 등록.
+# -----------------------------------------------------------------------------
+resource "aws_eip" "staging_app" {
+  domain     = "vpc"
+  depends_on = [aws_internet_gateway.main]
+  tags = {
+    Name = "team3-staging-app-eip"
+  }
+}
+
+resource "aws_eip_association" "staging_app" {
+  instance_id   = aws_instance.staging_app.id
+  allocation_id = aws_eip.staging_app.id
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -29,6 +29,7 @@ data "aws_iam_policy_document" "image_bucket_rw" {
     resources = [
       "${aws_s3_bucket.images.arn}/*",
       "${aws_s3_bucket.dev_images.arn}/*",
+      "${aws_s3_bucket.staging_images.arn}/*",
     ]
   }
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -62,3 +62,23 @@ output "dev_image_public_base_url" {
   description = "개발(dev) 이미지 버킷 공개 베이스 URL — dev env S3_PUBLIC_BASE_URL 에 넣을 값"
   value       = "https://${aws_s3_bucket.dev_images.bucket_regional_domain_name}"
 }
+
+output "staging_ec2_public_ip" {
+  description = "스테이징(staging) EC2 Elastic IP — 가비아 staging.api.piki.day A 레코드에 등록할 것"
+  value       = aws_eip.staging_app.public_ip
+}
+
+output "staging_ec2_public_dns" {
+  description = "스테이징(staging) EC2 퍼블릭 DNS (EIP 기준)"
+  value       = aws_eip.staging_app.public_dns
+}
+
+output "staging_image_bucket_name" {
+  description = "스테이징 이미지 버킷명 — staging env S3_BUCKET 에 넣을 값"
+  value       = aws_s3_bucket.staging_images.id
+}
+
+output "staging_image_public_base_url" {
+  description = "스테이징 이미지 버킷 공개 베이스 URL — staging env S3_PUBLIC_BASE_URL 에 넣을 값"
+  value       = "https://${aws_s3_bucket.staging_images.bucket_regional_domain_name}"
+}

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -97,3 +97,50 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "dev_images" {
     }
   }
 }
+
+# -----------------------------------------------------------------------------
+# 스테이징(staging) 전용 이미지 버킷 — staging-<기존 버킷명>. dev_images 4개 리소스 미러.
+# 앱은 staging env 의 S3_BUCKET / S3_PUBLIC_BASE_URL 로 이 버킷을 가리킨다.
+# -----------------------------------------------------------------------------
+resource "aws_s3_bucket" "staging_images" {
+  bucket = "staging-${var.image_bucket_name}"
+
+  tags = {
+    Name = "staging-${var.image_bucket_name}"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "staging_images" {
+  bucket = aws_s3_bucket.staging_images.id
+
+  block_public_acls       = true
+  ignore_public_acls      = true
+  block_public_policy     = false
+  restrict_public_buckets = false
+}
+
+resource "aws_s3_bucket_policy" "staging_images_public_read" {
+  bucket     = aws_s3_bucket.staging_images.id
+  depends_on = [aws_s3_bucket_public_access_block.staging_images]
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid       = "PublicReadGetObject"
+      Effect    = "Allow"
+      Principal = "*"
+      Action    = "s3:GetObject"
+      Resource  = "${aws_s3_bucket.staging_images.arn}/*"
+    }]
+  })
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "staging_images" {
+  bucket = aws_s3_bucket.staging_images.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}


### PR DESCRIPTION
## Situation

- dev/prod 2단 구조라 prod 직전 검증 게이트가 없다. dev 의 모든 변경이 main 머지로 곧장 prod 로 나가, #488 prod 이관 때 "6주치 408커밋이 한 번에 prod" 같은 대형 릴리스 리스크로 드러났다.
- dev(개발)와 prod(운영) 사이에 prod 프로파일로 도는 pre-prod staging 을 둬, 릴리스 전 prod 와 동일 동작으로 검증한다.

## Task

- staging 환경의 코드·IaC 부분을 신설한다 (apply·secret·DNS·OAuth 등 인프라 작업은 별도 단계로 분리).
- 핵심 결정: staging 을 dev 처럼 경량(별도 EC2 + 로컬 MySQL)으로 두되, 앱만 prod 프로파일로 돌려 진짜 pre-prod 로 만든다. 프로파일(prod)과 DB(로컬 MySQL)는 분리된 축이다.

## Action

### Terraform (staging 인프라 정의)

- dev EC2 정의를 복제해 staging EC2·EIP·전용 S3 버킷·instance role 정책·outputs 를 추가했다. VPC·서브넷·SG·instance role 은 재사용한다. AMI 는 기존 핀(고정값) 그대로라 기존 prod/dev 인스턴스는 교체되지 않는다.

### 런타임·nginx

- provision 스크립트의 로컬 MySQL 기동 조건을 dev 에서 dev·staging 으로 확장했다 (redis·alloy 는 이미 환경 무관이라 staging 도 자동 포함, Alloy 모니터링은 ENVIRONMENT=staging 으로 라벨링).
- staging.api.piki.day.conf 를 신설했다. 신규 도메인이라 옛 도메인 듀얼런 없이 단일 server_name 이다.

### CI/CD (3-branch 파이프라인)

- ci.yml·deploy.yml 트리거와 resolve 분기에 staging 을 추가했다 (staging 브랜치 -> staging.api.piki.day).
- SPRING_PROFILES_ACTIVE 를 prod·staging 에서 'prod' 로 활성화했다. @Profile("!prod") 의 dev 전용 빈(admin·DevAuth·/dev 엔드포인트)이 staging 에서도 OFF 라, prod 와 동일한 동작을 검증할 수 있다. ADMIN_ENABLED 는 dev 만 true 라 staging 은 자동 false.

### CORS

- staging.piki.day 프론트 origin 을 추가하고 preflight 허용 회귀 테스트를 더했다.

## Result

- 머지하면 dev 에 staging 지원 코드가 들어간다. 이후 dev 에서 staging 브랜치를 분기해 push 하면 resolve 가 staging.api.piki.day 로 매핑해 staging EC2 로 배포된다.
- 코드 외 인프라는 이 PR 범위 밖이며 이미 별도로 진행됐다: terraform apply(staging EC2·EIP 13.209.221.128·전용 S3 버킷), 가비아 DNS(staging.api), GitHub staging Environment + secret 15개. 남은 것은 staging 브랜치 첫 배포 검증과 OAuth 콘솔·프론트 staging 등록(외부)이다.
- 승격 경로는 dev -> staging -> main 선형이다. prod 직전 prod 프로파일 검증 게이트를 확보한다.

---
## 연관 이슈

- #498 (staging 환경 구축 - 이 PR 은 코드/IaC. 첫 배포 검증과 OAuth 콘솔·FE 등록까지 끝나면 close)
