### PR TITLE
위시 아이템 담기에 행 락 적용으로 32개 상한 동시성 버그 수정

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
@@ -108,7 +108,7 @@ class TournamentService(
         command: AddTournamentItemsFromWish,
     ): List<Long> {
         val tournament =
-            tournamentRepository.findTournamentById(command.tournamentId)
+            tournamentRepository.findTournamentByIdForUpdate(command.tournamentId)
                 ?: throw TournamentException.notFoundTournament()
         if (!tournament.isPending()) throw TournamentException.notPendingTournament()
         if (!tournament.isRoot()) throw TournamentException.clonedTournamentCannotAddItems()

--- a/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentWishAddConcurrencyIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentWishAddConcurrencyIntegrationTest.kt
@@ -31,6 +31,7 @@ import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 // 위시 아이템 담기가 행 락(findTournamentByIdForUpdate) 없이 조회하면, 동시 요청 두 개가 각각
 // existingCount=0 을 읽어 상한(32) 체크를 통과해 합산 40개가 들어간다.
@@ -89,65 +90,73 @@ class TournamentWishAddConcurrencyIntegrationTest : IntegrationTestSupport() {
             },
         )
 
-        // 토너먼트 생성 — TournamentUser(owner) 도 함께 생성된다
-        val createResult = mockMvc.perform(
-            post("/api/v1/tournaments")
-                .header(HttpHeaders.AUTHORIZATION, ownerAuth)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("""{"name":"위시동시성토너먼트"}"""),
-        ).andReturn()
-        val tournamentId = objectMapper.readTree(createResult.response.contentAsString)["data"]["tournamentId"].asLong()
-
         val itemIds = items.map { it.getId() }
-        val requestBodies = listOf(
-            objectMapper.writeValueAsString(mapOf("itemIds" to itemIds.subList(0, 20))),  // A: 아이템 1-20
-            objectMapper.writeValueAsString(mapOf("itemIds" to itemIds.subList(20, 40))), // B: 아이템 21-40
-        )
+        val placeholders = itemIds.joinToString(",") { "?" }
 
