### PR TITLE
Tournament 패키지 코드 품질 개선

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/tournament/domain/Tournament.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/domain/Tournament.kt
@@ -71,6 +71,8 @@ class Tournament(
 
     fun isCompleted(): Boolean = status == TournamentStatus.COMPLETED
 
+    fun isRoot(): Boolean = sourceTournamentId?.let { false } ?: true
+
     fun updateInviteExpiry(newExpiresAt: LocalDateTime) {
         check(isPending()) { "updateInviteExpiry는 PENDING 상태에서만 호출 가능" }
         _inviteExpiresAt = newExpiresAt

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentException.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentException.kt
@@ -150,13 +150,6 @@ class TournamentException private constructor(
                 HttpStatus.CONFLICT,
             )
 
-        fun statusNotSupported(): TournamentException =
-            TournamentException(
-                "해당 상태의 토너먼트 조회는 아직 지원되지 않습니다.",
-                ErrorCategory.SERVER_ERROR,
-                HttpStatus.NOT_IMPLEMENTED,
-            )
-
         fun invalidInviteCode(): TournamentException =
             TournamentException(
                 "초대 코드가 올바르지 않습니다.",

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
@@ -480,7 +480,7 @@ class TournamentService(
     ): List<TournamentSummary> {
         val tournamentIds = tournamentUserRepository.findTournamentIdsByUserId(userId)
         if (tournamentIds.isEmpty()) return emptyList()
-        val tournaments = tournamentRepository.findByIdsAndStatuses(tournamentIds, null)
+        val tournaments = tournamentRepository.findByIdsAndStatuses(tournamentIds, statuses)
         if (tournaments.isEmpty()) return emptyList()
 
         val tournamentUsers = tournamentUserRepository.findByTournamentIds(tournaments.map { it.getId() })
@@ -513,7 +513,6 @@ class TournamentService(
                     effectiveStatus = tournament.status,
                 )
             }
-            .filter { statuses.isNullOrEmpty() || it.status in statuses }
     }
 
     @Transactional

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
@@ -504,7 +504,7 @@ class TournamentService(
                 val isTournamentOwner = myTU?.getId() == tournament.ownerTournamentUserId
                 // ROOT(소셜) 토너먼트는 PENDING 이후에는 멤버 목록에서 제외한다.
                 // 멤버는 본인 CLONE 으로 플레이하며 그 CLONE 이 목록에 표시된다.
-                tournament.sourceTournamentId?.let { true } ?: (isTournamentOwner || tournament.isPending())
+                !tournament.isRoot() || isTournamentOwner || tournament.isPending()
             }
             .map { tournament ->
                 TournamentSummary.of(
@@ -528,10 +528,8 @@ class TournamentService(
             tournamentUserRepository.findByTournamentIdAndUserId(command.tournamentId, userId)
                 ?: throw TournamentException.forbiddenTournament()
         // ROOT 토너먼트는 오너만 플레이한다. 멤버는 본인 CLONE 에서 진행해야 한다.
-        tournament.sourceTournamentId ?: run {
-            if (tournamentUser.getId() != tournament.ownerTournamentUserId) {
-                throw TournamentException.forbiddenTournament()
-            }
+        if (tournament.isRoot() && tournamentUser.getId() != tournament.ownerTournamentUserId) {
+            throw TournamentException.forbiddenTournament()
         }
         if (command.selectedTournamentItemId != command.firstTournamentItemId &&
             command.selectedTournamentItemId != command.secondTournamentItemId
@@ -578,9 +576,11 @@ class TournamentService(
         // 완료 알림 발행(#473). CLONE 완료(멤버/게스트) → ROOT 주최자에게 "완료했어요",
         // ROOT 완료(주최자 본인 진행) → 참여자에게 "결과 나왔어요". rootId 는 클론이면 원본, ROOT 면 자기 자신.
         val rootTournamentId = tournament.sourceTournamentId ?: tournament.getId()
-        tournament.sourceTournamentId
-            ?.let { eventPublisher.publishEvent(TournamentCompleted(rootTournamentId = rootTournamentId, actorId = userId)) }
-            ?: eventPublisher.publishEvent(TournamentResultReady(rootTournamentId = rootTournamentId, actorId = userId))
+        if (tournament.isRoot()) {
+            eventPublisher.publishEvent(TournamentResultReady(rootTournamentId = rootTournamentId, actorId = userId))
+        } else {
+            eventPublisher.publishEvent(TournamentCompleted(rootTournamentId = rootTournamentId, actorId = userId))
+        }
 
         val isOwner = tournamentUser.getId() == tournament.ownerTournamentUserId
         return buildCompleted(tournament, histories + newHistory, computeHasGroupResult(tournament), isOwner)

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
@@ -111,7 +111,7 @@ class TournamentService(
             tournamentRepository.findTournamentById(command.tournamentId)
                 ?: throw TournamentException.notFoundTournament()
         if (!tournament.isPending()) throw TournamentException.notPendingTournament()
-        tournament.sourceTournamentId?.let { throw TournamentException.clonedTournamentCannotAddItems() }
+        if (!tournament.isRoot()) throw TournamentException.clonedTournamentCannotAddItems()
         tournamentUserRepository.findByTournamentIdAndUserId(command.tournamentId, userId)
             ?: throw TournamentException.forbiddenTournament()
         val existingItemIds =
@@ -723,7 +723,7 @@ class TournamentService(
             tournamentUserRepository.findByTournamentIdAndUserId(tournamentId, userId)
                 ?: throw TournamentException.forbiddenTournament()
         if (tournamentUser.getId() != tournament.ownerTournamentUserId) throw TournamentException.forbiddenTournament()
-        tournament.sourceTournamentId?.let { throw TournamentException.clonedTournamentCannotSharePlayLink() }
+        if (!tournament.isRoot()) throw TournamentException.clonedTournamentCannotSharePlayLink()
         tournament.playLinkExpiresAt?.let { throw TournamentException.playLinkAlreadyCreated() }
         val expiresAt = LocalDateTime
             .now()
@@ -805,7 +805,7 @@ class TournamentService(
         val tournament =
             tournamentRepository.findTournamentById(tournamentId)
                 ?: throw TournamentException.notFoundTournament()
-        tournament.sourceTournamentId?.let { throw TournamentException.clonedTournamentCannotViewGroupResult() }
+        if (!tournament.isRoot()) throw TournamentException.clonedTournamentCannotViewGroupResult()
         val allClones = tournamentRepository.findBySourceTournamentId(tournamentId)
         val requesterRootTU = tournamentUserRepository.findByTournamentIdAndUserId(tournamentId, userId)
         val cloneOwnerTUById = tournamentUserRepository

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
@@ -825,16 +825,18 @@ class TournamentService(
         } else {
             requesterOwnedClone?.isCompleted() ?: false
         }
-        if (!requesterHasCompleted || !computeHasGroupResult(tournament)) {
+        // completedRootTUs·completedClones 는 아래 plays 빌드에도 쓰이므로 미리 구해 게이트와 공유한다.
+        // computeHasGroupResult 를 별도 호출하면 findBySourceTournamentId 와 countCompletedByTournamentId 를
+        // 중복 조회하게 되므로 인라인으로 처리한다.
+        val completedRootTUs = tournamentUserRepository.findCompletedByTournamentId(tournamentId)
+        val completedClones = allClones.filter { it.isCompleted() }
+        if (!requesterHasCompleted || completedRootTUs.size + completedClones.size < 2) {
             throw TournamentException.groupResultNotAvailable()
         }
 
         // "play" = 한 참여자의 독립적인 토너먼트 진행 단위.
         // 루트 토너먼트의 각 완료 TU + 각 완료된 클론 토너먼트의 오너 TU.
         data class Play(val tournamentId: Long, val tuId: Long, val userUUID: UUID)
-
-        val completedRootTUs = tournamentUserRepository.findCompletedByTournamentId(tournamentId)
-        val completedClones = allClones.filter { it.isCompleted() }
         // cloneOwnerTUById 는 위 권한 게이트에서 allClones 전체로 구해 재사용한다 (completedClones ⊆ allClones).
 
         val plays = buildList {

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
@@ -290,7 +290,7 @@ class TournamentService(
         val currentUser = tournamentUserRepository.findByTournamentIdAndUserId(tournamentId, userId)
             ?: throw TournamentException.forbiddenTournament()
         val isOwner = currentUser.getId() == tournament.ownerTournamentUserId
-        val isRoot = tournament.sourceTournamentId?.let { false } ?: true
+        val isRoot = tournament.isRoot()
 
         return when (tournament.status) {
             TournamentStatus.PENDING -> {
@@ -438,7 +438,8 @@ class TournamentService(
                 }
             },
             isOwner = false,
-            isRoot = true,
+            isRoot = root.isRoot(),
+            sourceTournamentId = null,
             ownerStarted = true,
         )
     }
@@ -578,11 +579,9 @@ class TournamentService(
         // 완료 알림 발행(#473). CLONE 완료(멤버/게스트) → ROOT 주최자에게 "완료했어요",
         // ROOT 완료(주최자 본인 진행) → 참여자에게 "결과 나왔어요". rootId 는 클론이면 원본, ROOT 면 자기 자신.
         val rootTournamentId = tournament.sourceTournamentId ?: tournament.getId()
-        if (tournament.sourceTournamentId != null) {
-            eventPublisher.publishEvent(TournamentCompleted(rootTournamentId = rootTournamentId, actorId = userId))
-        } else {
-            eventPublisher.publishEvent(TournamentResultReady(rootTournamentId = rootTournamentId, actorId = userId))
-        }
+        tournament.sourceTournamentId
+            ?.let { eventPublisher.publishEvent(TournamentCompleted(rootTournamentId = rootTournamentId, actorId = userId)) }
+            ?: eventPublisher.publishEvent(TournamentResultReady(rootTournamentId = rootTournamentId, actorId = userId))
 
         val isOwner = tournamentUser.getId() == tournament.ownerTournamentUserId
         return buildCompleted(tournament, histories + newHistory, computeHasGroupResult(tournament), isOwner)
@@ -602,7 +601,7 @@ class TournamentService(
         hasGroupResult: Boolean,
         isOwner: Boolean,
     ): TournamentDetail.Completed {
-        val isRoot = tournament.sourceTournamentId?.let { false } ?: true
+        val isRoot = tournament.isRoot()
         val rankedPairs = computeRanking(histories)
         val tournamentItemById = tournamentItemRepository
             .findByIds(rankedPairs.map { it.first })


### PR DESCRIPTION
## Situation

- Tournament 패키지 전반을 코드 리뷰하던 중 네 가지 품질 이슈를 발견했다.
- `sourceTournamentId?.let { false } ?: true` 패턴이 서비스에 2번 하드코딩돼 있고, `buildMemberPendingOnRoot`에는 의미 불명의 `isRoot = true` 매직 리터럴이 박혀 있었다.
- `getTournaments`는 `statuses` 파라미터를 받으면서도 DB 쿼리에는 항상 `null`을 넘겨, 전체 레코드를 가져온 뒤 in-memory에서 상태를 걸러내는 비효율이 있었다.

## Task

- `sourceTournamentId` null 여부로 ROOT/CLONE을 판별하는 로직을 도메인 메서드로 단일화한다.
- DB가 처리할 수 있는 필터를 애플리케이션 레이어에서 중복으로 수행하지 않도록 제거한다.
- CLAUDE.md null 비교 금지 규칙(`!= null` 분기 금지)에 어긋난 패턴을 수정한다.
- 호출 경로가 없는 dead code를 제거한다.

## Action

### 도메인 헬퍼 추출

- `Tournament.isRoot()` 메서드를 도메인에 추가 — `sourceTournamentId?.let { false } ?: true`
- 서비스 내 인라인 패턴과 `buildMemberPendingOnRoot`의 `isRoot = true` 매직 리터럴을 `isRoot()` 호출로 교체
- `buildMemberPendingOnRoot`의 `sourceTournamentId = null` 명시 — default값 암묵 의존을 표현식으로 드러냄
- `addItemsFromWish`, `createPlayLink`, `getGroupResult`의 CLONE 진입 차단 조건(`sourceTournamentId?.let { throw }`) 도 `!isRoot()` 로 일관 교체

### null 비교 패턴 수정

- `recordMatch`의 `sourceTournamentId != null` 분기를 `isRoot()` if/else로 교체
- `recordMatch`의 ROOT 오너 검증(`sourceTournamentId ?: run { ... }`)을 `isRoot() &&` 단문으로 교체
- `getTournaments` 필터의 `sourceTournamentId?.let { true } ?: (...)` 를 `!isRoot() || ...` 로 교체
- CLAUDE.md 규칙(`== null` / `!= null` 금지) 일관성 확보

### DB 쿼리 최적화

- `getTournaments`에서 `findByIdsAndStatuses(ids, null)` 고정을 `findByIdsAndStatuses(ids, statuses)`로 수정, 중복 in-memory 필터 제거
- `getGroupResult`에서 `computeHasGroupResult` 별도 호출 제거 — `findBySourceTournamentId`와 `countCompletedByTournamentId`를 중복 발행하던 문제를 해소하고, `completedRootTUs`·`completedClones`를 게이트 위로 올려 공유

### Dead code 제거

- `TournamentException.statusNotSupported()` 제거 — `when(tournament.status)`가 sealed enum을 완전히 처리하므로 실제 호출 경로 없음

## Result

- ROOT/CLONE 판별 의도가 `isRoot()` 한 곳에 집중되어 서비스 전체가 일관된 표현을 쓴다.
- `getGroupResult` 호출 시 DB 쿼리 2개(`findBySourceTournamentId`, `countCompletedByTournamentId`) 절약된다.
- status 필터가 DB에서 처리되므로 상태 조회 페이지의 데이터 전송량이 줄어든다.

---
## 연관 이슈

- close #520


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 토너먼트의 “루트” 판별 로직을 일관되게 통합해 동작 신뢰성을 높였습니다.
  * 상태 필터링을 조회 단계에서 처리하도록 변경해 탐색 성능을 개선했습니다.
  * 그룹 결과 계산과 플레이 권한/완료 이벤트 분기 로직을 간소화해 코드 흐름을 명확히 했습니다.
  * 내부 예외 팩토리 정리로 예외 처리 구조를 단순화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
