### PR TITLE
Slack 배포 알림 staging 라벨 수정 (PiKi-Dev → PiKi-Staging)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -553,8 +553,12 @@ jobs:
           COMMIT_MSG=$(jq -r '(.workflow_run.head_commit.message // .head_commit.message // "")' "$GITHUB_EVENT_PATH" | head -n 1)
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
-          # 배포 대상을 PiKi-Dev / PiKi-Prod 로 브랜딩 + 도메인까지 보여 "어디에 배포됐는지" 명확히.
-          if [ "${{ needs.resolve.outputs.environment }}" = "prod" ]; then TARGET="PiKi-Prod"; else TARGET="PiKi-Dev"; fi
+          # 배포 대상을 PiKi-Dev / PiKi-Staging / PiKi-Prod 로 브랜딩 + 도메인까지 보여 "어디에 배포됐는지" 명확히.
+          case "${{ needs.resolve.outputs.environment }}" in
+            prod)    TARGET="PiKi-Prod" ;;
+            staging) TARGET="PiKi-Staging" ;;
+            *)       TARGET="PiKi-Dev" ;;
+          esac
           TEXT=$(printf '✅ `%s` 배포 성공!  ✅\n• 경로: `%s` 브랜치 → %s (%s)\n• 배포자: %s\n• 커밋: <%s|%s>  %s\n• <%s|워크플로우 로그>' \
             "$TARGET" "${{ needs.resolve.outputs.branch }}" "$TARGET" "${{ needs.resolve.outputs.domain }}" "$ACTOR_MENTION" "$COMMIT_URL" "$SHORT_SHA" "$COMMIT_MSG" "$RUN_URL")
 
@@ -606,7 +610,11 @@ jobs:
             CAUSE="알 수 없음 (환경 설정 단계)"
           fi
 
-          if [ "${{ needs.resolve.outputs.environment }}" = "prod" ]; then TARGET="PiKi-Prod"; else TARGET="PiKi-Dev"; fi
+          case "${{ needs.resolve.outputs.environment }}" in
+            prod)    TARGET="PiKi-Prod" ;;
+            staging) TARGET="PiKi-Staging" ;;
+            *)       TARGET="PiKi-Dev" ;;
+          esac
           TEXT=$(printf '❌ `%s` 배포 실패! ❌\n• 경로: `%s` 브랜치 → %s (%s)\n• 배포자: %s\n• 커밋: <%s|%s>  %s\n• 원인: %s\n• <%s|워크플로우 로그 확인>' \
             "$TARGET" "${{ needs.resolve.outputs.branch }}" "$TARGET" "${{ needs.resolve.outputs.domain }}" "$ACTOR_MENTION" "$COMMIT_URL" "$SHORT_SHA" "$COMMIT_MSG" "$CAUSE" "$RUN_URL")
 


### PR DESCRIPTION
## Situation

- staging 환경(#498) 첫 배포에서 Slack 배포 알림이 staging 인데 "PiKi-Dev" 로 떴다 (`경로: staging 브랜치 -> PiKi-Dev (staging.api.piki.day)`). 도메인·브랜치는 동적인데 환경 이름표만 staging 을 dev 로 잘못 찍었다.

## Task

- 배포 알림의 환경 라벨(TARGET)이 staging 을 정확히 표기하게 한다.

## Action

- TARGET 분기가 prod / 나머지 2-way 라 staging 이 else 로 빠져 PiKi-Dev 가 됐다. prod / staging / dev 3-way case 로 바꿔 staging 은 PiKi-Staging 으로 표기한다. 성공·실패 알림 두 곳에 동일 적용했다.

## Result

- 다음 staging 배포부터 알림이 "PiKi-Staging (staging.api.piki.day)" 로 정확히 뜬다. dev·prod 표기는 그대로다.

---
## 연관 이슈

- #498 관련 (staging 환경 첫 배포에서 드러난 알림 라벨 fix, 별도 close 대상 아님)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Slack 배포 알림(성공/실패)에서 배포 대상 환경 표시가 개선되었습니다. 스테이징 환경이 이제 `PiKi-Staging`으로 명확하게 구분되어 표시되며, 배포 알림을 통해 배포 환경을 보다 정확하게 파악할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->