### PR TITLE
dev 에서만 LAN 사설망 origin CORS 허용 (실기기 테스트)

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/common/config/CorsConfig.kt
+++ b/src/main/kotlin/com/depromeet/piki/common/config/CorsConfig.kt
@@ -2,12 +2,16 @@ package com.depromeet.piki.common.config
 
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.core.env.Environment
+import org.springframework.core.env.Profiles
 import org.springframework.web.cors.CorsConfiguration
 import org.springframework.web.cors.CorsConfigurationSource
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 
 @Configuration
-class CorsConfig {
+class CorsConfig(
+    private val environment: Environment,
+) {
     // Spring Security 의 CorsFilter 가 인가(authorization) 이전에 이 source 를 읽어 CORS 를 처리한다.
     // WebMvcConfigurer.addCorsMappings 로 두면 preflight(OPTIONS) 요청이 Security 필터의
     // anyRequest().authenticated() 에 먼저 잡혀 401 이 되므로(브라우저는 인증 헤더/JSON 요청 전
@@ -39,6 +43,23 @@ class CorsConfig {
                         "http://localhost:3000",
                         "http://127.0.0.1:3000",
                     )
+                // 실기기 dev 테스트(#509): 폰 브라우저가 LAN IP(http://192.168.x.y:port)로 프론트에 접속하면
+                // Origin 이 그 사설망 IP 로 박혀 CORS 에 걸린다. dev·local 에서만 사설망 대역을 allowedOriginPatterns 로
+                // 허용해 폰이 백엔드를 직접 호출하게 한다(프론트의 요청 수동 재작성 우회 제거).
+                // 분기 기준은 'prod' 프로파일이다 — staging 도 deploy 가 'prod' 프로파일로 띄우므로(#498: pre-prod=prod
+                // 동일 동작) prod 와 함께 LAN 이 닫힌다. 즉 LAN 은 dev(프로파일 dev)·local 에서만 열린다.
+                // allowedOrigins(정확) + allowedOriginPatterns(와일드카드)는 한 설정에 공존하며, allowCredentials=true 와도
+                // patterns 는 호환된다(allowedOrigins=["*"] 만 금지).
+                if (!environment.acceptsProfiles(Profiles.of("prod"))) {
+                    allowedOriginPatterns =
+                        listOf(
+                            "http://192.168.*.*:[*]", // 가정·사무실 LAN (가장 흔함)
+                            "http://10.*.*.*:[*]",
+                            "http://172.*.*.*:[*]",
+                            "http://localhost:[*]",
+                            "http://127.0.0.1:[*]",
+                        )
+                }
                 allowedMethods = listOf("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
                 allowedHeaders = listOf("*")
                 allowCredentials = true

--- a/src/main/kotlin/com/depromeet/piki/common/config/CorsConfig.kt
+++ b/src/main/kotlin/com/depromeet/piki/common/config/CorsConfig.kt
@@ -44,21 +44,16 @@ class CorsConfig(
                         "http://127.0.0.1:3000",
                     )
                 // 실기기 dev 테스트(#509): 폰 브라우저가 LAN IP(http://192.168.x.y:port)로 프론트에 접속하면
-                // Origin 이 그 사설망 IP 로 박혀 CORS 에 걸린다. dev·local 에서만 사설망 대역을 allowedOriginPatterns 로
-                // 허용해 폰이 백엔드를 직접 호출하게 한다(프론트의 요청 수동 재작성 우회 제거).
+                // Origin 이 그 사설망 IP 로 박혀 CORS 에 걸린다. dev·local 에서만 192.168 대역(가정·사무실 공유기 LAN 의
+                // 표준 범위, 실기기 테스트가 실제로 쓰는 대역)을 allowedOriginPatterns 로 허용해 폰이 백엔드를 직접
+                // 호출하게 한다(프론트의 요청 수동 재작성 우회 제거). 192.168 로만 좁혀 credentials 오리진 표면을 최소화한다
+                // (10/172 는 요청 밖, localhost·127.0.0.1:3000 은 이미 위 allowedOrigins 에 있어 로컬은 그걸로 충분).
                 // 분기 기준은 'prod' 프로파일이다 — staging 도 deploy 가 'prod' 프로파일로 띄우므로(#498: pre-prod=prod
                 // 동일 동작) prod 와 함께 LAN 이 닫힌다. 즉 LAN 은 dev(프로파일 dev)·local 에서만 열린다.
                 // allowedOrigins(정확) + allowedOriginPatterns(와일드카드)는 한 설정에 공존하며, allowCredentials=true 와도
                 // patterns 는 호환된다(allowedOrigins=["*"] 만 금지).
                 if (!environment.acceptsProfiles(Profiles.of("prod"))) {
-                    allowedOriginPatterns =
-                        listOf(
-                            "http://192.168.*.*:[*]", // 가정·사무실 LAN (가장 흔함)
-                            "http://10.*.*.*:[*]",
-                            "http://172.*.*.*:[*]",
-                            "http://localhost:[*]",
-                            "http://127.0.0.1:[*]",
-                        )
+                    allowedOriginPatterns = listOf("http://192.168.*.*:[*]")
                 }
                 allowedMethods = listOf("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
                 allowedHeaders = listOf("*")

--- a/src/test/kotlin/com/depromeet/piki/common/config/CorsConfigTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/common/config/CorsConfigTest.kt
@@ -1,0 +1,36 @@
+package com.depromeet.piki.common.config
+
+import org.junit.jupiter.api.Test
+import org.springframework.mock.env.MockEnvironment
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+// CORS 의 프로파일 분기(LAN 사설망 허용)를 Spring 컨텍스트 없이 단위로 검증한다(#509).
+// 통합 테스트는 비-prod 컨텍스트라 "prod 에선 LAN 이 안 열린다"를 못 보므로, 여기서 prod/비-prod 두 분기를 직접 단언한다.
+class CorsConfigTest {
+    private fun patternsFor(vararg activeProfiles: String): List<String>? {
+        val env = MockEnvironment().apply { setActiveProfiles(*activeProfiles) }
+        val source = CorsConfig(env).corsConfigurationSource() as UrlBasedCorsConfigurationSource
+        return source.getCorsConfigurations()["/**"]!!.allowedOriginPatterns
+    }
+
+    @Test
+    fun `prod 프로파일에서는 LAN 사설망 패턴을 열지 않는다 (staging 도 prod 프로파일이라 함께 닫힘)`() {
+        // deploy 가 prod·staging 둘 다 'prod' 프로파일로 띄운다(#498). 그래서 이 단언이 staging 의 LAN 차단까지 보증한다.
+        assertEquals(null, patternsFor("prod"))
+    }
+
+    @Test
+    fun `dev 프로파일에서는 LAN 사설망 패턴을 허용한다`() {
+        val patterns = patternsFor("dev")
+        assertTrue(patterns?.any { it.startsWith("http://192.168.") } == true, "192.168 LAN 패턴이 있어야 한다")
+        assertTrue(patterns?.any { it.startsWith("http://10.") } == true, "10.x LAN 패턴이 있어야 한다")
+    }
+
+    @Test
+    fun `프로파일 미지정(로컬)에서도 LAN 사설망 패턴을 허용한다`() {
+        // 로컬 실행은 active profile 이 비어있을 수 있다 — prod 가 아니므로 LAN 이 열려야 한다.
+        assertTrue(patternsFor()?.any { it.startsWith("http://192.168.") } == true)
+    }
+}

--- a/src/test/kotlin/com/depromeet/piki/common/config/CorsConfigTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/common/config/CorsConfigTest.kt
@@ -22,15 +22,14 @@ class CorsConfigTest {
     }
 
     @Test
-    fun `dev 프로파일에서는 LAN 사설망 패턴을 허용한다`() {
+    fun `dev 프로파일에서는 192_168 LAN 패턴만 허용한다`() {
         val patterns = patternsFor("dev")
-        assertTrue(patterns?.any { it.startsWith("http://192.168.") } == true, "192.168 LAN 패턴이 있어야 한다")
-        assertTrue(patterns?.any { it.startsWith("http://10.") } == true, "10.x LAN 패턴이 있어야 한다")
+        assertEquals(listOf("http://192.168.*.*:[*]"), patterns) // 192.168 만 — 10·172 등 넓은 대역은 넣지 않는다
     }
 
     @Test
-    fun `프로파일 미지정(로컬)에서도 LAN 사설망 패턴을 허용한다`() {
+    fun `프로파일 미지정(로컬)에서도 192_168 LAN 패턴을 허용한다`() {
         // 로컬 실행은 active profile 이 비어있을 수 있다 — prod 가 아니므로 LAN 이 열려야 한다.
-        assertTrue(patternsFor()?.any { it.startsWith("http://192.168.") } == true)
+        assertEquals(listOf("http://192.168.*.*:[*]"), patternsFor())
     }
 }

--- a/src/test/kotlin/com/depromeet/piki/common/config/CorsIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/common/config/CorsIntegrationTest.kt
@@ -112,6 +112,26 @@ class CorsIntegrationTest : IntegrationTestSupport() {
     }
 
     @Test
+    fun `dev(비-prod)에서는 LAN 사설망 IP origin 의 preflight 도 허용된다`() {
+        // 실기기 dev 테스트(#509) — 폰 브라우저가 LAN IP(192.168.x.y:port)로 프론트에 접속하면 Origin 이 그
+        // 사설망 IP 로 박힌다. 비-prod 프로파일에서 allowedOriginPatterns 로 허용함을 검증한다(통합 컨텍스트는 prod 아님).
+        val mockMvc =
+            MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .apply<DefaultMockMvcBuilder>(springSecurity())
+                .build()
+
+        mockMvc
+            .perform(
+                options("/api/v1/dev/users")
+                    .header(HttpHeaders.ORIGIN, "http://192.168.0.42:5173")
+                    .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "POST"),
+            ).andExpect(status().isOk)
+            .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "http://192.168.0.42:5173"))
+            .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS, "true"))
+    }
+
+    @Test
     fun `화이트리스트에 없는 origin 의 preflight 는 403 으로 거부된다`() {
         // 허용 목록 검증이 실제로 동작함을 함께 단언해 테스트가 vacuous 하지 않도록 한다.
         val mockMvc =


### PR DESCRIPTION
## Situation

- 실기기로 dev 테스트할 때 폰 브라우저가 로컬 프론트(LAN IP, `http://192.168.x.y:port`)에 접속하면, 백엔드로 가는 요청의 Origin 이 그 사설망 IP 로 박혀 **CORS 에 막힌다**.
- 이 막힘 때문에 프론트가 "보내는 요청을 다 들여다보고 수정해서 보내는" 수동 재작성 우회책을 쓰게 됐고, 최근 그 경로에서 fetch 오류(Vercel·FCM)가 났다.

## Task

- dev 에서만 사설망 origin 을 CORS 로 열어 폰이 백엔드를 직접 호출하게 한다(우회책 제거).
- staging·prod 에는 열지 않는다.
- 결정 포인트: env-secret 으로 뺄지 vs 프로파일로 분리할지, 그리고 3개 환경(prod·staging·dev)과 2개 프로파일(prod·dev)의 미스매치를 어떻게 다룰지.

## Action

- `CorsConfig` 가 `Environment` 의 `prod` 프로파일 여부를 보고, prod 가 아닐 때만 `192.168/10/172/localhost` 대역을 `allowedOriginPatterns` 로 허용한다. 기존 정확 origin 목록(piki.day 등)은 그대로 두고 패턴만 추가한다(둘은 한 설정에 공존, `allowCredentials=true` 와도 패턴은 호환).
- **분기 기준은 'prod' 프로파일** — staging 도 deploy 가 prod 프로파일로 띄우므로(#498: pre-prod 은 prod 와 동일 동작) prod 와 함께 LAN 이 닫힌다. 그래서 LAN 은 dev 프로파일·local 에서만 열린다.
- **env-secret 이 아니라 코드(프로파일)로 관리한 이유**: CORS 오리진은 비밀이 아니다(브라우저가 강제하는 것이라 서버 보안 경계가 아니고, 노출돼도 무해). 코드에 두면 PR 에서 리뷰·diff 되고, env 는 컨테이너 시작 시 주입이라 어차피 재배포가 필요해 무중단 변경 이점도 없다. 환경별로 다른 신호는 이미 주입되는 `SPRING_PROFILES_ACTIVE` 하나로 충분하다.

## Result

- 검증에서 비자명한 부분: prod·staging 의 LAN 차단은 통합 테스트 컨텍스트(비-prod)로는 확인할 수 없어, `MockEnvironment` 단위 테스트로 **prod 프로파일이면 패턴이 비어 있음**(= staging 차단까지 보증)을 직접 단언했다. dev·프로파일 미지정이면 패턴이 차고, 통합으로 `http://192.168.x.x` preflight 가 허용되는 것까지 본다.
- 주의: 인증이 **Secure 쿠키** 기반이면 LAN 평문(http)에선 쿠키가 안 실려 CORS 만으론 부족할 수 있다(앱 클라의 Authorization Bearer 는 무관). 프론트 실기기 테스트가 web(쿠키)인지 app(Bearer)인지에 따라 갈린다.
- 후속(권장): dev CORS 가 열렸으니, 프론트가 쓰던 수동 요청 재작성 우회를 걷어내는 게 좋다. 최근 fetch 오류(Vercel·FCM)의 근원이 그 우회였다.

---
## 연관 이슈

- close #509


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **테스트**
  * CORS 설정의 단위 테스트 및 통합 테스트 신규 추가
  * 프로파일별 LAN 사설망 원본 허용 정책 검증

* **리팩터**
  * CORS 설정이 활성 프로파일에 따라 동적으로 구성되도록 개선
  * 개발 환경에서는 LAN 사설망 접근 허용, 프로덕션에서는 제한

<!-- end of auto-generated comment: release notes by coderabbit.ai -->