### PR TITLE
admin·내부 컨트롤러를 api-docs 에서 제외

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/admin/access/SlackAccessController.kt
+++ b/src/main/kotlin/com/depromeet/piki/admin/access/SlackAccessController.kt
@@ -1,4 +1,5 @@
 package com.depromeet.piki.admin.access
+import io.swagger.v3.oas.annotations.Hidden
 
 import com.depromeet.piki.admin.audit.AdminAuditAction
 import com.depromeet.piki.admin.audit.AdminAuditService
@@ -19,6 +20,7 @@ import java.nio.charset.StandardCharsets
 
 // 백오피스 접근의 유일한 공개 표면 — 슬랙 슬래시커맨드 + grant 링크. 두 게이트 필터(EnvironmentAccessFilter·
 // AdminAccessFilter)는 이 경로(/admin-access/**)를 항상 통과시킨다(여기서 IP 를 등록해야 게이트를 열 수 있으므로).
+@Hidden
 @RestController
 @ConditionalOnAdminEnabled
 @RequestMapping("/admin-access")

--- a/src/main/kotlin/com/depromeet/piki/admin/announcement/AdminAnnouncementController.kt
+++ b/src/main/kotlin/com/depromeet/piki/admin/announcement/AdminAnnouncementController.kt
@@ -1,4 +1,5 @@
 package com.depromeet.piki.admin.announcement
+import io.swagger.v3.oas.annotations.Hidden
 import com.depromeet.piki.announcement.domain.Announcement
 
 import com.depromeet.piki.admin.access.AdminSession
@@ -18,6 +19,7 @@ import java.time.LocalDateTime
 
 // 공지 등록·예약/발송·결과 화면(#391/#489). 등록(초안)과 발송(목록에서 선택)을 분리해 발송 시 자유입력이 없어 오타가 안 생긴다.
 // 발송은 즉시 또는 예약(시각 지정), 결과는 집계+진행률 폴링으로 본다. 게이트(슬랙-세션)·actor 신원은 #526.
+@Hidden
 @Controller
 @ConditionalOnAdminEnabled
 @RequestMapping("/admin/announcements")

--- a/src/main/kotlin/com/depromeet/piki/admin/template/AdminTemplateController.kt
+++ b/src/main/kotlin/com/depromeet/piki/admin/template/AdminTemplateController.kt
@@ -1,4 +1,5 @@
 package com.depromeet.piki.admin.template
+import io.swagger.v3.oas.annotations.Hidden
 
 import com.depromeet.piki.admin.access.AdminSession
 import com.depromeet.piki.admin.config.ConditionalOnAdminEnabled
@@ -18,6 +19,7 @@ import org.springframework.web.server.ResponseStatusException
 
 // 알림 템플릿 관리 화면(#250). 목록·편집(SSR) + 라이브 미리보기(AJAX). 게이트(슬랙-세션)는 #526 — 토대 단계는
 // admin.enabled 로컬에서만 노출된다. actor 신원도 세션(#526) 전까지 "운영자" 로 둔다.
+@Hidden
 @Controller
 @ConditionalOnAdminEnabled
 @RequestMapping("/admin/templates")

--- a/src/main/kotlin/com/depromeet/piki/admin/web/AdminViewController.kt
+++ b/src/main/kotlin/com/depromeet/piki/admin/web/AdminViewController.kt
@@ -1,4 +1,5 @@
 package com.depromeet.piki.admin.web
+import io.swagger.v3.oas.annotations.Hidden
 
 import com.depromeet.piki.admin.config.ConditionalOnAdminEnabled
 import org.springframework.stereotype.Controller
@@ -7,6 +8,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 
 // 백오피스 SSR 진입점(랜딩). 접근 게이트(슬랙-IP)는 #526 에서 붙는다 — 토대 단계는 게이트 없이 셸만 둔다(admin.enabled
 // 기본 false 라 미배포). 실제 관리 기능(알림 템플릿)은 #250.
+@Hidden
 @Controller
 @ConditionalOnAdminEnabled
 @RequestMapping("/admin")

