### PR TITLE
ItemSnapshot READY 불변식에 price·imageUrl 필수 검증 추가

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/item/domain/ItemException.kt
+++ b/src/main/kotlin/com/depromeet/piki/item/domain/ItemException.kt
@@ -32,11 +32,25 @@ class ItemException private constructor(
                 HttpStatus.CONFLICT,
             )
 
-        // FAILED 항목 복구의 입력 경계 계약 — 이름 없이 보정하면 "쓸 수 있는 상품"(READY)이 될 수 없다.
+        // FAILED 항목 복구의 입력 경계 계약 — 필수 필드 없이 보정하면 "쓸 수 있는 상품"(READY)이 될 수 없다.
         // 엔티티 불변식(requireReadyInvariant)이 최후의 보루라면, 이건 그 전에 클라이언트에게 400 으로 돌려주는 경계다.
         fun nameRequiredForReady(): ItemException =
             ItemException(
                 "상품 이름을 입력해 주세요.",
+                ErrorCategory.INVALID_INPUT,
+                HttpStatus.BAD_REQUEST,
+            )
+
+        fun priceRequiredForReady(): ItemException =
+            ItemException(
+                "상품 가격을 입력해 주세요.",
+                ErrorCategory.INVALID_INPUT,
+                HttpStatus.BAD_REQUEST,
+            )
+
+        fun imageRequiredForReady(): ItemException =
+            ItemException(
+                "상품 이미지를 등록해 주세요.",
                 ErrorCategory.INVALID_INPUT,
                 HttpStatus.BAD_REQUEST,
             )

