### PR TITLE
초대 마감 시각 수정 API를 절대 시각으로 변경

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
@@ -687,7 +687,7 @@ interface TournamentApi {
 
     @Operation(
         summary = "친구 초대 마감 시각 수정",
-        description = "PENDING 상태 토너먼트의 초대 마감 시각을 지금으로부터 N분 후로 재설정한다. 주최자만 가능. 최소 1분, 최대 1440분(24시간).",
+        description = "PENDING 상태 토너먼트의 초대 마감 시각을 재설정한다. 주최자만 가능. 현재 시각 이후, 최대 24시간 이내의 절대 시각을 입력한다.",
     )
     @ApiResponses(
         value = [
@@ -698,7 +698,7 @@ interface TournamentApi {
             ),
             ApiResponse(
                 responseCode = "400",
-                description = "잘못된 요청 (inviteDurationMinutes 1 미만 또는 1440 초과)",
+                description = "잘못된 요청 (newExpiresAt 가 현재 시각 이전 · 24시간 초과)",
                 content = [Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = Schema(implementation = ApiResponseBody::class))],
             ),
             ApiResponse(

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApiExamples.kt
@@ -488,11 +488,11 @@ class TournamentApiExamples(
                         )
                         add(
                             status = HttpStatus.BAD_REQUEST,
-                            name = "유효 시간 범위 초과",
+                            name = "과거 시각 입력",
                             payload =
                                 ApiResponseBody.fail<Unit>(
                                     category = ErrorCategory.INVALID_INPUT,
-                                    detail = UpdateInviteDurationRequest.INVITE_DURATION_MAX_MESSAGE,
+                                    detail = UpdateInviteDurationRequest.INVITE_EXPIRY_PAST_MESSAGE,
                                 ),
                         )
                         unauthorized()

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentController.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentController.kt
@@ -165,7 +165,7 @@ class TournamentController(
         @PathVariable tournamentId: Long,
         @Valid @RequestBody request: UpdateInviteDurationRequest,
     ): ApiResponseBody<LocalDateTime> {
-        val newExpiresAt = tournamentService.updateInviteExpiry(userId, tournamentId, request.inviteDurationMinutes)
+        val newExpiresAt = tournamentService.updateInviteExpiry(userId, tournamentId, request.newExpiresAt)
         return ApiResponseBody.ok(newExpiresAt)
     }
 

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/dto/CreateTournamentRequest.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/dto/CreateTournamentRequest.kt
@@ -10,8 +10,8 @@ import jakarta.validation.constraints.NotBlank
 data class CreateTournamentRequest(
     @field:NotBlank(message = "토너먼트 이름을 입력해 주세요.")
     val name: String,
-    @field:Min(value = 1, message = UpdateInviteDurationRequest.INVITE_DURATION_MIN_MESSAGE)
-    @field:Max(value = TOURNAMENT_INVITE_MAX_DURATION_MINUTES, message = UpdateInviteDurationRequest.INVITE_DURATION_MAX_MESSAGE)
+    @field:Min(value = 1, message = INVITE_DURATION_MIN_MESSAGE)
+    @field:Max(value = TOURNAMENT_INVITE_MAX_DURATION_MINUTES, message = INVITE_DURATION_MAX_MESSAGE)
     val inviteDurationMinutes: Long? = null,
 ) {
     fun toCreateTournament(): CreateTournament =
@@ -19,4 +19,9 @@ data class CreateTournamentRequest(
             name = name,
             inviteDurationMinutes = inviteDurationMinutes ?: TOURNAMENT_INVITE_DEFAULT_DURATION_MINUTES,
         )
+
+    companion object {
+        const val INVITE_DURATION_MIN_MESSAGE = "초대 유효 시간은 1분 이상으로 입력해 주세요."
+        const val INVITE_DURATION_MAX_MESSAGE = "초대 유효 시간은 24시간 이내로 입력해 주세요."
+    }
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/dto/UpdateInviteDurationRequest.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/dto/UpdateInviteDurationRequest.kt
@@ -1,17 +1,15 @@
 package com.depromeet.piki.tournament.controller.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
-import jakarta.validation.constraints.Max
-import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.Future
+import java.time.LocalDateTime
 
 data class UpdateInviteDurationRequest(
-    @field:Schema(description = "새 초대 마감까지 남은 시간 (분 단위, 1-1440)", example = "60")
-    @field:Min(value = 1, message = INVITE_DURATION_MIN_MESSAGE)
-    @field:Max(value = 1440, message = INVITE_DURATION_MAX_MESSAGE)
-    val inviteDurationMinutes: Long,
+    @field:Schema(description = "새 초대 마감 시각 (현재 시각 이후, 최대 24시간 이내)", example = "2026-06-18T15:30:00")
+    @field:Future(message = INVITE_EXPIRY_PAST_MESSAGE)
+    val newExpiresAt: LocalDateTime,
 ) {
     companion object {
-        const val INVITE_DURATION_MIN_MESSAGE = "초대 유효 시간은 1분 이상으로 입력해 주세요."
-        const val INVITE_DURATION_MAX_MESSAGE = "초대 유효 시간은 24시간 이내로 입력해 주세요."
+        const val INVITE_EXPIRY_PAST_MESSAGE = "초대 마감 시각은 현재 시각 이후로 입력해 주세요."
     }
 }

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
@@ -664,8 +664,9 @@ class TournamentService(
     fun updateInviteExpiry(
         userId: UUID,
         tournamentId: Long,
-        inviteDurationMinutes: Long,
+        newExpiresAt: LocalDateTime,
     ): LocalDateTime {
+        require(newExpiresAt.isBefore(LocalDateTime.now().plusHours(24))) { "초대 마감 시각은 24시간 이내여야 합니다" }
         val tournament =
             tournamentRepository.findTournamentByIdForUpdate(tournamentId)
                 ?: throw TournamentException.notFoundTournament()
@@ -674,9 +675,6 @@ class TournamentService(
                 ?: throw TournamentException.forbiddenTournament()
         if (tournamentUser.getId() != tournament.ownerTournamentUserId) throw TournamentException.forbiddenTournament()
         if (!tournament.isPending()) throw TournamentException.notPendingTournament()
-        val newExpiresAt = LocalDateTime
-            .now()
-            .plusMinutes(inviteDurationMinutes)
         tournament.updateInviteExpiry(newExpiresAt)
         return newExpiresAt
     }

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
@@ -666,7 +666,8 @@ class TournamentService(
         tournamentId: Long,
         newExpiresAt: LocalDateTime,
     ): LocalDateTime {
-        require(newExpiresAt.isBefore(LocalDateTime.now().plusHours(24))) { "초대 마감 시각은 24시간 이내여야 합니다" }
+        val now = LocalDateTime.now()
+        require(!newExpiresAt.isAfter(now.plusHours(24))) { "초대 마감 시각은 24시간 이내여야 합니다" }
         val tournament =
             tournamentRepository.findTournamentByIdForUpdate(tournamentId)
                 ?: throw TournamentException.notFoundTournament()

--- a/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
@@ -2008,40 +2008,32 @@ class TournamentControllerTest : IntegrationTestSupport() {
     fun `PATCH tournaments-id-invite 는 주최자가 200 과 함께 새 inviteExpiresAt 을 반환하고 DB 에도 반영된다`() {
         val mockMvc = buildMockMvc()
         val tournamentId = createTournament(mockMvc)
-        val before = LocalDateTime.now()
-
-        val result = mockMvc
-            .perform(
-                patch("/api/v1/tournaments/$tournamentId/invite")
-                    .header(HttpHeaders.AUTHORIZATION, authHeader(userId))
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content("""{"inviteDurationMinutes":60}"""),
-            ).andExpect(status().isOk)
-            .andExpect(jsonPath("$.data").isString)
-            .andReturn()
-
-        val expiresAtStr = objectMapper.readTree(result.response.contentAsString)["data"].asText()
-        val expiresAt = java.time.OffsetDateTime.parse(expiresAtStr, DateTimeFormatter.ISO_OFFSET_DATE_TIME).toLocalDateTime()
-        val expectedMin = before.plusMinutes(60)
-        val expectedMax = LocalDateTime.now().plusMinutes(60)
-        assertTrue(expiresAt >= expectedMin && expiresAt <= expectedMax)
-
-        // 응답뿐 아니라 엔티티에 실제로 반영됐는지 확인 — backing field dirty-check가 깨져도 응답은 통과하므로
-        val saved = tournamentJpaRepository.findByIdAndDeletedAtIsNull(tournamentId)!!
-        assertTrue(saved.inviteExpiresAt >= expectedMin && saved.inviteExpiresAt <= expectedMax)
-    }
-
-    @Test
-    fun `PATCH tournaments-id-invite 에서 inviteDurationMinutes 가 0 이면 400 을 반환한다`() {
-        val mockMvc = buildMockMvc()
-        val tournamentId = createTournament(mockMvc)
+        val newExpiresAt = LocalDateTime.now().plusMinutes(60).withNano(0)
 
         mockMvc
             .perform(
                 patch("/api/v1/tournaments/$tournamentId/invite")
                     .header(HttpHeaders.AUTHORIZATION, authHeader(userId))
                     .contentType(MediaType.APPLICATION_JSON)
-                    .content("""{"inviteDurationMinutes":0}"""),
+                    .content("""{"newExpiresAt":"$newExpiresAt"}"""),
+            ).andExpect(status().isOk)
+
+        val saved = tournamentJpaRepository.findByIdAndDeletedAtIsNull(tournamentId)!!
+        assertEquals(newExpiresAt, saved.inviteExpiresAt)
+    }
+
+    @Test
+    fun `PATCH tournaments-id-invite 에서 newExpiresAt 이 과거 시각이면 400 을 반환한다`() {
+        val mockMvc = buildMockMvc()
+        val tournamentId = createTournament(mockMvc)
+        val pastTime = LocalDateTime.now().minusMinutes(1).withNano(0)
+
+        mockMvc
+            .perform(
+                patch("/api/v1/tournaments/$tournamentId/invite")
+                    .header(HttpHeaders.AUTHORIZATION, authHeader(userId))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"newExpiresAt":"$pastTime"}"""),
             ).andExpect(status().isBadRequest)
     }
 
@@ -2056,7 +2048,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
                 patch("/api/v1/tournaments/$tournamentId/invite")
                     .header(HttpHeaders.AUTHORIZATION, authHeader(otherUserId))
                     .contentType(MediaType.APPLICATION_JSON)
-                    .content("""{"inviteDurationMinutes":60}"""),
+                    .content("""{"newExpiresAt":"${LocalDateTime.now().plusMinutes(60).withNano(0)}"}"""),
             ).andExpect(status().isForbidden)
     }
 
@@ -2069,7 +2061,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
                 patch("/api/v1/tournaments/999999/invite")
                     .header(HttpHeaders.AUTHORIZATION, authHeader(userId))
                     .contentType(MediaType.APPLICATION_JSON)
-                    .content("""{"inviteDurationMinutes":60}"""),
+                    .content("""{"newExpiresAt":"${LocalDateTime.now().plusMinutes(60).withNano(0)}"}"""),
             ).andExpect(status().isNotFound)
     }
 
@@ -2083,7 +2075,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
                 patch("/api/v1/tournaments/$tournamentId/invite")
                     .header(HttpHeaders.AUTHORIZATION, authHeader(userId))
                     .contentType(MediaType.APPLICATION_JSON)
-                    .content("""{"inviteDurationMinutes":60}"""),
+                    .content("""{"newExpiresAt":"${LocalDateTime.now().plusMinutes(60).withNano(0)}"}"""),
             ).andExpect(status().isConflict)
     }
 


### PR DESCRIPTION
## Situation

- 초대 마감 시각 수정 API(`PATCH /tournaments/{id}/invite`)는 "지금으로부터 N분 후"라는 상대 시간(분)을 입력받았다.
- 프론트엔드 UI는 절대 시각 기반 시간 선택기를 사용하는데, API가 상대 시간을 요구해 UI에서 "절대 시각 → 분 수"로 변환하는 부담이 생겼다.
- 토너먼트 생성 API는 처음부터 상대 시간을 받는 게 자연스러웠지만(생성 시점 기준 N분 후), 수정 API는 이미 기준 시각 없이 값을 직접 고르는 UI라 불일치가 있었다.

## Task

- 초대 마감 시각 수정 API가 절대 시각(`LocalDateTime`)을 직접 받도록 요청 형식을 변경한다.
- 24시간 상한 제약과 과거 시각 차단은 그대로 유지하면서, 입력 형식만 바꾼다.
- 생성 API(`POST /tournaments`)는 여전히 상대 시간(분)을 쓰므로 영향 없어야 한다.

## Action

- `UpdateInviteDurationRequest` 필드 교체: `inviteDurationMinutes: Long` → `newExpiresAt: LocalDateTime`
- 과거 시각 차단은 `@Future(message = ...)` Bean Validation으로 처리
- 24시간 상한은 `@Future`로 표현 불가능("지금으로부터 24시간 이내"는 표준 어노테이션이 없다)하여, 서비스 레이어 `require`로 검증
- 기존 `INVITE_DURATION_MIN/MAX_MESSAGE` 상수는 `UpdateInviteDurationRequest`에서 제거하고 `CreateTournamentRequest.companion object`로 이동 (생성 API가 참조)
- 서비스의 `updateInviteExpiry` 시그니처: `inviteDurationMinutes: Long` → `newExpiresAt: LocalDateTime`. 내부에서 하던 `LocalDateTime.now().plusMinutes(...)` 계산 제거
- OpenAPI 문서(`TournamentApi.kt`) description·400 설명, example(`TournamentApiExamples.kt`) 실패 케이스 detail 갱신
- 테스트 요청 payload `{"inviteDurationMinutes":60}` → `{"newExpiresAt":"2026-06-18T..."}` 전환. 성공 케이스는 절대 시각을 미리 박아 DB 저장값과 `assertEquals`로 비교 (기존 범위 비교보다 단언이 명확)

## Result

- 프론트엔드가 시간 선택기 값을 변환 없이 그대로 API에 전달할 수 있다.
- 생성 API는 필드명·형식 모두 기존대로, 수정 API만 절대 시각으로 바뀌어 두 API의 의미가 각 UI에 맞게 정렬된다.

---
## 연관 이슈

- close #540


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 초대 만료 시각 설정 방식 개선 - 상대 시간(N분 후) 기반에서 절대 시각 입력(현재 이후 최대 24시간 이내)으로 변경하여 더 정확한 시간 지정 가능

* **문서**
  * API 문서 및 예시 업데이트 - 초대 만료 시각 설정 방식과 검증 규칙 명확화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->