-        val status200 = AtomicInteger(0)
-        val status400 = AtomicInteger(0)
-        val executor = Executors.newFixedThreadPool(2)
-        val ready = CountDownLatch(2)
-        val start = CountDownLatch(1)
-        val done = CountDownLatch(2)
+        // assertion 실패 시에도 정리가 보장되도록 try-finally 로 감싼다.
+        // 정리 없이 남으면 다음 실행 시 item/snapshot 수가 오염되어 다른 테스트에 영향을 줄 수 있다.
+        var tournamentId = 0L
+        try {
+            // 토너먼트 생성 — TournamentUser(owner) 도 함께 생성된다
+            val createResult = mockMvc.perform(
+                post("/api/v1/tournaments")
+                    .header(HttpHeaders.AUTHORIZATION, ownerAuth)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"name":"위시동시성토너먼트"}"""),
+            ).andReturn()
+            tournamentId = objectMapper.readTree(createResult.response.contentAsString)["data"]["tournamentId"].asLong()
 
-        for (body in requestBodies) {
-            executor.submit {
-                ready.countDown()
-                start.await()
-                try {
-                    val res = mockMvc.perform(
-                        post("/api/v1/tournaments/$tournamentId/items/wish")
-                            .header(HttpHeaders.AUTHORIZATION, ownerAuth)
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(body),
-                    ).andReturn()
-                    when (res.response.status) {
-                        200 -> status200.incrementAndGet()
-                        400 -> status400.incrementAndGet()
+            val requestBodies = listOf(
+                objectMapper.writeValueAsString(mapOf("itemIds" to itemIds.subList(0, 20))),  // A: 아이템 1-20
+                objectMapper.writeValueAsString(mapOf("itemIds" to itemIds.subList(20, 40))), // B: 아이템 21-40
+            )
+
+            val status200 = AtomicInteger(0)
+            val status400 = AtomicInteger(0)
+            val executor = Executors.newFixedThreadPool(2)
+            val ready = CountDownLatch(2)
+            val start = CountDownLatch(1)
+            val done = CountDownLatch(2)
+
+            for (body in requestBodies) {
+                executor.submit {
+                    ready.countDown()
+                    start.await()
+                    try {
+                        val res = mockMvc.perform(
+                            post("/api/v1/tournaments/$tournamentId/items/wish")
+                                .header(HttpHeaders.AUTHORIZATION, ownerAuth)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(body),
+                        ).andReturn()
+                        when (res.response.status) {
+                            200 -> status200.incrementAndGet()
+                            400 -> status400.incrementAndGet()
+                        }
+                    } finally {
+                        done.countDown()
                     }
-                } finally {
-                    done.countDown()
                 }
             }
+
+            ready.await()
+            start.countDown()
+            assertTrue(done.await(10, TimeUnit.SECONDS), "동시 요청이 10초 안에 완료되어야 한다")
+            executor.shutdown()
+
+            assertEquals(1, status200.get(), "정확히 하나만 200 이어야 한다 (20개 담기 성공)")
+            assertEquals(1, status400.get(), "나머지 하나는 락 대기 후 32개 초과로 400 이어야 한다")
+        } finally {
+            // @Transactional 자동 롤백 없으므로 직접 지운다
+            if (tournamentId != 0L) {
+                jdbcTemplate.update("DELETE FROM tournament_items WHERE tournament_id = ?", tournamentId)
+                jdbcTemplate.update("DELETE FROM tournament_users WHERE tournament_id = ?", tournamentId)
+                jdbcTemplate.update("DELETE FROM tournaments WHERE id = ?", tournamentId)
+            }
+            jdbcTemplate.update("DELETE FROM wishes WHERE user_id = ?", uuidToBytes(ownerId))
+            jdbcTemplate.update("DELETE FROM item_snapshots WHERE item_id IN ($placeholders)", *itemIds.toTypedArray())
+            jdbcTemplate.update("DELETE FROM items WHERE id IN ($placeholders)", *itemIds.toTypedArray())
+            jdbcTemplate.update("DELETE FROM users WHERE id = ?", uuidToBytes(ownerId))
         }
-
-        ready.await()
-        start.countDown()
-        done.await(10, TimeUnit.SECONDS)
-        executor.shutdown()
-
-        assertEquals(1, status200.get(), "정확히 하나만 200 이어야 한다 (20개 담기 성공)")
-        assertEquals(1, status400.get(), "나머지 하나는 락 대기 후 32개 초과로 400 이어야 한다")
-
-        // 정리 — @Transactional 자동 롤백 없으므로 직접 지운다
-        val placeholders = itemIds.joinToString(",") { "?" }
-        jdbcTemplate.update("DELETE FROM tournament_items WHERE tournament_id = ?", tournamentId)
-        jdbcTemplate.update("DELETE FROM tournament_users WHERE tournament_id = ?", tournamentId)
-        jdbcTemplate.update("DELETE FROM tournaments WHERE id = ?", tournamentId)
-        jdbcTemplate.update("DELETE FROM wishes WHERE user_id = ?", uuidToBytes(ownerId))
-        jdbcTemplate.update("DELETE FROM item_snapshots WHERE item_id IN ($placeholders)", *itemIds.toTypedArray())
-        jdbcTemplate.update("DELETE FROM items WHERE id IN ($placeholders)", *itemIds.toTypedArray())
-        jdbcTemplate.update("DELETE FROM users WHERE id = ?", uuidToBytes(ownerId))
     }
 }

--- a/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentWishAddConcurrencyIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentWishAddConcurrencyIntegrationTest.kt
@@ -1,0 +1,153 @@
+package com.depromeet.piki.tournament.controller
+
+import com.depromeet.piki.auth.infrastructure.jwt.JwtProvider
+import com.depromeet.piki.item.domain.Item
+import com.depromeet.piki.item.domain.ItemSnapshot
+import com.depromeet.piki.item.domain.ItemStatus
+import com.depromeet.piki.item.repository.ItemJpaRepository
+import com.depromeet.piki.item.repository.ItemSnapshotJpaRepository
+import com.depromeet.piki.support.IntegrationTestSupport
+import com.depromeet.piki.support.uuidToBytes
+import com.depromeet.piki.user.domain.IdentityType
+import com.depromeet.piki.user.domain.User
+import com.depromeet.piki.user.repository.UserJpaRepository
+import com.depromeet.piki.wishlist.domain.Wish
+import com.depromeet.piki.wishlist.repository.WishJpaRepository
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.web.context.WebApplicationContext
+import tools.jackson.databind.ObjectMapper
+import java.time.LocalDateTime
+import java.util.UUID
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.assertEquals
+
+// 위시 아이템 담기가 행 락(findTournamentByIdForUpdate) 없이 조회하면, 동시 요청 두 개가 각각
+// existingCount=0 을 읽어 상한(32) 체크를 통과해 합산 40개가 들어간다.
+// findTournamentByIdForUpdate 로 직렬화하면 두 번째 요청이 첫 번째 커밋 후 existingCount=20 을
+// 보고 20+20=40>32 로 400 처리된다. "정확히 1개 200, 1개 400" 이 그 직렬화의 시그니처다.
+//
+// 일반 통합 테스트와 달리 @Transactional 을 쓰지 않는다 — 별도 트랜잭션 동시 진행이 race 시뮬레이션의 본질이다.
+// 데이터 격리는 새 UUID 를 쓰고 finally 에서 직접 정리한다.
+class TournamentWishAddConcurrencyIntegrationTest : IntegrationTestSupport() {
+    @Autowired private lateinit var webApplicationContext: WebApplicationContext
+    @Autowired private lateinit var objectMapper: ObjectMapper
+    @Autowired private lateinit var jwtProvider: JwtProvider
+    @Autowired private lateinit var userJpaRepository: UserJpaRepository
+    @Autowired private lateinit var itemJpaRepository: ItemJpaRepository
+    @Autowired private lateinit var itemSnapshotJpaRepository: ItemSnapshotJpaRepository
+    @Autowired private lateinit var wishJpaRepository: WishJpaRepository
+    @Autowired private lateinit var jdbcTemplate: JdbcTemplate
+
+    @Test
+    fun `위시 아이템 담기를 동시에 두 번 요청하면 행 락으로 직렬화되어 32개 상한을 초과하지 않는다`() {
+        val ownerId = UUID.randomUUID()
+        userJpaRepository.save(
+            User(id = ownerId, nickname = "race-wish", profileImage = "https://cdn.example.com/o.jpg", identityType = IdentityType.GUEST),
+        )
+
+        val mockMvc = MockMvcBuilders
+            .webAppContextSetup(webApplicationContext)
+            .apply<DefaultMockMvcBuilder>(springSecurity())
+            .build()
+
+        val ownerAuth = "Bearer ${jwtProvider.generateAccessToken(ownerId, IdentityType.GUEST)}"
+
+        // 아이템 40개 + READY 스냅샷 생성 — A 요청(1-20), B 요청(21-40) 에서 나눠 씀.
+        // 합산 40개는 TOURNAMENT_MAX_ITEM_COUNT(32)를 초과해 두 요청이 직렬화되면 하나는 반드시 차단된다.
+        val items = itemJpaRepository.saveAll((1..40).map { Item() })
+        val snapshots = itemSnapshotJpaRepository.saveAll(
+            items.mapIndexed { i, item ->
+                ItemSnapshot(
+                    itemId = item.getId(),
+                    name = "race-wish-item-${i + 1}",
+                    currentPrice = 10_000,
+                    currency = "KRW",
+                    status = ItemStatus.READY,
+                    extractedAt = LocalDateTime.now(),
+                )
+            },
+        )
+        val snapshotIdByItemId = snapshots.associateBy({ it.itemId }, { it.getId() })
+        wishJpaRepository.saveAll(
+            items.map { item ->
+                Wish(
+                    userId = ownerId,
+                    itemId = item.getId(),
+                    snapshotId = snapshotIdByItemId[item.getId()],
+                )
+            },
+        )
+
+        // 토너먼트 생성 — TournamentUser(owner) 도 함께 생성된다
+        val createResult = mockMvc.perform(
+            post("/api/v1/tournaments")
+                .header(HttpHeaders.AUTHORIZATION, ownerAuth)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"name":"위시동시성토너먼트"}"""),
+        ).andReturn()
+        val tournamentId = objectMapper.readTree(createResult.response.contentAsString)["data"]["tournamentId"].asLong()
+
+        val itemIds = items.map { it.getId() }
+        val requestBodies = listOf(
+            objectMapper.writeValueAsString(mapOf("itemIds" to itemIds.subList(0, 20))),  // A: 아이템 1-20
+            objectMapper.writeValueAsString(mapOf("itemIds" to itemIds.subList(20, 40))), // B: 아이템 21-40
+        )
+
+        val status200 = AtomicInteger(0)
+        val status400 = AtomicInteger(0)
+        val executor = Executors.newFixedThreadPool(2)
+        val ready = CountDownLatch(2)
+        val start = CountDownLatch(1)
+        val done = CountDownLatch(2)
+
+        for (body in requestBodies) {
+            executor.submit {
+                ready.countDown()
+                start.await()
+                try {
+                    val res = mockMvc.perform(
+                        post("/api/v1/tournaments/$tournamentId/items/wish")
+                            .header(HttpHeaders.AUTHORIZATION, ownerAuth)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(body),
+                    ).andReturn()
+                    when (res.response.status) {
+                        200 -> status200.incrementAndGet()
+                        400 -> status400.incrementAndGet()
+                    }
+                } finally {
+                    done.countDown()
+                }
+            }
+        }
+
+        ready.await()
+        start.countDown()
+        done.await(10, TimeUnit.SECONDS)
+        executor.shutdown()
+
+        assertEquals(1, status200.get(), "정확히 하나만 200 이어야 한다 (20개 담기 성공)")
+        assertEquals(1, status400.get(), "나머지 하나는 락 대기 후 32개 초과로 400 이어야 한다")
+
+        // 정리 — @Transactional 자동 롤백 없으므로 직접 지운다
+        val placeholders = itemIds.joinToString(",") { "?" }
+        jdbcTemplate.update("DELETE FROM tournament_items WHERE tournament_id = ?", tournamentId)
+        jdbcTemplate.update("DELETE FROM tournament_users WHERE tournament_id = ?", tournamentId)
+        jdbcTemplate.update("DELETE FROM tournaments WHERE id = ?", tournamentId)
+        jdbcTemplate.update("DELETE FROM wishes WHERE user_id = ?", uuidToBytes(ownerId))
+        jdbcTemplate.update("DELETE FROM item_snapshots WHERE item_id IN ($placeholders)", *itemIds.toTypedArray())
+        jdbcTemplate.update("DELETE FROM items WHERE id IN ($placeholders)", *itemIds.toTypedArray())
+        jdbcTemplate.update("DELETE FROM users WHERE id = ?", uuidToBytes(ownerId))
+    }
+}


