### PR TITLE
파싱 관측을 로그/트레이스 기반으로 전환 (메트릭은 실패율 레드 스위치로)

### DIFF
--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -25,7 +25,9 @@ Grafana Cloud 가 호스팅하는 Grafana 이므로 셀프호스팅 provisioning
 5. **의존성** — 502율(Gemini 등 외부 실패) · executor active/queued · HikariCP active/idle/pending.
 6. **리소스** — 앱 process/system CPU · JVM 스레드 · 호스트 CPU.
 7. **로그** — 에러/경고 필터 로그 + 전체 로그(`team3-blue`/`team3-green`).
-8. **파싱·추출** — 파싱 결과(`item.parsing` result별)·실패 사유(reason별: not_product·ready_rejected·retry_exhausted·no_source)·추출 방법(`product.extract` via별: 직접 파싱 vs LLM). 상품 추출 실패가 트래픽에서 얼마나·왜 나는지 본다(#506).
+8. **파싱·추출 관측** — **파싱 실패율**(`item.parsing` 메트릭 rate 기반 레드 스위치, 임계 색상, 환경 따라감) + **파싱 결과(result별)·추출 방법(via별)**(`item.parse.result`·`extract via=` 로그를 `count_over_time | logfmt` 로 셈) + **파싱 이벤트 로그**(어느 URL 이 왜 실패했는지 맥락). 단건 파이프라인 드릴다운은 상단 트레이스의 **`아이템` 탭**(`name = "item.parse"`)으로 본다(#506).
+
+   - **누적 카운트 메트릭이 아니라 로그/트레이스 기반인 이유**: 인메모리 카운터는 앱 재배포마다 0으로 리셋된다. dev 는 하루 수십 번 배포해 누계가 무의미하고, `increase` 창집계도 잦은 재시작+blue/green instance churn 에 시리즈를 떨군다. 로그 이벤트는 Loki 에 durable 하게 쌓여 배포에 영향받지 않으므로 결과·방법 집계의 정확한 소스다. 메트릭은 "정확한 누계"가 아니라 "실패율 급등 감지(레드 스위치)" 한 가지에만 쓴다 — 그 역할엔 짧은 창 rate 라 리셋이 무관하다.
 
 앱 메트릭은 `application="PIKI"` 라벨로 필터한다(Alloy 의 prometheus.scrape 가 붙임).
 blue-green 이라 한 시점에 한 슬롯만 활성이며 `instance` 라벨로 blue/green 을 구분한다.

--- a/infra/grafana/dashboard.json
+++ b/infra/grafana/dashboard.json
@@ -1675,7 +1675,7 @@
             "type": "loki",
             "uid": "${DS_LOKI}"
           },
-          "expr": "{container=~\"team3-(blue|green)\", environment=\"$environment\"} |~ \"item.parse.result|extract via=|파싱 실패\""
+          "expr": "{container=~\"team3-(blue|green)\", environment=\"$environment\"} |~ \"item.parse.result|item.parse.error|extract via=|파싱 실패\""
         }
       ]
     }

--- a/infra/grafana/dashboard.json
+++ b/infra/grafana/dashboard.json
@@ -74,7 +74,7 @@
         "name": "traceFilter",
         "type": "custom",
         "label": "trace 필터",
-        "query": "전체 : resource.service.name = \"PIKI\",느린(>500ms) : resource.service.name = \"PIKI\" && trace:duration > 500ms,에러 : resource.service.name = \"PIKI\" && status = error",
+        "query": "전체 : resource.service.name = \"PIKI\",느린(>500ms) : resource.service.name = \"PIKI\" && trace:duration > 500ms,에러 : resource.service.name = \"PIKI\" && status = error,아이템 : resource.service.name = \"PIKI\" && name = \"item.parse\"",
         "current": {
           "text": "전체",
           "value": "resource.service.name = \"PIKI\"",
@@ -94,6 +94,11 @@
           {
             "text": "에러",
             "value": "resource.service.name = \"PIKI\" && status = error",
+            "selected": false
+          },
+          {
+            "text": "아이템",
+            "value": "resource.service.name = \"PIKI\" && name = \"item.parse\"",
             "selected": false
           }
         ],
