### PR TITLE
FCM 토큰 동시 등록 UNIQUE 충돌 500 을 retry-upsert 로 제거

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/notification/fcm/service/UserDeviceService.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/fcm/service/UserDeviceService.kt
@@ -1,9 +1,9 @@
 package com.depromeet.piki.notification.fcm.service
 
-import com.depromeet.piki.common.logging.SensitiveData
 import com.depromeet.piki.notification.fcm.domain.UserDevice
 import com.depromeet.piki.notification.fcm.repository.UserDeviceRepository
 import org.slf4j.LoggerFactory
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
@@ -14,33 +14,34 @@ import java.util.UUID
 @Service
 class UserDeviceService(
     private val userDeviceRepository: UserDeviceRepository,
+    private val userDeviceWriter: UserDeviceWriter,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
-    // 토큰 등록/갱신(POST). upsert 다 — 앱 진입·토큰 회전 어느 경로로 와도 기기당 1 row 로 수렴한다.
-    // 배달 정확성을 위해 같은 토큰을 들고 있던 다른 사용자 row 는 먼저 해제하고, 내 (user,device) row 가
-    // 있으면 토큰만 교체, 없으면 신규 생성한다.
-    @Transactional
+    // 토큰 등록/갱신(POST). 실제 upsert 는 UserDeviceWriter 의 짧은 트랜잭션에 위임하고, 여기선 동시 등록
+    // 충돌만 흡수한다(#396) — 같은 fcmToken 으로 동시 등록이 들어오면 둘 다 "없음"을 보고 INSERT 해 한쪽이
+    // UNIQUE 충돌(DataIntegrityViolationException)로 깨진다. 충돌을 일으킨 row 는 이미 다른 트랜잭션이
+    // 커밋했으므로, 새 트랜잭션으로 1회 재시도하면 upsert 가 그 row 를 찾아 갱신(또는 토큰 재배정)으로 수렴한다.
+    //
+    // register 에 @Transactional 을 두지 않는 게 핵심이다 — 두면 writer.upsert 가 같은 트랜잭션에 합류(REQUIRED)해,
+    // 첫 시도의 충돌이 트랜잭션을 rollback-only 로 오염시켜 재시도가 같은 트랜잭션 안에서 또 깨진다. writer 를
+    // 별도 빈으로 두고 proxy 를 거쳐 호출해야 매 시도가 독립 트랜잭션이 된다(self-invocation 회피).
     fun register(
         userId: UUID,
         deviceId: String,
         fcmToken: String,
-    ): UserDevice {
-        // deviceId·fcmToken 은 유니크 키다. 앞뒤 공백을 입력 경계에서 정규화해야 "x"/"x " 가 다른 키로
-        // 갈려 upsert 가 쪼개지거나 죽은 토큰 정리가 빗나가는 일을 막는다. (@NotBlank 는 공백-only 만 거른다)
-        val device = deviceId.trim()
-        val token = fcmToken.trim()
-        val mine = userDeviceRepository.findByUserIdAndDeviceId(userId, device)
-        releaseStaleTokenHolder(token, keep = mine)
-        // 토큰 원문은 크리덴셜이라 지문으로만. deviceId 는 기기 식별자라 그대로(같은 기기의 등록/해제 상관추적 키).
-        mine ?: run {
-            log.info("FCM 토큰 등록(신규) userId={} deviceId={} token={}", userId, device, SensitiveData.maskToken(token))
-            return userDeviceRepository.save(UserDevice(userId = userId, deviceId = device, fcmToken = token))
+    ): UserDevice =
+        try {
+            userDeviceWriter.upsert(userId, deviceId, fcmToken)
+        } catch (e: DataIntegrityViolationException) {
+            log.warn(
+                "FCM 토큰 등록 동시 충돌 — 새 트랜잭션으로 1회 재시도 userId={} deviceId={} reason={}",
+                userId,
+                deviceId.trim(),
+                e.javaClass.simpleName,
+            )
+            userDeviceWriter.upsert(userId, deviceId, fcmToken)
         }
-        log.info("FCM 토큰 등록(갱신) userId={} deviceId={} token={}", userId, device, SensitiveData.maskToken(token))
-        mine.refreshToken(token)
-        return userDeviceRepository.save(mine)
-    }
 
     // 기기 해제(DELETE, 로그아웃). 멱등 — 이미 없는 기기를 지워도 무해하다.
     @Transactional
@@ -72,17 +73,5 @@ class UserDeviceService(
     fun removeStaleTokens(fcmTokens: List<String>) {
         if (fcmTokens.isEmpty()) return
         userDeviceRepository.deleteAllByFcmTokenIn(fcmTokens)
-    }
-
-    // 같은 토큰을 들고 있던 다른 row 를 해제한다 — 토큰당 1 row(배달 정확성)를 유지하기 위함.
-    // keep(내 기기 row)과 동일 row 면 두고, 다르면 지운 뒤 flush 해 UNIQUE(fcm_token) 충돌을 막는다.
-    private fun releaseStaleTokenHolder(
-        fcmToken: String,
-        keep: UserDevice?,
-    ) {
-        val holder = userDeviceRepository.findByFcmToken(fcmToken) ?: return
-        keep?.let { if (holder.getId() == it.getId()) return }
-        userDeviceRepository.delete(holder)
-        userDeviceRepository.flush()
     }
 }

--- a/src/main/kotlin/com/depromeet/piki/notification/fcm/service/UserDeviceWriter.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/fcm/service/UserDeviceWriter.kt
@@ -1,0 +1,58 @@
+package com.depromeet.piki.notification.fcm.service
+
+import com.depromeet.piki.common.logging.SensitiveData
+import com.depromeet.piki.notification.fcm.domain.UserDevice
+import com.depromeet.piki.notification.fcm.repository.UserDeviceRepository
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+// FCM 토큰 등록 upsert 의 "한 번의 트랜잭션 시도"(#244 upsert + #396 동시성). 실제 영속화를 UserDeviceService 에서
+// 떼어내 별도 빈으로 둔다 — 같은 빈 안에서 @Transactional 메서드를 호출하면 self-invocation 으로 proxy 를 못 거쳐
+// 매 시도가 독립 트랜잭션이 되지 못하기 때문이다. UserDeviceService.register 가 이 빈을 proxy 경유로 호출해,
+// 동시 UNIQUE 충돌 시 실패한 트랜잭션을 버리고 새 트랜잭션으로 재시도할 수 있게 한다.
+@Component
+class UserDeviceWriter(
+    private val userDeviceRepository: UserDeviceRepository,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    // 토큰 등록/갱신 upsert 한 번 — 앱 진입·토큰 회전 어느 경로로 와도 기기당 1 row 로 수렴한다.
+    // 배달 정확성을 위해 같은 토큰을 들고 있던 다른 사용자 row 는 먼저 해제하고, 내 (user,device) row 가
+    // 있으면 토큰만 교체, 없으면 신규 생성한다. 동시 등록으로 INSERT 가 UNIQUE 충돌나면
+    // DataIntegrityViolationException 이 나며, 호출자(UserDeviceService.register)가 재시도로 흡수한다.
+    @Transactional
+    fun upsert(
+        userId: UUID,
+        deviceId: String,
+        fcmToken: String,
+    ): UserDevice {
+        // deviceId·fcmToken 은 유니크 키다. 앞뒤 공백을 입력 경계에서 정규화해야 "x"/"x " 가 다른 키로
+        // 갈려 upsert 가 쪼개지거나 죽은 토큰 정리가 빗나가는 일을 막는다. (@NotBlank 는 공백-only 만 거른다)
+        val device = deviceId.trim()
+        val token = fcmToken.trim()
+        val mine = userDeviceRepository.findByUserIdAndDeviceId(userId, device)
+        releaseStaleTokenHolder(token, keep = mine)
+        // 토큰 원문은 크리덴셜이라 지문으로만. deviceId 는 기기 식별자라 그대로(같은 기기의 등록/해제 상관추적 키).
+        mine ?: run {
+            log.info("FCM 토큰 등록(신규) userId={} deviceId={} token={}", userId, device, SensitiveData.maskToken(token))
+            return userDeviceRepository.save(UserDevice(userId = userId, deviceId = device, fcmToken = token))
+        }
+        log.info("FCM 토큰 등록(갱신) userId={} deviceId={} token={}", userId, device, SensitiveData.maskToken(token))
+        mine.refreshToken(token)
+        return userDeviceRepository.save(mine)
+    }
+
+    // 같은 토큰을 들고 있던 다른 row 를 해제한다 — 토큰당 1 row(배달 정확성)를 유지하기 위함.
+    // keep(내 기기 row)과 동일 row 면 두고, 다르면 지운 뒤 flush 해 UNIQUE(fcm_token) 충돌을 막는다.
+    private fun releaseStaleTokenHolder(
+        fcmToken: String,
+        keep: UserDevice?,
+    ) {
+        val holder = userDeviceRepository.findByFcmToken(fcmToken) ?: return
+        keep?.let { if (holder.getId() == it.getId()) return }
+        userDeviceRepository.delete(holder)
+        userDeviceRepository.flush()
+    }
+}

--- a/src/test/kotlin/com/depromeet/piki/notification/fcm/service/UserDeviceRegisterConcurrencyIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/notification/fcm/service/UserDeviceRegisterConcurrencyIntegrationTest.kt
@@ -1,0 +1,67 @@
+package com.depromeet.piki.notification.fcm.service
+
+import com.depromeet.piki.support.IntegrationTestSupport
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.jdbc.core.JdbcTemplate
+import java.util.Collections
+import java.util.UUID
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+// FCM 토큰 등록 동시성 검증(#396) — 같은 토큰으로 동시 등록 시 check-then-act 가 UNIQUE 충돌(500)을 내던 것을
+// retry-upsert 로 흡수하는지 본다. @Transactional 자동 롤백을 쓰지 않는다 — 별도 트랜잭션 동시 진행(각 register
+// 시도가 독립 커밋돼야 충돌이 재현)이 시뮬레이션의 본질이라, 격리된 token/deviceId 를 쓰고 끝에서 만든 행을
+// 직접 정리한다. (CLAUDE.md "동시성·시간 의존 통합 테스트" 분류)
+class UserDeviceRegisterConcurrencyIntegrationTest : IntegrationTestSupport() {
+    @Autowired
+    private lateinit var userDeviceService: UserDeviceService
+
+    @Autowired
+    private lateinit var jdbcTemplate: JdbcTemplate
+
+    private fun countByToken(token: String): Int =
+        jdbcTemplate.queryForObject("SELECT COUNT(*) FROM user_devices WHERE fcm_token = ?", Int::class.java, token) ?: 0
+
+    @Test
+    fun `같은 유저 기기 토큰으로 동시 등록해도 500 없이 기기 1개로 수렴한다`() {
+        val token = "concurrent-${UUID.randomUUID()}"
+        val userId = UUID.randomUUID()
+        val deviceId = "device-${UUID.randomUUID()}"
+        val threadCount = 4
+        val pool = Executors.newFixedThreadPool(threadCount)
+        val ready = CountDownLatch(threadCount)
+        val start = CountDownLatch(1)
+        val errors = Collections.synchronizedList(mutableListOf<Throwable>())
+
+        try {
+            repeat(threadCount) {
+                pool.submit {
+                    ready.countDown()
+                    start.await()
+                    runCatching { userDeviceService.register(userId, deviceId, token) }
+                        .onFailure { errors.add(it) }
+                }
+            }
+            // 모든 스레드가 시작 게이트에 도달했는지 강제 검증 — 안 하면 느린 CI 에서 일부가 준비 전에 start 가
+            // 풀려 동시성이 약해지고 race 가 거짓양성으로 통과할 수 있다.
+            assertTrue(ready.await(5, TimeUnit.SECONDS), "모든 스레드가 시작 게이트에 준비돼야 한다")
+            start.countDown() // 동시 출발
+            pool.shutdown()
+            assertTrue(pool.awaitTermination(15, TimeUnit.SECONDS), "동시 작업이 시간 내 끝나야 한다")
+
+            assertEquals(emptyList(), errors.map { it.message }, "동시 등록에서 예외(500)가 나면 안 된다")
+            assertEquals(1, countByToken(token), "동시 등록이 기기 1 row 로 수렴해야 한다")
+        } finally {
+            jdbcTemplate.update("DELETE FROM user_devices WHERE fcm_token = ?", token)
+        }
+    }
+}
+
+// 참고 — "서로 다른 유저가 같은 토큰을 동시 등록"하는 race 는 일부러 검증하지 않는다. FCM 토큰은 앱 설치(기기)
+// 하나당 전역 유일이라, 서로 다른 유저가 동일 토큰을 같은 순간에 등록하는 상황 자체가 현실에 없다(#396 이 노리는
+// race 는 같은 클라이언트의 중복 등록 = 위 테스트). 그 인위적 시나리오는 토큰 보유자 재배정(delete+insert)이
+// N-way 로 경합해 1회 재시도로는 못 푸는 별개의 어려운 문제라, 이슈 범위 밖으로 둔다.

--- a/src/test/kotlin/com/depromeet/piki/notification/fcm/service/UserDeviceRegisterConcurrencyIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/notification/fcm/service/UserDeviceRegisterConcurrencyIntegrationTest.kt
@@ -56,6 +56,12 @@ class UserDeviceRegisterConcurrencyIntegrationTest : IntegrationTestSupport() {
             assertEquals(emptyList(), errors.map { it.message }, "동시 등록에서 예외(500)가 나면 안 된다")
             assertEquals(1, countByToken(token), "동시 등록이 기기 1 row 로 수렴해야 한다")
         } finally {
+            // 실패 경로 정리 — ready.await 단언이 실패하면 start.countDown()/shutdown() 에 못 닿아 작업 스레드가
+            // start.await() 에서 영구 대기하고, non-daemon 풀이라 테스트 프로세스가 hang 된다. finally 에서 게이트
+            // 해제 + 풀 강제 종료를 보장한다 (정상 경로에선 이미 0/shutdown 이라 멱등하게 no-op).
+            start.countDown()
+            pool.shutdownNow()
+            pool.awaitTermination(5, TimeUnit.SECONDS)
             jdbcTemplate.update("DELETE FROM user_devices WHERE fcm_token = ?", token)
         }
     }


