### PR TITLE
토너먼트 출전 아이템 파싱 완료/실패를 참여자에게 SSE 라이브 동기화

### DIFF
--- a/notification-sse-spec.md
+++ b/notification-sse-spec.md
@@ -46,9 +46,9 @@
 
 ---
 
-## 4. 스트림에 흐르는 이벤트 3종
+## 4. 스트림에 흐르는 이벤트 4종
 
-SSE 한 연결 위로 아래 세 가지가 흐른다. 클라이언트는 **이벤트 `name`** 으로 구분한다.
+SSE 한 연결 위로 아래 네 가지가 흐른다. 클라이언트는 **이벤트 `name`** 으로 구분한다.
 
 ### (1) `connect` — 연결 성립 신호
 
@@ -68,7 +68,22 @@ event: notification
 data: {"id":123,"type":"TOURNAMENT_JOINED","category":"ACTIVITY","title":"홍길동님이 참가했어요","body":"","imageUrl":"https://.../profiles/{uid}.png","refId":45,"isRead":false,"createdAt":"2026-06-06T14:32:10"}
 ```
 
-### (3) 하트비트 (주석 ping)
+### (3) `tournament-item-parsed` — 출전 아이템 파싱 완료/실패 (라이브 동기화)
+
+토너먼트에 링크/이미지로 추가된 아이템의 파싱이 끝나면(`READY`/`FAILED`) 전송. `data` 는 아래 [5-1. payload](#5-1-tournament-item-parsed-payload-스키마) JSON.
+
+**이건 "알림"이 아니라 화면 갱신 신호다.** 알림센터에 쌓이지 않고 FCM 푸시도 가지 않으며, 오직 열려 있는 SSE 연결로만 흐른다. 목적은 단 하나 — 주최자가 아이템을 추가해 참여자 화면에 뜬 **PENDING 로딩 카드를 갱신**하는 것이다(`notification` 의 `TOURNAMENT_ITEM_ADDED` 로 카드가 뜬 뒤, 파싱이 끝나면 이 이벤트로 그 카드를 마무리한다).
+
+```text
+event: tournament-item-parsed
+data: {"tournamentId":99,"tournamentItemId":555,"status":"READY"}
+```
+
+- **수신자**: 그 토너먼트 참여자 **전원**(아이템을 올린 주최자 포함). 한 아이템이 여러 토너먼트에 출전 중이면 각 토너먼트 참여자가 **각자 그 토너먼트의 좌표**로 받는다.
+- **클라 동작**: `(tournamentId, tournamentItemId)` 로 그 출전 카드를 찾아 `status` 로 갱신 — `READY` 면 상품 정보 표시, `FAILED` 면 에러/재시도 UI. (또는 그 토너먼트 아이템 목록을 재조회.)
+- 위시로만 담긴(어느 토너먼트에도 없는) 아이템의 파싱 완료/실패는 이 이벤트로 오지 않는다 — 위시 주인은 `notification`(`ITEM_PARSING_*`)으로 받는다.
+
+### (4) 하트비트 (주석 ping)
 
 약 **30초 간격**. 연결 유지(프록시 read timeout 회피)용이며 **`data` 이벤트가 아니다.** SSE 주석 라인(`:` 으로 시작)이라 `EventSource` 의 `onmessage`/리스너에 잡히지 않는다. **클라이언트는 무시하면 된다.**
 
@@ -98,6 +113,20 @@ data: {"id":123,"type":"TOURNAMENT_JOINED","category":"ACTIVITY","title":"홍길
 | `tournamentItemId` | number (long) \| 생략 | **`kind=TOURNAMENT` 일 때만.** 입장한 토너먼트 안에서 지목할 출전 아이템. |
 
 > **라우팅 컨텍스트(`kind`·`tournamentId`·`tournamentItemId`)는 파싱 알림에만, 그것도 조건부로 실린다.** 같은 `type`(`ITEM_PARSING_*`)이 위시·토너먼트 두 출처에서 발행돼 `refId`(=itemId)만으론 출처를 구분할 수 없어 추가한다. 값이 없는 키는 **JSON 에서 아예 생략**된다(NON_NULL). 서버는 완성 URL 을 박지 않고 도메인 식별자만 내려보내며, URL 조립은 클라이언트가 한다.
+
+---
+
+## 5-1. `tournament-item-parsed` payload 스키마
+
+`tournament-item-parsed` 이벤트의 `data` 로 직렬화되는 JSON. `notification` payload 와 **별개 셰입**이며, 알림 식별자(`id`)·제목·읽음 같은 알림 필드가 없다 — 알림이 아니라 화면 갱신 신호이기 때문.
+
+| 필드 | 타입 | 설명 |
+|---|---|---|
+| `tournamentId` | number (long) | 갱신 대상 출전 카드가 속한 토너먼트. |
+| `tournamentItemId` | number (long) | 그 토너먼트 안에서 갱신할 출전 아이템(카드). 추가 시점에 받은 목록의 그 항목과 같은 id. |
+| `status` | string (enum) | 파싱 결과. **`READY`(완료) \| `FAILED`(실패)** 둘 중 하나만 실린다. 토너먼트 아이템 목록 응답의 `status` 와 같은 값 체계. |
+
+> 같은 아이템이 여러 토너먼트에 출전 중이면, 각 토너먼트 참여자는 **그 토너먼트의 `(tournamentId, tournamentItemId)`** 좌표로 각자 한 건씩 받는다. (`notification` 파싱 알림이 단일 출처 좌표만 싣는 것과 달리, 이 동기화는 모든 출전 토너먼트로 fan-out 한다.)
 
 ---
 
@@ -159,6 +188,7 @@ data: {"id":123,"type":"TOURNAMENT_JOINED","category":"ACTIVITY","title":"홍길
 
 - 현재 SSE 는 **연결 중에 발생한 알림만** 실시간 전달한다. **연결이 끊겨 있던 동안 쌓인 알림은 재연결해도 스트림으로 다시 오지 않는다.**
 - 단, 모든 알림은 DB(`notifications`)에 영속되므로, **목록/배지 조회 API** 로 놓친 알림을 따라잡는 설계가 정석이다. (해당 조회 API 는 후속 작업)
+- `tournament-item-parsed`(라이브 동기화)는 **영속되지 않는다** — 끊겨 있던 동안의 파싱 완료/실패는 재전송되지 않는다. 하지만 재연결·앱 진입 시 토너먼트 아이템 목록을 재조회하면 그 시점의 최신 `status`(READY/FAILED)가 그대로 내려오므로 자연히 따라잡힌다.
 - 따라서 권장 클라이언트 패턴: **앱 진입/재연결 시 목록 API 로 동기화 + SSE 로 실시간 갱신.**
 
 ---
@@ -202,6 +232,13 @@ es.addEventListener("notification", (e) => {
   showToast(n.title);
 });
 
+// 라이브 동기화 — 토너먼트 출전 카드 갱신(알림 아님, 토스트도 없음).
+es.addEventListener("tournament-item-parsed", (e) => {
+  const s = JSON.parse(e.data);
+  // (tournamentId, tournamentItemId)로 그 카드를 찾아 status 로 갱신 (또는 그 토너먼트 아이템 목록 재조회).
+  updateTournamentItemCard(s.tournamentId, s.tournamentItemId, s.status); // status: "READY" | "FAILED"
+});
+
 es.onerror = () => {
   // EventSource 가 자동 재연결을 시도한다. 필요 시 추가 처리.
 };
@@ -231,6 +268,10 @@ fun openSse() {
                     //   kind == "WISH"       -> /archive
                     //   TOURNAMENT_*         -> refId(= tournamentId) 로 토너먼트
                 }
+                "tournament-item-parsed" -> {
+                    // 라이브 동기화(알림 아님) — (tournamentId, tournamentItemId)로 그 출전 카드를 status 로 갱신.
+                    val s = json.decode<TournamentItemParsedPayload>(data)  // {tournamentId, tournamentItemId, status: READY|FAILED}
+                }
                 // 그 외(주석 ping 등)는 무시
             }
         }
@@ -251,6 +292,7 @@ fun openSse() {
 - [ ] `type` 으로 분기, **문구로 분기하지 않기**
 - [ ] `refId` 의미가 `type` 마다 다름 (tournamentId vs itemId)
 - [ ] 파싱 알림(`ITEM_PARSING_*`)은 `kind` 로 출처 분기 (WISH → `/archive`, TOURNAMENT → `tournamentId`·`tournamentItemId`)
+- [ ] `tournament-item-parsed` 는 알림이 아닌 **카드 갱신 신호** — `(tournamentId, tournamentItemId)` 로 카드를 찾아 `status`(READY/FAILED) 반영 (토스트·알림센터 아님)
 - [ ] 주석 `: ping` 은 무시 (data 이벤트 아님)
 - [ ] 재연결 시 목록 API 로 놓친 알림 동기화
 - [ ] WEB 은 쿠키 인증(`withCredentials`), APP 은 `Authorization` 헤더

--- a/src/main/kotlin/com/depromeet/piki/notification/controller/NotificationSseApi.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/controller/NotificationSseApi.kt
@@ -24,6 +24,8 @@ interface NotificationSseApi {
                 "| `connect` | 구독 직후 1회 | `data=\"connected\"`. 연결 성립 신호 |\n" +
                 "| `notification` | 알림 1건마다 | `type` 으로 화면을, 파싱 알림은 `kind` 로 출처(위시/토너먼트)를 분기. " +
                 "출처별 payload 셰입과 라우팅 필드(`kind`·`tournamentId`·`tournamentItemId`)는 `notification-sse-spec.md` 참조 |\n" +
