### PR TITLE
refresh_token 쿠키 Path 를 / 로 넓혀 엣지 proxy transparent refresh 복구

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/auth/web/TokenCookieWriter.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/web/TokenCookieWriter.kt
@@ -9,7 +9,16 @@ import org.springframework.stereotype.Component
 // 컨트롤러·서비스·토큰 도메인은 이 정책을 모른다 — advice 만 이 빈을 사용한다.
 //
 // - access_token: Path=/ (모든 API 요청에 전송돼 인증)
-// - refresh_token: Path=/api/v1/auth (refresh·logout 에만 전송 → 노출 최소화)
+// - refresh_token: Path=/ (#512) — 웹 Next.js proxy(엣지 미들웨어)가 페이지 네비게이션(/archive·/home)에서
+//   refresh_token 유무를 읽어 transparent refresh 를 판단해야 한다. /api/v1/auth 로 좁히면 일반 페이지
+//   요청엔 쿠키가 안 실려 proxy 의 refresh 분기가 죽는다. Path 좁히기는 defense-in-depth 였을 뿐, 실제
+//   보호는 HttpOnly·SameSite=Strict·Secure 가 하며 이 셋은 그대로 둔다. 넓힘으로 늘어나는 노출은 "모든
+//   same-origin 요청에 refresh_token 이 실려 로그 Cookie 헤더에 찍힘" 한 곳뿐이라 로그 마스킹으로 상쇄(#497).
+// - 전환기 cleanup: 배포 전 발급된 옛 refresh_token 은 Path=/api/v1/auth 로 남는다. 새 Path=/ 쿠키와
+//   공존하면 /api/v1/auth/token/refresh 요청에 둘 다 실리고, RFC 6265 상 더 구체적인 옛 경로 쿠키가 먼저
+//   선택된다. refresh 는 회전식(store 의 최신 토큰과 일치해야 통과)이라 옛 토큰은 불일치로 거부돼 갱신이
+//   실패한다. 그래서 토큰을 새로 내리거나(setCookies) 만료시킬(clearCookies) 때마다 옛 경로 쿠키를 함께
+//   Max-Age=0 으로 지운다. 활성 refresh TTL 이 지나 옛 쿠키가 전부 사라지면 이 cleanup 은 제거 가능.
 // - Domain 미설정(host-only): 쿠키는 api 호스트만 소비하므로 서브도메인 공유 불필요
 // - SameSite=Strict: same-site 전제라 SPA fetch 는 전송되고 third-party CSRF 는 차단
 @Component