### PR DESCRIPTION
## Situation

- FCM 토큰 등록(`POST /api/v1/fcm/tokens`)은 "찾아보고(find) 없으면 새로 넣는다(insert)"는 check-then-act 구조다. 같은 토큰으로 동시에 두 요청이 들어오면 둘 다 "없음"을 보고 동시에 insert 를 시도한다.
- 그 결과 한쪽이 토큰 유니크 제약(UNIQUE fcm_token) 충돌로 500 을 받는다. DB 제약 덕에 데이터가 깨지진 않지만, API 가 비결정적으로 500 을 내는 게 문제다. (PR #395 의 CodeRabbit 동시성 리뷰에서 지적된 건)

## Task

- 멱등 엔드포인트라 클라이언트가 재호출(`onTokenRefresh`, 앱 재진입)로 자가복구하긴 한다. 그래도 비결정적 500 자체를 없앤다.
- 동시 충돌을 서버가 흡수해 정상 응답으로 수렴시킨다. 단, API 계약(요청 DTO, 응답, 스키마)은 건드리지 않아 프론트 작업이 들어가지 않게 한다.

## Action

- 실제 등록 로직(토큰 보유자 재배정 + 신규 생성 또는 갱신)을 별도 빈으로 떼어내 짧은 트랜잭션으로 묶었다.
- 등록 진입점은 트랜잭션 없는 "오케스트레이터"로 바꿨다. 등록 시도가 유니크 충돌(`DataIntegrityViolationException`)을 내면 새 트랜잭션으로 한 번 재시도한다. 충돌을 일으킨 그 row 는 이미 다른 트랜잭션이 커밋해 둔 상태라, 재시도가 그 row 를 찾아 갱신으로 수렴한다.
- 진입점에 `@Transactional` 을 두지 않은 게 핵심이다. 두면 위임받은 빈이 같은 트랜잭션에 합류해, 첫 시도의 충돌이 트랜잭션을 rollback-only 로 오염시켜 재시도가 같은 트랜잭션 안에서 또 깨진다. 별도 빈을 proxy 경유로 호출해야 매 시도가 독립 트랜잭션이 된다(self-invocation 회피).
- 재시도 도구로 `@Retryable`(spring-retry) 대신 "트랜잭션 위임 별도 빈" 패턴을 골랐다. 새 의존성 추가 없이, 외부 호출을 별도 빈으로 떼던 기존 코드 컨벤션과 결이 맞는다.

## Result

- 동시성 통합 테스트로 확인: 같은 유저, 같은 기기, 같은 토큰을 4스레드가 동시에 등록해도 500 없이 기기 1개로 수렴한다.
- negative control: 재시도를 임시로 떼면 이 테스트가 500 으로 FAIL 하는 걸 확인했다. 테스트가 race 를 실제로 잡아내는 가드이지 거짓 통과가 아님을 보장한다.
- 의도적으로 다루지 않은 범위: "서로 다른 유저가 동일 토큰을 같은 순간 등록"하는 race 는 검증하지 않는다. FCM 토큰은 앱 설치(기기) 하나당 전역 유일이라 현실에 없는 상황이고, 토큰 재배정이 여러 요청 사이에서 경합해 1회 재시도로는 못 푸는 별개의 어려운 문제라 이슈 범위 밖으로 둔다.
- API 계약(엔드포인트, 요청/응답 DTO, 스키마) 변경 없음. 순수 서버 내부 변경이라 프론트 영향 없다.

---
## 연관 이슈

- close #396


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * 기기 토큰 동시 등록 시 중복 오류 처리 개선 및 자동 재시도 기능 추가

* **Tests**
  * FCM 토큰 동시 등록 시나리오에서 데이터 일관성을 검증하는 통합 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->