### PR TITLE
유저용 공지사항 조회 API (목록 · 단건)

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/admin/announcement/AdminAnnouncementController.kt
+++ b/src/main/kotlin/com/depromeet/piki/admin/announcement/AdminAnnouncementController.kt
@@ -1,4 +1,5 @@
 package com.depromeet.piki.admin.announcement
+import com.depromeet.piki.announcement.domain.Announcement
 
 import com.depromeet.piki.admin.access.AdminSession
 import com.depromeet.piki.admin.config.ClientIp

--- a/src/main/kotlin/com/depromeet/piki/admin/announcement/AdminAnnouncementService.kt
+++ b/src/main/kotlin/com/depromeet/piki/admin/announcement/AdminAnnouncementService.kt
@@ -1,4 +1,6 @@
 package com.depromeet.piki.admin.announcement
+import com.depromeet.piki.announcement.domain.Announcement
+import com.depromeet.piki.announcement.repository.AnnouncementRepository
 
 import com.depromeet.piki.admin.audit.AdminAuditAction
 import com.depromeet.piki.admin.audit.AdminAuditService

--- a/src/main/kotlin/com/depromeet/piki/admin/announcement/AnnouncementProgressWriter.kt
+++ b/src/main/kotlin/com/depromeet/piki/admin/announcement/AnnouncementProgressWriter.kt
@@ -1,4 +1,5 @@
 package com.depromeet.piki.admin.announcement
+import com.depromeet.piki.announcement.repository.AnnouncementRepository
 
 import com.depromeet.piki.notification.fcm.service.UserDeviceService
 import org.springframework.stereotype.Service

--- a/src/main/kotlin/com/depromeet/piki/admin/announcement/AnnouncementScheduler.kt
+++ b/src/main/kotlin/com/depromeet/piki/admin/announcement/AnnouncementScheduler.kt
@@ -1,4 +1,6 @@
 package com.depromeet.piki.admin.announcement
+import com.depromeet.piki.announcement.domain.Announcement
+import com.depromeet.piki.announcement.repository.AnnouncementRepository
 
 import com.depromeet.piki.admin.config.AdminProperties
 import com.depromeet.piki.admin.config.ConditionalOnAdminEnabled

--- a/src/main/kotlin/com/depromeet/piki/announcement/controller/AnnouncementApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/announcement/controller/AnnouncementApi.kt
@@ -1,0 +1,48 @@
+package com.depromeet.piki.announcement.controller
+
+import com.depromeet.piki.announcement.controller.dto.AnnouncementResponse
+import com.depromeet.piki.common.response.ApiResponseBody
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+
+@Tag(name = "Announcement", description = "공지사항 조회 (발송 완료된 공지만 노출)")
+interface AnnouncementApi {
+    @Operation(
+        summary = "공지사항 목록 조회",
+        description =
+            "발송 완료(SENT)된 공지를 최신순으로 페이징 조회한다. 미발송(DRAFT·SCHEDULED·SENDING·MISSED) 공지는 노출되지 않는다. " +
+                "응답 `pageResponse.nextCursor` 를 다음 요청의 `cursor` 로 넘겨 다음 페이지를 받는다(없으면 마지막 페이지).",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "조회 성공 (목록 + 페이지 정보)"),
+            ApiResponse(responseCode = "400", description = "유효하지 않은 cursor (숫자로 변환 불가)"),
+            ApiResponse(responseCode = "401", description = "인증 필요 (로그인하지 않음)"),
+        ],
+    )
+    fun list(
+        @Parameter(description = "다음 페이지 커서(이전 응답의 nextCursor). 첫 페이지는 생략", example = "1024")
+        cursor: String?,
+        @Parameter(description = "페이지 크기(1~50, 기본 20)", example = "20")
+        size: Int,
+    ): ApiResponseBody<List<AnnouncementResponse>>
+
+    @Operation(
+        summary = "공지사항 단건 조회",
+        description = "공지 id 로 발송 완료된 공지를 조회한다(알림 딥링크 착지). SENT 가 아니거나 없으면 404.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "조회 성공"),
+            ApiResponse(responseCode = "404", description = "존재하지 않거나 아직 발송되지 않은 공지"),
+            ApiResponse(responseCode = "401", description = "인증 필요 (로그인하지 않음)"),
+        ],
+    )
+    fun get(
+        @Parameter(description = "공지 id (알림 deeplink refId)", example = "42")
+        announcementId: Long,
+    ): ApiResponseBody<AnnouncementResponse>
+}