@@ -1470,7 +1475,7 @@
     {
       "id": 200,
       "type": "row",
-      "title": "파싱·추출 (결과 · 사유 · 방법)",
+      "title": "파싱·추출 관측 (실패율 red-switch · 결과 · 방법 · 로그)",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1481,7 +1486,8 @@
     {
       "id": 201,
       "type": "stat",
-      "title": "파싱 결과 (result별)",
+      "title": "파싱 실패율 (%)",
+      "description": "최근 구간 파싱 실패 비율. 레드 스위치 — 급등하면 특정 플랫폼 추출이 깨진 신호. environment 드롭다운을 따라간다(dev 는 저빈도라 노이즈, 주로 prod 기준으로 본다).",
       "gridPos": {
         "h": 8,
         "w": 8,
@@ -1494,25 +1500,38 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "short",
-          "decimals": 0,
-          "color": {
-            "mode": "palette-classic"
+          "unit": "percent",
+          "decimals": 1,
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 20
+              },
+              {
+                "color": "red",
+                "value": 50
+              }
+            ]
           }
         },
         "overrides": []
       },
       "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "textMode": "value_and_name",
-        "justifyMode": "auto",
+        "colorMode": "background",
+        "graphMode": "area",
+        "textMode": "auto",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
+          ]
         }
       },
       "targets": [
@@ -1522,16 +1541,15 @@
             "type": "prometheus",
             "uid": "${DS_PROM}"
           },
-          "expr": "sum by (result) (item_parsing_total{application=\"PIKI\", environment=\"$environment\"})",
-          "legendFormat": "{{result}}",
-          "instant": true
+          "expr": "sum(rate(item_parsing_total{application=\"PIKI\", environment=\"$environment\", result=\"failed\"}[$__rate_interval])) / clamp_min(sum(rate(item_parsing_total{application=\"PIKI\", environment=\"$environment\"}[$__rate_interval])), 0.001) * 100"
         }
       ]
     },
     {
       "id": 202,
-      "type": "bargauge",
-      "title": "파싱 실패 사유 (reason별)",
+      "type": "timeseries",
+      "title": "파싱 결과 (result별, 로그·배포무영향)",
+      "description": "item.parse.result 로그를 세어 결과 분포를 본다. 로그 이벤트라 앱 재배포(인메모리 카운터 리셋)에 영향받지 않는다.",
       "gridPos": {
         "h": 8,
         "w": 8,
@@ -1539,48 +1557,49 @@
         "y": 48
       },
       "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROM}"
+        "type": "loki",
+        "uid": "${DS_LOKI}"
       },
       "fieldConfig": {
         "defaults": {
           "unit": "short",
-          "decimals": 0,
-          "color": {
-            "mode": "palette-classic"
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 60,
+            "stacking": {
+              "mode": "normal"
+            }
           }
         },
         "overrides": []
       },
       "options": {
-        "orientation": "horizontal",
-        "displayMode": "gradient",
-        "showUnfilled": true,
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
         {
           "refId": "A",
           "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROM}"
+            "type": "loki",
+            "uid": "${DS_LOKI}"
           },
-          "expr": "sum by (reason) (item_parsing_total{application=\"PIKI\", environment=\"$environment\", result=\"failed\"})",
-          "legendFormat": "{{reason}}",
-          "instant": true
+          "expr": "sum by (result) (count_over_time({container=~\"team3-(blue|green)\", environment=\"$environment\"} |= \"item.parse.result\" | logfmt | __error__=\"\" [$__interval]))",
+          "legendFormat": "{{result}}"
         }
       ]
     },
     {
       "id": 203,
-      "type": "stat",
-      "title": "추출 방법 (직접 파싱 vs LLM)",
+      "type": "timeseries",
+      "title": "추출 방법 (via별, 로그)",
+      "description": "extract via= 로그를 세어 직접 파싱(structured) 대 LLM 비율을 본다. via=llm 이 비싼 호출이라, structured 비중이 곧 비용 절감 지표.",
       "gridPos": {
         "h": 8,
         "w": 8,
@@ -1588,42 +1607,75 @@
         "y": 48
       },
       "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROM}"
+        "type": "loki",
+        "uid": "${DS_LOKI}"
       },
       "fieldConfig": {
         "defaults": {
           "unit": "short",
-          "decimals": 0,
-          "color": {
-            "mode": "palette-classic"
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 60,
+            "stacking": {
+              "mode": "normal"
+            }
           }
         },
         "overrides": []
       },
       "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "textMode": "value_and_name",
