### PR TITLE
Apple form_post 콜백 CORS 허용 (컷오버 후 403 차단 해제)

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/common/config/CorsConfig.kt
+++ b/src/main/kotlin/com/depromeet/piki/common/config/CorsConfig.kt
@@ -60,7 +60,23 @@ class CorsConfig(
                 allowCredentials = true
             }
         return UrlBasedCorsConfigurationSource().apply {
+            // Apple 웹 form_post 콜백 브릿지(#430)는 appleid.apple.com 이 top-level 폼 POST 로 Origin 을 박아 보낸다.
+            // 그 origin 은 아래 /** 전역 allowedOrigins 에 없어 CorsFilter 가 컨트롤러 도달 전에 403("Invalid CORS request")으로
+            // 막는다(브라우저 네비게이션이라 정작 브라우저는 CORS 를 강제하지 않는데 서버가 먼저 거부). 이 경로는 JS 가 읽는
+            // API 가 아니라 브라우저 네비게이션(303 리다이렉트, 노출 데이터 없음)이라 credentials 가 불필요하므로,
+            // Apple origin 만 credentials 없이 허용해 CORS 거부만 피한다.
+            // UrlBasedCorsConfigurationSource 는 등록 순서로 '첫 매칭'을 반환하므로, /** 보다 먼저 등록해야 이 경로가 /** 에
+            // 잡혀 전역 설정(Apple origin 미허용)으로 떨어지지 않는다.
+            registerCorsConfiguration("/api/v1/auth/apple/callback", appleCallbackCorsConfiguration())
             registerCorsConfiguration("/**", configuration)
         }
     }
+
+    private fun appleCallbackCorsConfiguration(): CorsConfiguration =
+        CorsConfiguration().apply {
+            allowedOrigins = listOf("https://appleid.apple.com")
+            allowedMethods = listOf("POST", "OPTIONS")
+            allowedHeaders = listOf("*")
+            allowCredentials = false
+        }
 }

--- a/src/test/kotlin/com/depromeet/piki/auth/controller/AppleCallbackBridgeIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/controller/AppleCallbackBridgeIntegrationTest.kt
@@ -49,4 +49,22 @@ class AppleCallbackBridgeIntegrationTest : IntegrationTestSupport() {
             ).andExpect(status().isSeeOther)
             .andExpect(redirectedUrl("https://test.piki.day/auth/callback/apple?error=user_cancelled"))
     }
+
+    // Apple 은 top-level 폼 POST 로 Origin: https://appleid.apple.com 을 박아 보낸다. 전역 CORS 의 allowedOrigins 에
+    // 그 origin 이 없어 CorsFilter 가 컨트롤러 도달 전에 403("Invalid CORS request")으로 막던 회귀(#430)를 잡는다.
+    // 이 콜백 경로만 Apple origin 을 허용하므로, Origin 헤더가 박혀도 403 이 아니라 303 으로 정상 변환돼야 한다.
+    @Test
+    fun `Apple origin 을 단 form_post 콜백은 CORS 로 막히지 않고 303 한다`() {
+        mockMvc()
+            .perform(
+                post("/api/v1/auth/apple/callback")
+                    .header("Origin", "https://appleid.apple.com")
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .param("code", "apple-auth-code")
+                    .param("state", "csrf-state-1"),
+            ).andExpect(status().isSeeOther)
+            .andExpect(
+                redirectedUrl("https://test.piki.day/auth/callback/apple?code=apple-auth-code&state=csrf-state-1"),
+            )
+    }
 }


### PR DESCRIPTION
## Situation
- Apple 웹 로그인 브릿지(#571) 컷오버 후 실기기 테스트에서, Apple 이 브릿지(`/api/v1/auth/apple/callback`)로 form_post 할 때 BE 가 **403 "Invalid CORS request"** 를 반환해 로그인이 끝까지 안 됐다.
- 원인은 CSRF 가 아니다(이 프로젝트는 CSRF 전역 disable). Apple 이 top-level 폼 POST 로 `Origin: https://appleid.apple.com` 을 박아 보내는데, 전역 CORS(`/**`)의 allowedOrigins 에 그 origin 이 없어 CorsFilter 가 컨트롤러 도달 전에 거부한 것이다.

## Task
- Apple 의 콜백 POST 가 전역 CORS 에 막히지 않게, 콜백 경로만 Apple origin 을 허용한다.

## Action
- `CorsConfig` 에 `/api/v1/auth/apple/callback` 전용 CORS 설정을 추가해 `https://appleid.apple.com` 을 **credentials 없이** 허용한다. 이 경로는 JS 가 읽는 API 가 아니라 브라우저 네비게이션(303 리다이렉트)이라 노출되는 데이터가 없어 origin 허용이 안전하다.
- `UrlBasedCorsConfigurationSource` 는 등록 순서로 '첫 매칭' 을 반환하므로, 구체 경로를 `/**` 보다 **먼저** 등록한다. (순서를 바꾸면 콜백도 `/**` 에 먼저 잡혀 전역 설정으로 403 이 된다.)
- 통합 테스트: `Origin: https://appleid.apple.com` 을 단 콜백이 403 이 아니라 303 임을 단언해 회귀를 막는다.

## Result
- Apple 이 브릿지로 보내는 form_post 가 더 이상 CORS 로 막히지 않는다.
- 머지 + dev 재배포 후 Apple 웹 로그인 컷오버(Apple → 브릿지 → 303 → FE 공용 콜백)가 끝까지 동작한다.

---
## 연관 이슈

- #430 (브릿지 본체 #571 머지 후, 컷오버 실측에서 발견된 CORS 후속)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * Apple 로그인 콜백 요청에 대한 전용 CORS 설정을 추가했습니다. Apple 도메인에서의 요청만 허용하여 보안을 강화했습니다.

* **Tests**
  * Apple 로그인 콜백 처리 시 CORS 및 리다이렉트 동작을 검증하는 통합 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->