### PR TITLE
dev 단건 푸시(/dev/fcm/push) 미영속 알림 500 회귀 수정

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/notification/fcm/service/FirebaseMessageSender.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/fcm/service/FirebaseMessageSender.kt
@@ -70,8 +70,10 @@ class FirebaseMessageSender(
         // 어떤 페이로드(type·refId)를 몇 토큰에 보내 몇 건 성공/실패했고, 실패 사유(FCM code)별 분포 + 죽은 토큰 정리 수.
         // 렌더된 title/body 는 닉네임 등 PII 를 담을 수 있어 싣지 않는다 — 라우팅 식별자(type·refId·category)만.
         log.info(
+            // getIdOrNull — DevFcmController(/dev/fcm/push)는 영속화 안 한 throwaway Notification 을 넘긴다.
+            // getId() 면 "id 없음" 예외로 발송 자체가 500 으로 깨진다. 로그용 식별자라 미영속이면 null 로 둔다.
             "FCM 발송 결과 notificationId={} type={} category={} refId={} 토큰={} 성공={} 실패={} 실패사유={} 죽은토큰정리={}",
-            notification.getId(),
+            notification.getIdOrNull(),
             notification.type,
             NotificationCategory.of(notification.type),
             notification.refId,


### PR DESCRIPTION
## Situation
- 운영 백오피스(#528)가 dev 에 머지된 뒤, dev 단일 기기 푸시 확인용 `POST /api/v1/dev/fcm/push` 가 500 으로 깨졌다.
- 실기기 푸시 테스트 중 응답이 "일시적인 오류"로만 떠서, dev 앱 로그의 스택트레이스로 원인을 특정했다.

## Task
- 발송 자체를 막는 회귀를 제거한다. 공지 fan-out(영속 알림)과 dev 단건 발송(미영속 알림)이 같은 FCM 발송 경로를 쓰므로, 그 경로가 알림의 영속 여부에 따라 깨지면 안 된다.

## Action
- #528 에서 추가한 FCM 발송결과 로그가 `notification.getId()` 를 호출한다. 공지 브로드캐스트는 알림을 저장한 뒤 보내 id 가 있지만, `/dev/fcm/push` 는 저장하지 않는 throwaway 알림을 넘겨 "영속화 전엔 id 없다" IllegalStateException 으로 발송이 통째로 500 이 됐다.
- 로그용 식별자라 `getIdOrNull()` 로 바꿔, 미영속이면 notificationId 를 null 로 두고 발송은 정상 진행하게 했다.

## Result
- dev 단건 푸시 경로가 복구된다. 영속/미영속 알림 모두 같은 발송 경로를 안전하게 탄다.
- 한계: 실제 FirebaseMessageSender.send 는 외부 경계(Firebase 키 필요)라 통합 테스트에선 stub 으로 격리돼 있어, 이 경로의 자동 회귀 테스트가 없다. dev 실측(스택트레이스 확인 후 수정)으로 검증한다. 외부 경계라 자동화가 어렵다는 한계가 이번에 드러난 셈이다.

---
## 연관 이슈

- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **Bug Fixes**
  * 알림 발송 결과 로그 기록 시 null 값으로 인한 예외 발생을 방지하여 발송 흐름 안정성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->