### PR TITLE
파싱·추출 대시보드 패널을 raw 누계로 정정 (increase 창집계 깨짐)

### DIFF
--- a/infra/grafana/dashboard.json
+++ b/infra/grafana/dashboard.json
@@ -1522,7 +1522,7 @@
             "type": "prometheus",
             "uid": "${DS_PROM}"
           },
-          "expr": "sum by (result) (increase(item_parsing_total{application=\"PIKI\", environment=\"$environment\"}[$__range]))",
+          "expr": "sum by (result) (item_parsing_total{application=\"PIKI\", environment=\"$environment\"})",
           "legendFormat": "{{result}}",
           "instant": true
         }
@@ -1571,7 +1571,7 @@
             "type": "prometheus",
             "uid": "${DS_PROM}"
           },
-          "expr": "sum by (reason) (increase(item_parsing_total{application=\"PIKI\", environment=\"$environment\", result=\"failed\"}[$__range]))",
+          "expr": "sum by (reason) (item_parsing_total{application=\"PIKI\", environment=\"$environment\", result=\"failed\"})",
           "legendFormat": "{{reason}}",
           "instant": true
         }
@@ -1621,7 +1621,7 @@
             "type": "prometheus",
             "uid": "${DS_PROM}"
           },
-          "expr": "sum by (via) (increase(product_extract_total{application=\"PIKI\", environment=\"$environment\"}[$__range]))",
+          "expr": "sum by (via) (product_extract_total{application=\"PIKI\", environment=\"$environment\"})",
           "legendFormat": "{{via}}",
           "instant": true
         }


### PR DESCRIPTION
## Situation

- #515 에서 파싱 패널을 `increase([$__range])` 누적으로 바꿨는데, dev 에서 24시간 창으로 봐도 실제 카운터와 안 맞았다. SSH 로 읽은 raw 값(ready 3·failed 1·structured 3·llm 1)과 패널(ready 6·failed 0·실패사유 No data)이 어긋났다.

## Task

- 패널 숫자를 실제 카운터와 일치시킨다.

## Action

- 원인: `increase()` 가 dev 의 잦은 앱 재시작(카운터 0 리셋) + blue/green 인스턴스 라벨 churn 을 가로지르며 깨졌다. ready 는 옛/현 인스턴스 합산으로 2배, failed 는 짧게 산 시리즈를 외삽하다 누락됐다.
- `sum by (X)(increase(metric[$__range]))` → `sum by (X)(metric)` 현재 누계로 3개 패널 변경.

## Result

- raw 카운터와 정확히 일치하고 내부 합도 맞는다(파싱 N건 = 추출 N건). 외삽·리셋합산이 없어 안 깨진다.
- 트레이드오프: "선택 시간창" 대신 **"현재 배포 이후 누계"**(재배포 시 0 리셋). 저빈도 카운터 + 잦은 재배포인 dev 엔 increase 창보다 이게 정직하고 일관적이다.
- 검증은 dev EC2 에 SSH 후 `localhost:8080/actuator/prometheus` raw 카운터를 직접 대조해 확정했다(nginx 가 /actuator 외부 403 이라 Grafana 우회). import 는 수동.

---
## 연관 이슈

- 관련 #506 (메트릭 #508·패널 #511·viz #515 의 후속 정정)
