### PR TITLE
Grafana 대시보드에 파싱·추출 메트릭 패널 추가

### DIFF
--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -25,6 +25,7 @@ Grafana Cloud 가 호스팅하는 Grafana 이므로 셀프호스팅 provisioning
 5. **의존성** — 502율(Gemini 등 외부 실패) · executor active/queued · HikariCP active/idle/pending.
 6. **리소스** — 앱 process/system CPU · JVM 스레드 · 호스트 CPU.
 7. **로그** — 에러/경고 필터 로그 + 전체 로그(`team3-blue`/`team3-green`).
+8. **파싱·추출** — 파싱 결과(`item.parsing` result별)·실패 사유(reason별: not_product·ready_rejected·retry_exhausted·no_source)·추출 방법(`product.extract` via별: 직접 파싱 vs LLM). 상품 추출 실패가 트래픽에서 얼마나·왜 나는지 본다(#506).
 
 앱 메트릭은 `application="PIKI"` 라벨로 필터한다(Alloy 의 prometheus.scrape 가 붙임).
 blue-green 이라 한 시점에 한 슬롯만 활성이며 `instance` 라벨로 blue/green 을 구분한다.

--- a/infra/grafana/dashboard.json
+++ b/infra/grafana/dashboard.json
@@ -1466,6 +1466,158 @@
           "expr": "{container=~\"team3-(blue|green)\", environment=\"$environment\"}"
         }
       ]
+    },
+    {
+      "id": 200,
+      "type": "row",
+      "title": "파싱·추출 (결과 · 사유 · 방법)",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 47
+      }
+    },
+    {
+      "id": 201,
+      "type": "timeseries",
+      "title": "파싱 결과 (result별)",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 48
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROM}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROM}"
+          },
+          "expr": "sum by (result) (rate(item_parsing_total{application=\"PIKI\", environment=\"$environment\"}[$__rate_interval]))",
+          "legendFormat": "{{result}}"
+        }
+      ]
+    },
+    {
+      "id": 202,
+      "type": "timeseries",
+      "title": "파싱 실패 사유 (reason별)",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 48
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROM}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROM}"
+          },
+          "expr": "sum by (reason) (rate(item_parsing_total{application=\"PIKI\", environment=\"$environment\", result=\"failed\"}[$__rate_interval]))",
+          "legendFormat": "{{reason}}"
+        }
+      ]
+    },
+    {
+      "id": 203,
+      "type": "timeseries",
+      "title": "추출 방법 (직접 파싱 vs LLM)",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 48
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROM}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROM}"
+          },
+          "expr": "sum by (via) (rate(product_extract_total{application=\"PIKI\", environment=\"$environment\"}[$__rate_interval]))",
+          "legendFormat": "{{via}}"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Situation

- 운영 대시보드(PiKi)에 파싱·추출 관측 패널이 없어 "파싱이 얼마나·왜 실패하나"를 화면으로 볼 수 없었다. 파싱 결과 메트릭(`item.parsing`)은 PR #508로 들어갔지만, 그걸 그리는 패널은 #506의 남은 부분이었다.

## Task

- 버전관리 소스(`infra/grafana/dashboard.json`)에 파싱·추출 패널을 추가해, import 만 하면 화면에 뜨게 한다.

## Action

- 대시보드 맨 아래에 "파싱·추출" row + timeseries 3개 추가: 파싱 결과(result별), 파싱 실패 사유(reason별), 추출 방법(via별: 직접 파싱 vs LLM).
- 기존 패널과 동일 형식(`${DS_PROM}`, `application="PIKI"`·`environment="$environment"` 필터, `$__rate_interval`). 기존 패널 y 충돌을 피해 로그 아래(y=47)에 append 했다.
- README 패널 목록에 8번 섹션을 추가해 문서와 동기화.

## Result

- import 후 `item.parsing`(result/reason)·`product.extract`(via)를 한 화면에서 본다 → 추출 개선(#478 등)·cap 조정(#495) 우선순위를 추측이 아니라 데이터로 판단.
- Grafana Cloud 라 import 는 수동이다: 머지 후 `dashboard.json` 을 Grafana 에 import 해야 실제 화면에 반영된다(README "Import 방법"). 이 PR 은 버전관리 소스만 갱신한다.
- 검증 한계: 로컬에서 Grafana 렌더를 못 해 JSON 유효성(jq)·쿼리 형식만 확인했다. 패널 표시·쿼리 결과의 시각 확인은 import 시점의 몫이다.

---
## 연관 이슈

- 관련 #506 (메트릭은 PR #508 로 머지됨. 이 PR 은 그 대시보드 패널 부분 — #506 은 메모만 남기고 닫혀 있어 `close` 가 아니라 참조로 둔다)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Grafana 대시보드에 파싱·추출 모니터링 패널 추가됨
  * 파싱 결과별, 파싱 실패 사유별, 추출 방법별 지표를 시각화하여 상품 추출 실패 현황 및 원인 분석 가능

* **Documentation**
  * 대시보드 패널 구성 및 지표 설명 문서 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->