--- a/src/test/kotlin/com/depromeet/piki/common/config/OpenApiDocsIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/common/config/OpenApiDocsIntegrationTest.kt
@@ -72,7 +72,7 @@ class OpenApiDocsIntegrationTest : IntegrationTestSupport() {
     @Test
     fun `admin·내부 컨트롤러는 api-docs 에 노출되지 않는다`() {
         // admin Thymeleaf 페이지(/admin/**)·슬랙 웹훅(/admin-access/**)은 유저 API 가 아니라
-        // springdoc.packages-to-exclude(com.depromeet.piki.admin)로 spec 에서 제외한다. paths 에 /admin* 가 없어야 한다.
+        // 각 컨트롤러의 @Hidden 으로 spec 에서 제외한다. paths 에 /admin* 가 없어야 한다.
         val response =
             mockMvc()
                 .perform(get("/v3/api-docs"))

--- a/src/test/kotlin/com/depromeet/piki/common/config/OpenApiDocsIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/common/config/OpenApiDocsIntegrationTest.kt
@@ -11,6 +11,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.web.context.WebApplicationContext
 import tools.jackson.databind.ObjectMapper
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class OpenApiDocsIntegrationTest : IntegrationTestSupport() {
@@ -66,5 +67,21 @@ class OpenApiDocsIntegrationTest : IntegrationTestSupport() {
                 "${tag.get("name").asText()} 태그에 description 이 비어 있다",
             )
         }
+    }
+
+    @Test
+    fun `admin·내부 컨트롤러는 api-docs 에 노출되지 않는다`() {
+        // admin Thymeleaf 페이지(/admin/**)·슬랙 웹훅(/admin-access/**)은 유저 API 가 아니라
+        // springdoc.packages-to-exclude(com.depromeet.piki.admin)로 spec 에서 제외한다. paths 에 /admin* 가 없어야 한다.
+        val response =
+            mockMvc()
+                .perform(get("/v3/api-docs"))
+                .andExpect(status().isOk)
+                .andReturn()
+                .response
+                .contentAsString
+
+        val pathsJson = objectMapper.readTree(response).get("paths").toString()
+        assertFalse(pathsJson.contains("/admin"), "admin 경로가 api-docs paths 에 노출됨")
     }
 }


### PR DESCRIPTION
## Situation

- admin 페이지(Thymeleaf)·슬랙 웹훅은 **유저 API 가 아닌데**, `@Tag` 가 없어 springdoc 이 클래스명으로 자동 태깅한다. 그 탓에 Stoplight 사이드바에 `admin-announcement-controller`·`slack-access-controller` 등이 노이즈로 노출됐다.

## Task

- api-docs(Stoplight)는 FE·클라이언트용 유저 API 표면만 보여야 한다. 내부 admin 컨트롤러를 문서에서 제외한다.

## Action

- admin 컨트롤러 4개(slack-access · announcement · template · view)에 `@Hidden` 부여.
- `springdoc.packages-to-exclude`(com.depromeet.piki.admin)도 시도했으나, exact-match 라 하위 패키지(admin.announcement 등)를 못 걸러 폐기하고 `@Hidden` 을 택했다(확실·명시적).
- `health-controller`(헬스체크)·Dev API(@Profile, Dev 태그 의도 노출)는 그대로 둔다.

## Result

- 내부 admin 페이지·웹훅이 api-docs 의 paths 에서 빠진다. 엔드포인트 동작은 불변(문서 노출만 제거).
- 회귀 가드로 `/v3/api-docs` paths 에 `/admin*` 가 없음을 단언하는 통합 테스트를 추가했다.

---
## 연관 이슈

- close #563


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리즈 노트

* **Tests**
  * 관리자 엔드포인트가 API 문서에 노출되지 않는 동작을 검증하는 테스트 추가

* **Chores**
  * 내부 관리 관련 엔드포인트를 API 문서에서 숨김

<!-- end of auto-generated comment: release notes by coderabbit.ai -->