-        "justifyMode": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
         {
           "refId": "A",
           "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROM}"
+            "type": "loki",
+            "uid": "${DS_LOKI}"
           },
-          "expr": "sum by (via) (product_extract_total{application=\"PIKI\", environment=\"$environment\"})",
-          "legendFormat": "{{via}}",
-          "instant": true
+          "expr": "sum by (via) (count_over_time({container=~\"team3-(blue|green)\", environment=\"$environment\"} |= \"extract via=\" | logfmt | __error__=\"\" [$__interval]))",
+          "legendFormat": "{{via}}"
+        }
+      ]
+    },
+    {
+      "id": 204,
+      "type": "logs",
+      "title": "파싱 이벤트 로그 (결과 · 추출 방법 · 실패 사유)",
+      "description": "item.parse.result(결과·사유) · extract via=(추출 방법) · 파싱 실패 로그를 한데 본다. 어느 URL 이 왜 실패했는지 맥락까지 보이는 durable 기록.",
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 56
+      },
+      "datasource": {
+        "type": "loki",
+        "uid": "${DS_LOKI}"
+      },
+      "options": {
+        "showTime": true,
+        "showLabels": false,
+        "wrapLogMessage": true,
+        "enableLogDetails": true,
+        "dedupStrategy": "none",
+        "sortOrder": "Descending"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "${DS_LOKI}"
+          },
+          "expr": "{container=~\"team3-(blue|green)\", environment=\"$environment\"} |~ \"item.parse.result|extract via=|파싱 실패\""
         }
       ]
     }

--- a/src/main/kotlin/com/depromeet/piki/item/service/AsyncItemParsingWorker.kt
+++ b/src/main/kotlin/com/depromeet/piki/item/service/AsyncItemParsingWorker.kt
@@ -8,6 +8,8 @@ import com.depromeet.piki.product.service.ProductLinkExtractor
 import com.depromeet.piki.product.service.ProductSnapshot
 import com.depromeet.piki.product.service.ProductSnapshotException
 import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.observation.Observation
+import io.micrometer.observation.ObservationRegistry
 import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