+                "| `tournament-item-parsed` | 출전 아이템 파싱 완료/실패 시 | 토너먼트 참여자 화면 라이브 갱신용 신호(알림 아님). " +
+                "payload `{tournamentId, tournamentItemId, status}`(status=`READY`\\|`FAILED`). 알림센터·푸시 없이 SSE 로만 흐른다. `notification-sse-spec.md` 참조 |\n" +
                 "| `(주석 ping)` | 약 30초 간격 | 하트비트. 연결 유지용이며 data 이벤트가 아니다 |\n\n" +
                 "- 토너먼트 알림은 해당 토너먼트 참여자에게만 fan-out 되므로, **자기 스트림 1개만 구독**하면 토너먼트·개인 알림이 모두 도착한다.\n" +
                 "- 연결은 **30분 후 타임아웃**되며, 클라이언트는 끊기면 재연결한다.",

--- a/src/main/kotlin/com/depromeet/piki/notification/controller/dto/TournamentItemParsedPayload.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/controller/dto/TournamentItemParsedPayload.kt
@@ -1,0 +1,15 @@
+package com.depromeet.piki.notification.controller.dto
+
+import com.depromeet.piki.item.domain.ItemStatus
+
+// 토너먼트 출전 아이템의 파싱이 끝났음을 토너먼트 참여자 화면에 실시간 반영하는 SSE 라이브 동기화 payload
+// (event name = "tournament-item-parsed"). 이건 "알림"(notification)이 아니라 화면 갱신 신호다 —
+// 알림센터·FCM 푸시를 거치지 않고 SSE 로만 흐른다(NotificationSsePayload 와 별개 경로).
+//
+// 클라는 (tournamentId, tournamentItemId)로 그 토너먼트의 해당 출전 카드를 찾아 status 로 갱신한다:
+// PENDING/PROCESSING 로딩 → READY(상품 정보 표시) / FAILED(에러·재시도). status 는 항상 READY·FAILED 중 하나다.
+data class TournamentItemParsedPayload(
+    val tournamentId: Long,
+    val tournamentItemId: Long,
+    val status: ItemStatus,
+)

