### PR TITLE
fix: Slack 배포 알림이 staging 을 PiKi-Dev 로 표기하던 것 수정 (#502)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -553,8 +553,12 @@ jobs:
           COMMIT_MSG=$(jq -r '(.workflow_run.head_commit.message // .head_commit.message // "")' "$GITHUB_EVENT_PATH" | head -n 1)
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
-          # 배포 대상을 PiKi-Dev / PiKi-Prod 로 브랜딩 + 도메인까지 보여 "어디에 배포됐는지" 명확히.
-          if [ "${{ needs.resolve.outputs.environment }}" = "prod" ]; then TARGET="PiKi-Prod"; else TARGET="PiKi-Dev"; fi
+          # 배포 대상을 PiKi-Dev / PiKi-Staging / PiKi-Prod 로 브랜딩 + 도메인까지 보여 "어디에 배포됐는지" 명확히.
+          case "${{ needs.resolve.outputs.environment }}" in
+            prod)    TARGET="PiKi-Prod" ;;
+            staging) TARGET="PiKi-Staging" ;;
+            *)       TARGET="PiKi-Dev" ;;
+          esac
           TEXT=$(printf '✅ `%s` 배포 성공!  ✅\n• 경로: `%s` 브랜치 → %s (%s)\n• 배포자: %s\n• 커밋: <%s|%s>  %s\n• <%s|워크플로우 로그>' \
             "$TARGET" "${{ needs.resolve.outputs.branch }}" "$TARGET" "${{ needs.resolve.outputs.domain }}" "$ACTOR_MENTION" "$COMMIT_URL" "$SHORT_SHA" "$COMMIT_MSG" "$RUN_URL")
 
@@ -606,7 +610,11 @@ jobs:
             CAUSE="알 수 없음 (환경 설정 단계)"
           fi
 
-          if [ "${{ needs.resolve.outputs.environment }}" = "prod" ]; then TARGET="PiKi-Prod"; else TARGET="PiKi-Dev"; fi
+          case "${{ needs.resolve.outputs.environment }}" in
+            prod)    TARGET="PiKi-Prod" ;;
+            staging) TARGET="PiKi-Staging" ;;
+            *)       TARGET="PiKi-Dev" ;;
+          esac
           TEXT=$(printf '❌ `%s` 배포 실패! ❌\n• 경로: `%s` 브랜치 → %s (%s)\n• 배포자: %s\n• 커밋: <%s|%s>  %s\n• 원인: %s\n• <%s|워크플로우 로그 확인>' \
             "$TARGET" "${{ needs.resolve.outputs.branch }}" "$TARGET" "${{ needs.resolve.outputs.domain }}" "$ACTOR_MENTION" "$COMMIT_URL" "$SHORT_SHA" "$COMMIT_MSG" "$CAUSE" "$RUN_URL")
 


### PR DESCRIPTION
TARGET 분기가 prod/나머지 2-way 라 staging 배포 알림이 'PiKi-Dev' 로 떴다. prod/staging/dev 3-way case 로 바꿔 staging 은 'PiKi-Staging' 으로 정확히 표기한다. 성공·실패 알림 두 곳 동일 적용.


---

## Situation

- 
## Task 
> Slack PR 알림의「작업 요약」에 표시되는 섹터입니다.
- 

## Action

- 

## Result

- 
---
## 연관 이슈

- close #