@@ -23,6 +25,7 @@ class AsyncItemParsingWorker(
     private val productLinkExtractor: ProductLinkExtractor,
     private val itemParsingService: ItemParsingService,
     private val meterRegistry: MeterRegistry,
+    private val observationRegistry: ObservationRegistry,
 ) : ItemParsingWorker {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -31,10 +34,15 @@ class AsyncItemParsingWorker(
         itemId: Long,
         link: ProductLink,
     ) {
-        val started = System.nanoTime()
-        runCatching { productLinkExtractor.extract(link) }
-            .onSuccess { snapshot -> onExtracted(itemId, link, snapshot, started) }
-            .onFailure { e -> onExtractFailed(itemId, link, e) }
+        // 파싱 한 건을 "item.parse" span 하나로 묶는다 — fetch·structured·Gemini 호출이 그 자식 span 으로 붙어,
+        // 트레이스에서 단건 파이프라인(직접 파싱 → LLM fallback)을 끝까지 펼쳐 볼 수 있다. 디스패처가 @Scheduled 라
+        // 들어오는 trace 가 없어, 여기서 만들지 않으면 fetch·Gemini span 이 따로 떠 묶이지 않는다.
+        Observation.createNotStarted(PARSE_OBSERVATION, observationRegistry).observe {
+            val started = System.nanoTime()
+            runCatching { productLinkExtractor.extract(link) }
+                .onSuccess { snapshot -> onExtracted(itemId, link, snapshot, started) }
+                .onFailure { e -> onExtractFailed(itemId, link, e) }
+        }
     }
 
     private fun onExtracted(
@@ -47,12 +55,26 @@ class AsyncItemParsingWorker(
         // 전이가 실패(추출값 도메인 검증 위반·DB 오류·sweeper 와의 레이스로 이미 전이됨)해도 예외를 흡수한다.
         runCatching { itemParsingService.markReady(itemId, snapshot) }
             .onSuccess {
-                log.info("item {} 파싱 완료: latency={}ms url={}", itemId, elapsedMs, link.safeLogString())
+                log.info(
+                    "item.parse.result item={} result={} reason={} latency={}ms url={}",
+                    itemId,
+                    ItemParsingMetrics.RESULT_READY,
+                    ItemParsingMetrics.REASON_NONE,
+                    elapsedMs,
+                    link.safeLogString(),
+                )
                 ItemParsingMetrics.record(meterRegistry, ItemParsingMetrics.RESULT_READY, ItemParsingMetrics.REASON_NONE)
             }
             .onFailure { e ->
                 // 추출은 됐으나 값을 신뢰할 수 없어 READY 로 채울 수 없는 경우 → PROCESSING 방치 대신 FAILED 로.
-                log.warn("item {} READY 전이 실패 → FAILED: url={}", itemId, link.safeLogString(), e)
+                log.warn(
+                    "item.parse.result item={} result={} reason={} url={}",
+                    itemId,
+                    ItemParsingMetrics.RESULT_FAILED,
+                    ItemParsingMetrics.REASON_READY_REJECTED,
+                    link.safeLogString(),
+                    e,
+                )
                 markFailedQuietly(itemId)
                 ItemParsingMetrics.record(meterRegistry, ItemParsingMetrics.RESULT_FAILED, ItemParsingMetrics.REASON_READY_REJECTED)
             }
@@ -74,9 +96,17 @@ class AsyncItemParsingWorker(
         }
         // 확정 실패 — 상품 아님·추출값 신뢰 불가·호스트 차단·4xx 접근 불가 등. 같은 URL 을 다시 파싱해도 결과가
         // 같으므로 즉시 FAILED 로 종결한다(사용자에게 빨리 알림). 클라이언트 입력 계약 위반이라 서버 입장에선 정상 동작(info).
-        log.info("item {} 파싱 실패(확정·재시도 무의미): {} url={}", itemId, e.message, link.safeLogString())
+        val reason = reasonOf(e)
+        log.info(
+            "item.parse.result item={} result={} reason={} url={} cause={}",
+            itemId,
+            ItemParsingMetrics.RESULT_FAILED,
+            reason,
+            link.safeLogString(),
+            e.message,
+        )
         markFailedQuietly(itemId)
-        ItemParsingMetrics.record(meterRegistry, ItemParsingMetrics.RESULT_FAILED, reasonOf(e))
+        ItemParsingMetrics.record(meterRegistry, ItemParsingMetrics.RESULT_FAILED, reason)
     }
 
     // 재시도해도 의미 있는 일시 오류인가. ErrorCategory.RETRYABLE 만 재시도 대상이다. HttpMappable 이 아닌
@@ -100,5 +130,10 @@ class AsyncItemParsingWorker(
                     else -> log.error("item {} FAILED 전이 실패, PROCESSING 방치 위험", itemId, e)
                 }
             }
+    }
+
+    companion object {
+        // 파싱 단건 트레이스 span 이름. 대시보드 트레이스 "아이템" 탭이 TraceQL `name = "item.parse"` 로 이걸 거른다.
+        private const val PARSE_OBSERVATION = "item.parse"
     }
 }

--- a/src/main/kotlin/com/depromeet/piki/item/service/AsyncItemParsingWorker.kt
+++ b/src/main/kotlin/com/depromeet/piki/item/service/AsyncItemParsingWorker.kt
@@ -73,8 +73,9 @@ class AsyncItemParsingWorker(
                     ItemParsingMetrics.RESULT_FAILED,
                     ItemParsingMetrics.REASON_READY_REJECTED,
                     link.safeLogString(),
-                    e,
                 )
+                // 예외 상세(스택)는 별도 줄로 — 구조화(item.parse.result) 줄에 스택을 붙이면 logfmt 파싱이 깨진다.
+                log.warn("item.parse.error item={} reason={} READY 전이 거부", itemId, ItemParsingMetrics.REASON_READY_REJECTED, e)
                 markFailedQuietly(itemId)
                 ItemParsingMetrics.record(meterRegistry, ItemParsingMetrics.RESULT_FAILED, ItemParsingMetrics.REASON_READY_REJECTED)
             }