--- a/src/main/kotlin/com/depromeet/piki/notification/sse/LocalSseDelivery.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/sse/LocalSseDelivery.kt
@@ -1,6 +1,7 @@
 package com.depromeet.piki.notification.sse
 
 import com.depromeet.piki.notification.controller.dto.NotificationSsePayload
+import com.depromeet.piki.notification.controller.dto.TournamentItemParsedPayload
 import com.depromeet.piki.notification.domain.Notification
 import com.depromeet.piki.notification.service.DefaultPushImage
 import org.slf4j.LoggerFactory
@@ -32,6 +33,21 @@ class LocalSseDelivery(
                 .name(EVENT_NOTIFICATION)
                 .data(NotificationSsePayload.from(notification, defaultPushImage.url))
         registry.emittersOf(userId).forEach { sendOrEvict(userId, it, event) }
+    }
+
+    // 토너먼트 출전 아이템의 파싱 완료/실패를 그 토너먼트 참여자들 연결에 실시간 흘려보낸다(라이브 동기화, 알림 아님).
+    // notification 전달과 같은 emitter write 경로(sendOrEvict)를 공유하되 이벤트 name 만 다르다(클라가 name 으로 구분).
+    // 한 payload 이벤트를 만들어 대상 유저 전원의 emitter 에 재사용한다 — 같은 토너먼트 참여자들이 같은 카드 갱신을 받는다.
+    fun deliverTournamentItemParsed(
+        userIds: Collection<UUID>,
+        payload: TournamentItemParsedPayload,
+    ) {
+        val event =
+            SseEmitter
+                .event()
+                .name(EVENT_TOURNAMENT_ITEM_PARSED)
+                .data(payload)
+        userIds.forEach { userId -> registry.emittersOf(userId).forEach { sendOrEvict(userId, it, event) } }
     }
 
     // 탈퇴 시 그 유저의 모든 SSE 연결을 즉시 끊는다(best-effort). 레지스트리에서 키째 빼고 각 emitter 를
@@ -69,5 +85,9 @@ class LocalSseDelivery(
     companion object {
         // SSE 이벤트 name. 클라이언트는 이 이름으로 알림 이벤트와 connect/하트비트를 구분한다.
         const val EVENT_NOTIFICATION = "notification"
+
+        // 토너먼트 출전 아이템 파싱 완료/실패 화면 갱신 신호의 SSE 이벤트 name. notification 과 구분되며,
+        // 알림이 아니라 라이브 동기화라 알림센터·FCM 을 거치지 않는다(TournamentItemParsedPayload).
+        const val EVENT_TOURNAMENT_ITEM_PARSED = "tournament-item-parsed"
     }
 }

--- a/src/main/kotlin/com/depromeet/piki/notification/sse/TournamentItemParsedSseBroadcaster.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/sse/TournamentItemParsedSseBroadcaster.kt
@@ -12,7 +12,6 @@ import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
 import org.springframework.transaction.event.TransactionPhase
 import org.springframework.transaction.event.TransactionalEventListener
-import java.util.UUID
 
 // 토너먼트 출전 아이템의 파싱 완료/실패를 그 토너먼트 참여자 화면에 실시간 반영한다.
 //
@@ -47,11 +46,15 @@ class TournamentItemParsedSseBroadcaster(
         broadcast(event.itemId, ItemStatus.FAILED)
     }
 
