### PR TITLE
토너먼트 링크 담기 중복 URL 추가 방지

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentItemPersistenceService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentItemPersistenceService.kt
@@ -37,6 +37,11 @@ class TournamentItemPersistenceService(
         link: ProductLink,
     ): PersistedTournamentItem {
         validateAndCheckCapacity(userId, tournamentId, 1)
+        val existingItems = tournamentItemRepository.findAllByTournamentId(tournamentId)
+        if (existingItems.isNotEmpty()) {
+            val existingLinks = itemRepository.findByIds(existingItems.map { it.itemId }).mapNotNull { it.link }
+            if (link in existingLinks) throw TournamentException.duplicateTournamentItem()
+        }
         val item = itemRepository.save(Item(link))
         // 저장한 snapshot 의 id 를 tournament_item 에 고정한다. 출전 시점 버전이 박혀 위시 갱신과 격리된다.
         // URL 경로는 PENDING 으로 적재(outbox)하고 디스패처가 집어 파싱한다 — 워커를 여기서 트리거하지 않는다.


### PR DESCRIPTION
## Situation

- QA 중 토너먼트 후보 담기에서 상품 링크 1개를 담았는데 같은 아이템이 2개 등록되는 버그가 발견됐다.

## Task

- 링크 담기 경로에서 동일 URL이 같은 토너먼트에 중복으로 추가되지 않도록 막는다.

## Action

- `persistLinkItem`은 호출마다 새 `Item` 행을 생성하므로 `item_id`가 매번 달라진다. `tournament_items`의 unique key가 `(tournament_id, item_id)` 기준이라, 같은 URL을 두 번 담아도 key가 달라 constraint가 동작하지 않았다.
- `addItemsFromWish`는 이미 `item_id` 기준 중복 체크가 있었지만, 링크 담기 경로에는 없었다.
- `validateAndCheckCapacity`가 tournament 행에 `FOR UPDATE` 락을 잡은 직후, 기존 tournament_item들의 URL을 조회해 동일 URL이면 `TournamentException.duplicateTournamentItem()` (409)을 던지도록 추가했다. 락으로 동시 요청이 직렬화되므로 race condition도 없다.

## Result

- 같은 URL을 두 번 제출하면 두 번째 요청에서 409가 반환된다.

---
## 연관 이슈

- close #529


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 토너먼트에 동일한 링크를 가진 아이템이 중복으로 등록되는 것을 방지하는 검증 기능을 추가했습니다. 이제 이미 등록된 아이템과 동일한 링크를 가진 새로운 아이템을 추가하려 하면 오류 메시지가 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->