### PR TITLE
파싱 결과(성공/실패) 메트릭 추가 — 추출 관측 공백 보완

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/item/service/AsyncItemParsingWorker.kt
+++ b/src/main/kotlin/com/depromeet/piki/item/service/AsyncItemParsingWorker.kt
@@ -5,6 +5,7 @@ import com.depromeet.piki.product.domain.ProductLink
 import com.depromeet.piki.product.service.ProductLinkExtractor
 import com.depromeet.piki.product.service.ProductSnapshot
 import com.depromeet.piki.product.service.ProductSnapshotException
+import io.micrometer.core.instrument.MeterRegistry
 import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
@@ -19,6 +20,7 @@ import org.springframework.stereotype.Component
 class AsyncItemParsingWorker(
     private val productLinkExtractor: ProductLinkExtractor,
     private val itemParsingService: ItemParsingService,
+    private val meterRegistry: MeterRegistry,
 ) : ItemParsingWorker {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -42,11 +44,15 @@ class AsyncItemParsingWorker(
         val elapsedMs = (System.nanoTime() - started) / 1_000_000
         // 전이가 실패(추출값 도메인 검증 위반·DB 오류·sweeper 와의 레이스로 이미 전이됨)해도 예외를 흡수한다.
         runCatching { itemParsingService.markReady(itemId, snapshot) }
-            .onSuccess { log.info("item {} 파싱 완료: latency={}ms url={}", itemId, elapsedMs, link.safeLogString()) }
+            .onSuccess {
+                log.info("item {} 파싱 완료: latency={}ms url={}", itemId, elapsedMs, link.safeLogString())
+                ItemParsingMetrics.record(meterRegistry, ItemParsingMetrics.RESULT_READY, ItemParsingMetrics.REASON_NONE)
+            }
             .onFailure { e ->
                 // 추출은 됐으나 값을 신뢰할 수 없어 READY 로 채울 수 없는 경우 → PROCESSING 방치 대신 FAILED 로.
                 log.warn("item {} READY 전이 실패 → FAILED: url={}", itemId, link.safeLogString(), e)
                 markFailedQuietly(itemId)
+                ItemParsingMetrics.record(meterRegistry, ItemParsingMetrics.RESULT_FAILED, ItemParsingMetrics.REASON_READY_REJECTED)
             }
     }
 
@@ -62,6 +68,7 @@ class AsyncItemParsingWorker(
             is ProductSnapshotException -> {
                 log.info("item {} 파싱 실패(확정·재시도 무의미): {} url={}", itemId, e.message, link.safeLogString())
                 markFailedQuietly(itemId)
+                ItemParsingMetrics.record(meterRegistry, ItemParsingMetrics.RESULT_FAILED, ItemParsingMetrics.REASON_NOT_PRODUCT)
             }
             // 일시 외부 오류(네트워크·timeout·Gemini 5xx 등) — 다시 하면 될 수도 있으므로 FAILED 로 종결하지 않고
             // PROCESSING 그대로 둔다. recover 가 stale 로 잡아 상한까지 재실행한다(execution at-least-once, #461).

--- a/src/main/kotlin/com/depromeet/piki/item/service/ItemParsingMetrics.kt
+++ b/src/main/kotlin/com/depromeet/piki/item/service/ItemParsingMetrics.kt
@@ -1,0 +1,39 @@
+package com.depromeet.piki.item.service
+
+import io.micrometer.core.instrument.MeterRegistry
+
+// 파싱 단건의 종결 결과(READY/FAILED)를 result·reason 라벨로 센다 — 추출 실패가 트래픽에서 얼마나·왜 나는지 관측한다(#506).
+// 메트릭 이름·라벨 키를 한 곳에 고정해 여러 emit 경로(워커·recover)가 같은 키 집합을 쓰게 한다: 키가 어긋나면
+// Prometheus 가 뒤 시계열을 조용히 드롭하기 때문(#465 product.extract 사건). 모든 호출이 result·reason 둘 다 채운다.
+// host 는 등록 URL 마다 달라 카디널리티가 무한히 커질 수 있어 라벨에 넣지 않는다 — 호스트별 실패는 로그(safeLogString)로 본다.
+object ItemParsingMetrics {
+    const val METRIC = "item.parsing"
+    const val TAG_RESULT = "result"
+    const val TAG_REASON = "reason"
+
+    const val RESULT_READY = "ready"
+    const val RESULT_FAILED = "failed"
+
+    // 성공.
+    const val REASON_NONE = "none"
+
+    // 워커 확정 실패 — 상품 페이지 아님·추출값 신뢰 불가(ProductSnapshotException). 클라이언트 입력 계약 위반.
+    const val REASON_NOT_PRODUCT = "not_product"
+
+    // 추출은 됐으나 READY 전이가 값 검증에 막힘(이름 없음 등).
+    const val REASON_READY_REJECTED = "ready_rejected"
+
+    // recover — 일시 오류 재실행이 상한을 소진. "우리 파이프라인이 끝내 못 끝낸" 진짜 실패라 가장 주목할 reason.
+    const val REASON_RETRY_EXHAUSTED = "retry_exhausted"
+
+    // recover — 되살릴 원본이 없음(이미지: 원본이 메모리 ByteArray 라 크래시 시 소실 / orphan: link 부재).
+    const val REASON_NO_SOURCE = "no_source"
+
+    fun record(
+        registry: MeterRegistry,
+        result: String,
+        reason: String,
+    ) {
+        registry.counter(METRIC, TAG_RESULT, result, TAG_REASON, reason).increment()
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/item/service/ItemParsingService.kt
+++ b/src/main/kotlin/com/depromeet/piki/item/service/ItemParsingService.kt
@@ -5,6 +5,7 @@ import com.depromeet.piki.item.event.ItemParsingFailed
 import com.depromeet.piki.item.repository.ItemRepository
 import com.depromeet.piki.item.repository.ItemSnapshotRepository
 import com.depromeet.piki.product.service.ProductSnapshot
+import io.micrometer.core.instrument.MeterRegistry
 import org.slf4j.LoggerFactory
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
@@ -21,6 +22,7 @@ class ItemParsingService(
     private val itemRepository: ItemRepository,
     private val itemSnapshotRepository: ItemSnapshotRepository,
     private val eventPublisher: ApplicationEventPublisher,
+    private val meterRegistry: MeterRegistry,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -104,6 +106,7 @@ class ItemParsingService(
                 linkByItemId[snapshot.itemId] ?: run {
                     snapshot.markFailed()
                     eventPublisher.publishEvent(ItemParsingFailed(snapshot.itemId))
+                    ItemParsingMetrics.record(meterRegistry, ItemParsingMetrics.RESULT_FAILED, ItemParsingMetrics.REASON_NO_SOURCE)
                     failedCount++
                     return@forEach
                 }
@@ -111,6 +114,7 @@ class ItemParsingService(
             if (snapshot.attemptCount >= maxAttempts) {
                 snapshot.markFailed()
                 eventPublisher.publishEvent(ItemParsingFailed(snapshot.itemId))
+                ItemParsingMetrics.record(meterRegistry, ItemParsingMetrics.RESULT_FAILED, ItemParsingMetrics.REASON_RETRY_EXHAUSTED)
                 failedCount++
                 return@forEach
             }

--- a/src/test/kotlin/com/depromeet/piki/wishlist/controller/WishlistRegisterAsyncIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/wishlist/controller/WishlistRegisterAsyncIntegrationTest.kt
@@ -19,6 +19,7 @@ import com.depromeet.piki.support.StubProductImageExtractor
 import com.depromeet.piki.support.StubProductLinkExtractor
 import com.depromeet.piki.support.uuidToBytes
 import com.depromeet.piki.user.domain.IdentityType
+import io.micrometer.core.instrument.MeterRegistry
 import org.awaitility.Awaitility.await
 import org.hamcrest.Matchers.nullValue
 import org.junit.jupiter.api.Test
@@ -46,6 +47,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import javax.imageio.ImageIO
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 // 등록은 비동기(@Async)다. @Transactional 자동 롤백 패턴으로는 워커(별도 스레드·새 트랜잭션)가
 // 미커밋 데이터를 못 보므로, 여기서는 @Transactional 없이 실제 커밋하고 Awaitility 로 상태 전이를 기다린다.
@@ -77,6 +79,9 @@ class WishlistRegisterAsyncIntegrationTest : IntegrationTestSupport() {
 
     @Autowired
     private lateinit var jwtProvider: JwtProvider
+
+    @Autowired
+    private lateinit var meterRegistry: MeterRegistry
 
     @Test
     fun `등록하면 추출을 기다리지 않고 PENDING 상태로 201 이 즉시 반환된다`() {
@@ -114,11 +119,14 @@ class WishlistRegisterAsyncIntegrationTest : IntegrationTestSupport() {
             stubProductLinkExtractor.build = {
                 ProductSnapshot(link = it, name = "나이키 에어포스", currentPrice = 99_000, currency = "KRW")
             }
+            val readyBefore = parseCount("ready", "none")
             val itemId = registerAndGetItemId(mockMvc, userId, "https://shop.example.com/products/42")
 
             await().atMost(Duration.ofSeconds(5)).until {
                 latestSnapshot(itemId)?.status == ItemStatus.READY
             }
+            // 결과 메트릭(#506): 성공은 result=ready,reason=none 으로 +1 (워커 비동기라 메트릭 증가도 await).
+            await().atMost(Duration.ofSeconds(2)).until { parseCount("ready", "none") - readyBefore >= 1.0 }
 
             // 표시값·상태는 활성 snapshot 이 보유한다(4a) — item 은 정체성(link)만 든다.
             val snapshot = latestSnapshot(itemId) ?: error("item $itemId 의 snapshot 이 없다")
@@ -138,11 +146,14 @@ class WishlistRegisterAsyncIntegrationTest : IntegrationTestSupport() {
         try {
             // 파싱 결과 실패는 동기 400 이 아니라 FAILED 상태로 남는다 (등록 응답은 이미 201 로 끝났으므로).
             stubProductLinkExtractor.build = { throw ProductSnapshotException.notProductPage() }
+            val notProductBefore = parseCount("failed", "not_product")
             val itemId = registerAndGetItemId(mockMvc, userId, "https://shop.example.com/products/not-a-product")
 
             await().atMost(Duration.ofSeconds(5)).until {
                 latestSnapshot(itemId)?.status == ItemStatus.FAILED
             }
+            // 결과 메트릭(#506): 상품 아님 확정 실패는 result=failed,reason=not_product 로 +1.
+            await().atMost(Duration.ofSeconds(2)).until { parseCount("failed", "not_product") - notProductBefore >= 1.0 }
 
             val snapshot = latestSnapshot(itemId) ?: error("item $itemId 의 snapshot 이 없다")
             assertEquals(ItemStatus.FAILED, snapshot.status)
@@ -162,11 +173,14 @@ class WishlistRegisterAsyncIntegrationTest : IntegrationTestSupport() {
             // isProductPage=true 라도 이름을 못 뽑으면 name 이 비어 온다. READY 불변식(name 필수)에 걸려
             // markReady 가 거부하고, 워커가 이를 받아 PROCESSING 방치 대신 FAILED 로 떨어뜨린다.
             stubProductLinkExtractor.build = { ProductSnapshot(link = it, currentPrice = 99_000) }
+            val rejectedBefore = parseCount("failed", "ready_rejected")
             val itemId = registerAndGetItemId(mockMvc, userId, "https://shop.example.com/products/no-name")
 
             await().atMost(Duration.ofSeconds(5)).until {
                 latestSnapshot(itemId)?.status == ItemStatus.FAILED
             }
+            // 결과 메트릭(#506): 추출됐으나 READY 부적격(이름 없음)은 result=failed,reason=ready_rejected 로 +1.
+            await().atMost(Duration.ofSeconds(2)).until { parseCount("failed", "ready_rejected") - rejectedBefore >= 1.0 }
 
             val snapshot = latestSnapshot(itemId) ?: error("item $itemId 의 snapshot 이 없다")
             assertEquals(ItemStatus.FAILED, snapshot.status)
@@ -384,9 +398,12 @@ class WishlistRegisterAsyncIntegrationTest : IntegrationTestSupport() {
                 snapshot.getId(),
             )
 
+            val exhaustedBefore = parseCount("failed", "retry_exhausted")
             itemParsingScheduler.recover() // attempt 2 >= 2 → FAILED (재실행 없음, 동기 종결)
 
             assertEquals(ItemStatus.FAILED, latestSnapshot(itemId)?.status)
+            // 결과 메트릭(#506): recover 가 재시도 상한 소진으로 종결 → result=failed,reason=retry_exhausted +1 (recover 동기라 즉시 단언).
+            assertTrue(parseCount("failed", "retry_exhausted") - exhaustedBefore >= 1.0, "retry_exhausted 메트릭이 증가해야 한다")
         } finally {
             jdbcTemplate.update("DELETE FROM item_snapshots WHERE item_id = ?", itemId)
             jdbcTemplate.update("DELETE FROM items WHERE id = ?", itemId)
@@ -406,9 +423,12 @@ class WishlistRegisterAsyncIntegrationTest : IntegrationTestSupport() {
                 snapshot.getId(),
             )
 
+            val noSourceBefore = parseCount("failed", "no_source")
             itemParsingScheduler.recover() // link 없음 → FAILED
 
             assertEquals(ItemStatus.FAILED, latestSnapshot(itemId)?.status)
+            // 결과 메트릭(#506): 되살릴 원본 없음(이미지) 종결 → result=failed,reason=no_source +1.
+            assertTrue(parseCount("failed", "no_source") - noSourceBefore >= 1.0, "no_source 메트릭이 증가해야 한다")
         } finally {
             jdbcTemplate.update("DELETE FROM item_snapshots WHERE item_id = ?", itemId)
             jdbcTemplate.update("DELETE FROM items WHERE id = ?", itemId)
@@ -505,6 +525,12 @@ class WishlistRegisterAsyncIntegrationTest : IntegrationTestSupport() {
 
     // 표시값·상태는 item 의 활성(최신) snapshot 이 보유한다(4a). 폴링·단언이 이 snapshot 을 읽는다.
     private fun latestSnapshot(itemId: Long): ItemSnapshot? = itemSnapshotRepository.findLatestByItemId(itemId)
+
+    // item.parsing 카운터의 현재 값. 공유 컨텍스트라 누적되므로 호출 전후 증가분(delta)으로 단언한다(#468 패턴).
+    private fun parseCount(
+        result: String,
+        reason: String,
+    ): Double = meterRegistry.find("item.parsing").tags("result", result, "reason", reason).counter()?.count() ?: 0.0
 
     // @Transactional 자동 롤백이 없으므로 이 테스트가 만든 user·wish·item·snapshot 을 직접 정리한다.
     private fun cleanup(userId: UUID) {


### PR DESCRIPTION
## Situation

- 파싱·추출 작업 중 "무엇이·왜 실패했나"를 운영에서 볼 수단이 없었다. dev 대시보드를 봐도 파싱 문제가 안 보인 건 새로고침 문제가 아니라 관측 자체가 비어 있어서였다.
- 기존 `product.extract` 메트릭(#468)은 추출 방법(직접 파싱 vs LLM) 분포지 실패가 아니다. 파싱 outbox(#411 #461)는 결과(READY/FAILED)·재시도를 DB·로그로만 다뤄 메트릭이 0개였다.

## Task

- 파싱 단건의 종결 결과(성공/실패)와 사유를 메트릭으로 노출해, 실패가 트래픽에서 얼마나·왜 나는지 숫자로 본다.

## Action

- 종결 결과를 세는 Micrometer 카운터를 추가했다. 워커(성공·확정 실패)와 recover(재시도 소진·원본 없음) 양 경로에서 emit 한다.
- 일시 외부 오류는 종결이 아니라 PROCESSING 으로 남아 recover 가 재시도하므로 그 시점엔 세지 않는다. 한 아이템은 최종 결과로 한 번만 카운트된다.

### 설계
- 라벨 키 집합을 `ItemParsingMetrics` 한 곳에 고정했다 — 경로마다 키가 어긋나면 Prometheus 가 뒤 시계열을 조용히 드롭하기 때문(#465 product.extract 사건과 같은 함정).
- `host` 는 등록 URL 마다 달라 카디널리티가 무한히 커질 수 있어 라벨에서 뺐다. 호스트별 실패는 로그(safeLogString)로 본다.

## Result

메트릭 `item.parsing`, 라벨 `result` + `reason`:

| result/reason | 언제 | 의미 |
|---|---|---|
| ready/none | 워커 성공 | 정상 |
| failed/not_product | 상품 아님(ProductSnapshotException) | 클라이언트 입력 계약 위반 |
| failed/ready_rejected | 추출됐으나 이름 없음 | 저품질 |
| failed/retry_exhausted | recover 재시도 상한 소진 | 우리 파이프라인이 끝내 못 끝냄(가장 주목할 실패) |
| failed/no_source | recover 원본 없음(이미지·orphan) | 되살림 불가 |

- 이제 실패율·사유 분포를 쿼리할 수 있어, 추출 개선(#478 등)·cap 조정(#495) 우선순위를 추측이 아니라 데이터로 판단한다.
- 검증: 5개 reason 각각을 통합 테스트에서 호출 전후 delta 로 단언했다(워커 비동기 경로는 메트릭 증가까지 await, recover 동기 경로는 즉시 단언).

---
## 연관 이슈

- 관련 #506 (메트릭 부분 구현. 대시보드 패널은 수동 import 라 이 PR 범위 밖 — #506 에 남긴다)
