### PR TITLE
외부 이미지 CORS 우회를 위한 이미지 프록시 API 추가

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/common/config/OpenApiConfig.kt
+++ b/src/main/kotlin/com/depromeet/piki/common/config/OpenApiConfig.kt
@@ -87,6 +87,7 @@ class OpenApiConfig {
                 "Tournament Item",
                 "Notification",
                 "Announcement",
+                "Image Proxy",
                 "FCM",
                 "Dev",
             )

--- a/src/main/kotlin/com/depromeet/piki/common/imageproxy/ImageProxyApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/common/imageproxy/ImageProxyApi.kt
@@ -1,0 +1,67 @@
+package com.depromeet.piki.common.imageproxy
+
+import com.depromeet.piki.common.response.ApiResponseBody
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+
+@Tag(name = "Image Proxy", description = "외부 이미지 프록시 API")
+interface ImageProxyApi {
+    @Operation(
+        summary = "외부 이미지 프록시",
+        description = """
+            CORS 제약으로 프론트엔드가 직접 불러올 수 없는 외부 CDN 이미지를 서버가 중계합니다.
+            허용 도메인(무신사·네이버·카카오 등)의 URL 만 처리하며, 5 MB 초과 이미지는 거부됩니다.
+            성공 시 이미지 바이너리를 원본 Content-Type 과 함께 반환합니다.
+        """,
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "이미지 바이너리 반환",
+                content = [Content(mediaType = "image/*")],
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청 (허용되지 않은 도메인 · 이미지 크기 5 MB 초과)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "미인증 (JWT 토큰 없음 또는 유효하지 않음)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "502",
+                description = "외부 이미지 서버 오류 (이미지를 불러올 수 없음 · 재시도 가능)",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ApiResponseBody::class),
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun proxyImage(
+        @Parameter(description = "프록시할 이미지 URL", required = true)
+        url: String,
+    ): ResponseEntity<ByteArray>
+}

