### PR TITLE
토너먼트 아이템 삭제 시 SSE 알림 발행 (web 폴링 제거)

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/notification/controller/NotificationHistoryApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/controller/NotificationHistoryApi.kt
@@ -35,12 +35,13 @@ interface NotificationHistoryApi {
                 "사람/시스템 구분은 `category`. 클라는 `imageUrl` 을 그대로 아바타로 렌더한다.\n" +
                 "- 각 항목 셰입은 SSE `notification` 이벤트 payload 와 동일하다 — `type` 으로 화면을, " +
                 "`refId` 로 딥링크 이동을, 파싱 알림은 `kind` 로 출처(위시/토너먼트)를 분기하고, `id` 로 단건 읽음 처리(`POST /read`)를 한다.\n\n" +
-                "**알림 타입 카탈로그 (전 9종)**\n\n" +
+                "**알림 타입 카탈로그 (전 10종)**\n\n" +
                 "`type` 으로 화면을 분기하고 `refId` 로 이동 대상을 정한다. `body` 는 현재 전 타입 빈 문자열(`\"\"`).\n\n" +
                 "| `type` | 트리거 | 카테고리 | `refId` | `title` 예시 | 아바타(`imageUrl`) |\n" +
                 "|---|---|---|---|---|---|\n" +
                 "| `TOURNAMENT_JOINED` | 토너먼트 참가 | ACTIVITY | tournamentId | {참가자}님이 참가했어요 | 행위자 프사 |\n" +
                 "| `TOURNAMENT_ITEM_ADDED` | 아이템 추가 | ACTIVITY | tournamentId | {참가자}님이 아이템을 추가했어요 | 행위자 프사 |\n" +
+                "| `TOURNAMENT_ITEM_DELETED` | 아이템 삭제 | ACTIVITY | tournamentId | {참가자}님이 '{상품명}'을(를) 삭제했어요 | 행위자 프사 |\n" +
                 "| `TOURNAMENT_STARTED` | 토너먼트 시작 | ACTIVITY | tournamentId | {주최자}님이 토너먼트를 시작했어요 | 행위자 프사 |\n" +
                 "| `TOURNAMENT_PLAYED_FROM_LINK` | 플레이링크로 플레이 시작 | ACTIVITY | ROOT 토너먼트 id | {플레이어}님이 회원님 토너먼트를 플레이했어요 | 행위자 프사 |\n" +
                 "| `TOURNAMENT_COMPLETED` | 멤버가 클론 완료 | ACTIVITY | ROOT 토너먼트 id | {멤버}님이 회원님 토너먼트를 완료했어요 | 행위자 프사 |\n" +
@@ -48,8 +49,9 @@ interface NotificationHistoryApi {
                 "| `ITEM_PARSING_COMPLETED` | 상품 추출 성공 | SYSTEM | itemId | 상품 정보가 저장됐어요 | 피키 로고 |\n" +
                 "| `ITEM_PARSING_FAILED` | 상품 추출 실패 | SYSTEM | itemId | 상품 정보를 가져오지 못했어요 | 피키 로고 |\n" +
                 "| `ANNOUNCEMENT` | 관리자 공지(후속) | SYSTEM | 공지 id/0 | (관리자 입력) | 피키 로고 |\n\n" +
-                "> 파싱 알림(`ITEM_PARSING_*`)만 출처별 `kind`(WISH/TOURNAMENT)·`tournamentId`·`tournamentItemId` 가 추가로 실린다. " +
-                "나머지 타입엔 그 키가 없다. `title` 은 발송 시점 렌더 값이라 클라는 문구가 아니라 `type` 으로 분기한다.",
+                "> 아이템 좌표(`kind`·`tournamentId`·`tournamentItemId`)가 추가로 실리는 타입: 파싱 알림(`ITEM_PARSING_*`)은 출처 `kind`(WISH/TOURNAMENT), " +
+                "토너먼트 출처면 `tournamentId`·`tournamentItemId` 까지. 아이템 삭제(`TOURNAMENT_ITEM_DELETED`)는 `kind`=TOURNAMENT·`tournamentId`·`tournamentItemId` 를 실어 " +
+                "클라가 재조회 없이 그 항목만 제거하게 한다. 나머지 타입엔 그 키가 없다. `title` 은 발송 시점 렌더 값이라 클라는 문구가 아니라 `type` 으로 분기한다.",
     )
     @ApiResponses(
         value = [

--- a/src/main/kotlin/com/depromeet/piki/notification/controller/NotificationHistoryApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/controller/NotificationHistoryApiExamples.kt
@@ -132,7 +132,7 @@ class NotificationHistoryApiExamples(
 
     // 토너먼트 출처 파싱 완료 알림 (kind=TOURNAMENT + 두 식별자) — 시스템, imageUrl=defaultPushImg, 안읽음.
     private val tournamentParsingItem =
-        NotificationSsePayload.TournamentParsing(
+        NotificationSsePayload.TournamentRouted(
             id = 1024,
             type = NotificationType.ITEM_PARSING_COMPLETED,
             category = NotificationCategory.SYSTEM,

--- a/src/main/kotlin/com/depromeet/piki/notification/controller/dto/NotificationSsePayload.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/controller/dto/NotificationSsePayload.kt
@@ -54,8 +54,10 @@ sealed interface NotificationSsePayload {
         val kind: NotificationKind = NotificationKind.WISH
     }
 
-    // 토너먼트 출처 파싱 알림. refId(=itemId) + kind=TOURNAMENT + 입장(tournamentId)·아이템 지목(tournamentItemId).
-    data class TournamentParsing(
+    // 토너먼트 아이템을 지목하는 알림. kind=TOURNAMENT + 입장(tournamentId)·아이템 지목(tournamentItemId) 좌표를 싣는다.
+    // 두 용도가 공유한다: 파싱 알림(refId=itemId) · 아이템 삭제 알림(refId=tournamentId). refId 의미는 type 별로 갈리니
+    // 클라는 type 으로 먼저 분기한다. (파싱 전용이 아니라 "토너먼트 아이템 라우팅" 셰입이라 이름이 중립적이다.)
+    data class TournamentRouted(
         override val id: Long,
         override val type: NotificationType,
         override val category: NotificationCategory,
@@ -111,7 +113,7 @@ sealed interface NotificationSsePayload {
                     )
 
                 is NotificationRouting.Tournament ->
-                    TournamentParsing(
+                    TournamentRouted(
                         id = id,
                         type = notification.type,
                         category = category,

--- a/src/main/kotlin/com/depromeet/piki/notification/domain/NotificationCategory.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/domain/NotificationCategory.kt
@@ -15,6 +15,7 @@ enum class NotificationCategory {
             when (type) {
                 NotificationType.TOURNAMENT_JOINED,
                 NotificationType.TOURNAMENT_ITEM_ADDED,
+                NotificationType.TOURNAMENT_ITEM_DELETED,
                 NotificationType.TOURNAMENT_STARTED,
                 NotificationType.TOURNAMENT_PLAYED_FROM_LINK,
                 NotificationType.TOURNAMENT_COMPLETED,

--- a/src/main/kotlin/com/depromeet/piki/notification/domain/NotificationType.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/domain/NotificationType.kt
@@ -5,6 +5,7 @@ package com.depromeet.piki.notification.domain
 enum class NotificationType {
     TOURNAMENT_JOINED,
     TOURNAMENT_ITEM_ADDED,
+    TOURNAMENT_ITEM_DELETED,
     TOURNAMENT_STARTED,
     // 플레이링크로 내 토너먼트를 누군가 플레이/완료한 사실 — ROOT 주최자에게 간다(actor=플레이/완료한 사람).
     TOURNAMENT_PLAYED_FROM_LINK,

--- a/src/main/kotlin/com/depromeet/piki/notification/fcm/service/FirebaseMessageSender.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/fcm/service/FirebaseMessageSender.kt
@@ -188,7 +188,7 @@ class FirebaseMessageSender(
                 when (payload) {
                     is NotificationSsePayload.Reference -> Unit
                     is NotificationSsePayload.WishParsing -> put(DATA_KEY_KIND, payload.kind.name)
-                    is NotificationSsePayload.TournamentParsing -> {
+                    is NotificationSsePayload.TournamentRouted -> {
                         put(DATA_KEY_KIND, payload.kind.name)
                         put(DATA_KEY_TOURNAMENT_ID, payload.tournamentId.toString())
                         put(DATA_KEY_TOURNAMENT_ITEM_ID, payload.tournamentItemId.toString())

--- a/src/main/kotlin/com/depromeet/piki/notification/handler/TournamentItemDeletedHandler.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/handler/TournamentItemDeletedHandler.kt
@@ -1,0 +1,42 @@
+package com.depromeet.piki.notification.handler
+
+import com.depromeet.piki.item.repository.ItemSnapshotRepository
+import com.depromeet.piki.notification.domain.NotificationRouting
+import com.depromeet.piki.notification.domain.NotificationType
+import com.depromeet.piki.tournament.event.TournamentItemDeleted
+import com.depromeet.piki.tournament.repository.TournamentUserRepository
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+// 토너먼트 아이템 삭제 알림. 그 토너먼트 참가자들에게 보내되, 삭제한 본인(actor=등록자 또는 주최자)은 제외한다 —
+// 자기가 지운 건 자기 화면이 이미 알고 있어 "남에게 알림" 성격이기 때문(TOURNAMENT_ITEM_ADDED 와 동일 규칙).
+// 추가와 달리 삭제는 클라가 그 아이템을 이미 들고 있어, 어느 아이템인지(tournamentItemId)와 상품명(itemName)을 실어
+// 재조회 없이 그 항목만 빼고 "OO님이 '상품명'을 삭제" 로 보여줄 수 있게 한다.
+//   - refId=tournamentId : 딥링크(탭하면 그 토너먼트로 입장). 추가 알림과 동일.
+//   - routing=Tournament(tournamentId, tournamentItemId) : payload 에 아이템 좌표를 싣는다(파싱 알림과 공유 셰입).
+//   - itemName : snapshotId 로 상품명 해석. 아직 파싱 전(PROCESSING)이라 name 이 없으면 fallback.
+@Component
+class TournamentItemDeletedHandler(
+    private val tournamentUserRepository: TournamentUserRepository,
+    private val tournamentVariables: TournamentNotificationVariables,
+    private val itemSnapshotRepository: ItemSnapshotRepository,
+) : NotificationEventHandler<TournamentItemDeleted>(NotificationType.TOURNAMENT_ITEM_DELETED) {
+    override fun resolveRefId(event: TournamentItemDeleted): Long = event.tournamentId
+
+    override fun resolveRecipients(event: TournamentItemDeleted): Set<UUID> =
+        tournamentUserRepository.findByTournamentId(event.tournamentId).map { it.userId }.toSet() - event.actorId
+
+    override fun resolveRouting(event: TournamentItemDeleted): NotificationRouting =
+        NotificationRouting.Tournament(tournamentId = event.tournamentId, tournamentItemId = event.tournamentItemId)
+
+    override fun resolveActorContext(event: TournamentItemDeleted): ActorContext {
+        val base = tournamentVariables.context(event.tournamentId, event.actorId)
+        val itemName = itemSnapshotRepository.findById(event.snapshotId)?.name ?: FALLBACK_ITEM_NAME
+        return base.copy(variables = base.variables + ("itemName" to itemName))
+    }
+
+    companion object {
+        // 삭제 시점에 상품명이 아직 없을 때(파싱 전 PENDING/PROCESSING 아이템 삭제)의 대체 문구.
+        private const val FALLBACK_ITEM_NAME = "상품"
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/notification/service/NotificationEventListener.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/service/NotificationEventListener.kt
@@ -4,6 +4,7 @@ import com.depromeet.piki.common.config.AsyncConfig
 import com.depromeet.piki.item.event.ItemParsingCompleted
 import com.depromeet.piki.item.event.ItemParsingFailed
 import com.depromeet.piki.tournament.event.TournamentItemAdded
+import com.depromeet.piki.tournament.event.TournamentItemDeleted
 import com.depromeet.piki.tournament.event.TournamentJoined
 import com.depromeet.piki.tournament.event.TournamentStarted
 import org.springframework.scheduling.annotation.Async
@@ -34,6 +35,12 @@ class NotificationEventListener(
     @Async(AsyncConfig.NOTIFICATION_EXECUTOR)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     fun on(event: TournamentItemAdded) {
+        dispatcher.dispatch(event)
+    }
+
+    @Async(AsyncConfig.NOTIFICATION_EXECUTOR)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun on(event: TournamentItemDeleted) {
         dispatcher.dispatch(event)
     }
 

--- a/src/main/kotlin/com/depromeet/piki/notification/service/NotificationTemplateVariables.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/service/NotificationTemplateVariables.kt
@@ -20,10 +20,14 @@ object NotificationTemplateVariables {
             TemplateVariable("tournamentId", "42"),
         )
 
+    // 삭제 알림은 어느 상품이 빠졌는지 문구에 담는다 — 공유 TOURNAMENT 변수에 itemName 을 더한다.
+    private val TOURNAMENT_WITH_ITEM = TOURNAMENT + TemplateVariable("itemName", "나이키 에어맥스")
+
     private val catalog: Map<NotificationType, List<TemplateVariable>> =
         mapOf(
             NotificationType.TOURNAMENT_JOINED to TOURNAMENT,
             NotificationType.TOURNAMENT_ITEM_ADDED to TOURNAMENT,
+            NotificationType.TOURNAMENT_ITEM_DELETED to TOURNAMENT_WITH_ITEM,
             NotificationType.TOURNAMENT_STARTED to TOURNAMENT,
             NotificationType.TOURNAMENT_PLAYED_FROM_LINK to TOURNAMENT,
             NotificationType.TOURNAMENT_COMPLETED to TOURNAMENT,

--- a/src/main/kotlin/com/depromeet/piki/tournament/event/TournamentItemDeleted.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/event/TournamentItemDeleted.kt
@@ -1,0 +1,14 @@
+package com.depromeet.piki.tournament.event
+
+import java.util.UUID
+
+// 토너먼트 아이템 삭제 — 도메인 사실. actorId 는 삭제한 사용자(아이템 등록자 본인 또는 토너먼트 주최자).
+// tournamentItemId 는 빠진 출전 아이템(클라가 그 항목만 제거하도록 알림 payload 에 실린다).
+// snapshotId 는 그 아이템의 고정 snapshot — 알림 도메인이 여기서 상품명을 해석한다. tournament_item 은 삭제 직후
+// soft delete 라 핸들러(AFTER_COMMIT)가 역조회로 못 닿지만, snapshot 은 공유 immutable 행이라 살아 있다.
+data class TournamentItemDeleted(
+    val tournamentId: Long,
+    val tournamentItemId: Long,
+    val snapshotId: Long,
+    val actorId: UUID,
+)

--- a/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
+++ b/src/main/kotlin/com/depromeet/piki/tournament/service/TournamentService.kt
@@ -10,6 +10,7 @@ import com.depromeet.piki.tournament.domain.TournamentStatus
 import com.depromeet.piki.tournament.domain.TournamentUser
 import com.depromeet.piki.tournament.event.TournamentCompleted
 import com.depromeet.piki.tournament.event.TournamentItemAdded
+import com.depromeet.piki.tournament.event.TournamentItemDeleted
 import com.depromeet.piki.tournament.event.TournamentJoined
 import com.depromeet.piki.tournament.event.TournamentPlayedFromLink
 import com.depromeet.piki.tournament.event.TournamentResultReady
@@ -950,6 +951,18 @@ class TournamentService(
 
         val deleted = tournamentItemRepository.softDeleteIfPending(tournamentItemId, tournamentId)
         if (deleted == 0) throw TournamentException.notPendingTournament()
+
+        // 삭제로 출전 목록이 바뀌었음을 다른 참가자에게 알린다(폴링 대체) — 추가(TournamentItemAdded)와 대칭.
+        // tournamentItemId·snapshotId 를 함께 실어 알림 도메인이 어느 아이템인지·상품명을 끌어내게 한다
+        // (tournament_item 은 방금 soft delete 돼 핸들러가 역조회로 못 닿지만, snapshot 은 살아 있다).
+        eventPublisher.publishEvent(
+            TournamentItemDeleted(
+                tournamentId = tournamentId,
+                tournamentItemId = tournamentItemId,
+                snapshotId = tournamentItem.snapshotId,
+                actorId = userId,
+            ),
+        )
     }
 
     private fun toItemDetail(

--- a/src/main/kotlin/db/migration/V20260617215313__seed_tournament_item_deleted_template.kt
+++ b/src/main/kotlin/db/migration/V20260617215313__seed_tournament_item_deleted_template.kt
@@ -1,0 +1,23 @@
+package db.migration
+
+import org.flywaydb.core.api.migration.BaseJavaMigration
+import org.flywaydb.core.api.migration.Context
+
+// TOURNAMENT_ITEM_DELETED 템플릿 시드 — 토너먼트 아이템 삭제 알림(추가 알림 TOURNAMENT_ITEM_ADDED 의 거울).
+// 본문의 리터럴 dollar-brace(${actorName})를 SQL 마이그레이션에 두면 Flyway 가 placeholder 로 오인해 파싱이
+// 깨지므로, 시드(V20260615015148)와 동일하게 JDBC 로 직접 적재한다. 전 타입 템플릿이 있어야 부팅이 통과한다
+// (DbNotificationTemplateProvider.load 의 누락 검증).
+@Suppress("ClassName")
+class V20260617215313__seed_tournament_item_deleted_template : BaseJavaMigration() {
+    override fun migrate(context: Context) {
+        context.connection
+            .prepareStatement(
+                "INSERT INTO notification_templates (type, title_template, body_template, updated_at) VALUES (?, ?, ?, NOW(6))",
+            ).use { statement ->
+                statement.setString(1, "TOURNAMENT_ITEM_DELETED")
+                statement.setString(2, "\${actorName}님이 '\${itemName}'을(를) 삭제했어요")
+                statement.setString(3, "")
+                statement.executeUpdate()
+            }
+    }
+}

--- a/src/test/kotlin/com/depromeet/piki/notification/domain/NotificationCategoryTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/notification/domain/NotificationCategoryTest.kt
@@ -11,6 +11,7 @@ class NotificationCategoryTest {
     @CsvSource(
         "TOURNAMENT_JOINED, ACTIVITY",
         "TOURNAMENT_ITEM_ADDED, ACTIVITY",
+        "TOURNAMENT_ITEM_DELETED, ACTIVITY",
         "TOURNAMENT_STARTED, ACTIVITY",
         "TOURNAMENT_PLAYED_FROM_LINK, ACTIVITY",
         "TOURNAMENT_COMPLETED, ACTIVITY",
@@ -38,6 +39,7 @@ class NotificationCategoryTest {
             listOf(
                 NotificationType.TOURNAMENT_JOINED,
                 NotificationType.TOURNAMENT_ITEM_ADDED,
+                NotificationType.TOURNAMENT_ITEM_DELETED,
                 NotificationType.TOURNAMENT_STARTED,
                 NotificationType.TOURNAMENT_PLAYED_FROM_LINK,
                 NotificationType.TOURNAMENT_COMPLETED,

--- a/src/test/kotlin/com/depromeet/piki/notification/handler/NotificationEventHandlerTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/notification/handler/NotificationEventHandlerTest.kt
@@ -5,6 +5,7 @@ import com.depromeet.piki.item.event.ItemParsingFailed
 import com.depromeet.piki.notification.domain.NotificationType
 import com.depromeet.piki.support.IntegrationTestSupport
 import com.depromeet.piki.tournament.event.TournamentItemAdded
+import com.depromeet.piki.tournament.event.TournamentItemDeleted
 import com.depromeet.piki.tournament.event.TournamentJoined
 import com.depromeet.piki.tournament.event.TournamentStarted
 import org.junit.jupiter.api.Test
@@ -20,6 +21,8 @@ class NotificationEventHandlerTest : IntegrationTestSupport() {
 
     @Autowired private lateinit var tournamentItemAddedHandler: TournamentItemAddedHandler
 
+    @Autowired private lateinit var tournamentItemDeletedHandler: TournamentItemDeletedHandler
+
     @Autowired private lateinit var tournamentJoinedHandler: TournamentJoinedHandler
 
     @Autowired private lateinit var tournamentStartedHandler: TournamentStartedHandler
@@ -33,6 +36,7 @@ class NotificationEventHandlerTest : IntegrationTestSupport() {
         assertEquals(ItemParsingCompleted::class, itemParsingCompletedHandler.eventType)
         assertEquals(ItemParsingFailed::class, itemParsingFailedHandler.eventType)
         assertEquals(TournamentItemAdded::class, tournamentItemAddedHandler.eventType)
+        assertEquals(TournamentItemDeleted::class, tournamentItemDeletedHandler.eventType)
         assertEquals(TournamentJoined::class, tournamentJoinedHandler.eventType)
         assertEquals(TournamentStarted::class, tournamentStartedHandler.eventType)
     }
@@ -42,6 +46,7 @@ class NotificationEventHandlerTest : IntegrationTestSupport() {
         assertEquals(NotificationType.ITEM_PARSING_COMPLETED, itemParsingCompletedHandler.notificationType)
         assertEquals(NotificationType.ITEM_PARSING_FAILED, itemParsingFailedHandler.notificationType)
         assertEquals(NotificationType.TOURNAMENT_ITEM_ADDED, tournamentItemAddedHandler.notificationType)
+        assertEquals(NotificationType.TOURNAMENT_ITEM_DELETED, tournamentItemDeletedHandler.notificationType)
         assertEquals(NotificationType.TOURNAMENT_JOINED, tournamentJoinedHandler.notificationType)
         assertEquals(NotificationType.TOURNAMENT_STARTED, tournamentStartedHandler.notificationType)
     }

--- a/src/test/kotlin/com/depromeet/piki/notification/handler/NotificationRecipientResolutionIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/notification/handler/NotificationRecipientResolutionIntegrationTest.kt
@@ -5,6 +5,7 @@ import com.depromeet.piki.item.event.ItemParsingCompleted
 import com.depromeet.piki.item.event.ItemParsingFailed
 import com.depromeet.piki.item.repository.ItemSnapshotRepository
 import com.depromeet.piki.notification.domain.NotificationRouting
+import com.depromeet.piki.notification.domain.NotificationType
 import com.depromeet.piki.notification.repository.NotificationRepository
 import com.depromeet.piki.notification.service.NotificationDispatcher
 import com.depromeet.piki.support.IntegrationTestSupport
@@ -13,6 +14,7 @@ import com.depromeet.piki.tournament.domain.TournamentItem
 import com.depromeet.piki.tournament.domain.TournamentUser
 import com.depromeet.piki.tournament.event.TournamentCompleted
 import com.depromeet.piki.tournament.event.TournamentItemAdded
+import com.depromeet.piki.tournament.event.TournamentItemDeleted
 import com.depromeet.piki.tournament.event.TournamentJoined
 import com.depromeet.piki.tournament.event.TournamentPlayedFromLink
 import com.depromeet.piki.tournament.event.TournamentResultReady
@@ -38,6 +40,8 @@ import kotlin.test.assertTrue
 @Transactional
 class NotificationRecipientResolutionIntegrationTest : IntegrationTestSupport() {
     @Autowired private lateinit var itemAddedHandler: TournamentItemAddedHandler
+
+    @Autowired private lateinit var itemDeletedHandler: TournamentItemDeletedHandler
 
     @Autowired private lateinit var joinedHandler: TournamentJoinedHandler
 
@@ -80,6 +84,61 @@ class NotificationRecipientResolutionIntegrationTest : IntegrationTestSupport() 
         val recipients = itemAddedHandler.resolveRecipients(TournamentItemAdded(tournamentId, actor))
 
         assertEquals(setOf(other1, other2), recipients)
+    }
+
+    @Test
+    fun `토너먼트 아이템 삭제 수신자는 참가자에서 삭제한 본인을 뺀 집합이다`() {
+        val tournamentId = 1201L
+        val actor = UUID.randomUUID()
+        val other1 = UUID.randomUUID()
+        val other2 = UUID.randomUUID()
+        // 삭제한 본인(등록자 또는 주최자)은 자기 화면이 이미 알고 있어 제외 — 추가 알림과 동일 규칙.
+        listOf(actor, other1, other2).forEach { tournamentUserRepository.save(TournamentUser(tournamentId, it)) }
+
+        val recipients = itemDeletedHandler.resolveRecipients(TournamentItemDeleted(tournamentId, tournamentItemId = 1L, snapshotId = 1L, actorId = actor))
+
+        assertEquals(setOf(other1, other2), recipients)
+    }
+
+    @Test
+    fun `토너먼트 아이템 삭제 라우팅은 그 토너먼트와 빠진 아이템 좌표다`() {
+        val routing =
+            itemDeletedHandler.resolveRouting(
+                TournamentItemDeleted(tournamentId = 1204L, tournamentItemId = 5555L, snapshotId = 1L, actorId = UUID.randomUUID()),
+            )
+
+        assertEquals(NotificationRouting.Tournament(tournamentId = 1204L, tournamentItemId = 5555L), routing)
+    }
+
+    @Test
+    fun `토너먼트 아이템 삭제 변수는 actorName 과 snapshot 에서 끌어온 itemName 을 함께 담는다`() {
+        val tournamentId = 1202L
+        val actor = UUID.randomUUID()
+        userRepository.save(User(id = actor, nickname = "홍길동", profileImage = "https://x/p.jpg", identityType = IdentityType.GUEST))
+        val snapshotId = itemSnapshotRepository.save(ItemSnapshot(itemId = 7202L, name = "나이키 에어맥스")).getId()
+
+        val variables =
+            itemDeletedHandler.resolveActorContext(
+                TournamentItemDeleted(tournamentId, tournamentItemId = 1L, snapshotId = snapshotId, actorId = actor),
+            ).variables
+
+        assertEquals(
+            mapOf("actorName" to "홍길동", "tournamentId" to "1202", "tournamentName" to "토너먼트", "itemName" to "나이키 에어맥스"),
+            variables,
+        )
+    }
+
+    @Test
+    fun `토너먼트 아이템 삭제 변수 itemName 은 상품명이 아직 없으면 fallback 이다`() {
+        // 파싱 전(PROCESSING) 아이템을 지운 경우 — snapshot.name 이 null 이라 fallback 문구로 채운다.
+        val snapshotId = itemSnapshotRepository.save(ItemSnapshot.processing(7203L)).getId()
+
+        val variables =
+            itemDeletedHandler.resolveActorContext(
+                TournamentItemDeleted(tournamentId = 1203L, tournamentItemId = 1L, snapshotId = snapshotId, actorId = UUID.randomUUID()),
+            ).variables
+
+        assertEquals("상품", variables["itemName"])
     }
 
     @Test
@@ -179,6 +238,32 @@ class NotificationRecipientResolutionIntegrationTest : IntegrationTestSupport() 
         assertEquals("https://x/snap.png", saved.first().actorImageUrl) // 발송 시점 actor 프사가 그대로 박혔다
         // 같은 컨텍스트의 변수(actorName)가 템플릿에 렌더돼 제목에 박힌다 — 변수·프사가 한 조회에서 함께 흐르는지 end-to-end 로 가드한다.
         assertEquals("행위자님이 아이템을 추가했어요", saved.first().title)
+    }
+
+    @Test
+    fun `dispatch 가 아이템 삭제 알림을 상품명까지 렌더하고 아이템 좌표를 라우팅에 박는다 - end-to-end`() {
+        val tournamentId = 1205L
+        val tournamentItemId = 6001L
+        val actor = UUID.randomUUID()
+        val recipient = UUID.randomUUID()
+        listOf(actor, recipient).forEach { tournamentUserRepository.save(TournamentUser(tournamentId, it)) }
+        userRepository.save(User(id = actor, nickname = "행위자", profileImage = "https://x/snap.png", identityType = IdentityType.GUEST))
+        val snapshotId = itemSnapshotRepository.save(ItemSnapshot(itemId = 7205L, name = "나이키 에어맥스")).getId()
+
+        // 이벤트 발행 → dispatch → 삭제 핸들러(snapshot 으로 상품명 해석) → 삭제 템플릿 렌더 + 라우팅까지 실제 체인을 탄다.
+        notificationDispatcher.dispatch(
+            TournamentItemDeleted(tournamentId, tournamentItemId = tournamentItemId, snapshotId = snapshotId, actorId = actor),
+        )
+
+        val saved = notificationRepository.findPage(recipient, cursor = null, limit = 10, types = null)
+        assertEquals(1, saved.size)
+        assertEquals(NotificationType.TOURNAMENT_ITEM_DELETED, saved.first().type)
+        assertEquals(tournamentId, saved.first().refId)
+        // 상품명이 템플릿에 렌더돼 제목에 박힌다.
+        assertEquals("행위자님이 '나이키 에어맥스'을(를) 삭제했어요", saved.first().title)
+        assertEquals("https://x/snap.png", saved.first().actorImageUrl)
+        // 어느 토너먼트의 어느 아이템이 빠졌는지 좌표가 payload 로 흐를 라우팅에 박힌다(클라가 그 항목만 제거).
+        assertEquals(NotificationRouting.Tournament(tournamentId, tournamentItemId), saved.first().routing())
     }
 
     @Test

--- a/src/test/kotlin/com/depromeet/piki/notification/sse/NotificationSseIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/notification/sse/NotificationSseIntegrationTest.kt
@@ -191,7 +191,7 @@ class NotificationSseIntegrationTest : IntegrationTestSupport() {
         try {
             sseNotificationChannel.send(userId, notification)
 
-            val payload = emitter.sentData.filterIsInstance<NotificationSsePayload.TournamentParsing>().first()
+            val payload = emitter.sentData.filterIsInstance<NotificationSsePayload.TournamentRouted>().first()
             assertEquals(NotificationKind.TOURNAMENT, payload.kind)
             assertEquals(99L, payload.tournamentId)
             assertEquals(555L, payload.tournamentItemId)
@@ -245,7 +245,7 @@ class NotificationSseIntegrationTest : IntegrationTestSupport() {
         val reloaded = notificationJpaRepository.findById(saved.getId()).orElseThrow()
 
         val payload = NotificationSsePayload.from(reloaded, DEFAULT_PUSH_IMAGE_URL)
-        val tournament = assertIs<NotificationSsePayload.TournamentParsing>(payload)
+        val tournament = assertIs<NotificationSsePayload.TournamentRouted>(payload)
         assertEquals(NotificationKind.TOURNAMENT, tournament.kind)
         assertEquals(99L, tournament.tournamentId)
         assertEquals(555L, tournament.tournamentItemId)


### PR DESCRIPTION
## Situation

- web 이 토너먼트 단건 조회를 30초마다 폴링하고 있었다.
- 원인은 **아이템 삭제를 알리는 SSE 이벤트가 없어서**였다. 다른 참가자가 출전 아이템을 빼도 클라가 알 길이 없어, 폴링으로 목록 변화를 메우던 임시 처리였다.
- 아이템 추가는 이미 SSE 알림(`TOURNAMENT_ITEM_ADDED`)으로 나가고 있어, 삭제만 비어 있는 비대칭 상태였다.

## Task

- 토너먼트 아이템 삭제 시 SSE 이벤트를 발행해 web 의 30초 폴링을 제거한다.
- 핵심 결정 둘:
  - 이 프로젝트의 SSE 는 **알림 단일 스트림**이고 디스패처가 한 알림을 모든 채널(SSE + 알림센터 + FCM)로 일괄 발송한다. "SSE 만" 보내는 경로가 없어, 삭제를 어떤 알림으로 처리할지 정해야 했다.
  - 삭제는 추가와 달리 클라가 그 아이템을 이미 화면에 들고 있다. 어느 아이템인지(`tournamentItemId`)와 상품명을 함께 내려, 재조회 없이 그 항목만 빼고 "OO님이 '상품명'을 삭제" 로 보이게 한다.

## Action

### 설계 결정 (검토한 대안 포함)

| 안 | 동작 | 변경 범위 | 채택 |
|---|---|---|---|
| 추가 알림과 대칭 풀 알림 | SSE + 알림센터 기록 + FCM 푸시 모두 발송 | 기존 파이프라인 재사용, 최소 | O |
| SSE 전용 sync 신호 | 푸시·알림센터 노출 없이 SSE 로만 | 디스패처 채널 선택 정책 + 알림센터 필터 신설 필요, 큼 | X |

- 추가 알림(`TOURNAMENT_ITEM_ADDED`)을 거울로 떠서 삭제 알림 타입을 신설하는 쪽을 택했다. 구조가 알림 파이프라인과 결합돼 있어, 별도 채널을 새로 파기보다 검증된 경로를 재사용하는 편이 적은 변경으로 일관성을 지킨다.

### 동작

- **발행 지점**: 아이템 soft delete 가 성공한 직후에만 발행한다. 트랜잭션 커밋 이후(AFTER_COMMIT) 비동기로 디스패치되어, 삭제가 롤백되면 알림도 안 나간다.
- **수신자**: 그 토너먼트 참가자에서 삭제한 본인(아이템 등록자 또는 주최자)을 뺀 집합. 자기가 지운 건 자기 화면이 이미 알고 있어서로, 추가 알림과 동일 규칙이다.
- **어떤 아이템인지**: payload 에 `tournamentId`(=`refId`, 탭하면 그 토너먼트로 입장)와 `tournamentItemId`(빠진 아이템)를 싣는다. 클라는 재조회 없이 그 항목만 제거한다.
- **상품명**: 메시지에 상품명을 렌더한다("OO님이 '나이키 에어맥스'을(를) 삭제했어요"). 파싱 전(PROCESSING) 아이템이라 이름이 없으면 fallback 문구.

### 상품명 해석 — soft delete 함정

- `tournament_item` 은 삭제 직후 soft delete 라, AFTER_COMMIT 으로 도는 알림 핸들러가 `tournamentItemId` 로 역조회하면 못 닿는다(`findById` 가 deleted 를 거른다).
- 그래서 이벤트가 `snapshotId` 를 함께 싣고, 핸들러가 **살아있는 snapshot**(공유 immutable 행)에서 상품명을 해석한다. snapshot 은 soft delete 대상이 아니라 안전하다. (도메인 이벤트는 식별자만 싣고 표시 데이터는 알림 도메인이 해석하는 기존 패턴 유지.)

### 구현

- 도메인 이벤트 `TournamentItemDeleted`(tournamentId, tournamentItemId, snapshotId, actorId), `TournamentService.deleteItem` 에서 발행.
- 알림 타입 `TOURNAMENT_ITEM_DELETED`(카테고리 ACTIVITY). 카테고리 매핑이 전수 `when` 이라 누락 시 컴파일이 깨져 분류가 강제된다.
- 핸들러 `TournamentItemDeletedHandler` + 리스너 + 변수 카탈로그(`itemName` 추가) + 알림 타입 카탈로그 docs(전 10종).
- 아이템 좌표를 싣는 SSE payload 셰입이 파싱 알림 전용이 아니게 돼 `TournamentParsing` → `TournamentRouted` 로 중립화(파싱·삭제가 공유). FCM data 매핑·예시도 함께 갱신.
- 템플릿 시드는 Flyway 마이그레이션. 본문의 리터럴 dollar-brace 가 Flyway placeholder 로 오인되는 함정 때문에, 기존 시드와 동일하게 SQL 이 아닌 JDBC Java 마이그레이션으로 적재.

## Result

- web 은 새 SSE 타입 `TOURNAMENT_ITEM_DELETED`(`event:notification` 스트림 합류, `refId=tournamentId` + `tournamentId`·`tournamentItemId` 좌표 + 상품명 렌더된 `title`)를 구독해 30초 폴링을 제거하고, 빠진 항목만 제거할 수 있다.
- 트레이드오프: 삭제도 추가와 대칭으로 알림센터 기록 + FCM 푸시까지 함께 나간다. SSE 신호만 원했다면 노이즈일 수 있으나, 채널 분리 비용 대비 일관성을 택한 결과다.
- 후속: web 측 구독 전환은 별도 작업(프론트).

---
## 연관 이슈

- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 토너먼트 아이템 삭제 시 참가 사용자에게 알림 전송 기능 추가
  * 삭제 알림에 삭제자 정보와 상품명 포함
  * 새로운 알림 템플릿 및 라우팅 지원

<!-- end of auto-generated comment: release notes by coderabbit.ai -->