-    // itemId 가 출전한 각 토너먼트마다 그 좌표(tournamentItemId)와 참여자 전원을 풀어, 참여자 화면에 카드 갱신을 보낸다.
-    // 한 아이템이 여러 토너먼트에 공유될 수 있어 좌표가 복수다 — 알림 라우팅(firstOrNull 단건)과 달리 전부 순회해
-    // 각 토너먼트 참여자에게 그 토너먼트의 좌표를 보낸다. adder(주최자)도 참여자라 함께 받는다(이 신호는 "알림"이 아니라
-    // 카드 갱신이라, 모든 보는 화면이 동일하게 갱신되는 게 옳다 — adder 의 ITEM_PARSING_COMPLETED 알림과는 목적이 다르다).
-    // 위시 전용(어느 토너먼트에도 없는) 아이템이면 routings 가 비어 아무 것도 보내지 않는다(위시 주인은 ITEM_PARSING_* 로 받음).
+    // itemId 로 그 아이템의 토너먼트 출전 좌표(tournamentItemId)와 참여자 전원을 풀어 카드 갱신을 보낸다.
+    // adder(주최자)도 참여자라 함께 받는다 — 이 신호는 "알림"이 아니라 카드 갱신이라, 보는 화면이 모두 동일하게
+    // 갱신되는 게 옳다(adder 의 ITEM_PARSING_COMPLETED 알림과는 목적이 다르다).
+    //
+    // 파싱 시점엔 add 마다 새 item·snapshot 이 생겨(persistLinkItem·persistProcessingItems) 한 itemId 가 한
+    // tournament_item 에만 매이므로 routings 는 0~1 행이다. List·순회로 둔 건 향후 item 공유(한 아이템이 여러
+    // 토너먼트에 동시 출전) 도입 대비이며, 그땐 routing 별로 각 snapshot 의 실제 상태를 확인해야 한다 — 지금은
+    // 단일이라 이벤트 status 를 그대로 싣는다(공유 도입 시 spurious 갱신 주의, 후속 이슈). 위시 전용(어느 토너먼트에도
+    // 없는) 아이템이면 routings 가 비어 아무 것도 보내지 않는다(위시 주인은 ITEM_PARSING_* 알림으로 받음).
     fun broadcast(
         itemId: Long,
         status: ItemStatus,
@@ -59,23 +62,35 @@ class TournamentItemParsedSseBroadcaster(
         val routings = tournamentItemRepository.findRoutingByItemId(itemId)
         if (routings.isEmpty()) return
         routings.forEach { routing ->
-            val participants: List<UUID> =
-                tournamentUserRepository.findByTournamentId(routing.tournamentId).map { it.userId }
-            localDelivery.deliverTournamentItemParsed(
-                participants,
-                TournamentItemParsedPayload(
-                    tournamentId = routing.tournamentId,
-                    tournamentItemId = routing.tournamentItemId,
-                    status = status,
-                ),
-            )
-            log.info(
-                "토너먼트 아이템 파싱 동기화 전송 tournamentId={} tournamentItemId={} status={} 참여자={}명",
-                routing.tournamentId,
-                routing.tournamentItemId,
-                status,
-                participants.size,
-            )
+            // 한 토너먼트의 조회·전달 실패가 나머지 fan-out 을 막지 않게 토너먼트 단위로 격리한다
+            // (NotificationDispatcher 의 수신자 단위 격리와 같은 결). @Async 워커라 여기서 삼키지 않으면 기본
+            // 핸들러가 맥락 없는 스택트레이스만 남겨 동기화 누락이 무음이 된다 — itemId 맥락을 실어 warn 으로 남긴다.
+            runCatching {
+                val participants = tournamentUserRepository.findByTournamentId(routing.tournamentId).map { it.userId }
+                localDelivery.deliverTournamentItemParsed(
+                    participants,
+                    TournamentItemParsedPayload(
+                        tournamentId = routing.tournamentId,
+                        tournamentItemId = routing.tournamentItemId,
+                        status = status,
+                    ),
+                )
+                log.info(
+                    "토너먼트 아이템 파싱 동기화 전송 tournamentId={} tournamentItemId={} status={} 참여자={}명",
+                    routing.tournamentId,
+                    routing.tournamentItemId,
+                    status,
+                    participants.size,
+                )
+            }.onFailure { e ->
+                log.warn(
+                    "토너먼트 아이템 파싱 동기화 실패 tournamentId={} itemId={} status={}",
+                    routing.tournamentId,
+                    itemId,
+                    status,
+                    e,
+                )
+            }
         }
     }
 }