@@ -20,7 +29,8 @@ class TokenCookieWriter(
     fun setCookies(tokenPair: TokenPair): List<ResponseCookie> =
         listOf(
             build(ACCESS_COOKIE, tokenPair.accessToken, ROOT_PATH, jwtProperties.accessTokenExpiry.seconds),
-            build(REFRESH_COOKIE, tokenPair.refreshToken, AUTH_PATH, jwtProperties.refreshTokenExpiry.seconds),
+            build(REFRESH_COOKIE, tokenPair.refreshToken, ROOT_PATH, jwtProperties.refreshTokenExpiry.seconds),
+            expireLegacyRefreshCookie(),
         )
 
     // 만료(삭제) 쿠키: 동일 name·path·속성 + 빈 값 + Max-Age=0.
@@ -28,8 +38,13 @@ class TokenCookieWriter(
     fun clearCookies(): List<ResponseCookie> =
         listOf(
             build(ACCESS_COOKIE, "", ROOT_PATH, 0),
-            build(REFRESH_COOKIE, "", AUTH_PATH, 0),
+            build(REFRESH_COOKIE, "", ROOT_PATH, 0),
+            expireLegacyRefreshCookie(),
         )
+
+    // 전환기 cleanup (클래스 주석 참조, #512): 옛 Path=/api/v1/auth refresh_token 쿠키를 만료시켜
+    // 새 Path=/ 쿠키와의 공존(→ 회전 토큰 불일치로 갱신 실패)을 막는다. 옛 쿠키가 전부 만료되면 제거 가능.
+    private fun expireLegacyRefreshCookie(): ResponseCookie = build(REFRESH_COOKIE, "", LEGACY_REFRESH_PATH, 0)
 
     private fun build(
         name: String,
@@ -50,7 +65,7 @@ class TokenCookieWriter(
         const val ACCESS_COOKIE = "access_token"
         const val REFRESH_COOKIE = "refresh_token"
         private const val ROOT_PATH = "/"
-        private const val AUTH_PATH = "/api/v1/auth"
+        private const val LEGACY_REFRESH_PATH = "/api/v1/auth" // 전환기 cleanup 전용 (#512), 옛 쿠키 만료 후 제거 가능
         private const val SAME_SITE = "Strict"
     }
 }

--- a/src/test/kotlin/com/depromeet/piki/auth/controller/CookieBodyContractIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/controller/CookieBodyContractIntegrationTest.kt
@@ -66,17 +66,27 @@ class CookieBodyContractIntegrationTest : IntegrationTestSupport() {
                 .andExpect(cookie().path("access_token", "/"))
                 .andExpect(cookie().exists("refresh_token"))
                 .andExpect(cookie().httpOnly("refresh_token", true))
-                .andExpect(cookie().path("refresh_token", "/api/v1/auth"))
                 .andExpect(jsonPath("$.data.accessToken").value(nullValue()))
                 .andExpect(jsonPath("$.data.refreshToken").value(nullValue()))
                 .andExpect(jsonPath("$.data.user.identityType").value("GUEST"))
                 .andReturn()
 
-        // SameSite 는 jakarta Cookie 에 없어 Set-Cookie 헤더 문자열로 확인한다.
+        // SameSite·정확한 Path 는 jakarta Cookie / cookie() 매처로 단언하기 모호하므로(refresh_token 이
+        // 새 쿠키 + 전환기 cleanup 쿠키로 2개 내려간다) Set-Cookie 헤더 문자열로 확인한다.
         val setCookies = result.response.getHeaders(HttpHeaders.SET_COOKIE)
         assertTrue(
             setCookies.any { it.startsWith("access_token=") && it.contains("SameSite=Strict") },
             "access_token 쿠키에 SameSite=Strict 가 있어야 한다",
+        )
+        // #512: refresh_token 은 Path=/ 로 넓혀 내려간다 — 엣지 proxy 가 페이지 네비게이션에서 읽도록.
+        assertTrue(
+            setCookies.any { it.startsWith("refresh_token=") && !it.startsWith("refresh_token=;") && it.contains("Path=/;") },
+            "값이 있는 refresh_token 은 Path=/ 로 내려가야 한다",
+        )
+        // 전환기 cleanup: 옛 Path=/api/v1/auth refresh_token 쿠키를 빈 값·Max-Age=0 으로 함께 만료시킨다.
+        assertTrue(
+            setCookies.any { it.startsWith("refresh_token=;") && it.contains("Path=/api/v1/auth") && it.contains("Max-Age=0") },
+            "옛 Path=/api/v1/auth refresh_token 쿠키가 Max-Age=0 으로 만료돼야 한다",
         )
     }
 
@@ -167,15 +177,27 @@ class CookieBodyContractIntegrationTest : IntegrationTestSupport() {
         // 쿠키 만료는 fail-safe 로 ClientType 무관하게 내려가야 한다. 살아있는 access 쿠키가 확실히 삭제되도록.
         val accessCookie = createGuestWeb().response.getCookie("access_token")!!
 
-        mockMvc()
-            .perform(
-                post("/api/v1/auth/logout").cookie(accessCookie),
-            ).andExpect(status().isOk)
-            .andExpect(cookie().maxAge("access_token", 0))
-            // path 까지 set 시점과 동일해야 브라우저가 실제로 삭제한다. path 가 틀려도 Max-Age=0 만 보면 통과하므로 함께 고정.
-            .andExpect(cookie().path("access_token", "/"))
-            .andExpect(cookie().maxAge("refresh_token", 0))
-            .andExpect(cookie().path("refresh_token", "/api/v1/auth"))
-            .andExpect(jsonPath("$.data.loggedOut").value(true))
+        val result =
+            mockMvc()
+                .perform(
+                    post("/api/v1/auth/logout").cookie(accessCookie),
+                ).andExpect(status().isOk)
+                .andExpect(cookie().maxAge("access_token", 0))
+                // path 까지 set 시점과 동일해야 브라우저가 실제로 삭제한다. path 가 틀려도 Max-Age=0 만 보면 통과하므로 함께 고정.
+                .andExpect(cookie().path("access_token", "/"))
+                .andExpect(jsonPath("$.data.loggedOut").value(true))
+                .andReturn()
+
+        // #512: refresh_token 만료는 새 Path=/ 와 옛 Path=/api/v1/auth 를 둘 다 내려야 브라우저가 실제로 지운다.
+        // (옛 경로 쿠키를 안 지우면 만료까지 잔존해 갱신 경로에서 회전 토큰 불일치를 일으킨다.)
+        val setCookies = result.response.getHeaders(HttpHeaders.SET_COOKIE)
+        assertTrue(
+            setCookies.any { it.startsWith("refresh_token=;") && it.contains("Path=/;") && it.contains("Max-Age=0") },
+            "새 Path=/ refresh_token 이 Max-Age=0 으로 만료돼야 한다",
+        )
+        assertTrue(
+            setCookies.any { it.startsWith("refresh_token=;") && it.contains("Path=/api/v1/auth") && it.contains("Max-Age=0") },
+            "옛 Path=/api/v1/auth refresh_token 이 Max-Age=0 으로 만료돼야 한다",
+        )
     }
 }

--- a/src/test/kotlin/com/depromeet/piki/auth/web/TokenCookieWriterTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/web/TokenCookieWriterTest.kt
@@ -34,12 +34,27 @@ class TokenCookieWriterTest {
     }
 
     @Test
-    fun `refresh_token 쿠키는 Path 가 api_v1_auth 로 좁혀지고 refresh 만료시간을 갖는다`() {
-        val refresh = writer().setCookies(TokenPair("at", "rt")).first { it.name == "refresh_token" }
+    fun `refresh_token 쿠키는 Path 가 루트로 넓혀지고 refresh 만료시간을 갖는다`() {
+        // #512: 엣지 proxy 가 페이지 네비게이션에서 refresh_token 을 읽어야 해 Path 를 / 로 넓혔다.
+        // 값을 가진(만료 아님) refresh_token 만 골라야 전환기 cleanup 쿠키(빈 값)와 안 섞인다.
+        val refresh = writer().setCookies(TokenPair("at", "rt")).first { it.name == "refresh_token" && it.value.isNotEmpty() }
 
         assertEquals("rt", refresh.value)
-        assertEquals("/api/v1/auth", refresh.path)
+        assertEquals("/", refresh.path)
         assertEquals(refreshExpiry, refresh.maxAge)
+    }
+
+    @Test
+    fun `setCookies 는 옛 Path=api_v1_auth refresh_token 쿠키를 함께 만료시킨다 (전환기 cleanup)`() {
+        // #512 전환기: 옛 경로 쿠키가 새 Path=/ 쿠키와 공존하면 회전 토큰 불일치로 갱신이 실패하므로,
+        // 토큰 발급 때마다 옛 경로 쿠키를 Max-Age=0 으로 지운다.
+        val legacy =
+            writer()
+                .setCookies(TokenPair("at", "rt"))
+                .first { it.name == "refresh_token" && it.path == "/api/v1/auth" }
+
+        assertTrue(legacy.value.isEmpty())
+        assertTrue(legacy.maxAge.isZero)
     }
 
     @Test
@@ -50,11 +65,14 @@ class TokenCookieWriterTest {
     }
 
     @Test
-    fun `clearCookies 는 두 쿠키 모두 빈 값·Max-Age 0 으로 만료시키며 path 는 set 과 동일하다`() {
+    fun `clearCookies 는 모든 쿠키를 빈 값·Max-Age 0 으로 만료시키고 refresh 는 새 경로와 옛 경로를 모두 지운다`() {
         val cleared = writer().clearCookies()
 
         assertTrue(cleared.all { it.value.isEmpty() && it.maxAge.isZero })
         assertEquals("/", cleared.first { it.name == "access_token" }.path)
-        assertEquals("/api/v1/auth", cleared.first { it.name == "refresh_token" }.path)
+        // #512: 로그아웃은 새 Path=/ 와 옛 Path=/api/v1/auth refresh_token 을 둘 다 만료시켜야 한다
+        // (옛 쿠키를 안 지우면 만료까지 잔존해 갱신 경로에서 회전 토큰 불일치를 일으킨다).
+        val refreshPaths = cleared.filter { it.name == "refresh_token" }.map { it.path }.toSet()
+        assertEquals(setOf("/", "/api/v1/auth"), refreshPaths)
     }
 }


### PR DESCRIPTION
## Situation

- 웹앱 Next.js proxy(엣지 미들웨어)는 페이지가 렌더되기 전에 세션을 확보한다. 페이지 네비게이션(`/archive`·`/home`)마다 access 만료를 보고, 만료됐으면 refresh 로 갱신해 통과시키거나, refresh 가 없으면 게스트 로그인 / 로그인 리다이렉트로 분기한다.
- proxy 는 이 판단을 위해 요청 쿠키의 `refresh_token` 유무를 읽는다. 그런데 백엔드가 `refresh_token` 을 `Path=/api/v1/auth` 로 좁게 내려, 브라우저 쿠키 규칙상 `/archive`·`/home` 같은 일반 페이지 요청엔 쿠키가 실리지 않았다.
- 그 결과 proxy 의 refresh 분기가 죽어(요청에 refresh_token 이 안 와 갱신 로직 미실행), access 만 만료돼도 멤버가 불필요하게 게스트로 떨어지거나 로그인으로 튕겼다.

## Task

- proxy 가 페이지 요청에서도 `refresh_token` 을 읽어 서버사이드로 transparent refresh(중간 리다이렉트 없이) 하도록, 쿠키가 일반 페이지 경로에도 실리게 한다.
- 보안 형상을 무너뜨리지 않는다. Path 를 넓히면서 늘어나는 노출을 정확히 파악하고 상쇄한다.
- 프론트 작업이 추가로 필요하지 않은 방식이어야 한다. proxy 코드는 이미 refresh_token 을 읽도록 작성돼 있고, 좁은 Path 때문에 죽어 있었을 뿐이다.

## Action

### 핵심 변경
- `refresh_token` 쿠키 Path 를 `/api/v1/auth` 에서 `/` 로 넓혔다. 페이지 경로(`/archive` 등)와 갱신 엔드포인트(`/api/v1/auth/token/refresh`)를 동시에 덮는 Path 는 `/` 뿐이라(둘 다 루트 아래) 선택지가 사실상 이것 하나다.
- `HttpOnly`·`SameSite=Strict`·`Secure` 는 그대로 뒀다. Path 좁히기는 defense-in-depth 였을 뿐, refresh_token 의 실제 보호는 이 셋이 한다. 넓혀도 XSS/CSRF 위험은 불변이다.

### 왜 이 방식인가 (검토한 대안)
- "좁은 Path 유지 + 무리다이렉트 서버사이드 refresh" 는 구조적으로 불가능하다. 엣지 proxy 가 토큰을 손에 쥐려면 페이지 요청에 쿠키가 실려야 하고, 그건 곧 `Path=/` 다.
- 비밀 아닌 플래그 쿠키로 proxy 에 "refresh 가능 여부"만 알리는 대안은, 실제 갱신이 리다이렉트 왕복이 돼 프론트가 원한 "중간 리다이렉트 없음" 과 충돌한다.
- 진짜 BFF(refresh_token 을 브라우저에서 빼 서버 세션 보관)는 형상이 더 좋아지지만 프론트 인증 구조 재설계라 범위 밖이다.
- 넓힘으로 새로 늘어나는 노출은 "모든 same-origin 요청에 refresh_token 이 실려 로그 Cookie 헤더에 찍힐 수 있음" 한 곳뿐이다. 이건 관측성 이슈(#497, 로그 마스킹)에서 Cookie 헤더 마스킹으로 덮는다.

### 전환기 dual-cookie 대응 (놓치기 쉬운 부분)
- refresh 토큰은 회전식(single-use)이다. 갱신은 저장소의 최신 토큰과 일치해야만 통과하고, 통과 시 회전된다.
- 배포 전 발급된 옛 `refresh_token` 은 `Path=/api/v1/auth` 로 남는다. 새 `Path=/` 쿠키와 공존하면 갱신 요청에 둘 다 실리고, 쿠키 규칙(RFC 6265)상 더 구체적인 옛 경로 쿠키가 먼저 선택된다.
- 저장소엔 최신(새 경로) 토큰만 있으니 옛 토큰은 불일치로 거부돼 갱신이 실패한다. 단순 Path 변경만 하면 전환기에 갱신 401 이 터진다.
- 그래서 토큰을 새로 내리거나(로그인·갱신) 만료시킬(로그아웃) 때마다 옛 경로 쿠키를 `Max-Age=0` 으로 함께 지운다. 활성 refresh TTL 이 지나 옛 쿠키가 전부 사라지면 이 cleanup 은 제거 가능하다(코드 주석에 명시).

### 테스트
- 단위: 새 Path=`/` 단언, 옛 경로 cleanup 쿠키 존재 단언, 로그아웃이 두 경로(`/`·`/api/v1/auth`)를 모두 만료시킴 단언.
- 통합: refresh_token 이 두 개(값 있는 새 쿠키 + 빈 값 cleanup 쿠키)로 내려가 `cookie()` 매처가 어느 걸 집을지 모호하므로, `Set-Cookie` 헤더 문자열로 새/옛 경로를 각각 직접 단언해 모호성을 제거했다.

## Result

- 프론트는 코드 변경이 없다. 좁은 Path 때문에 죽어 있던 proxy 의 갱신 분기가 쿠키가 실려 오기 시작하며 되살아난다.
- 배포 직후 옛 쿠키를 든 기존 유저도, 다음 토큰 발급(로그인·갱신) 한 사이클이면 옛 경로 쿠키가 정리돼 dual-cookie 갱신 실패를 겪지 않는다.
- 후속: 노출 상쇄의 한 축인 로그 Cookie 헤더 마스킹이 #497 에 걸려 있다. 이 PR 과 별개지만 함께 가야 노출 상쇄가 완성된다.

---
## 연관 이슈

- close #512


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 인증 쿠키 저장 경로를 개선하여 세션 관리 안정성이 향상됨
  * 전환 기간 중 레거시 인증 쿠키가 자동으로 정리되어 로그인/로그아웃 과정이 더욱 안정적으로 동작

<!-- end of auto-generated comment: release notes by coderabbit.ai -->