### PR TITLE
토너먼트 단건 조회 items[]에 userId 추가

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApi.kt
@@ -78,6 +78,7 @@ interface TournamentApi {
             응답의 status 필드에 따라 포함되는 데이터가 달라진다.
             - PENDING: pending 필드 (아이템 목록, 참여자 목록)
               - 각 아이템에 status 포함 (READY / PENDING / PROCESSING / FAILED). PENDING·PROCESSING 이면 name·price·imageUrl 은 null 이라 응답에서 제외됨
+              - 각 아이템에 userId 포함 (해당 아이템을 담은 참여자의 userId)
               - 각 참여자에 itemCount 포함 (해당 참여자가 이 토너먼트에 담은 아이템 수)
               - pending.ownerStarted = false
             - IN_PROGRESS: 요청자 역할에 따라 두 가지 응답이 있다.

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/TournamentApiExamples.kt
@@ -255,6 +255,7 @@ class TournamentApiExamples(
                                                         TournamentDetailResponse.ItemDetailResponse(
                                                             tournamentItemId = 1,
                                                             itemId = 10,
+                                                            userId = UUID.fromString("11111111-2222-3333-4444-555555555555"),
                                                             name = "나이키 에어맥스",
                                                             price = 129_000,
                                                             currency = "KRW",
@@ -264,6 +265,7 @@ class TournamentApiExamples(
                                                         TournamentDetailResponse.ItemDetailResponse(
                                                             tournamentItemId = 2,
                                                             itemId = 20,
+                                                            userId = UUID.fromString("11111111-2222-3333-4444-555555555555"),
                                                             name = "아디다스 울트라부스트",
                                                             price = 189_000,
                                                             currency = "KRW",
@@ -311,6 +313,7 @@ class TournamentApiExamples(
                                                         TournamentDetailResponse.ItemDetailResponse(
                                                             tournamentItemId = 1,
                                                             itemId = 10,
+                                                            userId = UUID.fromString("11111111-2222-3333-4444-555555555555"),
                                                             name = "나이키 에어맥스",
                                                             price = 129_000,
                                                             currency = "KRW",
@@ -320,6 +323,7 @@ class TournamentApiExamples(
                                                         TournamentDetailResponse.ItemDetailResponse(
                                                             tournamentItemId = 2,
                                                             itemId = 20,
+                                                            userId = UUID.fromString("22222222-3333-4444-5555-666666666666"),
                                                             name = "아디다스 울트라부스트",
                                                             price = 189_000,
                                                             currency = "KRW",
@@ -379,6 +383,7 @@ class TournamentApiExamples(
                                                         TournamentDetailResponse.ItemDetailResponse(
                                                             tournamentItemId = 3,
                                                             itemId = 30,
+                                                            userId = UUID.fromString("11111111-2222-3333-4444-555555555555"),
                                                             name = "뉴발란스 993",
                                                             price = 259_000,
                                                             currency = "KRW",
@@ -388,6 +393,7 @@ class TournamentApiExamples(
                                                         TournamentDetailResponse.ItemDetailResponse(
                                                             tournamentItemId = 4,
                                                             itemId = 40,
+                                                            userId = UUID.fromString("22222222-3333-4444-5555-666666666666"),
                                                             name = "살로몬 XT-6",
                                                             price = 279_000,
                                                             currency = "KRW",

--- a/src/main/kotlin/com/depromeet/piki/tournament/controller/dto/TournamentDetailResponse.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/controller/dto/TournamentDetailResponse.kt
@@ -27,6 +27,7 @@ data class TournamentDetailResponse(
     data class ItemDetailResponse(
         val tournamentItemId: Long,
         val itemId: Long,
+        val userId: UUID,
         val name: String?,
         val price: Int?,
         val currency: String?,
@@ -35,7 +36,7 @@ data class TournamentDetailResponse(
     ) {
         companion object {
             fun from(d: TournamentDetail.ItemDetail): ItemDetailResponse =
-                ItemDetailResponse(d.tournamentItemId, d.itemId, d.name, d.price, d.currency, d.imageUrl, d.status)
+                ItemDetailResponse(d.tournamentItemId, d.itemId, d.userId, d.name, d.price, d.currency, d.imageUrl, d.status)
         }
     }
 

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
@@ -960,6 +960,7 @@ class TournamentService(
         return TournamentDetail.ItemDetail(
             tournamentItemId = tournamentItem.getId(),
             itemId = snapshot.itemId,
+            userId = tournamentItem.userId,
             name = snapshot.name,
             price = snapshot.currentPrice,
             currency = snapshot.currency,

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/dto/TournamentDetail.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/dto/TournamentDetail.kt
@@ -45,6 +45,7 @@ sealed class TournamentDetail {
     data class ItemDetail(
         val tournamentItemId: Long,
         val itemId: Long,
+        val userId: UUID,
         val name: String?,
         val price: Int?,
         val currency: String?,

--- a/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
@@ -912,6 +912,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
             .andExpect(jsonPath("$.data.pending.items[0].price").value(99_000))
             .andExpect(jsonPath("$.data.pending.items[0].tournamentItemId").isNumber)
             .andExpect(jsonPath("$.data.pending.items[0].itemId").value(itemId))
+            .andExpect(jsonPath("$.data.pending.items[0].userId").value(userId.toString()))
     }
 
     @Test


### PR DESCRIPTION
## Situation
- 토너먼트 단건 조회(`GET /tournaments/{id}`) 응답의 `items[]`에 아이템을 담은 참여자 정보가 없어, 프론트엔드가 누가 어떤 아이템을 담았는지 알 수 없는 상태였다.
- 프론트엔드 팀 요청으로, 각 아이템별로 담은 참여자를 식별할 수 있는 `userId`가 필요했다.

## Task
- `items[]` 각 항목에 `userId`를 추가해 아이템을 담은 참여자를 식별 가능하게 한다.
- 처음에는 `userId`와 `profileImage` 모두 요청됐으나, `profileImage`는 User 엔티티 추가 조회가 필요하다는 점에서 이번 범위에서는 `userId`만 추가하기로 조정했다.

## Action
- `TournamentItem.userId: UUID` 필드가 이미 존재해, 추가 DB 조회 없이 `toItemDetail()` 매핑 한 곳에서 바로 읽어 전달한다.
- 서비스 DTO(`TournamentDetail.ItemDetail`)와 응답 DTO(`TournamentDetailResponse.ItemDetailResponse`) 양쪽에 `userId: UUID` 추가.
- `toItemDetail()`은 PENDING·IN_PROGRESS 양쪽에서 공유하는 private helper라, 한 곳 수정으로 두 상태 모두 커버된다.
- `TournamentApi.kt` description에 `items[].userId` 설명 추가, `TournamentApiExamples.kt`의 6개 example 인스턴스 전부 갱신.

## Result
- `items[].userId`를 통해 프론트엔드가 각 아이템을 담은 참여자를 식별할 수 있다.
- 추가 쿼리 없이 기존 `TournamentItem.userId`를 매핑하는 방식이라 N+1 없음.
- `profileImage` 추가는 User 엔티티 조회가 별도로 필요해 이번 범위에서 포함하지 않았다. 필요 시 후속 이슈로 분리.

---
## 연관 이슈

- close #543


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 토너먼트 상세 조회 API 응답에 각 아이템의 사용자 식별자 정보 추가
  * API 예시 응답에 사용자 ID 값 포함

* **Tests**
  * 토너먼트 상세 조회 응답에서 아이템 사용자 ID 검증 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->