--- a/src/main/kotlin/com/depromeet/piki/common/imageproxy/ImageProxyApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/common/imageproxy/ImageProxyApi.kt
@@ -30,7 +30,7 @@ interface ImageProxyApi {
             ),
             ApiResponse(
                 responseCode = "400",
-                description = "잘못된 요청 (허용되지 않은 도메인 · 이미지 크기 5 MB 초과)",
+                description = "잘못된 요청 (허용되지 않은 도메인 · https 외 스킴 · 이미지 크기 5 MB 초과)",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,

--- a/src/main/kotlin/com/depromeet/piki/common/imageproxy/ImageProxyApiExamples.kt
+++ b/src/main/kotlin/com/depromeet/piki/common/imageproxy/ImageProxyApiExamples.kt
@@ -1,0 +1,27 @@
+package com.depromeet.piki.common.imageproxy
+
+import com.depromeet.piki.common.openapi.OpenApiObjectMapper
+import com.depromeet.piki.common.openapi.binds
+import com.depromeet.piki.common.openapi.examples
+import org.springdoc.core.customizers.OperationCustomizer
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class ImageProxyApiExamples(
+    private val openApiObjectMapper: OpenApiObjectMapper,
+) {
+    @Bean
+    fun imageProxyOpenApiExamples(): OperationCustomizer =
+        OperationCustomizer { operation, handlerMethod ->
+            if (handlerMethod.binds(ImageProxyController::proxyImage)) {
+                operation.examples(openApiObjectMapper.delegate) {
+                    add(ImageProxyException.blockedDomain(), name = "허용되지 않은 도메인")
+                    add(ImageProxyException.imageTooLarge(), name = "이미지 크기 초과 (5 MB)")
+                    unauthorized()
+                    add(ImageProxyException.fetchFailed(), name = "외부 이미지 서버 오류")
+                }
+            }
+            operation
+        }
+}

--- a/src/main/kotlin/com/depromeet/piki/common/imageproxy/ImageProxyController.kt
+++ b/src/main/kotlin/com/depromeet/piki/common/imageproxy/ImageProxyController.kt
@@ -1,0 +1,25 @@
+package com.depromeet.piki.common.imageproxy
+
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1")
+class ImageProxyController(
+    private val imageProxyFetcher: ImageProxyFetcher,
+) : ImageProxyApi {
+    @GetMapping("/image-proxy")
+    override fun proxyImage(
+        @RequestParam url: String,
+    ): ResponseEntity<ByteArray> {
+        val image = imageProxyFetcher.fetch(url)
+        return ResponseEntity
+            .ok()
+            .header("Content-Type", image.contentType)
+            .header("Cache-Control", "public, max-age=86400")
+            .body(image.bytes)
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/common/imageproxy/ImageProxyException.kt
+++ b/src/main/kotlin/com/depromeet/piki/common/imageproxy/ImageProxyException.kt
@@ -1,0 +1,36 @@
+package com.depromeet.piki.common.imageproxy
+
+import com.depromeet.piki.common.exception.BaseException
+import com.depromeet.piki.common.exception.ErrorCategory
+import com.depromeet.piki.common.exception.HttpMappable
+import org.springframework.http.HttpStatus
+
+class ImageProxyException private constructor(
+    message: String,
+    override val category: ErrorCategory,
+    override val httpStatus: HttpStatus,
+) : BaseException(message),
+    HttpMappable {
+    companion object {
+        fun blockedDomain(): ImageProxyException =
+            ImageProxyException(
+                "허용되지 않은 이미지 도메인입니다.",
+                ErrorCategory.INVALID_INPUT,
+                HttpStatus.BAD_REQUEST,
+            )
+
+        fun imageTooLarge(): ImageProxyException =
+            ImageProxyException(
+                "이미지 크기가 너무 큽니다.",
+                ErrorCategory.INVALID_INPUT,
+                HttpStatus.BAD_REQUEST,
+            )
+
+        fun fetchFailed(): ImageProxyException =
+            ImageProxyException(
+                "이미지를 불러올 수 없습니다.",
+                ErrorCategory.RETRYABLE,
+                HttpStatus.BAD_GATEWAY,
+            )
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/common/imageproxy/ImageProxyFetcher.kt
+++ b/src/main/kotlin/com/depromeet/piki/common/imageproxy/ImageProxyFetcher.kt
@@ -1,21 +1,25 @@
 package com.depromeet.piki.common.imageproxy
 
 import org.slf4j.LoggerFactory
-import org.springframework.http.ResponseEntity
 import org.springframework.http.client.SimpleClientHttpRequestFactory
 import org.springframework.stereotype.Component
-import org.springframework.web.client.RestClient
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
 import java.net.HttpURLConnection
 import java.net.URI
 import java.time.Duration
 
+interface ImageProxyFetcher {
+    fun fetch(url: String): FetchedImage
+}
+
 @Component
-class ImageProxyFetcher(
+class DefaultImageProxyFetcher(
     private val properties: ImageProxyProperties,
-) {
+) : ImageProxyFetcher {
     private val log = LoggerFactory.getLogger(javaClass)
-    private val client: RestClient =
-        RestClient
+    private val client =
+        org.springframework.web.client.RestClient
             .builder()
             .requestFactory(
                 // 리다이렉트 자동 추적 차단 — 화이트리스트 도메인에서 내부망(IMDS 등)으로 유도하는 SSRF 방어.
@@ -36,29 +40,47 @@ class ImageProxyFetcher(
                 },
             ).build()
 
-    fun fetch(url: String): FetchedImage {
+    override fun fetch(url: String): FetchedImage {
         validateDomain(url)
         return try {
-            val response: ResponseEntity<ByteArray> =
-                client
-                    .get()
-                    .uri(URI.create(url))
-                    .retrieve()
-                    .onStatus({ it.isError || it.is3xxRedirection }) { _, res ->
-                        log.warn("image-proxy fetch 실패: status={}", res.statusCode)
+            client
+                .get()
+                .uri(URI.create(url))
+                .exchange { _, response ->
+                    if (response.statusCode.isError || response.statusCode.is3xxRedirection) {
+                        log.warn("image-proxy fetch 실패: status={}", response.statusCode)
                         throw ImageProxyException.fetchFailed()
-                    }.toEntity(ByteArray::class.java)
-
-            val bytes = response.body ?: throw ImageProxyException.fetchFailed()
-            if (bytes.size > properties.maxBytes) throw ImageProxyException.imageTooLarge()
-            val contentType = response.headers.contentType?.toString() ?: "image/jpeg"
-            FetchedImage(bytes = bytes, contentType = contentType)
+                    }
+                    val contentType =
+                        response.headers.contentType?.takeIf { it.type == "image" }
+                            ?: run {
+                                log.warn("image-proxy 잘못된 Content-Type: {}", response.headers.contentType)
+                                throw ImageProxyException.fetchFailed()
+                            }
+                    val bytes = readWithLimit(response.body, properties.maxBytes)
+                    FetchedImage(bytes = bytes, contentType = contentType.toString())
+                }
         } catch (e: ImageProxyException) {
             throw e
         } catch (e: Exception) {
             log.warn("image-proxy 네트워크 오류: {}", e.message)
             throw ImageProxyException.fetchFailed()
         }
+    }
+
+    private fun readWithLimit(stream: InputStream, maxBytes: Long): ByteArray {
+        val buffer = ByteArrayOutputStream()
+        val chunk = ByteArray(8192)
+        var totalRead = 0L
+        stream.use {
+            var n: Int
+            while (it.read(chunk).also { n = it } != -1) {
+                totalRead += n
+                if (totalRead > maxBytes) throw ImageProxyException.imageTooLarge()
+                buffer.write(chunk, 0, n)
+            }
+        }
+        return buffer.toByteArray()
     }
 
     private fun validateDomain(url: String) {

--- a/src/main/kotlin/com/depromeet/piki/common/imageproxy/ImageProxyFetcher.kt
+++ b/src/main/kotlin/com/depromeet/piki/common/imageproxy/ImageProxyFetcher.kt
@@ -1,0 +1,69 @@
+package com.depromeet.piki.common.imageproxy
+
+import org.slf4j.LoggerFactory
+import org.springframework.http.ResponseEntity
+import org.springframework.http.client.SimpleClientHttpRequestFactory
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestClient
+import java.net.URI
+import java.time.Duration
+
+@Component
+class ImageProxyFetcher(
+    private val properties: ImageProxyProperties,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+    private val client: RestClient =
+        RestClient
+            .builder()
+            .requestFactory(
+                SimpleClientHttpRequestFactory().apply {
+                    setConnectTimeout(Duration.ofSeconds(properties.timeoutSeconds))
+                    setReadTimeout(Duration.ofSeconds(properties.timeoutSeconds))
+                },
+            ).build()
+
+    fun fetch(url: String): FetchedImage {
+        validateDomain(url)
+        return try {
+            val response: ResponseEntity<ByteArray> =
+                client
+                    .get()
+                    .uri(URI.create(url))
+                    .retrieve()
+                    .onStatus({ it.isError }) { _, res ->
+                        log.warn("image-proxy fetch 실패: status={}", res.statusCode)
+                        throw ImageProxyException.fetchFailed()
+                    }.toEntity(ByteArray::class.java)
+
+            val bytes = response.body ?: throw ImageProxyException.fetchFailed()
+            if (bytes.size > properties.maxBytes) throw ImageProxyException.imageTooLarge()
+            val contentType = response.headers.contentType?.toString() ?: "image/jpeg"
+            FetchedImage(bytes = bytes, contentType = contentType)
+        } catch (e: ImageProxyException) {
+            throw e
+        } catch (e: Exception) {
+            log.warn("image-proxy 네트워크 오류: {}", e.message)
+            throw ImageProxyException.fetchFailed()
+        }
+    }
+
+    private fun validateDomain(url: String) {
+        val host =
+            try {
+                val uri = URI.create(url)
+                if (uri.scheme != "https" && uri.scheme != "http") throw ImageProxyException.blockedDomain()
+                uri.host ?: throw ImageProxyException.blockedDomain()
+            } catch (e: IllegalArgumentException) {
+                throw ImageProxyException.blockedDomain()
+            }
+        if (properties.allowedDomains.none { host == it || host.endsWith(".$it") }) {
+            throw ImageProxyException.blockedDomain()
+        }
+    }
+}
+
+data class FetchedImage(
+    val bytes: ByteArray,
+    val contentType: String,
+)

--- a/src/main/kotlin/com/depromeet/piki/common/imageproxy/ImageProxyFetcher.kt
+++ b/src/main/kotlin/com/depromeet/piki/common/imageproxy/ImageProxyFetcher.kt
@@ -52,7 +52,7 @@ class ImageProxyFetcher(
         val host =
             try {
                 val uri = URI.create(url)
-                if (uri.scheme != "https" && uri.scheme != "http") throw ImageProxyException.blockedDomain()
+                if (uri.scheme != "https") throw ImageProxyException.blockedDomain()
                 uri.host ?: throw ImageProxyException.blockedDomain()
             } catch (e: IllegalArgumentException) {
                 throw ImageProxyException.blockedDomain()

--- a/src/main/kotlin/com/depromeet/piki/common/imageproxy/ImageProxyFetcher.kt
+++ b/src/main/kotlin/com/depromeet/piki/common/imageproxy/ImageProxyFetcher.kt
@@ -5,6 +5,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.http.client.SimpleClientHttpRequestFactory
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestClient
+import java.net.HttpURLConnection
 import java.net.URI
 import java.time.Duration
 
@@ -17,9 +18,21 @@ class ImageProxyFetcher(
         RestClient
             .builder()
             .requestFactory(
-                SimpleClientHttpRequestFactory().apply {
-                    setConnectTimeout(Duration.ofSeconds(properties.timeoutSeconds))
-                    setReadTimeout(Duration.ofSeconds(properties.timeoutSeconds))
+                // 리다이렉트 자동 추적 차단 — 화이트리스트 도메인에서 내부망(IMDS 등)으로 유도하는 SSRF 방어.
+                // 3xx 는 onStatus 에서 fetchFailed() 로 즉시 실패 처리한다.
+                object : SimpleClientHttpRequestFactory() {
+                    init {
+                        setConnectTimeout(Duration.ofSeconds(properties.timeoutSeconds))
+                        setReadTimeout(Duration.ofSeconds(properties.timeoutSeconds))
+                    }
+
+                    override fun prepareConnection(
+                        connection: HttpURLConnection,
+                        httpMethod: String,
+                    ) {
+                        super.prepareConnection(connection, httpMethod)
+                        connection.instanceFollowRedirects = false
+                    }
                 },
             ).build()
 
@@ -31,7 +44,7 @@ class ImageProxyFetcher(
                     .get()
                     .uri(URI.create(url))
                     .retrieve()
-                    .onStatus({ it.isError }) { _, res ->
+                    .onStatus({ it.isError || it.is3xxRedirection }) { _, res ->
                         log.warn("image-proxy fetch 실패: status={}", res.statusCode)
                         throw ImageProxyException.fetchFailed()
                     }.toEntity(ByteArray::class.java)

--- a/src/main/kotlin/com/depromeet/piki/common/imageproxy/ImageProxyProperties.kt
+++ b/src/main/kotlin/com/depromeet/piki/common/imageproxy/ImageProxyProperties.kt
@@ -1,0 +1,10 @@
+package com.depromeet.piki.common.imageproxy
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "image.proxy")
+data class ImageProxyProperties(
+    val allowedDomains: List<String>,
+    val maxBytes: Long = 5 * 1024 * 1024,
+    val timeoutSeconds: Long = 10,
+)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -113,6 +113,22 @@ s3:
   region: ${S3_REGION:ap-northeast-2}
   public-base-url: ${S3_PUBLIC_BASE_URL:}
 
+image:
+  proxy:
+    # CORS 우회 이미지 프록시 허용 도메인 목록. 서브도메인 포함 (host == domain || host.endsWith(".domain")).
+    allowed-domains:
+      - msscdn.net         # 무신사
+      - pstatic.net        # 네이버 / 스마트스토어
+      - kakaocdn.net       # 카카오
+      - coupangcdn.com     # 쿠팡
+      - thumbnail.10x10.co.kr
+      - image.29cm.co.kr
+      - image.ably.team
+      - static.zara.com
+      - lp2.hm.com
+    max-bytes: 5242880     # 5 MB
+    timeout-seconds: 10
+
 springdoc:
   api-docs:
     path: /v3/api-docs

--- a/src/test/kotlin/com/depromeet/piki/common/config/OpenApiDocsIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/common/config/OpenApiDocsIntegrationTest.kt
@@ -43,6 +43,7 @@ class OpenApiDocsIntegrationTest : IntegrationTestSupport() {
                 "Tournament Item",
                 "Notification",
                 "Announcement",
+                "Image Proxy",
                 "FCM",
                 "Dev",
             )

--- a/src/test/kotlin/com/depromeet/piki/common/imageproxy/ImageProxyControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/common/imageproxy/ImageProxyControllerIntegrationTest.kt
@@ -1,0 +1,52 @@
+package com.depromeet.piki.common.imageproxy
+
+import com.depromeet.piki.auth.infrastructure.jwt.JwtProvider
+import com.depromeet.piki.support.IntegrationTestSupport
+import com.depromeet.piki.user.domain.IdentityType
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpHeaders
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.web.context.WebApplicationContext
+import java.util.UUID
+
+class ImageProxyControllerIntegrationTest : IntegrationTestSupport() {
+    @Autowired
+    private lateinit var webApplicationContext: WebApplicationContext
+
+    @Autowired
+    private lateinit var jwtProvider: JwtProvider
+
+    @Test
+    fun `토큰 없이 호출하면 401 응답이 반환된다`() {
+        buildMockMvc()
+            .perform(
+                get("/api/v1/image-proxy")
+                    .param("url", "https://msscdn.net/some/image.jpg"),
+            ).andExpect(status().isUnauthorized)
+    }
+
+    @Test
+    fun `허용되지 않은 도메인이면 400 blockedDomain 응답이 반환된다`() {
+        val token = jwtProvider.generateAccessToken(UUID.randomUUID(), IdentityType.GUEST)
+
+        buildMockMvc()
+            .perform(
+                get("/api/v1/image-proxy")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer $token")
+                    .param("url", "https://not-allowed-domain.com/image.jpg"),
+            ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.detail").value(ImageProxyException.blockedDomain().message))
+    }
+
+    private fun buildMockMvc() =
+        MockMvcBuilders
+            .webAppContextSetup(webApplicationContext)
+            .apply<DefaultMockMvcBuilder>(springSecurity())
+            .build()
+}

--- a/src/test/kotlin/com/depromeet/piki/common/imageproxy/ImageProxyControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/common/imageproxy/ImageProxyControllerIntegrationTest.kt
@@ -2,6 +2,7 @@ package com.depromeet.piki.common.imageproxy
 
 import com.depromeet.piki.auth.infrastructure.jwt.JwtProvider
 import com.depromeet.piki.support.IntegrationTestSupport
+import com.depromeet.piki.support.StubImageProxyFetcher
 import com.depromeet.piki.user.domain.IdentityType
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -22,6 +23,9 @@ class ImageProxyControllerIntegrationTest : IntegrationTestSupport() {
     @Autowired
     private lateinit var jwtProvider: JwtProvider
 
+    @Autowired
+    private lateinit var stubImageProxyFetcher: StubImageProxyFetcher
+
     @Test
     fun `토큰 없이 호출하면 401 응답이 반환된다`() {
         buildMockMvc()
@@ -34,6 +38,7 @@ class ImageProxyControllerIntegrationTest : IntegrationTestSupport() {
     @Test
     fun `허용되지 않은 도메인이면 400 blockedDomain 응답이 반환된다`() {
         val token = jwtProvider.generateAccessToken(UUID.randomUUID(), IdentityType.GUEST)
+        stubImageProxyFetcher.handler = { throw ImageProxyException.blockedDomain() }
 
         buildMockMvc()
             .perform(
@@ -42,6 +47,20 @@ class ImageProxyControllerIntegrationTest : IntegrationTestSupport() {
                     .param("url", "https://not-allowed-domain.com/image.jpg"),
             ).andExpect(status().isBadRequest)
             .andExpect(jsonPath("$.detail").value(ImageProxyException.blockedDomain().message))
+    }
+
+    @Test
+    fun `외부 이미지 서버 오류 시 502 fetchFailed 응답이 반환된다`() {
+        val token = jwtProvider.generateAccessToken(UUID.randomUUID(), IdentityType.GUEST)
+        stubImageProxyFetcher.handler = { throw ImageProxyException.fetchFailed() }
+
+        buildMockMvc()
+            .perform(
+                get("/api/v1/image-proxy")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer $token")
+                    .param("url", "https://msscdn.net/image.jpg"),
+            ).andExpect(status().isBadGateway)
+            .andExpect(jsonPath("$.detail").value(ImageProxyException.fetchFailed().message))
     }
 
     private fun buildMockMvc() =

--- a/src/test/kotlin/com/depromeet/piki/common/imageproxy/ImageProxyFetcherTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/common/imageproxy/ImageProxyFetcherTest.kt
@@ -4,12 +4,14 @@ import org.junit.jupiter.api.Test
 import kotlin.test.assertFailsWith
 
 class ImageProxyFetcherTest {
+    // test.invalid 는 RFC 6761 에서 DNS 가 항상 NXDOMAIN 을 반환하도록 예약된 TLD.
+    // 외부망 없이 결정론적으로 실패하므로 "도메인 체크 통과 후 fetchFailed" 케이스에 사용한다.
     private val fetcher =
         DefaultImageProxyFetcher(
             ImageProxyProperties(
-                allowedDomains = listOf("msscdn.net", "pstatic.net"),
+                allowedDomains = listOf("msscdn.net", "test.invalid"),
                 maxBytes = 5 * 1024 * 1024,
-                timeoutSeconds = 10,
+                timeoutSeconds = 3,
             ),
         )
 
@@ -50,11 +52,11 @@ class ImageProxyFetcherTest {
 
     @Test
     fun `허용 도메인의 서브도메인은 통과되고 네트워크 오류는 fetchFailed 예외를 던진다`() {
-        // img.pstatic.net → allowedDomains 에 pstatic.net 이 있으므로 도메인 체크는 통과
-        // 실제 fetch 는 네트워크 오류로 fetchFailed() 로 변환됨
+        // sub.test.invalid → allowedDomains 에 test.invalid 가 있으므로 서브도메인 체크 통과.
+        // .invalid TLD 는 RFC 6761 예약 도메인이라 DNS NXDOMAIN 으로 즉시 실패해 fetchFailed() 로 변환됨.
         val ex =
             assertFailsWith<ImageProxyException> {
-                fetcher.fetch("https://img.pstatic.net/nonexistent.jpg")
+                fetcher.fetch("https://sub.test.invalid/image.jpg")
             }
         assert(ex.httpStatus.value() == 502) { "fetchFailed 이어야 하지만 ${ex.httpStatus}" }
     }
@@ -63,7 +65,7 @@ class ImageProxyFetcherTest {
     fun `허용 도메인과 정확히 일치하는 host 는 통과되고 네트워크 오류는 fetchFailed 예외를 던진다`() {
         val ex =
             assertFailsWith<ImageProxyException> {
-                fetcher.fetch("https://pstatic.net/nonexistent.jpg")
+                fetcher.fetch("https://test.invalid/image.jpg")
             }
         assert(ex.httpStatus.value() == 502) { "fetchFailed 이어야 하지만 ${ex.httpStatus}" }
     }

--- a/src/test/kotlin/com/depromeet/piki/common/imageproxy/ImageProxyFetcherTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/common/imageproxy/ImageProxyFetcherTest.kt
@@ -21,6 +21,13 @@ class ImageProxyFetcherTest {
     }
 
     @Test
+    fun `http 스킴이면 blockedDomain 예외를 던진다`() {
+        assertFailsWith<ImageProxyException> {
+            fetcher.fetch("http://msscdn.net/image.jpg")
+        }
+    }
+
+    @Test
     fun `file 스킴이면 blockedDomain 예외를 던진다`() {
         assertFailsWith<ImageProxyException> {
             fetcher.fetch("file:///etc/passwd")

--- a/src/test/kotlin/com/depromeet/piki/common/imageproxy/ImageProxyFetcherTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/common/imageproxy/ImageProxyFetcherTest.kt
@@ -1,0 +1,63 @@
+package com.depromeet.piki.common.imageproxy
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertFailsWith
+
+class ImageProxyFetcherTest {
+    private val fetcher =
+        ImageProxyFetcher(
+            ImageProxyProperties(
+                allowedDomains = listOf("msscdn.net", "pstatic.net"),
+                maxBytes = 5 * 1024 * 1024,
+                timeoutSeconds = 10,
+            ),
+        )
+
+    @Test
+    fun `허용되지 않은 도메인이면 blockedDomain 예외를 던진다`() {
+        assertFailsWith<ImageProxyException> {
+            fetcher.fetch("https://evil.com/image.jpg")
+        }
+    }
+
+    @Test
+    fun `file 스킴이면 blockedDomain 예외를 던진다`() {
+        assertFailsWith<ImageProxyException> {
+            fetcher.fetch("file:///etc/passwd")
+        }
+    }
+
+    @Test
+    fun `URL 형식이 잘못되면 blockedDomain 예외를 던진다`() {
+        assertFailsWith<ImageProxyException> {
+            fetcher.fetch("not-a-valid-url")
+        }
+    }
+
+    @Test
+    fun `host 가 없는 URL 이면 blockedDomain 예외를 던진다`() {
+        assertFailsWith<ImageProxyException> {
+            fetcher.fetch("https:///image.jpg")
+        }
+    }
+
+    @Test
+    fun `허용 도메인의 서브도메인은 통과되고 네트워크 오류는 fetchFailed 예외를 던진다`() {
+        // img.pstatic.net → allowedDomains 에 pstatic.net 이 있으므로 도메인 체크는 통과
+        // 실제 fetch 는 네트워크 오류로 fetchFailed() 로 변환됨
+        val ex =
+            assertFailsWith<ImageProxyException> {
+                fetcher.fetch("https://img.pstatic.net/nonexistent.jpg")
+            }
+        assert(ex.httpStatus.value() == 502) { "fetchFailed 이어야 하지만 ${ex.httpStatus}" }
+    }
+
+    @Test
+    fun `허용 도메인과 정확히 일치하는 host 는 통과되고 네트워크 오류는 fetchFailed 예외를 던진다`() {
+        val ex =
+            assertFailsWith<ImageProxyException> {
+                fetcher.fetch("https://pstatic.net/nonexistent.jpg")
+            }
+        assert(ex.httpStatus.value() == 502) { "fetchFailed 이어야 하지만 ${ex.httpStatus}" }
+    }
+}

--- a/src/test/kotlin/com/depromeet/piki/common/imageproxy/ImageProxyFetcherTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/common/imageproxy/ImageProxyFetcherTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.assertFailsWith
 
 class ImageProxyFetcherTest {
     private val fetcher =
-        ImageProxyFetcher(
+        DefaultImageProxyFetcher(
             ImageProxyProperties(
                 allowedDomains = listOf("msscdn.net", "pstatic.net"),
                 maxBytes = 5 * 1024 * 1024,

--- a/src/test/kotlin/com/depromeet/piki/support/IntegrationStubs.kt
+++ b/src/test/kotlin/com/depromeet/piki/support/IntegrationStubs.kt
@@ -86,4 +86,10 @@ class IntegrationStubs {
     // 구현하지만 oauth.client.enabled=false 로 꺼지므로, 이 stub 이 유일한 AppleNotificationVerifier 라 @Primary 불필요.
     @Bean
     fun appleNotificationVerifier(): StubAppleNotificationVerifier = StubAppleNotificationVerifier()
+
+    // 이미지 프록시 외부 HTTP 호출 경계. DefaultImageProxyFetcher 는 실제 외부 CDN 을 호출하므로
+    // 통합 테스트에서 stub 으로 교체한다.
+    @Bean
+    @Primary
+    fun imageProxyFetcher(): StubImageProxyFetcher = StubImageProxyFetcher()
 }

--- a/src/test/kotlin/com/depromeet/piki/support/StubImageProxyFetcher.kt
+++ b/src/test/kotlin/com/depromeet/piki/support/StubImageProxyFetcher.kt
@@ -1,0 +1,12 @@
+package com.depromeet.piki.support
+
+import com.depromeet.piki.common.imageproxy.FetchedImage
+import com.depromeet.piki.common.imageproxy.ImageProxyFetcher
+
+class StubImageProxyFetcher : ImageProxyFetcher {
+    var handler: (url: String) -> FetchedImage = {
+        error("stub.handler 를 테스트 본문에서 명시 세팅해야 한다.")
+    }
+
+    override fun fetch(url: String): FetchedImage = handler(url)
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -56,6 +56,16 @@ s3:
   region: ap-northeast-2
   public-base-url: https://test-bucket.s3.ap-northeast-2.amazonaws.com
 
+# ImageProxyProperties 바인딩을 통과시키기 위한 테스트 더미 설정.
+# 실제 fetch 는 통합 테스트에서 도메인 차단(blockedDomain) 케이스만 검증하므로 도메인 목록은 운영과 동일하게 둔다.
+image:
+  proxy:
+    allowed-domains:
+      - msscdn.net
+      - pstatic.net
+      - kakaocdn.net
+      - coupangcdn.com
+
 # actuator 노출은 운영과 동일하게 박는다 — test classpath 의 application.yml 이 main 을 대체하므로
 # 여기 없으면 health(기본 노출)만 떠 /actuator/prometheus 통합 테스트가 깨진다.
 management:


### PR DESCRIPTION
## Situation

- 프론트엔드가 영수증 이미지 캡처(Canvas API)를 구현하는데 외부 CDN 이미지가 CORS에 걸림
- `<img>` 태그는 CORS 없이 표시되지만, `Canvas.drawImage()` 후 `toDataURL()`을 부르면 cross-origin 이미지가 캔버스를 오염시켜 데이터 추출이 막힘
- 외부 쇼핑몰 CDN은 직접 제어할 수 없고, S3 CORS 설정은 별도 작업으로 분리됨

## Task

- 서버가 외부 이미지를 대신 fetch해서 우리 도메인으로 응답하는 프록시 엔드포인트 추가
- 허용 도메인 화이트리스트로 SSRF 방어

## Action

- `GET /api/v1/image-proxy?url={url}` 엔드포인트 추가. 서버가 외부 URL을 fetch해 이미지 바이너리를 응답함
- 화이트리스트 8개 도메인(무신사·네이버·카카오·쿠팡 등) + 서브도메인 매칭으로 허용 범위 통제
- 허용되지 않은 도메인·https 외 스킴·잘못된 URL → 400, 외부 서버 오류 → 502
- `CorsConfig`가 이미 `/**` 전체에 적용되어 있어 별도 CORS 헤더 추가 없이도 응답에 `Access-Control-Allow-Origin`이 붙음
- http 스킴은 실제 CDN에서 쓰지 않고 중간자 공격 위험이 있어 차단(https만 허용)
- 응답에 `Cache-Control: public, max-age=86400` 추가. CDN 이미지는 URL이 동일하면 내용이 바뀌지 않아 하루 캐시가 적절
- 5MB 초과 응답은 전체를 메모리에 올린 뒤 버리는 방식. 화이트리스트 CDN에서 5MB 초과 이미지가 올 가능성이 낮아 실용적으로 허용
- 새 도메인 추가는 `application.yml`의 `image.proxy.allowed-domains` 배열만 수정하면 됨

## Result

- 프론트엔드가 `/api/v1/image-proxy?url=...`를 거쳐 외부 CDN 이미지를 Canvas API에서 사용 가능
- 도메인 체크 로직(차단·서브도메인 매칭·스킴 검증) 5건을 단위 테스트로, 미인증·도메인 차단 contract를 통합 테스트로 검증

---
## 연관 이슈

- close #568


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 이미지 프록시 API(`GET /api/v1/image-proxy`) 추가 - 지정된 URL의 이미지를 조회하고 전달합니다.
  * 설정 가능한 허용 도메인, 최대 이미지 크기(기본 5MB), 타임아웃(기본 10초) 지원
  * 차단된 도메인, 이미지 크기 초과, 인증 실패 등 오류 케이스에 대한 명확한 응답 코드 반환

* **Tests**
  * 이미지 프록시 기능에 대한 통합 테스트 및 단위 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->