### PR TITLE
인증 쿠키 SameSite Strict→Lax (OAuth 리다이렉트 후 미부착·provider 일관)

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/auth/web/TokenCookieWriter.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/web/TokenCookieWriter.kt
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component
 // - refresh_token: Path=/ (#512) — 웹 Next.js proxy(엣지 미들웨어)가 페이지 네비게이션(/archive·/home)에서
 //   refresh_token 유무를 읽어 transparent refresh 를 판단해야 한다. /api/v1/auth 로 좁히면 일반 페이지
 //   요청엔 쿠키가 안 실려 proxy 의 refresh 분기가 죽는다. Path 좁히기는 defense-in-depth 였을 뿐, 실제
-//   보호는 HttpOnly·SameSite=Strict·Secure 가 하며 이 셋은 그대로 둔다. 넓힘으로 늘어나는 노출은 "모든
+//   보호는 HttpOnly·SameSite=Lax·Secure 가 하며 이 셋은 그대로 둔다. 넓힘으로 늘어나는 노출은 "모든
 //   same-origin 요청에 refresh_token 이 실려 로그 Cookie 헤더에 찍힘" 한 곳뿐이라 로그 마스킹으로 상쇄(#497).
 // - 전환기 cleanup: 배포 전 발급된 옛 refresh_token 은 Path=/api/v1/auth 로 남는다. 새 Path=/ 쿠키와
 //   공존하면 /api/v1/auth/token/refresh 요청에 둘 다 실리고, RFC 6265 상 더 구체적인 옛 경로 쿠키가 먼저
@@ -20,7 +20,10 @@ import org.springframework.stereotype.Component
 //   실패한다. 그래서 토큰을 새로 내리거나(setCookies) 만료시킬(clearCookies) 때마다 옛 경로 쿠키를 함께
 //   Max-Age=0 으로 지운다. 활성 refresh TTL 이 지나 옛 쿠키가 전부 사라지면 이 cleanup 은 제거 가능.
 // - Domain 미설정(host-only): 쿠키는 api 호스트만 소비하므로 서브도메인 공유 불필요
-// - SameSite=Strict: same-site 전제라 SPA fetch 는 전송되고 third-party CSRF 는 차단
+// - SameSite=Lax: OAuth provider 콜백처럼 cross-site 리다이렉트로 우리 사이트에 도착한 직후의 top-level
+//   네비게이션에도 쿠키가 실려야 로그인이 끊기지 않는다. Strict 는 그 첫 요청에 안 붙어 OAuth 후 로그아웃처럼
+//   보였다(provider 마다 FE 가 따로 패치하던 문제의 근원). Lax 도 state-changing(POST·PUT·DELETE) cross-site
+//   요청엔 쿠키를 안 보내 third-party CSRF 는 그대로 차단한다. FE·BE 가 same-site(piki.day)라 None 은 불필요.
 @Component
 class TokenCookieWriter(
     private val jwtProperties: JwtProperties,
@@ -66,6 +69,6 @@ class TokenCookieWriter(
         const val REFRESH_COOKIE = "refresh_token"
         private const val ROOT_PATH = "/"
         private const val LEGACY_REFRESH_PATH = "/api/v1/auth" // 전환기 cleanup 전용 (#512), 옛 쿠키 만료 후 제거 가능
-        private const val SAME_SITE = "Strict"
+        private const val SAME_SITE = "Lax"
     }
 }

--- a/src/test/kotlin/com/depromeet/piki/auth/controller/CookieBodyContractIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/controller/CookieBodyContractIntegrationTest.kt
@@ -75,8 +75,8 @@ class CookieBodyContractIntegrationTest : IntegrationTestSupport() {
         // 새 쿠키 + 전환기 cleanup 쿠키로 2개 내려간다) Set-Cookie 헤더 문자열로 확인한다.
         val setCookies = result.response.getHeaders(HttpHeaders.SET_COOKIE)
         assertTrue(
-            setCookies.any { it.startsWith("access_token=") && it.contains("SameSite=Strict") },
-            "access_token 쿠키에 SameSite=Strict 가 있어야 한다",
+            setCookies.any { it.startsWith("access_token=") && it.contains("SameSite=Lax") },
+            "access_token 쿠키에 SameSite=Lax 가 있어야 한다",
         )
         // #512: refresh_token 은 Path=/ 로 넓혀 내려간다 — 엣지 proxy 가 페이지 네비게이션에서 읽도록.
         assertTrue(

--- a/src/test/kotlin/com/depromeet/piki/auth/web/TokenCookieWriterTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/web/TokenCookieWriterTest.kt
@@ -22,13 +22,13 @@ class TokenCookieWriterTest {
         )
 
     @Test
-    fun `access_token 쿠키는 정책대로 HttpOnly·SameSite=Strict·Path 루트·만료시간을 갖는다`() {
+    fun `access_token 쿠키는 정책대로 HttpOnly·SameSite=Lax·Path 루트·만료시간을 갖는다`() {
         val access = writer().setCookies(TokenPair("at", "rt")).first { it.name == "access_token" }
 
         assertEquals("at", access.value)
         assertTrue(access.isHttpOnly)
         assertTrue(access.isSecure)
-        assertEquals("Strict", access.sameSite)
+        assertEquals("Lax", access.sameSite)
         assertEquals("/", access.path)
         assertEquals(accessExpiry, access.maxAge)
     }


### PR DESCRIPTION
## Situation

- 인증 쿠키(access·refresh)가 서버에서 `SameSite=Strict` 로 내려갔다. Strict 쿠키는 **OAuth provider 콜백 같은 cross-site 리다이렉트 직후 첫 top-level 요청에 부착되지 않아**, OAuth 로그인 후 로그아웃처럼 보였다.
- FE 가 Apple 콜백만 `Lax` 로 패치해 우회한 상태라, google/kakao 는 Strict · Apple 만 Lax 로 **provider 별 SameSite 정책이 갈렸다.**

## Task

- 쿠키 SameSite 를 서버 한 곳에서 **전 provider 일관되게** 고친다 (FE 의 provider 별 패치를 걷어낼 수 있도록).

## Action

- 쿠키 정책 단일 소유자인 `TokenCookieWriter` 의 `SAME_SITE` 를 `Strict` → `Lax`. 모든 토큰 쿠키·전 provider 에 단일 적용된다(provider 분기 없음).
- 쿠키 정책 주석을 Lax 근거(OAuth 리다이렉트 호환 · CSRF 유지 · same-site 라 None 불필요)로 갱신.
- 기존 `SameSite=Strict` 단언(`TokenCookieWriterTest` · `CookieBodyContractIntegrationTest`)을 Lax 로 갱신.

## Result

- 전 provider 로그인이 OAuth 리다이렉트 직후에도 끊기지 않고, provider 별 SameSite 분기가 사라진다.
- 보안: Lax 도 state-changing(POST·PUT·DELETE) cross-site 요청엔 쿠키를 안 보내 third-party CSRF 차단은 유지된다. FE·BE 가 same-site(piki.day)라 None 은 불필요.
- 후속: FE 가 Apple 콜백의 Lax 패치를 revert 하고 자기 PR 을 close 할 예정.

---
## 연관 이슈

- close #565


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - 소셜 로그인 및 OAuth 인증 플로우에서 외부 사이트로부터의 최상위 레벨 네비게이션 시 인증 쿠키가 올바르게 전송되도록 개선되었습니다.

* **Tests**
  - 쿠키 보안 정책 변경에 따라 관련 테스트가 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->