### PR TITLE
파싱·추출 대시보드 패널을 누적 건수(stat·bargauge) viz로 변경

### DIFF
--- a/infra/grafana/dashboard.json
+++ b/infra/grafana/dashboard.json
@@ -1480,7 +1480,7 @@
     },
     {
       "id": 201,
-      "type": "timeseries",
+      "type": "stat",
       "title": "파싱 결과 (result별)",
       "gridPos": {
         "h": 8,
@@ -1494,23 +1494,25 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "ops",
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "showPoints": "never"
+          "unit": "short",
+          "decimals": 0,
+          "color": {
+            "mode": "palette-classic"
           }
         },
         "overrides": []
       },
       "options": {
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "value_and_name",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
         }
       },
       "targets": [
@@ -1520,14 +1522,15 @@
             "type": "prometheus",
             "uid": "${DS_PROM}"
           },
-          "expr": "sum by (result) (rate(item_parsing_total{application=\"PIKI\", environment=\"$environment\"}[$__rate_interval]))",
-          "legendFormat": "{{result}}"
+          "expr": "sum by (result) (increase(item_parsing_total{application=\"PIKI\", environment=\"$environment\"}[$__range]))",
+          "legendFormat": "{{result}}",
+          "instant": true
         }
       ]
     },
     {
       "id": 202,
-      "type": "timeseries",
+      "type": "bargauge",
       "title": "파싱 실패 사유 (reason별)",
       "gridPos": {
         "h": 8,
@@ -1541,23 +1544,24 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "ops",
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "showPoints": "never"
+          "unit": "short",
+          "decimals": 0,
+          "color": {
+            "mode": "palette-classic"
           }
         },
         "overrides": []
       },
       "options": {
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "showUnfilled": true,
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
         }
       },
       "targets": [
@@ -1567,14 +1571,15 @@
             "type": "prometheus",
             "uid": "${DS_PROM}"
           },
-          "expr": "sum by (reason) (rate(item_parsing_total{application=\"PIKI\", environment=\"$environment\", result=\"failed\"}[$__rate_interval]))",
-          "legendFormat": "{{reason}}"
+          "expr": "sum by (reason) (increase(item_parsing_total{application=\"PIKI\", environment=\"$environment\", result=\"failed\"}[$__range]))",
+          "legendFormat": "{{reason}}",
+          "instant": true
         }
       ]
     },
     {
       "id": 203,
-      "type": "timeseries",
+      "type": "stat",
       "title": "추출 방법 (직접 파싱 vs LLM)",
       "gridPos": {
         "h": 8,
@@ -1588,23 +1593,25 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "ops",
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "showPoints": "never"
+          "unit": "short",
+          "decimals": 0,
+          "color": {
+            "mode": "palette-classic"
           }
         },
         "overrides": []
       },
       "options": {
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "value_and_name",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
         }
       },
       "targets": [
@@ -1614,8 +1621,9 @@
             "type": "prometheus",
             "uid": "${DS_PROM}"
           },
-          "expr": "sum by (via) (rate(product_extract_total{application=\"PIKI\", environment=\"$environment\"}[$__rate_interval]))",
-          "legendFormat": "{{via}}"
+          "expr": "sum by (via) (increase(product_extract_total{application=\"PIKI\", environment=\"$environment\"}[$__range]))",
+          "legendFormat": "{{via}}",
+          "instant": true
         }
       ]
     }


### PR DESCRIPTION
## Situation

- #511 로 파싱·추출 패널을 추가했는데 dev 에서 보니 데이터가 무의미하게 보였다. 파싱은 드문드문 일어나는 저빈도 이벤트인데, 패널이 HTTP 트래픽용 `rate`(초당) timeseries 라 1회성 증가가 짧은 spike 로 떴다 0 으로 꺼졌다.

## Task

- 저빈도 카운터에 맞는 viz 로 바꿔, 적은 건수도 의미 있게 읽히게 한다.

## Action

- `rate` → `increase([$__range])` 누적 + instant 쿼리로 변경. "초당 비율"이 아니라 "선택 시간범위의 누적 건수"를 센다.
- 파싱 결과(result)·추출 방법(via) → `stat`(value_and_name 큰 숫자). 실패 사유(reason) → `bargauge`(가로 막대).

## Result

- dev 처럼 건수가 적어도 "ready N / failed M", "structured N / llm M", reason별 막대로 한눈에 읽힌다. (rate 시계열은 prod 고트래픽엔 맞지만 파싱 저빈도엔 부적합했다)
- 데이터가 적을 때 timeseries 가 0-100 으로 auto-scale 돼 소량 spike 가 바닥에 깔려 안 보이던 것도 해소.
- Grafana Cloud 라 import 는 수동: 머지 후 `dashboard.json` 을 재 import 해야 반영된다(README). 렌더·표시는 import 시점에 확인.

---
## 연관 이슈

- 관련 #506 (메트릭 #508·패널 추가 #511 의 후속 viz 개선)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 모니터링 대시보드의 파싱·추출 관련 패널들의 시각화 방식을 업데이트했습니다.
  * 파싱 결과, 파싱 실패 사유, 추출 방법 패널의 차트 표시 형식을 개선하여 더 명확한 통계 정보를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->