--- a/src/main/kotlin/com/depromeet/piki/item/domain/ItemSnapshot.kt
+++ b/src/main/kotlin/com/depromeet/piki/item/domain/ItemSnapshot.kt
@@ -149,8 +149,10 @@ class ItemSnapshot(
             ItemStatus.PENDING, ItemStatus.PROCESSING -> throw ItemException.stillProcessing()
             ItemStatus.FAILED -> {
                 apply(name = name, currentPrice = currentPrice, imageUrl = imageUrl, currency = currency)
-                // 입력 경계 계약 — 보정 후에도 이름이 없으면 쓸 수 없는 버전이 READY 로 새어 들어간다(409 아닌 400).
+                // 입력 경계 계약 — 보정 후에도 필수 필드가 없으면 쓸 수 없는 버전이 READY 로 새어 들어간다(400).
                 if (this.name.isNullOrBlank()) throw ItemException.nameRequiredForReady()
+                this.currentPrice ?: throw ItemException.priceRequiredForReady()
+                this.imageUrl ?: throw ItemException.imageRequiredForReady()
                 status = ItemStatus.READY
                 this.extractedAt = LocalDateTime.now()
             }
@@ -165,11 +167,14 @@ class ItemSnapshot(
     // 미리 걸러 헛된 비용(orphan 업로드)을 막는 사전 가드용. 도메인 최후 보루는 recover 가 진다.
     fun isFailed(): Boolean = status == ItemStatus.FAILED
 
-    // READY 불변식 — "쓸 수 있는 버전"은 최소한 이름이 있어야 한다. isReady() 게이트(목록 노출·토너먼트 출전)가
-    // 미완성 버전을 정상으로 취급하지 않도록, READY 가 되는 명시 경로(markReady)에서 검사한다. 엔티티 최후의 보루이므로
-    // require(500) — 정상 흐름에선 입력 경계(recover 의 nameRequiredForReady, 추출 워커의 FAILED 흡수)가 먼저 거른다.
+    // READY 불변식 — 유저가 가격·이미지·이름을 보고 아이템을 선택하는 구조라 셋 다 있어야 쓸 수 있는 버전이다.
+    // isReady() 게이트(목록 노출·토너먼트 출전)가 미완성 버전을 정상으로 취급하지 않도록,
+    // READY 가 되는 명시 경로(markReady)에서 검사한다. 엔티티 최후의 보루이므로
+    // require(500) — 정상 흐름에선 입력 경계(recover 의 *RequiredForReady, 추출 워커의 FAILED 흡수)가 먼저 거른다.
     private fun requireReadyInvariant() {
-        require(!name.isNullOrBlank()) { "READY snapshot 은 최소한 name 이 있어야 한다 (status=$status)" }
+        require(!name.isNullOrBlank()) { "READY snapshot 은 name 이 있어야 한다 (status=$status)" }
+        requireNotNull(currentPrice) { "READY snapshot 은 price 가 있어야 한다 (status=$status)" }
+        requireNotNull(imageUrl) { "READY snapshot 은 imageUrl 이 있어야 한다 (status=$status)" }
     }
 
     private fun validate(

--- a/src/main/kotlin/com/depromeet/piki/item/service/AsyncImageParsingWorker.kt
+++ b/src/main/kotlin/com/depromeet/piki/item/service/AsyncImageParsingWorker.kt
@@ -30,17 +30,13 @@ class AsyncImageParsingWorker(
     ) {
         runCatching {
             val extraction = productImageExtractor.extract(image)
-            val imageUrl =
+            // bbox 있으면 크롭 이미지를, 없으면 원본 이미지를 S3에 올린다.
+            // 어떤 경우든 이미지 파일로 등록한 이상 imageUrl 이 채워져야 한다(READY 불변식).
+            val bytes =
                 extraction.boundingBox
                     ?.let { imageCropper.crop(image.bytes, it) }
-                    ?.let { cropped ->
-                        runCatching {
-                            imageStorage.upload(cropped, "items/${UUID.randomUUID()}.png", "image/png")
-                        }.getOrElse { e ->
-                            log.warn("item {} 크롭 이미지 S3 업로드 실패, imageUrl 없이 등록: {}", itemId, e.message)
-                            null
-                        }
-                    }
+                    ?: image.bytes
+            val imageUrl = imageStorage.upload(bytes, "items/${UUID.randomUUID()}.png", "image/png")
             extraction.snapshot.copy(imageUrl = imageUrl)
         }.onSuccess { snapshot ->
             runCatching { itemParsingService.markReady(itemId, snapshot) }

--- a/src/test/kotlin/com/depromeet/piki/item/domain/ItemSnapshotTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/item/domain/ItemSnapshotTest.kt
@@ -95,10 +95,26 @@ class ItemSnapshotTest {
     }
 
     @Test
-    fun `markReady 시 추출 결과에 name 이 없으면 READY 불변식 위반으로 실패한다`() {
+    fun `markReady 시 name 이 없으면 READY 불변식 위반으로 실패한다`() {
         val snapshot = ItemSnapshot(itemId = 1L)
         assertFailsWith<IllegalArgumentException> {
-            snapshot.markReady(ProductSnapshot(currentPrice = 1_000))
+            snapshot.markReady(ProductSnapshot(currentPrice = 1_000, imageUrl = "https://img.example.com/a.png"))
+        }
+    }
+
+    @Test
+    fun `markReady 시 price 가 없으면 READY 불변식 위반으로 실패한다`() {
+        val snapshot = ItemSnapshot(itemId = 1L)
+        assertFailsWith<IllegalArgumentException> {
+            snapshot.markReady(ProductSnapshot(name = "나이키", imageUrl = "https://img.example.com/a.png"))
+        }
+    }
+
+    @Test
+    fun `markReady 시 imageUrl 이 없으면 READY 불변식 위반으로 실패한다`() {
+        val snapshot = ItemSnapshot(itemId = 1L)
+        assertFailsWith<IllegalArgumentException> {
+            snapshot.markReady(ProductSnapshot(name = "나이키", currentPrice = 99_000))
         }
     }
 
@@ -113,7 +129,7 @@ class ItemSnapshotTest {
     fun `FAILED 스냅샷을 recover 하면 채워지고 READY 와 extractedAt 이 설정된다`() {
         val snapshot = ItemSnapshot(itemId = 1L)
         snapshot.markFailed()
-        snapshot.recover(name = "수동 보정", currentPrice = 5_000, imageUrl = null, currency = "KRW")
+        snapshot.recover(name = "수동 보정", currentPrice = 5_000, imageUrl = "https://img.example.com/a.png", currency = "KRW")
         assertEquals(ItemStatus.READY, snapshot.status)
         assertEquals("수동 보정", snapshot.name)
         assertNotNull(snapshot.extractedAt)
@@ -124,7 +140,7 @@ class ItemSnapshotTest {
         val snapshot = ItemSnapshot(itemId = 1L)
         snapshot.markFailed()
         assertFailsWith<IllegalStateException> {
-            snapshot.markReady(ProductSnapshot(name = "x"))
+            snapshot.markReady(ProductSnapshot(name = "x", currentPrice = 1_000, imageUrl = "https://img.example.com/a.png"))
         }
     }
 
@@ -133,7 +149,7 @@ class ItemSnapshotTest {
     @Test
     fun `READY 스냅샷을 recover 하면 이미 완료라 ItemException(409)`() {
         val snapshot = ItemSnapshot(itemId = 1L)
-        snapshot.markReady(ProductSnapshot(name = "나이키"))
+        snapshot.markReady(ProductSnapshot(name = "나이키", currentPrice = 99_000, imageUrl = "https://img.example.com/a.png"))
         assertFailsWith<ItemException> {
             snapshot.recover(name = "수정", currentPrice = null, imageUrl = null, currency = null)
         }
@@ -152,7 +168,25 @@ class ItemSnapshotTest {
         val snapshot = ItemSnapshot(itemId = 1L)
         snapshot.markFailed()
         assertFailsWith<ItemException> {
-            snapshot.recover(name = null, currentPrice = 1_000, imageUrl = null, currency = "KRW")
+            snapshot.recover(name = null, currentPrice = 1_000, imageUrl = "https://img.example.com/a.png", currency = "KRW")
+        }
+    }
+
+    @Test
+    fun `FAILED 스냅샷을 보정해도 price 가 없으면 ItemException(400)`() {
+        val snapshot = ItemSnapshot(itemId = 1L)
+        snapshot.markFailed()
+        assertFailsWith<ItemException> {
+            snapshot.recover(name = "수동 보정", currentPrice = null, imageUrl = "https://img.example.com/a.png", currency = "KRW")
+        }
+    }
+
+    @Test
+    fun `FAILED 스냅샷을 보정해도 imageUrl 이 없으면 ItemException(400)`() {
+        val snapshot = ItemSnapshot(itemId = 1L)
+        snapshot.markFailed()
+        assertFailsWith<ItemException> {
+            snapshot.recover(name = "수동 보정", currentPrice = 5_000, imageUrl = null, currency = "KRW")
         }
     }
 
@@ -177,7 +211,9 @@ class ItemSnapshotTest {
         // 이미 claim 된(PROCESSING)·완료(READY)·실패(FAILED)는 다시 claim 할 수 없다 — 디스패처 중복 집기 방어.
         assertFailsWith<IllegalStateException> { ItemSnapshot.processing(1L).markProcessing() }
         assertFailsWith<IllegalStateException> {
-            ItemSnapshot(itemId = 1L).apply { markReady(ProductSnapshot(name = "x")) }.markProcessing()
+            ItemSnapshot(itemId = 1L)
+                .apply { markReady(ProductSnapshot(name = "x", currentPrice = 1_000, imageUrl = "https://img.example.com/a.png")) }
+                .markProcessing()
         }
         assertFailsWith<IllegalStateException> { ItemSnapshot(itemId = 1L).apply { markFailed() }.markProcessing() }
     }
@@ -215,7 +251,9 @@ class ItemSnapshotTest {
         // PENDING(claim 전)·READY(완료)·FAILED(실패)는 재실행 claim 대상이 아니다 — recover 가 잘못된 행을 집은 코드 버그 방어.
         assertFailsWith<IllegalStateException> { ItemSnapshot.pending(1L).reclaim() }
         assertFailsWith<IllegalStateException> {
-            ItemSnapshot(itemId = 1L).apply { markReady(ProductSnapshot(name = "x")) }.reclaim()
+            ItemSnapshot(itemId = 1L)
+                .apply { markReady(ProductSnapshot(name = "x", currentPrice = 1_000, imageUrl = "https://img.example.com/a.png")) }
+                .reclaim()
         }
         assertFailsWith<IllegalStateException> { ItemSnapshot(itemId = 1L).apply { markFailed() }.reclaim() }
     }

--- a/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/tournament/controller/TournamentControllerTest.kt
@@ -1215,7 +1215,8 @@ class TournamentControllerTest : IntegrationTestSupport() {
         val mockMvc = buildMockMvc()
         val tournamentId = createTournament(mockMvc)
         val failedItem = itemJpaRepository.save(Item())
-        val snapshot = saveSnapshot(failedItem.getId(), status = ItemStatus.FAILED)
+        // imageUrl 있는 FAILED — recover 시 imageUrl 파라미터를 보내지 않아도 apply 가 기존 값을 유지해 READY 불변식 통과
+        val snapshot = saveSnapshot(failedItem.getId(), status = ItemStatus.FAILED, imageUrl = "https://img.example.com/a.png")
         tournamentItemJpaRepository.save(
             TournamentItem(tournamentId = tournamentId, userId = userId, snapshotId = snapshot.getId()),
         )
@@ -1316,9 +1317,9 @@ class TournamentControllerTest : IntegrationTestSupport() {
     fun `PATCH tournaments-id-items-itemId 는 이름이 있는 FAILED 아이템에 가격만 보내면 이름을 유지하며 200 을 반환한다`() {
         val mockMvc = buildMockMvc()
         val tournamentId = createTournament(mockMvc)
-        // 이름이 이미 있는 FAILED snapshot — 가격만 보정해도 이름이 유지되는지 검증한다(표시값은 snapshot 소관).
+        // 이름과 imageUrl 이 이미 있는 FAILED snapshot — 가격만 보정해도 이름과 이미지가 유지되는지 검증한다(apply 가 기존 값 보존).
         val failedItem = itemJpaRepository.save(Item())
-        val snapshot = saveSnapshot(failedItem.getId(), status = ItemStatus.FAILED, name = "기존 이름")
+        val snapshot = saveSnapshot(failedItem.getId(), status = ItemStatus.FAILED, name = "기존 이름", imageUrl = "https://img.example.com/a.png")
         tournamentItemJpaRepository.save(
             TournamentItem(tournamentId = tournamentId, userId = userId, snapshotId = snapshot.getId()),
         )
@@ -1821,7 +1822,7 @@ class TournamentControllerTest : IntegrationTestSupport() {
         val result = wishPersistenceService.persistProcessingImages(owner, 1).first()
         itemParsingService.markReady(
             result.item.getId(),
-            ProductSnapshot(name = name, currentPrice = price, currency = "KRW"),
+            ProductSnapshot(name = name, currentPrice = price, currency = "KRW", imageUrl = "https://img.example.com/a.png"),
         )
         return result.item.getId()
     }

--- a/src/test/kotlin/com/depromeet/piki/wishlist/controller/WishlistControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/wishlist/controller/WishlistControllerIntegrationTest.kt
@@ -86,9 +86,9 @@ class WishlistControllerIntegrationTest : IntegrationTestSupport() {
         userId: UUID,
         url: String,
         name: String,
-        currentPrice: Int? = null,
-        currency: String? = null,
-        imageUrl: String? = null,
+        currentPrice: Int? = 10_000,
+        currency: String? = "KRW",
+        imageUrl: String? = "https://img.example.com/a.png",
     ): Long {
         val result = wishPersistenceService.persist(userId, Item(ProductLink.parse(url)))
         itemParsingService.claimDuePending(100)
@@ -366,9 +366,11 @@ class WishlistControllerIntegrationTest : IntegrationTestSupport() {
         val authHeader = "Bearer ${memberToken(userId)}"
         val wishId = seedFailedWish(userId, "https://shop.example.com/products/1")
 
+        val image = MockMultipartFile("image", "p.png", "image/png", byteArrayOf(1, 2, 3))
         mockMvc
             .perform(
                 multipart("/api/v1/wishlists/$wishId")
+                    .file(image)
                     .param("name", "직접 입력한 이름")
                     .param("currentPrice", "50000")
                     .with {
@@ -475,6 +477,7 @@ class WishlistControllerIntegrationTest : IntegrationTestSupport() {
                 multipart("/api/v1/wishlists/$wishId")
                     .file(image)
                     .param("name", "직접 입력한 이름")
+                    .param("currentPrice", "50000")
                     .with {
                         it.method = "PATCH"
                         it

--- a/src/test/kotlin/com/depromeet/piki/wishlist/controller/WishlistRegisterAsyncIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/wishlist/controller/WishlistRegisterAsyncIntegrationTest.kt
@@ -118,7 +118,7 @@ class WishlistRegisterAsyncIntegrationTest : IntegrationTestSupport() {
         insertMember(userId)
         try {
             stubProductLinkExtractor.build = {
-                ProductSnapshot(link = it, name = "나이키 에어포스", currentPrice = 99_000, currency = "KRW")
+                ProductSnapshot(link = it, name = "나이키 에어포스", currentPrice = 99_000, currency = "KRW", imageUrl = "https://img.example.com/a.png")
             }
             val readyBefore = parseCount("ready", "none")
             val itemId = registerAndGetItemId(mockMvc, userId, "https://shop.example.com/products/42")
@@ -360,7 +360,7 @@ class WishlistRegisterAsyncIntegrationTest : IntegrationTestSupport() {
         // 디스패처가 claim(attempt 1)한 직후 워커가 크래시해 실행 0회로 PROCESSING 에 갇힌 상황.
         // recover 가 재실행(reclaim)해 완성시킨다 — claim-at-least-once 를 execution at-least-once 로 끌어올리는 핵심(#461).
         stubProductLinkExtractor.build = {
-            ProductSnapshot(link = it, name = "되살아난 상품", currentPrice = 1_000, currency = "KRW")
+            ProductSnapshot(link = it, name = "되살아난 상품", currentPrice = 1_000, currency = "KRW", imageUrl = "https://img.example.com/a.png")
         }
         val item = itemRepository.save(Item(ProductLink.parse("https://shop.example.com/products/revive")))
         val snapshot = itemSnapshotRepository.save(ItemSnapshot.pending(item.getId()).apply { markProcessing() })


### PR DESCRIPTION
## Situation

- 토너먼트 아이템은 유저가 이름·가격·이미지를 보고 선택하는 구조라, 세 필드가 모두 있어야 "쓸 수 있는 아이템"이다.
- `requireReadyInvariant()`가 name만 검증해서 price·imageUrl이 null이어도 READY 처리됐다.
- 실제로 LLM이 가격이나 이미지를 추출 못 하면 READY 상태인데 price/imageUrl이 응답에서 빠지는 버그가 발생 가능했다.

## Task

- READY 불변식에 price·imageUrl 필수 검증 추가
- 링크 파싱과 이미지 파싱 두 경로 모두 `ItemParsingService.markReady()` → `ItemSnapshot.markReady()` → `requireReadyInvariant()`로 합류하므로, 한 곳만 수정하면 양쪽에 동시 적용됨을 확인
- FAILED 아이템 수동 보정(`recover`) 경로에도 같은 검증을 클라이언트 계약으로 추가

## Action

### 불변식 강화

- `requireReadyInvariant()`에 `requireNotNull(currentPrice)`, `requireNotNull(imageUrl)` 추가 — READY가 되는 모든 경로의 엔티티 최후 보루 (500)
- `recover()`에 `priceRequiredForReady()`, `imageRequiredForReady()` 계약 검증 추가 — 클라이언트 입력 경계이므로 커스텀 예외(400)로 먼저 걸러 다층 방어 구성

### 이미지 파싱 경로 보완

- `AsyncImageParsingWorker`에서 bbox=null일 때 imageUrl=null로 두던 fallback 제거
- bbox 없으면 원본 이미지를 그대로 S3에 업로드해 이미지 파일 등록 시 항상 imageUrl이 채워지도록 변경

### 테스트 파급 수정

- READY 불변식 강화로 74개 통합 테스트 실패 → 기존 stub ProductSnapshot에 imageUrl 추가, recover 성공 케이스에 image 파일 첨부 또는 currentPrice 추가, FAILED 시딩에 imageUrl 추가로 수정
- FAILED 아이템을 imageUrl 없이 시딩하고 name+price만으로 recover하던 테스트 → FAILED snapshot에 imageUrl을 가진 상태로 시딩하거나 image 파일을 함께 제공하는 방식으로 전환 (apply가 null 파라미터를 기존 값으로 유지하는 성질 활용)

## Result

- READY가 되는 모든 경로(markReady, recover)에서 name·price·imageUrl 세 필드가 동시에 보장됨
- FAILED 아이템 보정 시 imageUrl이 없으면 image 파일을 첨부하거나 기존 FAILED snapshot에 이미 imageUrl이 있어야 READY로 복구 가능 — 이 정책이 API 계약으로 명시됨

---
## 연관 이슈

- close #542