@@ -98,13 +99,14 @@ class AsyncItemParsingWorker(
         // 같으므로 즉시 FAILED 로 종결한다(사용자에게 빨리 알림). 클라이언트 입력 계약 위반이라 서버 입장에선 정상 동작(info).
         val reason = reasonOf(e)
         log.info(
-            "item.parse.result item={} result={} reason={} url={} cause={}",
+            "item.parse.result item={} result={} reason={} url={}",
             itemId,
             ItemParsingMetrics.RESULT_FAILED,
             reason,
             link.safeLogString(),
-            e.message,
         )
+        // 실패 사유 원문(공백 포함 가능)은 별도 줄로 — 구조화 줄의 logfmt 필드 파싱을 깨지 않게 분리한다.
+        log.info("item.parse.error item={} reason={} cause={}", itemId, reason, e.message)
         markFailedQuietly(itemId)
         ItemParsingMetrics.record(meterRegistry, ItemParsingMetrics.RESULT_FAILED, reason)
     }


### PR DESCRIPTION
## Situation

- 파싱 결과를 누적 카운트 메트릭 패널로 봤는데, 인메모리 카운터가 앱 재배포마다 0으로 리셋돼 dev(하루 수십 배포)에서 무의미했다. raw 누계도 increase 창집계도 잦은 재시작 + blue/green instance churn 에 깨졌다(SSH 로 읽은 raw 카운터와 패널 값이 안 맞는 걸 실측). 파싱 결과는 "카운터"보다 "이벤트" 성격이라, 처음부터 로그/트레이스가 더 맞는 그릇이었다.

## Task

- 파싱 관측을 배포에 영향받지 않는 정확한 소스(로그/트레이스)로 옮기고, 메트릭은 레드 스위치 한 역할로만 남긴다.

## Action

### 앱 (관측 계측)
- 파싱 단건을 `item.parse` Observation 으로 감쌌다 → fetch·structured·Gemini 호출이 자식 span 으로 묶여, 단건 파이프라인(직접 파싱 → LLM fallback)을 트레이스로 끝까지 펼쳐 본다. 디스패처가 `@Scheduled` 라 들어오는 trace 가 없어 직접 생성한다. `@Observed` 는 ObservedAspect 미설정이라 수동 Observation 사용.
- 워커 결과 로그를 logfmt(`result=`·`reason=`)로 구조화했다. 값은 `ItemParsingMetrics` 상수를 재사용해 로그·메트릭이 어긋나지 않는다.

### 대시보드
- 누적 카운트 stat/bargauge 3패널 제거 → 넷으로 재구성: 실패율 레드 스위치(`item.parsing` rate, 환경 따라감) + 파싱 결과·추출 방법(`item.parse.result`·`extract via=` 로그를 `count_over_time | logfmt`, 배포무영향) + 파싱 이벤트 로그 + 트레이스 `아이템` 탭(`name = "item.parse"`).

## Result

- 결과·방법 집계가 durable 로그 기반이라 재배포에 안 흔들린다(dev 의 잦은 배포에서도 정확). 메트릭은 짧은 창 rate 라 리셋과 무관한 "실패율 급등 감지"에만 쓴다.
- via 는 추출기가 이미 logfmt(`extract via=`)로 로깅 중이라 추출기 변경이 필요 없었다.
- 검증 한계: 전체 테스트로 워커 동작·메트릭 회귀 없음은 확인했으나, 로그 렌더·LogQL/TraceQL 결과는 로컬에서 못 본다. 머지 후 `dashboard.json` 재 import 시 화면에서 확인해야 한다. 대시보드 LogQL 은 워커/추출기 로그 포맷(`item.parse.result`·`extract via=`)에 의존하는 soft contract 다.

---
## 연관 이슈

- 관련 #506 (파싱 관측 — 누적 메트릭에서 로그/트레이스 기반으로 전환)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * 파싱·추출 대시보드 모니터링 가이드 갱신: 파싱 실패율, 결과별 집계, 이벤트 로그 관측 방법 안내 추가

* **New Features**
  * Grafana 대시보드에 아이템 트레이스 필터 옵션 추가
  * 로그 기반 파싱 메트릭 패널 추가: 파싱 실패율, 결과별 집계, 추출 방법별 통계

<!-- end of auto-generated comment: release notes by coderabbit.ai -->