### PR DESCRIPTION
## Situation

- 토너먼트 아이템 담기 경로가 세 가지(링크, 이미지, 위시)인데, 위시 경로에만 행 락이 빠져 있었다.
- 링크·이미지 업로드는 토너먼트를 조회할 때 `findTournamentByIdForUpdate`(비관적 락)를 써서 동시 요청을 직렬화한다.
- 위시 담기는 `findTournamentById`(락 없음)를 쓰고 있어, 두 요청이 동시에 들어오면 둘 다 `existingCount=0`을 읽고 32개 상한 체크를 통과해 합산 40개가 들어가는 race condition이 존재한다.

## Task

- 위시 경로의 토너먼트 조회를 `findTournamentByIdForUpdate`로 교체해 세 경로를 일관되게 직렬화한다.
- 락이 실제로 동작하는지 동시성 통합 테스트로 검증한다.

## Action

- `TournamentService.addItemsFromWish`의 `findTournamentById` 호출을 `findTournamentByIdForUpdate`로 교체
- `TournamentWishAddConcurrencyIntegrationTest` 추가:
  - 사용자가 위시리스트에 40개 아이템을 보유한 상태에서 20개씩 나눠 동시에 두 요청을 발사
  - 두 요청 합산(40개)이 상한(32개)을 초과하므로, 행 락 직렬화 시 먼저 커밋된 쪽(200)은 성공하고 나머지(400)는 상한 초과로 차단되는지 검증
  - 락이 없었다면 둘 다 `existingCount=0`을 보고 통과해 40개가 들어간다. "1개 200, 1개 400"이 직렬화의 시그니처

## Result

- 위시·링크·이미지 세 경로가 모두 `findTournamentByIdForUpdate` 패턴으로 일관화되어 어느 경로로 담아도 32개 상한이 보장된다.
- 동시성 테스트가 positive control 역할을 한다. 락을 제거하면 두 요청 모두 200이 나와 테스트가 실패하므로 회귀를 잡는다.

---
## 연관 이슈

- close #523


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 개선 사항

* **버그 수정**
  * 같은 토너먼트에 여러 사용자가 동시에 위시 아이템을 추가할 때 발생할 수 있는 동시성 문제를 해결했습니다. 이제 아이템 개수 제한이 안정적으로 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->