--- a/src/main/kotlin/com/depromeet/piki/announcement/controller/AnnouncementApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/announcement/controller/AnnouncementApiExamples.kt
@@ -37,7 +37,8 @@ class AnnouncementApiExamples(
                         payload =
                             ApiResponseBody.ok(
                                 data = listOf(sampleAnnouncement),
-                                pageResponse = PageResponse(nextCursor = "42", hasNext = true),
+                                // nextCursor 는 (sentAt, id)를 base64 로 인코딩한 opaque 토큰 — 다음 요청의 cursor 로 그대로 넘긴다.
+                                pageResponse = PageResponse(nextCursor = "MjAyNi0wNi0xOFQxMDowMDowMF80Mw", hasNext = true),
                             ),
                     )
                     add(

--- a/src/main/kotlin/com/depromeet/piki/announcement/controller/AnnouncementApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/announcement/controller/AnnouncementApiExamples.kt
@@ -1,0 +1,81 @@
+package com.depromeet.piki.announcement.controller
+
+import com.depromeet.piki.announcement.controller.dto.AnnouncementResponse
+import com.depromeet.piki.announcement.domain.AnnouncementException
+import com.depromeet.piki.common.openapi.OpenApiObjectMapper
+import com.depromeet.piki.common.openapi.binds
+import com.depromeet.piki.common.openapi.examples
+import com.depromeet.piki.common.response.ApiResponseBody
+import com.depromeet.piki.common.response.PageResponse
+import org.springdoc.core.customizers.OperationCustomizer
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpStatus
+import java.time.LocalDateTime
+
+@Configuration
+class AnnouncementApiExamples(
+    private val openApiObjectMapper: OpenApiObjectMapper,
+) {
+    @Bean
+    fun announcementOpenApiExamples(): OperationCustomizer =
+        OperationCustomizer { operation, handlerMethod ->
+            if (handlerMethod.binds(AnnouncementController::list)) {
+                operation.examples(openApiObjectMapper.delegate) {
+                    add(
+                        status = HttpStatus.OK,
+                        name = "조회 성공 (마지막 페이지)",
+                        payload =
+                            ApiResponseBody.ok(
+                                data = listOf(sampleAnnouncement, olderAnnouncement),
+                                pageResponse = PageResponse(nextCursor = null, hasNext = false),
+                            ),
+                    )
+                    add(
+                        status = HttpStatus.OK,
+                        name = "조회 성공 (다음 페이지 있음)",
+                        payload =
+                            ApiResponseBody.ok(
+                                data = listOf(sampleAnnouncement),
+                                pageResponse = PageResponse(nextCursor = "42", hasNext = true),
+                            ),
+                    )
+                    add(
+                        status = HttpStatus.OK,
+                        name = "공지 없음 (빈 목록)",
+                        payload =
+                            ApiResponseBody.ok(
+                                data = emptyList<AnnouncementResponse>(),
+                                pageResponse = PageResponse(nextCursor = null, hasNext = false),
+                            ),
+                    )
+                    add(AnnouncementException.invalidCursor(), name = "유효하지 않은 cursor")
+                    unauthorized()
+                }
+            }
+            if (handlerMethod.binds(AnnouncementController::get)) {
+                operation.examples(openApiObjectMapper.delegate) {
+                    add(status = HttpStatus.OK, name = "조회 성공", payload = ApiResponseBody.ok(data = sampleAnnouncement))
+                    add(AnnouncementException.notFound(), name = "존재하지 않거나 미발송 공지")
+                    unauthorized()
+                }
+            }
+            operation
+        }
+
+    private val sampleAnnouncement =
+        AnnouncementResponse(
+            id = 43,
+            title = "서비스 점검 안내",
+            body = "6월 20일 02:00~04:00 점검이 예정되어 있어요.",
+            sentAt = LocalDateTime.of(2026, 6, 18, 10, 0, 0),
+        )
+
+    private val olderAnnouncement =
+        AnnouncementResponse(
+            id = 42,
+            title = "신규 기능 추가",
+            body = "토너먼트 결과 공유가 추가되었어요.",
+            sentAt = LocalDateTime.of(2026, 6, 15, 9, 30, 0),
+        )
+}

--- a/src/main/kotlin/com/depromeet/piki/announcement/controller/AnnouncementController.kt
+++ b/src/main/kotlin/com/depromeet/piki/announcement/controller/AnnouncementController.kt
@@ -2,6 +2,7 @@ package com.depromeet.piki.announcement.controller
 
 import com.depromeet.piki.announcement.controller.dto.AnnouncementResponse
 import com.depromeet.piki.announcement.domain.AnnouncementException
+import com.depromeet.piki.announcement.service.AnnouncementCursor
 import com.depromeet.piki.announcement.service.AnnouncementQueryService
 import com.depromeet.piki.common.response.ApiResponseBody
 import com.depromeet.piki.common.response.PageResponse
@@ -21,12 +22,12 @@ class AnnouncementController(
         @RequestParam(required = false) cursor: String?,
         @RequestParam(defaultValue = "${AnnouncementQueryService.DEFAULT_PAGE_SIZE}") size: Int,
     ): ApiResponseBody<List<AnnouncementResponse>> {
-        // cursor 가 있으나 숫자가 아니면 입력 경계 계약 위반 → 400. 없으면 첫 페이지.
-        val cursorId = cursor?.let { it.toLongOrNull() ?: throw AnnouncementException.invalidCursor() }
-        val page = announcementQueryService.listSent(cursorId, size)
+        // cursor 가 있으나 디코딩 안 되면(변조·잘못된 형식) 입력 경계 계약 위반 → 400. 없으면 첫 페이지.
+        val cursorKey = cursor?.let { AnnouncementCursor.decode(it) ?: throw AnnouncementException.invalidCursor() }
+        val page = announcementQueryService.listSent(cursorKey, size)
         return ApiResponseBody.ok(
             data = page.items.map(AnnouncementResponse::from),
-            pageResponse = PageResponse(nextCursor = page.nextCursor?.toString(), hasNext = page.hasNext),
+            pageResponse = PageResponse(nextCursor = page.nextCursor?.encode(), hasNext = page.hasNext),
         )
     }
 

--- a/src/main/kotlin/com/depromeet/piki/announcement/controller/AnnouncementController.kt
+++ b/src/main/kotlin/com/depromeet/piki/announcement/controller/AnnouncementController.kt
@@ -1,0 +1,37 @@
+package com.depromeet.piki.announcement.controller
+
+import com.depromeet.piki.announcement.controller.dto.AnnouncementResponse
+import com.depromeet.piki.announcement.domain.AnnouncementException
+import com.depromeet.piki.announcement.service.AnnouncementQueryService
+import com.depromeet.piki.common.response.ApiResponseBody
+import com.depromeet.piki.common.response.PageResponse
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/announcements")
+class AnnouncementController(
+    private val announcementQueryService: AnnouncementQueryService,
+) : AnnouncementApi {
+    @GetMapping
+    override fun list(
+        @RequestParam(required = false) cursor: String?,
+        @RequestParam(defaultValue = "${AnnouncementQueryService.DEFAULT_PAGE_SIZE}") size: Int,
+    ): ApiResponseBody<List<AnnouncementResponse>> {
+        // cursor 가 있으나 숫자가 아니면 입력 경계 계약 위반 → 400. 없으면 첫 페이지.
+        val cursorId = cursor?.let { it.toLongOrNull() ?: throw AnnouncementException.invalidCursor() }
+        val page = announcementQueryService.listSent(cursorId, size)
+        return ApiResponseBody.ok(
+            data = page.items.map(AnnouncementResponse::from),
+            pageResponse = PageResponse(nextCursor = page.nextCursor?.toString(), hasNext = page.hasNext),
+        )
+    }
+
+    @GetMapping("/{announcementId}")
+    override fun get(
+        @PathVariable announcementId: Long,
+    ): ApiResponseBody<AnnouncementResponse> = ApiResponseBody.ok(AnnouncementResponse.from(announcementQueryService.getSent(announcementId)))
+}

--- a/src/main/kotlin/com/depromeet/piki/announcement/controller/dto/AnnouncementResponse.kt
+++ b/src/main/kotlin/com/depromeet/piki/announcement/controller/dto/AnnouncementResponse.kt
@@ -1,0 +1,29 @@
+package com.depromeet.piki.announcement.controller.dto
+
+import com.depromeet.piki.announcement.domain.Announcement
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+@Schema(description = "공지사항 단건")
+data class AnnouncementResponse(
+    @field:Schema(description = "공지 id (알림 딥링크 refId 와 동일)", example = "42")
+    val id: Long,
+    @field:Schema(description = "제목", example = "서비스 점검 안내")
+    val title: String,
+    @field:Schema(description = "본문", example = "6월 20일 02:00~04:00 점검이 예정되어 있어요.")
+    val body: String,
+    @field:Schema(description = "발송 시각(KST)", example = "2026-06-18T10:00:00")
+    val sentAt: LocalDateTime,
+) {
+    companion object {
+        // 도메인 → 응답 매핑 (받는 쪽이 책임). SENT 공지만 노출하므로 sentAt 은 markSent() 가 채워 항상 존재한다 —
+        // 없으면 SENT 인데 sentAt 이 비었다는 불변식 위반(서비스 버그)이라 requireNotNull(500).
+        fun from(announcement: Announcement): AnnouncementResponse =
+            AnnouncementResponse(
+                id = announcement.getId(),
+                title = announcement.title,
+                body = announcement.body,
+                sentAt = requireNotNull(announcement.sentAt) { "SENT 공지에 sentAt 이 없다" },
+            )
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/announcement/domain/Announcement.kt
+++ b/src/main/kotlin/com/depromeet/piki/announcement/domain/Announcement.kt
@@ -1,4 +1,4 @@
-package com.depromeet.piki.admin.announcement
+package com.depromeet.piki.announcement.domain
 
 import com.depromeet.piki.common.domain.LongBaseEntity
 import jakarta.persistence.Column

--- a/src/main/kotlin/com/depromeet/piki/announcement/domain/AnnouncementException.kt
+++ b/src/main/kotlin/com/depromeet/piki/announcement/domain/AnnouncementException.kt
@@ -1,0 +1,34 @@
+package com.depromeet.piki.announcement.domain
+
+import com.depromeet.piki.common.exception.BaseException
+import com.depromeet.piki.common.exception.ErrorCategory
+import com.depromeet.piki.common.exception.HttpMappable
+import org.springframework.http.HttpStatus
+
+// 공지 도메인 예외. WishException 과 같은 결로 status·category 를 예외 정의 한 곳에 박는다(HttpMappable).
+// message 는 사용자 대면 고정 문구 — 내부 정보(미발송 공지 존재 등)를 노출하지 않는다.
+class AnnouncementException private constructor(
+    message: String,
+    override val category: ErrorCategory,
+    override val httpStatus: HttpStatus,
+) : BaseException(message),
+    HttpMappable {
+    companion object {
+        // 발송 완료(SENT)되지 않았거나 존재하지 않는 공지. 미발송(DRAFT/SCHEDULED 등) 공지의 존재를 노출하지
+        // 않기 위해 "없음"과 동일하게 404 로 응답한다.
+        fun notFound(): AnnouncementException =
+            AnnouncementException(
+                "존재하지 않는 공지예요.",
+                ErrorCategory.NOT_FOUND,
+                HttpStatus.NOT_FOUND,
+            )
+
+        // 커서가 숫자로 변환되지 않는 등 잘못된 페이지 요청.
+        fun invalidCursor(): AnnouncementException =
+            AnnouncementException(
+                "페이지를 불러오지 못했어요. 새로고침 해주세요.",
+                ErrorCategory.INVALID_INPUT,
+                HttpStatus.BAD_REQUEST,
+            )
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/announcement/repository/AnnouncementRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/announcement/repository/AnnouncementRepository.kt
@@ -22,16 +22,28 @@ interface AnnouncementRepository : JpaRepository<Announcement, Long> {
         status: String,
     ): Announcement?
 
-    // 목록 첫 페이지(커서 없음) — SENT 만 최신순(id desc). limit 는 Pageable 로 +1 조회해 hasNext 판정.
-    fun findByStatusOrderByIdDesc(
+    // 목록 첫 페이지(커서 없음) — SENT 만 발송순(sentAt desc, 동시각 tie-breaker id desc).
+    // 정렬 키를 id 가 아니라 sentAt 으로 둔다 — 오래전 등록(낮은 id)한 공지를 나중에 예약 발송하면
+    // id 순과 실제 발송순이 어긋나, "방금 온 공지"가 목록 아래로 내려가기 때문. limit 는 Pageable 로 +1 조회해 hasNext 판정.
+    fun findByStatusOrderBySentAtDescIdDesc(
         status: String,
         pageable: Pageable,
     ): List<Announcement>
 
-    // 목록 다음 페이지 — cursor(id) 이전(더 오래된) SENT 만 최신순.
-    fun findByStatusAndIdLessThanOrderByIdDesc(
-        status: String,
-        id: Long,
+    // 목록 다음 페이지 — (sentAt, id) 복합 키셋 커서보다 "이전(더 오래된)" SENT 만. 동시각이면 id 로 가른다.
+    // 파생 쿼리로는 (a < b) OR (a = b AND c < d) 형태를 못 만들어 JPQL 로 둔다.
+    @Query(
+        """
+        select a from Announcement a
+        where a.status = :status
+          and (a.sentAt < :sentAt or (a.sentAt = :sentAt and a.id < :id))
+        order by a.sentAt desc, a.id desc
+        """,
+    )
+    fun findNextByStatusAndSentAtCursor(
+        @Param("status") status: String,
+        @Param("sentAt") sentAt: LocalDateTime,
+        @Param("id") id: Long,
         pageable: Pageable,
     ): List<Announcement>
 

--- a/src/main/kotlin/com/depromeet/piki/announcement/repository/AnnouncementRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/announcement/repository/AnnouncementRepository.kt
@@ -1,5 +1,6 @@
-package com.depromeet.piki.admin.announcement
+package com.depromeet.piki.announcement.repository
 
+import com.depromeet.piki.announcement.domain.Announcement
 import jakarta.persistence.LockModeType
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
@@ -9,10 +10,30 @@ import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import java.time.LocalDateTime
 
-// 공지 저장소. 발송 내역은 최신순으로 본다.
+// 공지 저장소(중립 도메인). admin 이 작성·발송에 쓰고, 유저 조회(공지사항 페이지·딥링크)도 같은 도메인을 단방향 참조한다.
 interface AnnouncementRepository : JpaRepository<Announcement, Long> {
     // 목록은 누적되므로 페이징한다(최신순). 한 페이지씩만 로드.
     fun findAllByOrderByCreatedAtDesc(pageable: Pageable): Page<Announcement>
+
+    // ── 유저 조회(#556) — 발송 완료(SENT)된 공지만 노출한다. DRAFT/SCHEDULED/SENDING/MISSED 는 보이지 않는다. ──
+    // 단건(딥링크 착지). SENT 가 아니거나 없으면 null → 서비스가 404 로 변환(미발송 공지의 존재를 노출하지 않음).
+    fun findByIdAndStatus(
+        id: Long,
+        status: String,
+    ): Announcement?
+
+    // 목록 첫 페이지(커서 없음) — SENT 만 최신순(id desc). limit 는 Pageable 로 +1 조회해 hasNext 판정.
+    fun findByStatusOrderByIdDesc(
+        status: String,
+        pageable: Pageable,
+    ): List<Announcement>
+
+    // 목록 다음 페이지 — cursor(id) 이전(더 오래된) SENT 만 최신순.
+    fun findByStatusAndIdLessThanOrderByIdDesc(
+        status: String,
+        id: Long,
+        pageable: Pageable,
+    ): List<Announcement>
 
     // SENDING 클레임용 비관적 락(SELECT ... FOR UPDATE). claim 의 조회→상태검사→저장을 한 트랜잭션 안에서
     // 직렬화해, 더블클릭·스케줄러/수동 경합으로 같은 공지가 두 번 SENDING 으로 전환돼 전체 유저에게 중복

--- a/src/main/kotlin/com/depromeet/piki/announcement/service/AnnouncementQueryService.kt
+++ b/src/main/kotlin/com/depromeet/piki/announcement/service/AnnouncementQueryService.kt
@@ -1,0 +1,51 @@
+package com.depromeet.piki.announcement.service
+
+import com.depromeet.piki.announcement.domain.Announcement
+import com.depromeet.piki.announcement.domain.AnnouncementException
+import com.depromeet.piki.announcement.repository.AnnouncementRepository
+import org.springframework.data.domain.PageRequest
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+// 유저용 공지 조회(#556) — 발송 완료(SENT)된 공지만 노출한다. 작성·발송은 admin 이, 조회는 여기서.
+@Service
+class AnnouncementQueryService(
+    private val announcementRepository: AnnouncementRepository,
+) {
+    // 단건(딥링크 착지). SENT 가 아니거나 없으면 404 — 미발송 공지의 존재를 노출하지 않는다.
+    @Transactional(readOnly = true)
+    fun getSent(id: Long): Announcement =
+        announcementRepository.findByIdAndStatus(id, Announcement.STATUS_SENT)
+            ?: throw AnnouncementException.notFound()
+
+    // 목록(공지사항 페이지) — SENT 만 최신순(id desc), 커서 페이지네이션. size+1 을 조회해 hasNext 를 판정하고
+    // 초과분을 잘라 다음 커서(마지막 항목 id)를 만든다.
+    @Transactional(readOnly = true)
+    fun listSent(
+        cursor: Long?,
+        size: Int,
+    ): AnnouncementPage {
+        val pageSize = size.coerceIn(1, MAX_PAGE_SIZE)
+        val pageable = PageRequest.of(0, pageSize + 1)
+        val rows =
+            cursor
+                ?.let { announcementRepository.findByStatusAndIdLessThanOrderByIdDesc(Announcement.STATUS_SENT, it, pageable) }
+                ?: announcementRepository.findByStatusOrderByIdDesc(Announcement.STATUS_SENT, pageable)
+        val hasNext = rows.size > pageSize
+        val items = if (hasNext) rows.dropLast(1) else rows
+        val nextCursor = if (hasNext) items.last().getId() else null
+        return AnnouncementPage(items = items, nextCursor = nextCursor, hasNext = hasNext)
+    }
+
+    companion object {
+        const val DEFAULT_PAGE_SIZE = 20
+        const val MAX_PAGE_SIZE = 50
+    }
+}
+
+// 커서 페이지 결과 — 컨트롤러가 ApiResponseBody(data + pageResponse)로 펼친다.
+data class AnnouncementPage(
+    val items: List<Announcement>,
+    val nextCursor: Long?,
+    val hasNext: Boolean,
+)

--- a/src/main/kotlin/com/depromeet/piki/announcement/service/AnnouncementQueryService.kt
+++ b/src/main/kotlin/com/depromeet/piki/announcement/service/AnnouncementQueryService.kt
@@ -6,6 +6,8 @@ import com.depromeet.piki.announcement.repository.AnnouncementRepository
 import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+import java.util.Base64
 
 // 유저용 공지 조회(#556) — 발송 완료(SENT)된 공지만 노출한다. 작성·발송은 admin 이, 조회는 여기서.
 @Service
@@ -18,22 +20,28 @@ class AnnouncementQueryService(
         announcementRepository.findByIdAndStatus(id, Announcement.STATUS_SENT)
             ?: throw AnnouncementException.notFound()
 
-    // 목록(공지사항 페이지) — SENT 만 최신순(id desc), 커서 페이지네이션. size+1 을 조회해 hasNext 를 판정하고
-    // 초과분을 잘라 다음 커서(마지막 항목 id)를 만든다.
+    // 목록(공지사항 페이지) — SENT 만 발송순(sentAt desc, 동시각 tie-breaker id desc), 커서 페이지네이션.
+    // 정렬 키를 id 가 아니라 sentAt 으로 둔다 — 예약 발송으로 등록순(id)과 발송순이 어긋나도 목록이 실제 발송순을 따르게.
+    // size+1 을 조회해 hasNext 를 판정하고, 초과분을 잘라 다음 커서(마지막 항목의 sentAt·id)를 만든다.
     @Transactional(readOnly = true)
     fun listSent(
-        cursor: Long?,
+        cursor: AnnouncementCursor?,
         size: Int,
     ): AnnouncementPage {
         val pageSize = size.coerceIn(1, MAX_PAGE_SIZE)
         val pageable = PageRequest.of(0, pageSize + 1)
         val rows =
             cursor
-                ?.let { announcementRepository.findByStatusAndIdLessThanOrderByIdDesc(Announcement.STATUS_SENT, it, pageable) }
-                ?: announcementRepository.findByStatusOrderByIdDesc(Announcement.STATUS_SENT, pageable)
+                ?.let {
+                    announcementRepository.findNextByStatusAndSentAtCursor(Announcement.STATUS_SENT, it.sentAt, it.id, pageable)
+                }
+                ?: announcementRepository.findByStatusOrderBySentAtDescIdDesc(Announcement.STATUS_SENT, pageable)
         val hasNext = rows.size > pageSize
         val items = if (hasNext) rows.dropLast(1) else rows
-        val nextCursor = if (hasNext) items.last().getId() else null
+        val nextCursor =
+            items.lastOrNull()
+                ?.takeIf { hasNext }
+                ?.let { AnnouncementCursor(sentAt = requireNotNull(it.sentAt) { "SENT 공지에 sentAt 이 없다" }, id = it.getId()) }
         return AnnouncementPage(items = items, nextCursor = nextCursor, hasNext = hasNext)
     }
 
@@ -46,6 +54,32 @@ class AnnouncementQueryService(
 // 커서 페이지 결과 — 컨트롤러가 ApiResponseBody(data + pageResponse)로 펼친다.
 data class AnnouncementPage(
     val items: List<Announcement>,
-    val nextCursor: Long?,
+    val nextCursor: AnnouncementCursor?,
     val hasNext: Boolean,
 )
+
+// 복합 커서 — 정렬 키(sentAt, id)를 그대로 담는다. 클라이언트엔 base64 한 줄(opaque)로 인코딩해 내려가고, 다시 받아 디코딩한다.
+// 단일 id 가 아니라 (sentAt, id) 두 좌표가 필요한 이유는 sentAt 동시각 tie-breaker(id) 때문.
+data class AnnouncementCursor(
+    val sentAt: LocalDateTime,
+    val id: Long,
+) {
+    // "{ISO-8601 LocalDateTime}_{id}" 를 base64 URL-safe 로 — 내부 정렬 키를 노출하지 않고 한 토큰으로 주고받는다.
+    fun encode(): String = Base64.getUrlEncoder().withoutPadding().encodeToString("$sentAt$DELIM$id".toByteArray())
+
+    companion object {
+        private const val DELIM = "_"
+
+        // 잘못된 커서(임의 문자열·변조)는 null → 컨트롤러가 400 으로 변환한다. ISO LocalDateTime 엔 '_' 가 없어 마지막 '_' 로 가른다.
+        fun decode(raw: String): AnnouncementCursor? =
+            runCatching {
+                val decoded = String(Base64.getUrlDecoder().decode(raw))
+                val sep = decoded.lastIndexOf(DELIM)
+                if (sep < 0) return null
+                AnnouncementCursor(
+                    sentAt = LocalDateTime.parse(decoded.substring(0, sep)),
+                    id = decoded.substring(sep + 1).toLong(),
+                )
+            }.getOrNull()
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/common/config/OpenApiConfig.kt
+++ b/src/main/kotlin/com/depromeet/piki/common/config/OpenApiConfig.kt
@@ -86,6 +86,7 @@ class OpenApiConfig {
                 "Tournament",
                 "Tournament Item",
                 "Notification",
+                "Announcement",
                 "FCM",
                 "Dev",
             )

--- a/src/test/kotlin/com/depromeet/piki/admin/announcement/AnnouncementSchedulingIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/admin/announcement/AnnouncementSchedulingIntegrationTest.kt
@@ -1,4 +1,6 @@
 package com.depromeet.piki.admin.announcement
+import com.depromeet.piki.announcement.domain.Announcement
+import com.depromeet.piki.announcement.repository.AnnouncementRepository
 
 import com.depromeet.piki.notification.domain.NotificationType
 import com.depromeet.piki.notification.fcm.domain.UserDevice

--- a/src/test/kotlin/com/depromeet/piki/announcement/controller/AnnouncementControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/announcement/controller/AnnouncementControllerIntegrationTest.kt
@@ -1,0 +1,150 @@
+package com.depromeet.piki.announcement.controller
+
+import com.depromeet.piki.announcement.domain.Announcement
+import com.depromeet.piki.announcement.repository.AnnouncementRepository
+import com.depromeet.piki.auth.infrastructure.jwt.JwtProvider
+import com.depromeet.piki.support.IntegrationTestSupport
+import com.depromeet.piki.user.domain.IdentityType
+import org.hamcrest.Matchers.notNullValue
+import org.hamcrest.Matchers.nullValue
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpHeaders
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.context.WebApplicationContext
+import java.util.UUID
+
+@Transactional
+class AnnouncementControllerIntegrationTest : IntegrationTestSupport() {
+    @Autowired private lateinit var webApplicationContext: WebApplicationContext
+
+    @Autowired private lateinit var jwtProvider: JwtProvider
+
+    @Autowired private lateinit var announcementRepository: AnnouncementRepository
+
+    private fun authHeader(userId: UUID = UUID.randomUUID()): String =
+        "Bearer ${jwtProvider.generateAccessToken(userId, IdentityType.MEMBER)}"
+
+    private fun buildMockMvc(): MockMvc =
+        MockMvcBuilders
+            .webAppContextSetup(webApplicationContext)
+            .apply<DefaultMockMvcBuilder>(springSecurity())
+            .build()
+
+    // 발송 완료(SENT) 공지 — DRAFT → SENDING → SENT 전이로 sentAt 까지 채운다.
+    private fun sent(
+        title: String = "점검 안내",
+        body: String = "본문",
+    ): Announcement =
+        announcementRepository.save(
+            Announcement(title = title, body = body, target = "토큰 보유자 전체").apply {
+                markSending(recipientCount = 1, sentBy = "tester")
+                markSent()
+            },
+        )
+
+    // 미발송(DRAFT) 공지 — 유저에게 노출되면 안 된다.
+    private fun draft(): Announcement = announcementRepository.save(Announcement(title = "초안", body = "본문", target = "전체"))
+
+    @Test
+    fun `SENT 공지를 id 로 조회하면 200 과 본문이 ApiResponseBody contract 로 내려온다`() {
+        val announcement = sent(title = "서비스 점검 안내", body = "6월 20일 점검 예정")
+
+        buildMockMvc()
+            .perform(get("/api/v1/announcements/${announcement.getId()}").header(HttpHeaders.AUTHORIZATION, authHeader()))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.id").value(announcement.getId()))
+            .andExpect(jsonPath("$.data.title").value("서비스 점검 안내"))
+            .andExpect(jsonPath("$.data.body").value("6월 20일 점검 예정"))
+            .andExpect(jsonPath("$.data.sentAt", notNullValue()))
+    }
+
+    @Test
+    fun `미발송 공지나 없는 id 는 단건 조회 시 404 다 (미발송 존재를 노출하지 않음)`() {
+        val draft = draft()
+        val mockMvc = buildMockMvc()
+
+        // DRAFT — 존재하지만 SENT 가 아니라 404
+        mockMvc
+            .perform(get("/api/v1/announcements/${draft.getId()}").header(HttpHeaders.AUTHORIZATION, authHeader()))
+            .andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.detail", notNullValue()))
+
+        // 없는 id — 404
+        mockMvc
+            .perform(get("/api/v1/announcements/999999").header(HttpHeaders.AUTHORIZATION, authHeader()))
+            .andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.detail", notNullValue()))
+    }
+
+    @Test
+    fun `목록은 SENT 만 최신순으로 내려오고 미발송은 제외된다`() {
+        val older = sent(title = "오래된 공지")
+        val newer = sent(title = "최신 공지")
+        draft() // 미발송 — 목록에 섞이면 안 됨
+
+        buildMockMvc()
+            .perform(get("/api/v1/announcements").header(HttpHeaders.AUTHORIZATION, authHeader()))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.length()").value(2))
+            // 최신순(id desc): newer → older
+            .andExpect(jsonPath("$.data[0].id").value(newer.getId()))
+            .andExpect(jsonPath("$.data[1].id").value(older.getId()))
+            .andExpect(jsonPath("$.pageResponse.hasNext").value(false))
+            .andExpect(jsonPath("$.pageResponse.nextCursor").value(nullValue()))
+    }
+
+    @Test
+    fun `목록은 size 로 페이지를 나누고 nextCursor 로 다음 페이지를 잇는다`() {
+        val first = sent(title = "1")
+        val second = sent(title = "2")
+        val third = sent(title = "3")
+        val mockMvc = buildMockMvc()
+
+        // 1페이지: size=2 → 최신 2건(third, second), 다음 페이지 있음, 커서=second
+        mockMvc
+            .perform(get("/api/v1/announcements").param("size", "2").header(HttpHeaders.AUTHORIZATION, authHeader()))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.length()").value(2))
+            .andExpect(jsonPath("$.data[0].id").value(third.getId()))
+            .andExpect(jsonPath("$.data[1].id").value(second.getId()))
+            .andExpect(jsonPath("$.pageResponse.hasNext").value(true))
+            .andExpect(jsonPath("$.pageResponse.nextCursor").value(second.getId().toString()))
+
+        // 2페이지: cursor=second → 남은 1건(first), 다음 페이지 없음
+        mockMvc
+            .perform(
+                get("/api/v1/announcements")
+                    .param("size", "2")
+                    .param("cursor", second.getId().toString())
+                    .header(HttpHeaders.AUTHORIZATION, authHeader()),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.length()").value(1))
+            .andExpect(jsonPath("$.data[0].id").value(first.getId()))
+            .andExpect(jsonPath("$.pageResponse.hasNext").value(false))
+            .andExpect(jsonPath("$.pageResponse.nextCursor").value(nullValue()))
+    }
+
+    @Test
+    fun `유효하지 않은 cursor 는 400 으로 거른다`() {
+        buildMockMvc()
+            .perform(get("/api/v1/announcements").param("cursor", "abc").header(HttpHeaders.AUTHORIZATION, authHeader()))
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.detail", notNullValue()))
+    }
+
+    @Test
+    fun `토큰 없이 조회하면 401 이 ApiResponseBody contract 로 내려간다`() {
+        buildMockMvc()
+            .perform(get("/api/v1/announcements"))
+            .andExpect(status().isUnauthorized)
+            .andExpect(jsonPath("$.detail", notNullValue()))
+    }
+}

--- a/src/test/kotlin/com/depromeet/piki/announcement/controller/AnnouncementControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/announcement/controller/AnnouncementControllerIntegrationTest.kt
@@ -5,6 +5,7 @@ import com.depromeet.piki.announcement.repository.AnnouncementRepository
 import com.depromeet.piki.auth.infrastructure.jwt.JwtProvider
 import com.depromeet.piki.support.IntegrationTestSupport
 import com.depromeet.piki.user.domain.IdentityType
+import com.jayway.jsonpath.JsonPath
 import org.hamcrest.Matchers.notNullValue
 import org.hamcrest.Matchers.nullValue
 import org.junit.jupiter.api.Test
@@ -29,8 +30,10 @@ class AnnouncementControllerIntegrationTest : IntegrationTestSupport() {
 
     @Autowired private lateinit var announcementRepository: AnnouncementRepository
 
-    private fun authHeader(userId: UUID = UUID.randomUUID()): String =
-        "Bearer ${jwtProvider.generateAccessToken(userId, IdentityType.MEMBER)}"
+    private fun authHeader(
+        userId: UUID = UUID.randomUUID(),
+        identityType: IdentityType = IdentityType.MEMBER,
+    ): String = "Bearer ${jwtProvider.generateAccessToken(userId, identityType)}"
 
     private fun buildMockMvc(): MockMvc =
         MockMvcBuilders
@@ -108,28 +111,49 @@ class AnnouncementControllerIntegrationTest : IntegrationTestSupport() {
         val third = sent(title = "3")
         val mockMvc = buildMockMvc()
 
-        // 1페이지: size=2 → 최신 2건(third, second), 다음 페이지 있음, 커서=second
-        mockMvc
-            .perform(get("/api/v1/announcements").param("size", "2").header(HttpHeaders.AUTHORIZATION, authHeader()))
-            .andExpect(status().isOk)
-            .andExpect(jsonPath("$.data.length()").value(2))
-            .andExpect(jsonPath("$.data[0].id").value(third.getId()))
-            .andExpect(jsonPath("$.data[1].id").value(second.getId()))
-            .andExpect(jsonPath("$.pageResponse.hasNext").value(true))
-            .andExpect(jsonPath("$.pageResponse.nextCursor").value(second.getId().toString()))
+        // 1페이지: size=2 → 발송순 최신 2건(third, second), 다음 페이지 있음. nextCursor 는 opaque 토큰이라 값을 받아 다음 요청에 그대로 넘긴다.
+        val page1 =
+            mockMvc
+                .perform(get("/api/v1/announcements").param("size", "2").header(HttpHeaders.AUTHORIZATION, authHeader()))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.data[0].id").value(third.getId()))
+                .andExpect(jsonPath("$.data[1].id").value(second.getId()))
+                .andExpect(jsonPath("$.pageResponse.hasNext").value(true))
+                .andExpect(jsonPath("$.pageResponse.nextCursor", notNullValue()))
+                .andReturn()
+        val nextCursor: String = JsonPath.read(page1.response.getContentAsString(Charsets.UTF_8), "$.pageResponse.nextCursor")
 
-        // 2페이지: cursor=second → 남은 1건(first), 다음 페이지 없음
+        // 2페이지: 1페이지가 준 커서 → 남은 1건(first), 다음 페이지 없음
         mockMvc
             .perform(
                 get("/api/v1/announcements")
                     .param("size", "2")
-                    .param("cursor", second.getId().toString())
+                    .param("cursor", nextCursor)
                     .header(HttpHeaders.AUTHORIZATION, authHeader()),
             ).andExpect(status().isOk)
             .andExpect(jsonPath("$.data.length()").value(1))
             .andExpect(jsonPath("$.data[0].id").value(first.getId()))
             .andExpect(jsonPath("$.pageResponse.hasNext").value(false))
             .andExpect(jsonPath("$.pageResponse.nextCursor").value(nullValue()))
+    }
+
+    @Test
+    fun `게스트도 발송된 공지를 목록·단건으로 조회할 수 있다`() {
+        val announcement = sent(title = "게스트도 보는 공지")
+        val mockMvc = buildMockMvc()
+        val guest = authHeader(identityType = IdentityType.GUEST)
+
+        mockMvc
+            .perform(get("/api/v1/announcements").header(HttpHeaders.AUTHORIZATION, guest))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.length()").value(1))
+            .andExpect(jsonPath("$.data[0].id").value(announcement.getId()))
+
+        mockMvc
+            .perform(get("/api/v1/announcements/${announcement.getId()}").header(HttpHeaders.AUTHORIZATION, guest))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.id").value(announcement.getId()))
     }
 
     @Test

--- a/src/test/kotlin/com/depromeet/piki/common/config/OpenApiDocsIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/common/config/OpenApiDocsIntegrationTest.kt
@@ -41,6 +41,7 @@ class OpenApiDocsIntegrationTest : IntegrationTestSupport() {
                 "Tournament",
                 "Tournament Item",
                 "Notification",
+                "Announcement",
                 "FCM",
                 "Dev",
             )


### PR DESCRIPTION
## Situation

- PiKi 알림은 공지(ANNOUNCEMENT) 타입을 이미 `refId=공지id` 로 딥링크 정보를 담아 발송한다(FCM·SSE 모두).
- 그런데 그 딥링크가 도착할 **유저용 공지 조회 API가 없었다**. 공지는 `/admin`(슬랙·IP 게이트) 관리자 화면에서만 다룰 수 있었다.
- 그래서 공지 알림을 눌러도 착지할 곳이 없고, 마이페이지의 공지사항 목록·상세 화면을 FE가 붙일 수 없었다.

## Task

- FE가 공지사항 목록 페이지와 개별 공지 상세를 만들 수 있도록, 유저용 조회 엔드포인트를 선제적으로 마련한다.
- 발송된 공지만 보여야 하고(작성 중 초안 비노출), 도메인 경계를 지켜 유저 조회가 admin 에 의존하지 않게 한다.

## Action

### 조회 API

| 엔드포인트 | 용도 | 응답 |
|---|---|---|
| `GET /api/v1/announcements` | 공지사항 목록(최신순, 커서 페이지네이션) | `id·title·body·sentAt` 리스트 |
| `GET /api/v1/announcements/{id}` | 단건 (알림 딥링크 착지점) | `id·title·body·sentAt` |

- `status=SENT` 인 공지만 노출한다. 미발송(작성 중·예약·발송 중·유예초과) 공지는 목록에서 빠지고, 단건은 404 로 응답해 그 존재 자체를 노출하지 않는다.
- 인증한 유저(게스트 포함, 공지 수신자) 대상. 공지사항은 개인 inbox 가 아니라 전역 게시판이라, 읽기 권한은 수신자보다 넓게 둔다.

### 도메인 경계

- 처음엔 admin 의 공지 엔티티를 유저 조회가 그대로 읽는 안을 검토했으나, 유저 영역이 admin 에 의존하는 단방향 도메인 누수라 배제했다.
- 공지 엔티티와 저장소를 admin 패키지에서 **중립 `announcement` 도메인으로 이동**했다. admin 의 작성·발송과 유저 조회가 모두 이 도메인을 단방향으로 참조한다. admin 작성 측 4개 파일은 import 만 갱신했고 로직은 그대로다.

### 구현

- 조회 전용 `AnnouncementQueryService`(SENT 한정), `AnnouncementController` + `AnnouncementApi` + `AnnouncementApiExamples`(응답 전수 문서화: 목록 200·400·401, 단건 200·404·401), 응답 매핑 `AnnouncementResponse.from`, 도메인 예외 `AnnouncementException`(notFound 404·invalidCursor 400).
- OpenApi 사이드바 태그 순서(`TAG_ORDER`)에 Announcement 를 Notification 뒤로 등록.

## Result

- FE 는 마이페이지 → 공지사항 탭(목록 API) → 특정 공지(단건 API) → 본문 읽기 플로우를 그대로 구현할 수 있다. 목록 응답에 본문도 포함돼, 필요하면 단건 호출 없이 펼쳐 보여도 된다.
- 작업 중 새 Announcement 태그가 늘며 api-docs 태그 순서 회귀 가드가 깨진 것을 발견해 함께 정정했다. 통합 테스트는 단건 200·404, 목록 SENT 한정·커서 페이지네이션, 잘못된 cursor 400, 미인증 401 의 응답 contract 까지 망라한다.
- 후속(별도 이슈): 누가 등록·예약·발송했는지 admin attribution 보강(#558), admin audit 도메인 응집(#557).

---
## 연관 이슈

- close #556


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 공지사항 조회 API 추가 (목록 및 단건 조회)
  * 커서 기반 페이지네이션 지원 (기본 20개, 최대 50개)
  * 발송 완료된 공지만 사용자에게 노출
  * 모든 조회는 사용자 인증 필요

* **Tests**
  * 공지사항 조회 API 통합 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->