### PR TITLE
admin audit 도메인 응집

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/admin/audit/AdminAuditLog.kt
+++ b/src/main/kotlin/com/depromeet/piki/admin/audit/AdminAuditLog.kt
@@ -1,4 +1,4 @@
-package com.depromeet.piki.admin.domain
+package com.depromeet.piki.admin.audit
 
 import com.depromeet.piki.common.domain.LongBaseEntity
 import jakarta.persistence.Column

--- a/src/main/kotlin/com/depromeet/piki/admin/audit/AdminAuditLogRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/admin/audit/AdminAuditLogRepository.kt
@@ -1,6 +1,5 @@
-package com.depromeet.piki.admin.repository
+package com.depromeet.piki.admin.audit
 
-import com.depromeet.piki.admin.domain.AdminAuditLog
 import org.springframework.data.jpa.repository.JpaRepository
 
 // 감사 기록 저장소. append-only — 기록만 쌓고 수정/삭제하지 않는다.

--- a/src/main/kotlin/com/depromeet/piki/admin/audit/AdminAuditService.kt
+++ b/src/main/kotlin/com/depromeet/piki/admin/audit/AdminAuditService.kt
@@ -1,8 +1,6 @@
 package com.depromeet.piki.admin.audit
 
 import com.depromeet.piki.admin.config.ConditionalOnAdminEnabled
-import com.depromeet.piki.admin.domain.AdminAuditLog
-import com.depromeet.piki.admin.repository.AdminAuditLogRepository
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional


### PR DESCRIPTION
## Situation

- admin 하위는 기능 단위로 패키지가 응집돼 있는데(access·announcement·template), **audit 만 세 곳에 흩어져 있었다**: `audit/`(action·service) + `domain/`(AdminAuditLog) + `repository/`(AdminAuditLogRepository).
- `domain/`·`repository/` 는 파일 1개짜리 고아 패키지로, 레이어명으로 쪼갠 탓에 한 기능(audit)이 분산됐다.

## Task

- audit 관련 파일을 한 패키지로 모아 다른 admin 기능과 같은 응집도로 맞춘다. 동작은 바꾸지 않는다.

## Action

- `AdminAuditLog`·`AdminAuditLogRepository` 를 `admin/audit` 로 이동.
- 세 파일이 같은 패키지가 되며 불필요해진 import 제거(`AdminAuditService` 2개, repository 1개).
- 비게 된 `admin/domain`·`admin/repository` 고아 패키지 제거.

## Result

- admin 하위가 전부 기능 자기완결(access·announcement·audit·template + config·web)로 일관됐다.
- 순수 구조 변경이라 동작·API·DB 영향 없음. (feature 통합이 아니라 흩어진 audit 조각만 제자리로 모은 것)

---
## 연관 이슈

- close #557


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 감시 감사 관련 기능의 패키지 구조를 정리하여 코드 조직을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->