### PR TITLE
공지 등록·예약·발송 행위자(슬랙 admin) attribution

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/admin/announcement/AdminAnnouncementController.kt
+++ b/src/main/kotlin/com/depromeet/piki/admin/announcement/AdminAnnouncementController.kt
@@ -46,13 +46,14 @@ class AdminAnnouncementController(
     fun register(
         @RequestParam title: String,
         @RequestParam(required = false) body: String?,
+        request: HttpServletRequest,
     ): String {
         // 입력 경계 검증 — 길이 초과는 등록 전에 친화적으로 막는다(엔티티 init 불변식이 최후의 보루).
         val safeBody = body ?: ""
         if (title.isBlank() || title.length > Announcement.MAX_TITLE_LENGTH || safeBody.length > Announcement.MAX_BODY_LENGTH) {
             return "redirect:/admin/announcements?error=length"
         }
-        adminAnnouncementService.register(title, safeBody)
+        adminAnnouncementService.register(title, safeBody, actor(request), clientIp(request))
         return "redirect:/admin/announcements?registered"
     }
 

--- a/src/main/kotlin/com/depromeet/piki/admin/announcement/AdminAnnouncementService.kt
+++ b/src/main/kotlin/com/depromeet/piki/admin/announcement/AdminAnnouncementService.kt
@@ -34,11 +34,18 @@ class AdminAnnouncementService(
     fun recipientCount(): Long = userDeviceService.countTokenHolders()
 
     // 공지 초안 등록 — 발송 전 상태(DRAFT). 발송/예약은 schedule() 로만.
+    // 누가 등록했는지(#558)를 audit 으로 남긴다 — 발송 전 단계도 행위자 추적 대상이다.
     @Transactional
     fun register(
         title: String,
         body: String,
-    ): Announcement = announcementRepository.save(Announcement(title = title, body = body, target = TARGET_ALL))
+        actor: String,
+        clientIp: String?,
+    ): Announcement {
+        val announcement = announcementRepository.save(Announcement(title = title, body = body, target = TARGET_ALL))
+        auditService.record(actor, AdminAuditAction.ANNOUNCEMENT_REGISTER, "공지 초안 등록 id=${announcement.getId()}", clientIp)
+        return announcement
+    }
 
     // 발송 예약/즉시 발송 — scheduledAt 이 null 이면 지금 발송, 있으면 그 시각으로 예약(스케줄러가 발송).
     // 즉시 발송은 async execute 를 직접 호출(claim 이 DRAFT→SENDING 전환, 별도 트랜잭션). 예약은 여기서 SCHEDULED 로 박는다.
@@ -61,7 +68,7 @@ class AdminAnnouncementService(
         require(scheduledAt.isAfter(LocalDateTime.now(Announcement.KST))) { "예약 시각은 현재보다 미래여야 합니다." }
         announcement.schedule(scheduledAt)
         announcementRepository.save(announcement)
-        auditService.record(actor, AdminAuditAction.ANNOUNCEMENT_SEND, "공지 발송 예약 id=$id at=$scheduledAt", clientIp)
+        auditService.record(actor, AdminAuditAction.ANNOUNCEMENT_SCHEDULE, "공지 발송 예약 id=$id at=$scheduledAt", clientIp)
     }
 
     // 예약 취소 — SCHEDULED → DRAFT 로 되돌린다(다시 편집·삭제·재예약 가능).
@@ -77,7 +84,7 @@ class AdminAnnouncementService(
             announcementRepository.findByIdForUpdate(id) ?: throw IllegalArgumentException("공지를 찾을 수 없습니다.")
         announcement.cancelSchedule()
         announcementRepository.save(announcement)
-        auditService.record(actor, AdminAuditAction.ANNOUNCEMENT_SEND, "공지 예약 취소 id=$id", clientIp)
+        auditService.record(actor, AdminAuditAction.ANNOUNCEMENT_SCHEDULE_CANCEL, "공지 예약 취소 id=$id", clientIp)
     }
 
     // 등록한 초안 삭제. 발송된·예약된 공지는 삭제하지 않는다(예약은 먼저 취소).

--- a/src/main/kotlin/com/depromeet/piki/admin/audit/AdminAuditAction.kt
+++ b/src/main/kotlin/com/depromeet/piki/admin/audit/AdminAuditAction.kt
@@ -3,6 +3,12 @@ package com.depromeet.piki.admin.audit
 // 감사 대상 행위 코드. 기능 액션(템플릿 수정·공지 발송)과 접근 제어(ACCESS_*, 슬랙-IP 게이트 #526)를 함께 남긴다.
 enum class AdminAuditAction {
     TEMPLATE_UPDATE,
+
+    // 공지 행위자 추적(#558) — 등록·예약·예약취소·발송을 각각 다른 코드로 남겨 audit 에서 action 별로 가른다.
+    // (이전엔 예약·취소·발송이 ANNOUNCEMENT_SEND 한 코드로 뭉쳐 detail 문자열로만 구분됐다.)
+    ANNOUNCEMENT_REGISTER,
+    ANNOUNCEMENT_SCHEDULE,
+    ANNOUNCEMENT_SCHEDULE_CANCEL,
     ANNOUNCEMENT_SEND,
 
     // 슬랙-IP 접근 게이트(#526) — 누가(슬랙명) 어느 IP 를 허용/해제했는지, 거부된 접근은 무엇인지.

--- a/src/test/kotlin/com/depromeet/piki/admin/announcement/AnnouncementAttributionIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/admin/announcement/AnnouncementAttributionIntegrationTest.kt
@@ -1,0 +1,73 @@
+package com.depromeet.piki.admin.announcement
+
+import com.depromeet.piki.admin.audit.AdminAuditLogRepository
+import com.depromeet.piki.announcement.domain.Announcement
+import com.depromeet.piki.announcement.repository.AnnouncementRepository
+import com.depromeet.piki.support.IntegrationTestSupport
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.context.WebApplicationContext
+import java.time.LocalDateTime
+import kotlin.test.assertTrue
+
+// 공지 행위자 추적(#558) — 등록·예약·예약취소가 각각 다른 audit action 으로, 행위자와 함께 admin_audit_logs 에 남는지 검증.
+// admin 게이트는 IntegrationTestSupport 의 admin.local-bypass 로 우회되고, 폼 POST 는 CSRF 를 유지하므로 with(csrf()) 로 통과한다.
+@Transactional
+class AnnouncementAttributionIntegrationTest : IntegrationTestSupport() {
+    @Autowired private lateinit var webApplicationContext: WebApplicationContext
+
+    @Autowired private lateinit var announcementRepository: AnnouncementRepository
+
+    @Autowired private lateinit var adminAuditLogRepository: AdminAuditLogRepository
+
+    private fun mockMvc(): MockMvc =
+        MockMvcBuilders
+            .webAppContextSetup(webApplicationContext)
+            .apply<DefaultMockMvcBuilder>(springSecurity())
+            .build()
+
+    @Test
+    fun `공지 등록하면 ANNOUNCEMENT_REGISTER 감사 로그가 행위자와 함께 남는다`() {
+        mockMvc()
+            .perform(post("/admin/announcements").param("title", "점검 안내").param("body", "내용").with(csrf()))
+            .andExpect(status().is3xxRedirection)
+
+        val logs = adminAuditLogRepository.findAll()
+        assertTrue(
+            logs.any { it.action == "ANNOUNCEMENT_REGISTER" && it.actor.isNotBlank() },
+            "등록 시 ANNOUNCEMENT_REGISTER 가 행위자와 함께 남아야 한다. 실제=${logs.map { it.action }}",
+        )
+    }
+
+    @Test
+    fun `예약은 ANNOUNCEMENT_SCHEDULE, 예약취소는 ANNOUNCEMENT_SCHEDULE_CANCEL 로 구분돼 남는다`() {
+        val announcement = announcementRepository.save(Announcement(title = "예약 공지", body = "내용", target = "토큰 보유자 전체"))
+        val id = announcement.getId()
+        val future = LocalDateTime.now(Announcement.KST).plusDays(1).toString()
+        val mockMvc = mockMvc()
+
+        mockMvc
+            .perform(post("/admin/announcements/$id/send").param("scheduledAt", future).with(csrf()))
+            .andExpect(status().is3xxRedirection)
+        assertTrue(
+            adminAuditLogRepository.findAll().any { it.action == "ANNOUNCEMENT_SCHEDULE" },
+            "예약 시 ANNOUNCEMENT_SCHEDULE 가 남아야 한다(발송과 다른 코드)",
+        )
+
+        mockMvc
+            .perform(post("/admin/announcements/$id/cancel").with(csrf()))
+            .andExpect(status().is3xxRedirection)
+        assertTrue(
+            adminAuditLogRepository.findAll().any { it.action == "ANNOUNCEMENT_SCHEDULE_CANCEL" },
+            "예약취소 시 ANNOUNCEMENT_SCHEDULE_CANCEL 가 남아야 한다",
+        )
+    }
+}


### PR DESCRIPTION
## Situation

- 공지는 `/admin`(슬랙·IP 게이트)에서만 다루는데, **행위자 추적이 불완전했다.** 발송(send)은 `sent_by` + `ANNOUNCEMENT_SEND` 로 추적됐지만:
  - **등록(register)** 은 actor 를 아예 안 받아 "누가 초안을 만들었나"가 **전혀 안 남았고**,
  - **예약·취소·발송**이 모두 `ANNOUNCEMENT_SEND` 한 코드로 뭉쳐 detail 문자열로만 구분됐다(action 코드 필터로 안 갈림).

## Task

- 등록·예약·취소·발송 각각 **누가 했는지를 audit 으로 빠짐없이, 코드로 구분되게** 추적한다.

## Action

- `register` 가 actor·clientIp 를 받아 **`ANNOUNCEMENT_REGISTER`** 감사 로그를 남긴다(기존 누락 보완).
- 예약·취소 action 코드 분리: **`ANNOUNCEMENT_SCHEDULE`** · **`ANNOUNCEMENT_SCHEDULE_CANCEL`** 추가(발송은 `ANNOUNCEMENT_SEND` 유지). detail 의존 없이 action 으로 가른다.
- actor 는 슬랙 게이트가 세션에 바인딩한 신원(`AdminSession.slackName`), clientIp 는 `X-Real-IP` — 기존 발송 경로와 동일 헬퍼 재사용.

## Result

- `admin_audit_logs` 에서 등록·예약·취소·발송을 action 코드로 구분해 "누가 언제 무엇을 했나"를 추적할 수 있다.
- (deferred) 이슈에 선택 항목이던 엔티티 `created_by`/`scheduled_by` 컬럼은 **audit 로그만으로 추적이 충족돼 후속으로 둔다** — admin 화면에 inline 표시가 필요해지면 그때 additive 로 추가.

---
## 연관 이슈

- close #558
