### PR TITLE
이미지 버킷 CORS 설정 (영수증 캡처 cross-origin read)

### DIFF
--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -144,3 +144,55 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "staging_images" {
     }
   }
 }
+
+# -----------------------------------------------------------------------------
+# CORS (#영수증 캡처) — html-to-image 가 이미지를 canvas 에 그린 뒤 export 하려면, 브라우저가
+# cross-origin 이미지의 픽셀을 읽도록 S3 가 Access-Control-Allow-Origin 헤더를 내려줘야 한다.
+# CORS 는 접근 제어가 아니다(버킷은 이미 public-read) — 브라우저 JS 의 read 허용 헤더일 뿐이라
+# 노출 표면이 늘지 않는다. GET/HEAD 만(읽기 전용, 업로드는 instance role 유지), origin 은
+# piki.day + 로컬 개발로 한정한다.
+# 외부 쇼핑몰 CDN 이미지(msscdn·pstatic·kakaocdn 등)는 우리 버킷이 아니라 여기서 못 푼다 —
+# 그건 별도 이미지 프록시 API 로 처리한다.
+# -----------------------------------------------------------------------------
+locals {
+  image_cors_origins = [
+    "https://piki.day",
+    "https://www.piki.day",
+    "https://*.piki.day",
+    "http://localhost:3000",
+    "http://localhost:3001",
+  ]
+}
+
+resource "aws_s3_bucket_cors_configuration" "images" {
+  bucket = aws_s3_bucket.images.id
+
+  cors_rule {
+    allowed_methods = ["GET", "HEAD"]
+    allowed_origins = local.image_cors_origins
+    allowed_headers = ["*"]
+    max_age_seconds = 3600
+  }
+}
+
+resource "aws_s3_bucket_cors_configuration" "dev_images" {
+  bucket = aws_s3_bucket.dev_images.id
+
+  cors_rule {
+    allowed_methods = ["GET", "HEAD"]
+    allowed_origins = local.image_cors_origins
+    allowed_headers = ["*"]
+    max_age_seconds = 3600
+  }
+}
+
+resource "aws_s3_bucket_cors_configuration" "staging_images" {
+  bucket = aws_s3_bucket.staging_images.id
+
+  cors_rule {
+    allowed_methods = ["GET", "HEAD"]
+    allowed_origins = local.image_cors_origins
+    allowed_headers = ["*"]
+    max_age_seconds = 3600
+  }
+}


### PR DESCRIPTION
## Situation

- 영수증 이미지 공유에서 상품 사진이 빠진 채 캡처되는 버그가 보고됐다. html-to-image 가 영수증을 canvas 로 그려 export 할 때, cross-origin 이미지의 픽셀을 읽으려면 그 서버가 Access-Control-Allow-Origin 헤더를 줘야 하는데, 우리 S3 버킷이 그 헤더를 안 내려줘서 canvas 가 tainted 되고 해당 이미지가 export 에서 빠졌다.
- 증상이 시크릿 모드·앱 WebView·첫 진입에서 100% 재현됐다 (일반 웹은 캐시 hit 으로 우연히 됨).

## Task

- 우리 S3 이미지 버킷이 piki.day 프론트에 CORS 헤더를 내려주게 해, 영수증 캡처가 우리 호스팅 이미지(프로필·기본·OCR 업로드)를 canvas 로 읽을 수 있게 한다.
- 범위 경계: 영수증의 외부 쇼핑몰 상품 사진(msscdn·pstatic·kakaocdn 등)은 우리 버킷이 아니라 이 PR 로 못 푼다. 그건 별도 이미지 프록시 API 로 다른 파트가 처리한다.

## Action

- prod·dev·staging 이미지 버킷에 CORS 설정을 추가했다. GET/HEAD 만(읽기 전용), origin 은 piki.day·www·서브도메인(*.piki.day)·로컬 개발로 한정. origin 목록은 local 로 묶어 세 버킷이 공유한다.
- CORS 는 접근 제어가 아니라는 점을 살렸다: 버킷은 이미 public-read 라 다운로드 가능 범위는 그대로고, CORS 는 브라우저 JS 의 read 허용 헤더만 추가하므로 노출 표면이 늘지 않는다. 업로드(쓰기)는 여전히 instance role 만.

## Result

- 적용 후 실측: 세 버킷 모두 piki.day origin 에 Access-Control-Allow-Origin 을 내려주고, *.piki.day 와일드카드가 서브도메인(dev.piki.day 등)에 매칭된다. 미허용 origin(evil.com)에는 헤더를 주지 않아 제한이 동작함을 negative control 로 확인했다.
- 이걸로 우리 호스팅 이미지는 영수증 캡처에 정상 포함된다. 외부 쇼핑몰 상품 사진은 별도 프록시가 붙어야 완전 해결된다.
- 참고: prod 이미지 버킷명은 prod- 접두가 아니라 piki-images-... 다 (FE 가 prod-piki-images 로 추정했던 것 정정).

---
## 연관 이슈

- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * S3 이미지 버킷에 CORS(Cross-Origin Resource Sharing) 지원 추가
  * 여러 오리진에서 이미지 접근 가능 (piki.day 및 로컬 개발 환경)
  * 개발 및 스테이징 환경의 모든 이미지 버킷에 CORS 구성 적용

<!-- end of auto-generated comment: release notes by coderabbit.ai -->