--- a/src/main/kotlin/com/depromeet/piki/notification/sse/TournamentItemParsedSseBroadcaster.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/sse/TournamentItemParsedSseBroadcaster.kt
@@ -1,0 +1,81 @@
+package com.depromeet.piki.notification.sse
+
+import com.depromeet.piki.common.config.AsyncConfig
+import com.depromeet.piki.item.domain.ItemStatus
+import com.depromeet.piki.item.event.ItemParsingCompleted
+import com.depromeet.piki.item.event.ItemParsingFailed
+import com.depromeet.piki.notification.controller.dto.TournamentItemParsedPayload
+import com.depromeet.piki.tournament.repository.TournamentItemRepository
+import com.depromeet.piki.tournament.repository.TournamentUserRepository
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+import java.util.UUID
+
+// 토너먼트 출전 아이템의 파싱 완료/실패를 그 토너먼트 참여자 화면에 실시간 반영한다.
+//
+// 문제: 주최자가 링크/이미지로 아이템을 추가하면 참여자는 TOURNAMENT_ITEM_ADDED 로 PENDING 카드(로딩바)를 띄우지만,
+// 파싱이 끝나도 별도 신호가 없어 새로고침 전까지 로딩이 멈추지 않았다. 파싱 완료/실패 알림(ITEM_PARSING_*)은
+// 올린 본인(adder)·위시 주인에게만 가고(노이즈 방지, ItemParsingRecipientResolver) 다른 참여자에겐 가지 않기 때문.
+//
+// 해결: 파싱이 끝나면(READY/FAILED) 그 아이템이 출전한 모든 토너먼트의 참여자 전원에게 SSE 라이브 동기화 이벤트
+// (tournament-item-parsed)를 보내 카드를 갱신하게 한다. 이건 "알림"이 아니라 화면 갱신 신호라 알림센터·FCM 을
+// 거치지 않고 SSE 로만 흐른다(NotificationDispatcher 경로와 별개 — 추가 알림 노이즈를 만들지 않는다).
+//
+// 결합 방향: 알림 -> 도메인 (단방향). item·tournament 도메인은 이 클래스를 모른다(자기 이벤트만 발행).
+// AFTER_COMMIT + @Async: 파싱 상태 전이가 커밋된 뒤에만(롤백 시 미발송) 워커 스레드와 분리해 전달한다
+// (notification 의 NotificationEventListener 와 같은 결, 같은 executor).
+@Component
+class TournamentItemParsedSseBroadcaster(
+    private val tournamentItemRepository: TournamentItemRepository,
+    private val tournamentUserRepository: TournamentUserRepository,
+    private val localDelivery: LocalSseDelivery,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Async(AsyncConfig.NOTIFICATION_EXECUTOR)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun on(event: ItemParsingCompleted) {
+        broadcast(event.itemId, ItemStatus.READY)
+    }
+
+    @Async(AsyncConfig.NOTIFICATION_EXECUTOR)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun on(event: ItemParsingFailed) {
+        broadcast(event.itemId, ItemStatus.FAILED)
+    }
+
+    // itemId 가 출전한 각 토너먼트마다 그 좌표(tournamentItemId)와 참여자 전원을 풀어, 참여자 화면에 카드 갱신을 보낸다.
+    // 한 아이템이 여러 토너먼트에 공유될 수 있어 좌표가 복수다 — 알림 라우팅(firstOrNull 단건)과 달리 전부 순회해
+    // 각 토너먼트 참여자에게 그 토너먼트의 좌표를 보낸다. adder(주최자)도 참여자라 함께 받는다(이 신호는 "알림"이 아니라
+    // 카드 갱신이라, 모든 보는 화면이 동일하게 갱신되는 게 옳다 — adder 의 ITEM_PARSING_COMPLETED 알림과는 목적이 다르다).
+    // 위시 전용(어느 토너먼트에도 없는) 아이템이면 routings 가 비어 아무 것도 보내지 않는다(위시 주인은 ITEM_PARSING_* 로 받음).
+    fun broadcast(
+        itemId: Long,
+        status: ItemStatus,
+    ) {
+        val routings = tournamentItemRepository.findRoutingByItemId(itemId)
+        if (routings.isEmpty()) return
+        routings.forEach { routing ->
+            val participants: List<UUID> =
+                tournamentUserRepository.findByTournamentId(routing.tournamentId).map { it.userId }
+            localDelivery.deliverTournamentItemParsed(
+                participants,
+                TournamentItemParsedPayload(
+                    tournamentId = routing.tournamentId,
+                    tournamentItemId = routing.tournamentItemId,
+                    status = status,
+                ),
+            )
+            log.info(
+                "토너먼트 아이템 파싱 동기화 전송 tournamentId={} tournamentItemId={} status={} 참여자={}명",
+                routing.tournamentId,
+                routing.tournamentItemId,
+                status,
+                participants.size,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/notification/sse/TournamentItemParsedSseBroadcaster.kt
+++ b/src/main/kotlin/com/depromeet/piki/notification/sse/TournamentItemParsedSseBroadcaster.kt
@@ -55,42 +55,42 @@ class TournamentItemParsedSseBroadcaster(
     // 토너먼트에 동시 출전) 도입 대비이며, 그땐 routing 별로 각 snapshot 의 실제 상태를 확인해야 한다 — 지금은
     // 단일이라 이벤트 status 를 그대로 싣는다(공유 도입 시 spurious 갱신 주의, 후속 이슈). 위시 전용(어느 토너먼트에도
     // 없는) 아이템이면 routings 가 비어 아무 것도 보내지 않는다(위시 주인은 ITEM_PARSING_* 알림으로 받음).
+    // @Async 워커라 여기서 throw 를 삼키지 않으면 기본 핸들러가 맥락 없는 스택트레이스만 남겨 동기화 누락이 무음이 된다.
+    // 전체를 runCatching 으로 감싸 itemId 맥락을 실어 warn 으로 남긴다(NotificationDispatcher 가 fan-out 실패를
+    // 격리·기록하는 결). emitter write 실패는 deliver 내부(sendOrEvict)가 연결 단위로 이미 격리한다.
     fun broadcast(
         itemId: Long,
         status: ItemStatus,
     ) {
-        val routings = tournamentItemRepository.findRoutingByItemId(itemId)
-        if (routings.isEmpty()) return
-        routings.forEach { routing ->
-            // 한 토너먼트의 조회·전달 실패가 나머지 fan-out 을 막지 않게 토너먼트 단위로 격리한다
-            // (NotificationDispatcher 의 수신자 단위 격리와 같은 결). @Async 워커라 여기서 삼키지 않으면 기본
-            // 핸들러가 맥락 없는 스택트레이스만 남겨 동기화 누락이 무음이 된다 — itemId 맥락을 실어 warn 으로 남긴다.
-            runCatching {
-                val participants = tournamentUserRepository.findByTournamentId(routing.tournamentId).map { it.userId }
-                localDelivery.deliverTournamentItemParsed(
-                    participants,
-                    TournamentItemParsedPayload(
-                        tournamentId = routing.tournamentId,
-                        tournamentItemId = routing.tournamentItemId,
-                        status = status,
-                    ),
-                )
-                log.info(
-                    "토너먼트 아이템 파싱 동기화 전송 tournamentId={} tournamentItemId={} status={} 참여자={}명",
-                    routing.tournamentId,
-                    routing.tournamentItemId,
-                    status,
-                    participants.size,
-                )
-            }.onFailure { e ->
-                log.warn(
-                    "토너먼트 아이템 파싱 동기화 실패 tournamentId={} itemId={} status={}",
-                    routing.tournamentId,
-                    itemId,
-                    status,
-                    e,
-                )
+        runCatching {
+            val routings = tournamentItemRepository.findRoutingByItemId(itemId)
+            if (routings.isNotEmpty()) {
+                // 참여자는 토너먼트들을 한 번에 모아 bulk 조회한다(반복문 내 쿼리 N+1 회피). tournamentId -> userIds 색인 후 재사용.
+                val participantsByTournament =
+                    tournamentUserRepository
+                        .findByTournamentIds(routings.map { it.tournamentId }.distinct())
+                        .groupBy({ it.tournamentId }, { it.userId })
+                routings.forEach { routing ->
+                    val participants = participantsByTournament[routing.tournamentId].orEmpty()
+                    localDelivery.deliverTournamentItemParsed(
+                        participants,
+                        TournamentItemParsedPayload(
+                            tournamentId = routing.tournamentId,
+                            tournamentItemId = routing.tournamentItemId,
+                            status = status,
+                        ),
+                    )
+                    log.info(
+                        "토너먼트 아이템 파싱 동기화 전송 tournamentId={} tournamentItemId={} status={} 참여자={}명",
+                        routing.tournamentId,
+                        routing.tournamentItemId,
+                        status,
+                        participants.size,
+                    )
+                }
             }
+        }.onFailure { e ->
+            log.warn("토너먼트 아이템 파싱 동기화 실패 itemId={} status={}", itemId, status, e)
         }
     }
 }

--- a/src/test/kotlin/com/depromeet/piki/notification/sse/TournamentItemParsedSseIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/notification/sse/TournamentItemParsedSseIntegrationTest.kt
@@ -1,0 +1,153 @@
+package com.depromeet.piki.notification.sse
+
+import com.depromeet.piki.item.domain.ItemSnapshot
+import com.depromeet.piki.item.domain.ItemStatus
+import com.depromeet.piki.item.repository.ItemSnapshotRepository
+import com.depromeet.piki.notification.controller.dto.TournamentItemParsedPayload
+import com.depromeet.piki.support.IntegrationTestSupport
+import com.depromeet.piki.tournament.domain.TournamentItem
+import com.depromeet.piki.tournament.domain.TournamentUser
+import com.depromeet.piki.tournament.repository.TournamentItemRepository
+import com.depromeet.piki.tournament.repository.TournamentUserRepository
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
+import java.util.UUID
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+// 토너먼트 출전 아이템의 파싱 완료/실패 → 참여자 SSE 라이브 동기화(tournament-item-parsed)를 실제 빈으로 검증한다.
+// 브로드캐스터의 수신자·좌표 도출은 DB 역조회(tournament_item⋈item_snapshot, tournament_user)에 의존하므로 통합으로 검증한다.
+// 영속 fixture 는 @Transactional 자동 롤백. SseEmitterRegistry 는 인메모리 싱글톤이라 롤백 대상이 아니므로,
+// 각 테스트가 랜덤 userId 로 등록하고 finally 에서 자기 emitter 를 정리한다(NotificationSseIntegrationTest 와 동일 규약).
+@Transactional
+class TournamentItemParsedSseIntegrationTest : IntegrationTestSupport() {
+    @Autowired private lateinit var broadcaster: TournamentItemParsedSseBroadcaster
+
+    @Autowired private lateinit var registry: SseEmitterRegistry
+
+    @Autowired private lateinit var tournamentItemRepository: TournamentItemRepository
+
+    @Autowired private lateinit var tournamentUserRepository: TournamentUserRepository
+
+    @Autowired private lateinit var itemSnapshotRepository: ItemSnapshotRepository
+
+    @Test
+    fun `파싱 완료 시 그 토너먼트 참여자 전원이 출전 좌표와 status=READY 를 받고 비참여자는 못 받는다`() {
+        val itemId = 5001L
+        val tournamentId = 7001L
+        val adder = UUID.randomUUID()
+        val participant = UUID.randomUUID()
+        val outsider = UUID.randomUUID()
+        listOf(adder, participant).forEach { tournamentUserRepository.save(TournamentUser(tournamentId, it)) }
+        val tournamentItemId =
+            tournamentItemRepository.saveAll(listOf(TournamentItem(tournamentId, adder, snapshotIdFor(itemId)))).first().getId()
+
+        val adderEmitter = ItemParsedRecordingEmitter().also { registry.register(adder, it) }
+        val participantEmitter = ItemParsedRecordingEmitter().also { registry.register(participant, it) }
+        val outsiderEmitter = ItemParsedRecordingEmitter().also { registry.register(outsider, it) }
+
+        try {
+            broadcaster.broadcast(itemId, ItemStatus.READY)
+
+            // 참여자 전원(올린 본인 adder 포함)이 그 토너먼트 좌표 + READY 를 받는다.
+            listOf(adderEmitter, participantEmitter).forEach { emitter ->
+                val payload = emitter.payloads().single()
+                assertEquals(tournamentId, payload.tournamentId)
+                assertEquals(tournamentItemId, payload.tournamentItemId)
+                assertEquals(ItemStatus.READY, payload.status)
+                assertTrue(emitter.sentData.any { it is String && it.contains("event:tournament-item-parsed") })
+            }
+            // 그 토너먼트 비참여자에겐 가지 않는다.
+            assertTrue(outsiderEmitter.payloads().isEmpty())
+        } finally {
+            listOf(adder to adderEmitter, participant to participantEmitter, outsider to outsiderEmitter)
+                .forEach { (userId, emitter) -> registry.unregister(userId, emitter) }
+        }
+    }
+
+    @Test
+    fun `파싱 실패 시 참여자는 status=FAILED 로 받는다`() {
+        val itemId = 5002L
+        val tournamentId = 7002L
+        val participant = UUID.randomUUID()
+        tournamentUserRepository.save(TournamentUser(tournamentId, participant))
+        tournamentItemRepository.saveAll(listOf(TournamentItem(tournamentId, participant, snapshotIdFor(itemId))))
+        val emitter = ItemParsedRecordingEmitter().also { registry.register(participant, it) }
+
+        try {
+            broadcaster.broadcast(itemId, ItemStatus.FAILED)
+
+            assertEquals(ItemStatus.FAILED, emitter.payloads().single().status)
+        } finally {
+            registry.unregister(participant, emitter)
+        }
+    }
+
+    @Test
+    fun `위시로만 담긴(어느 토너먼트에도 없는) 아이템이면 아무 emitter 에도 보내지 않는다`() {
+        // 토너먼트 출전(tournament_item)이 없으면 findRoutingByItemId 가 비어 broadcast 가 early return 한다.
+        val itemId = 5003L
+        snapshotIdFor(itemId) // snapshot 만 있고 토너먼트엔 안 올림(위시 전용 상황 시뮬레이션)
+        val someUser = UUID.randomUUID()
+        val emitter = ItemParsedRecordingEmitter().also { registry.register(someUser, it) }
+
+        try {
+            broadcaster.broadcast(itemId, ItemStatus.READY)
+
+            assertTrue(emitter.payloads().isEmpty())
+        } finally {
+            registry.unregister(someUser, emitter)
+        }
+    }
+
+    @Test
+    fun `한 아이템이 여러 토너먼트에 출전 중이면 각 토너먼트 참여자가 각자 그 토너먼트 좌표로 받는다`() {
+        val itemId = 5004L
+        val snapshotId = snapshotIdFor(itemId)
+        val tournamentA = 7004L
+        val tournamentB = 7005L
+        val userA = UUID.randomUUID()
+        val userB = UUID.randomUUID()
+        tournamentUserRepository.save(TournamentUser(tournamentA, userA))
+        tournamentUserRepository.save(TournamentUser(tournamentB, userB))
+        // 같은 item(=같은 snapshot)을 두 토너먼트에 각각 올린다 → 좌표(tournamentItemId)가 토너먼트별로 다르다.
+        val itemIdA = tournamentItemRepository.saveAll(listOf(TournamentItem(tournamentA, userA, snapshotId))).first().getId()
+        val itemIdB = tournamentItemRepository.saveAll(listOf(TournamentItem(tournamentB, userB, snapshotId))).first().getId()
+        val emitterA = ItemParsedRecordingEmitter().also { registry.register(userA, it) }
+        val emitterB = ItemParsedRecordingEmitter().also { registry.register(userB, it) }
+
+        try {
+            broadcaster.broadcast(itemId, ItemStatus.READY)
+
+            val payloadA = emitterA.payloads().single()
+            assertEquals(tournamentA, payloadA.tournamentId)
+            assertEquals(itemIdA, payloadA.tournamentItemId)
+
+            val payloadB = emitterB.payloads().single()
+            assertEquals(tournamentB, payloadB.tournamentId)
+            assertEquals(itemIdB, payloadB.tournamentItemId)
+        } finally {
+            registry.unregister(userA, emitterA)
+            registry.unregister(userB, emitterB)
+        }
+    }
+
+    // 알림 역조회는 tournament_item→item_snapshots 를 snapshot_id 로 조인해 s.item_id 로 매칭한다.
+    // 그 itemId 로 시딩한 snapshot 의 id 를 tournament_item 의 snapshotId 로 넘겨야 역조회가 맞아떨어진다.
+    private fun snapshotIdFor(itemId: Long): Long = itemSnapshotRepository.save(ItemSnapshot.processing(itemId)).getId()
+}
+
+// send(SseEventBuilder) 를 가로채 실제 IO 없이 전송 내용을 기록한다. build() 가 내놓는 data 항목
+// (메타 라인 문자열 + payload 객체)을 그대로 모아, 테스트가 payload 와 이벤트 name 을 단언할 수 있게 한다.
+private class ItemParsedRecordingEmitter : SseEmitter() {
+    val sentData = CopyOnWriteArrayList<Any>()
+
+    override fun send(builder: SseEmitter.SseEventBuilder) {
+        builder.build().forEach { sentData.add(it.data) }
+    }
+
+    fun payloads(): List<TournamentItemParsedPayload> = sentData.filterIsInstance<TournamentItemParsedPayload>()
+}


### PR DESCRIPTION
## Situation

- 주최자가 참여자를 초대한 토너먼트에서, 주최자가 **링크/이미지로 아이템을 추가**하면 참여자 화면에도 그 아이템이 PENDING 상태(로딩바)로 뜬다 (`TOURNAMENT_ITEM_ADDED` 알림).
- 그런데 파싱이 끝나도 참여자에겐 **완료 신호가 가지 않아**, 새로고침 전까지 로딩바가 무한히 돈다.
- 원인: 파싱 완료/실패 알림(`ITEM_PARSING_*`)은 **그 아이템을 올린 본인(adder)에게만** 가고, 다른 참여자는 의도적으로 제외돼 있었다 (FCM 푸시/알림센터 노이즈 방지).

## Task

- 파싱이 끝나면(완료/실패) **참여자 화면이 새로고침 없이 갱신**되게 한다.
- 단, 참여자에게 **푸시 알림·알림센터 노이즈를 만들지 않는다** (원작자가 참여자를 제외한 그 이유를 되살리지 않는다).

## 누가 파싱 → 누가 무엇을 받나 (핵심)

> 이 PR 은 **토너먼트에 링크/이미지로 추가된 아이템**에 한정한다 (위시 등록 흐름은 이 PR 과 무관, 변경 없음). 파싱 자체는 사용자가 아니라 **백그라운드 워커**가 수행하며, 아래 "누구의 파싱"은 **그 아이템을 토너먼트에 추가한 사람(adder, 보통 주최자)** 의 아이템 파싱을 가리킨다.

### 받는 사람 관점 (토너먼트에 추가된 아이템 1건의 생애)

| 받는 사람 | 추가 시점 | 파싱 완료/실패 시점 |
|---|---|---|
| **adder (올린 본인, 보통 주최자)** | (자기 화면이라 알림 없음) | `ITEM_PARSING_COMPLETED`/`FAILED` 알림 [SSE + FCM 푸시 + 알림센터] **그리고** `tournament-item-parsed` 동기화 [SSE만] |
| **그 외 토너먼트 참여자** | `TOURNAMENT_ITEM_ADDED` 알림 [SSE] → PENDING 카드(로딩바) | `tournament-item-parsed` 동기화 [SSE만] **← 이번 PR 로 추가** (알림은 안 받음) |

- adder 가 받는 `ITEM_PARSING_*` 알림은 **기존 그대로, 이번 PR 이 건드리지 않는다.**
- "그 외 참여자"가 받던 게 **추가 시점의 `TOURNAMENT_ITEM_ADDED` 단 한 번**뿐이라 로딩바가 안 멈췄다. 여기에 파싱 완료/실패 시점의 `tournament-item-parsed` 동기화를 더한 게 이번 변경의 전부다.

### 신호 관점 (각 신호가 누구에게, 어느 채널로)

| 신호 | 종류 | 보내는 대상 | 채널 | 상태 |
|---|---|---|---|---|
| `TOURNAMENT_ITEM_ADDED` | 알림 | 그 토너먼트 참여자 중 **adder 제외** 전원 | SSE만 (#573 이후 sync 타입) | 기존 |
| `ITEM_PARSING_COMPLETED` / `FAILED` | 알림 | 그 아이템을 올린 **adder** | SSE + FCM 푸시 + 알림센터 | 기존 |
| `tournament-item-parsed` | **동기화 (알림 아님)** | 그 아이템이 출전한 토너먼트의 참여자 **전원 (adder 포함)** | **SSE만** (FCM·알림센터 없음) | **신규** |

- adder 가 파싱 완료 시 두 신호를 다 받는 건 의도된 것이다: `ITEM_PARSING_*` 는 "네 아이템이 됐다"는 알림(앱 닫혀도 푸시), `tournament-item-parsed` 는 "이 카드 갱신해"라는 화면 신호. 목적이 다르다.

## Action

핵심 판단: 이건 "알림"이 아니라 "화면 갱신 신호"다. 기존 알림 경로에 참여자를 끼워 넣는 대신, 알림센터·FCM 을 거치지 않고 SSE 로만 흐르는 **별도 라이브 동기화 이벤트**로 분리했다.

### 왜 별도 이벤트인가 (검토한 대안 비교)

| 방식 | FCM 푸시 | 알림센터 히스토리 | 채택 |
|---|---|---|---|
| 기존 `ITEM_PARSING_COMPLETED` 수신자에 참여자 추가 | 참여자 전원에게 푸시(노이즈) | 참여자마다 쌓임 | X |
| SSE-only 알림 타입 신설 | 없음 | 참여자마다 "파싱 완료" 엔트리 쌓임 | X |
| **별도 SSE 동기화 이벤트 (알림 아님)** | **없음** | **없음** | **O** |

- 알림 디스패처는 모든 알림을 SSE+FCM+히스토리로 한 번에 fan-out 하므로, 참여자를 수신자에 넣으면 푸시·알림센터 노이즈가 그대로 부활한다.
- 파싱 완료는 (이미 받은 "OO이 추가함" 과 달리) 활동이 아니라 plumbing 이라, 알림센터 엔트리로 남길 가치도 없다.

### 구현

- 파싱 상태 전이가 커밋된 뒤(`AFTER_COMMIT`, `@Async`) `ItemParsingCompleted`·`ItemParsingFailed` 를 구독하는 브로드캐스터를 추가했다 (notification 도메인이 item 이벤트를 단방향 구독, 알림 리스너와 같은 결).
- 그 아이템이 출전한 토너먼트의 참여자 연결에 새 SSE 이벤트 `tournament-item-parsed` 를 흘려보낸다. payload 는 `{tournamentId, tournamentItemId, status}` (status=`READY`|`FAILED`).
- emitter 전달은 기존 SSE 의 죽은 연결 정리 경로(`sendOrEvict`)를 재사용하고, 이벤트 name 만 달리해 클라가 알림(`notification`)과 구분하게 했다.

### 동작 규칙

- **참여자 전원에게 (adder 포함)**: 이 신호는 알림이 아니라 카드 갱신이라, 보는 화면이 모두 동일하게 갱신되는 게 옳다.
- **멀티 토너먼트 fan-out**: 한 아이템이 여러 토너먼트에 출전 중이면, 각 토너먼트 참여자가 각자 그 토너먼트의 좌표로 받는다 (알림 라우팅이 단건 좌표만 싣는 것과 달리 전부 순회).
- **토너먼트 미출전 아이템은 건너뜀**: 브로드캐스터는 모든 파싱 완료/실패를 구독하므로, 어느 토너먼트에도 출전하지 않은 아이템이면 아무것도 보내지 않는다 (no-op).
- **완료·실패 둘 다**: 실패해도 참여자 로딩바가 똑같이 무한히 돌던 쌍둥이 버그를 함께 막는다.

### 문서

- `notification-sse-spec.md` (클라용 SSE 명세)에 4번째 이벤트·payload 스키마·웹/앱 클라 예시·체크리스트를 추가했다.

## Result

- 직전 머지된 #573(알림 타입별 채널 선택, sync 는 SSE only) 위에 올라탔다. 이번 동기화는 거기서 한 단계 더 가벼운, **알림 자체가 아닌 순수 SSE 신호**라 알림센터에도 남지 않는다.
- **비영속 신호의 한계와 보정**: 연결이 끊겨 있던 동안의 완료/실패는 재전송되지 않는다. 하지만 재연결·앱 진입 시 토너먼트 아이템 목록을 재조회하면 최신 `status` 가 그대로 내려와 자연히 따라잡힌다 (명세에 명시).
- **검증 폭**: 통합 테스트로 분기를 망라했다. 완료(READY)·실패(FAILED) 전달, 비참여자 제외, 토너먼트 미출전 아이템 no-op, 멀티 토너먼트 fan-out 4 시나리오. DB schema 변경·마이그레이션은 없다.
- **후속(클라)**: 프론트는 `tournament-item-parsed` 이벤트를 받아 `(tournamentId, tournamentItemId)` 로 카드를 찾아 `status` 로 갱신하면 된다 (명세 9장 예시 참조).

---
## 연관 이슈

- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* **토너먼트 항목 상태 실시간 갱신** - 토너먼트 항목의 처리가 완료되거나 실패할 때 토너먼트 참여자들의 화면이 자동으로 갱신되어 항목 상태(완료/실패)를 실시간으로 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->