### PR TITLE
런칭데이 리캡 admin 페이지 + 일별 활동 캡처

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/metrics/activity/DailyActivityRecorder.kt
+++ b/src/main/kotlin/com/depromeet/piki/metrics/activity/DailyActivityRecorder.kt
@@ -1,0 +1,36 @@
+package com.depromeet.piki.metrics.activity
+
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import java.time.LocalDate
+import java.time.ZoneId
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+
+// 인증된 요청의 활성 유저를 "오늘(KST)" 단위 1행으로 기록한다(리텐션·DAU). best-effort — 기록 실패가 절대
+// 요청을 막지 않는다. 인메모리 쓰로틀로 같은 유저의 같은 날 두 번째 호출부터는 DB 에 닿지조차 않아, 런칭날
+// 트래픽에서도 유저당 ~1쓰기/일로 묶인다.
+@Component
+class DailyActivityRecorder(
+    private val repository: UserDailyActivityRepository,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    // userId -> 마지막으로 기록한 KST 날짜. 같은 날 재호출을 DB 없이 걸러낸다. 크기는 활성 유저 수로 바운드되고
+    // 날짜가 바뀌면 다음 첫 호출이 값을 덮어쓴다.
+    private val recordedToday = ConcurrentHashMap<UUID, LocalDate>()
+
+    fun record(userId: UUID) {
+        val today = LocalDate.now(KST)
+        if (recordedToday[userId] == today) return
+        runCatching {
+            repository.recordActive(userId, today)
+            recordedToday[userId] = today
+        }.onFailure { log.warn("일별 활동 기록 실패 — best-effort 라 요청에는 영향 없음", it) }
+    }
+
+    companion object {
+        // JVM 기본 TZ 는 UTC 라 "활성한 날"은 KST 로 끊어야 런칭데이 경계와 일치한다(Announcement.KST 와 같은 결).
+        private val KST: ZoneId = ZoneId.of("Asia/Seoul")
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/metrics/activity/DailyActivityRecordingInterceptor.kt
+++ b/src/main/kotlin/com/depromeet/piki/metrics/activity/DailyActivityRecordingInterceptor.kt
@@ -1,0 +1,26 @@
+package com.depromeet.piki.metrics.activity
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
+import org.springframework.web.servlet.HandlerInterceptor
+import java.util.UUID
+
+// 인증된 요청의 userId 를 일별 활동으로 기록한다. Security 필터 뒤(SecurityContext 채워진 후)에 도는 인터셉터라
+// JwtAuthenticationFilter 가 심은 principal(UUID)을 그대로 읽는다 — 미인증·슬랙admin 요청은 principal 이 UUID 가
+// 아니라 자연히 제외된다. afterCompletion 에서 호출해 응답 생성 경로(critical path) 밖에서 best-effort 로 기록한다.
+@Component
+class DailyActivityRecordingInterceptor(
+    private val recorder: DailyActivityRecorder,
+) : HandlerInterceptor {
+    override fun afterCompletion(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        handler: Any,
+        ex: Exception?,
+    ) {
+        val principal = SecurityContextHolder.getContext().authentication?.principal
+        if (principal is UUID) recorder.record(principal)
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/metrics/activity/MetricsWebConfig.kt
+++ b/src/main/kotlin/com/depromeet/piki/metrics/activity/MetricsWebConfig.kt
@@ -1,0 +1,16 @@
+package com.depromeet.piki.metrics.activity
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+// 일별 활동 캡처 인터셉터를 전 경로에 등록한다. principal 이 UUID 인 인증 요청만 실제 기록되고 나머지는 무시되므로
+// path 제외 없이 둔다(활성 유저 측정이 목적). 루트 redirect 를 담당하는 WebConfig 와 관심사를 분리해 metrics 패키지에 둔다.
+@Configuration
+class MetricsWebConfig(
+    private val dailyActivityRecordingInterceptor: DailyActivityRecordingInterceptor,
+) : WebMvcConfigurer {
+    override fun addInterceptors(registry: InterceptorRegistry) {
+        registry.addInterceptor(dailyActivityRecordingInterceptor)
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/metrics/activity/UserDailyActivityRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/metrics/activity/UserDailyActivityRepository.kt
@@ -1,0 +1,34 @@
+package com.depromeet.piki.metrics.activity
+
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.stereotype.Repository
+import java.nio.ByteBuffer
+import java.sql.Date
+import java.time.LocalDate
+import java.util.UUID
+
+// 일별 활성 유저 기록 전용 저장소. INSERT IGNORE 로 (user_id, active_date) 유니크 충돌을 멱등 무시한다 —
+// 인메모리 쓰로틀을 비켜간 동시 첫 요청·인스턴스 재시작 등으로 중복 INSERT 가 와도 1행만 남고 예외도 안 난다.
+// user_id 는 users.id(BINARY(16))와 같은 big-endian 16바이트로 인코딩해 동일 유저로 join·집계된다.
+@Repository
+class UserDailyActivityRepository(
+    private val jdbcTemplate: JdbcTemplate,
+) {
+    fun recordActive(
+        userId: UUID,
+        activeDate: LocalDate,
+    ) {
+        jdbcTemplate.update(
+            "INSERT IGNORE INTO user_daily_activity (user_id, active_date, created_at) VALUES (?, ?, NOW(6))",
+            uuidToBytes(userId),
+            Date.valueOf(activeDate),
+        )
+    }
+
+    private fun uuidToBytes(uuid: UUID): ByteArray =
+        ByteBuffer
+            .allocate(16)
+            .putLong(uuid.mostSignificantBits)
+            .putLong(uuid.leastSignificantBits)
+            .array()
+}

--- a/src/main/kotlin/com/depromeet/piki/metrics/launch/LaunchMetricsController.kt
+++ b/src/main/kotlin/com/depromeet/piki/metrics/launch/LaunchMetricsController.kt
@@ -1,0 +1,34 @@
+package com.depromeet.piki.metrics.launch
+
+import com.depromeet.piki.admin.config.ConditionalOnAdminEnabled
+import io.swagger.v3.oas.annotations.Hidden
+import org.springframework.format.annotation.DateTimeFormat
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import java.time.LocalDate
+
+// 런칭데이 리캡 화면(admin). 슬랙-IP 게이트(/admin/**)·admin.enabled 아래에서만 노출된다. date 파라미터로 런칭
+// 경계를 조정할 수 있고 기본은 2026-06-20. 새로고침(재요청)할수록 "런칭 후" 수치가 커진다(on-demand 집계).
+@Hidden
+@Controller
+@ConditionalOnAdminEnabled
+@RequestMapping("/admin/metrics")
+class LaunchMetricsController(
+    private val launchMetricsService: LaunchMetricsService,
+) {
+    @GetMapping("/launch")
+    fun launch(
+        @RequestParam(required = false)
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+        date: LocalDate?,
+        model: Model,
+    ): String {
+        val launchDate = date ?: LaunchMetricsService.DEFAULT_LAUNCH_DATE
+        model.addAttribute("recap", launchMetricsService.recap(launchDate))
+        model.addAttribute("launchDate", launchDate)
+        return "admin/launch-recap"
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/metrics/launch/LaunchMetricsRepository.kt
+++ b/src/main/kotlin/com/depromeet/piki/metrics/launch/LaunchMetricsRepository.kt
@@ -1,0 +1,185 @@
+package com.depromeet.piki.metrics.launch
+
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.stereotype.Repository
+import java.sql.Timestamp
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+// 런칭데이 리캡 집계 전용 읽기 저장소. 모든 시각 컬럼(created_at 등)은 JVM 기본 TZ(UTC)로 저장되므로,
+// 서비스가 "런칭 경계(KST)"를 UTC LocalDateTime 으로 변환해 넘긴다(boundary 는 UTC 값이다). KST 시간대별 집계는
+// created_at 에 +9h 를 더해 버킷팅한다. user_daily_activity.active_date 만은 이미 KST 날짜로 적재돼 그대로 쓴다.
+@Repository
+class LaunchMetricsRepository(
+    private val jdbcTemplate: JdbcTemplate,
+) {
+    // ---- 가입자 ----
+    fun countActiveUsersBefore(boundaryUtc: LocalDateTime): Long =
+        count("SELECT COUNT(*) FROM users WHERE created_at < ? AND deleted_at IS NULL", ts(boundaryUtc))
+
+    fun countActiveUsersAfter(boundaryUtc: LocalDateTime): Long =
+        count("SELECT COUNT(*) FROM users WHERE created_at >= ? AND deleted_at IS NULL", ts(boundaryUtc))
+
+    fun countAfterByIdentityType(boundaryUtc: LocalDateTime): Map<String, Long> =
+        keyCounts(
+            "SELECT identity_type, COUNT(*) FROM users WHERE created_at >= ? AND deleted_at IS NULL GROUP BY identity_type",
+            ts(boundaryUtc),
+        )
+
+    fun countSignupsByProvider(boundaryUtc: LocalDateTime): Map<String, Long> =
+        keyCounts(
+            "SELECT provider, COUNT(*) FROM user_details WHERE created_at >= ? GROUP BY provider",
+            ts(boundaryUtc),
+        )
+
+    // 게스트→회원 전환 근사 — 소셜 연결(user_details) 시각이 가입(users.created_at)보다 1분 이상 늦으면, 게스트로 먼저
+    // 존재하다 런칭 중 연결한 것으로 본다. 동시 신규가입(거의 동시각)과 구분한다.
+    fun countGuestToMemberConversions(boundaryUtc: LocalDateTime): Long =
+        count(
+            """
+            SELECT COUNT(*) FROM user_details ud JOIN users u ON u.id = ud.user_id
+            WHERE ud.created_at >= ? AND u.created_at < ud.created_at - INTERVAL 1 MINUTE
+            """.trimIndent(),
+            ts(boundaryUtc),
+        )
+
+    // ---- 위시 ----
+    fun countWishes(boundaryUtc: LocalDateTime): Long =
+        count("SELECT COUNT(*) FROM wishes WHERE created_at >= ?", ts(boundaryUtc))
+
+    // source_url IS NULL = 이미지 등록, NOT NULL = URL 등록. wish 는 snapshot_id 로 정규화돼 item 정체성은
+    // item_snapshots.item_id 를 거쳐 items 에 도달한다(item_id 컬럼 제거됨).
+    fun countWishesBySource(boundaryUtc: LocalDateTime): Pair<Long, Long> {
+        val byImage =
+            keyCounts(
+                """
+                SELECT i.source_url IS NULL AS is_image, COUNT(*)
+                FROM wishes w
+                JOIN item_snapshots s ON s.id = w.snapshot_id
+                JOIN items i ON i.id = s.item_id
+                WHERE w.created_at >= ? GROUP BY is_image
+                """.trimIndent(),
+                ts(boundaryUtc),
+            )
+        val url = byImage["0"] ?: 0L
+        val image = byImage["1"] ?: 0L
+        return url to image
+    }
+
+    fun countParsing(boundaryUtc: LocalDateTime): Pair<Long, Long> {
+        val byStatus =
+            keyCounts(
+                "SELECT status, COUNT(*) FROM item_snapshots WHERE created_at >= ? AND status IN ('READY','FAILED') GROUP BY status",
+                ts(boundaryUtc),
+            )
+        return (byStatus["READY"] ?: 0L) to (byStatus["FAILED"] ?: 0L)
+    }
+
+    // ---- 토너먼트 ----
+    fun countTournamentsCreated(boundaryUtc: LocalDateTime): Long =
+        count("SELECT COUNT(*) FROM tournaments WHERE created_at >= ?", ts(boundaryUtc))
+
+    fun countTournamentParticipants(boundaryUtc: LocalDateTime): Long =
+        count("SELECT COUNT(DISTINCT user_id) FROM tournament_users WHERE created_at >= ?", ts(boundaryUtc))
+
+    fun countTournamentItems(boundaryUtc: LocalDateTime): Long =
+        count("SELECT COUNT(*) FROM tournament_items WHERE created_at >= ?", ts(boundaryUtc))
+
+    // tournaments 에 상태 전이 시각이 없어, 완료는 tournament_users.completed_at 으로 센다(참가자별 완료).
+    fun countTournamentCompleted(boundaryUtc: LocalDateTime): Long =
+        count("SELECT COUNT(*) FROM tournament_users WHERE completed_at >= ?", ts(boundaryUtc))
+
+    // 플레이 활동량 = 라운드 픽 1건당 history 1행.
+    fun countTournamentPlays(boundaryUtc: LocalDateTime): Long =
+        count("SELECT COUNT(*) FROM tournament_histories WHERE created_at >= ?", ts(boundaryUtc))
+
+    // ---- 푸시 도달 가능 ----
+    fun countPushReachableUsers(): Long =
+        count("SELECT COUNT(DISTINCT user_id) FROM user_devices WHERE deleted_at IS NULL")
+
+    // ---- 리텐션 / DAU ----
+    fun countLaunchDaySignups(
+        boundaryUtc: LocalDateTime,
+        boundaryPlus1dUtc: LocalDateTime,
+    ): Long = count("SELECT COUNT(*) FROM users WHERE created_at >= ? AND created_at < ?", ts(boundaryUtc), ts(boundaryPlus1dUtc))
+
+    // 런칭날 가입자 중 다음날(KST)에 활동 기록이 있는 수 = D1 재방문.
+    fun countD1Returned(
+        boundaryUtc: LocalDateTime,
+        boundaryPlus1dUtc: LocalDateTime,
+        nextDayKst: LocalDate,
+    ): Long =
+        count(
+            """
+            SELECT COUNT(*) FROM user_daily_activity uda
+            WHERE uda.active_date = ?
+              AND uda.user_id IN (SELECT id FROM users WHERE created_at >= ? AND created_at < ?)
+            """.trimIndent(),
+            java.sql.Date.valueOf(nextDayKst),
+            ts(boundaryUtc),
+            ts(boundaryPlus1dUtc),
+        )
+
+    fun dailyActiveUsers(): List<LaunchRecap.DateCount> =
+        jdbcTemplate.query(
+            "SELECT active_date, COUNT(*) FROM user_daily_activity GROUP BY active_date ORDER BY active_date",
+        ) { rs, _ -> LaunchRecap.DateCount(rs.getDate(1).toLocalDate(), rs.getLong(2)) }
+
+    // ---- 푸시 히스토리 / CTR 근사 ----
+    fun notificationsByType(boundaryUtc: LocalDateTime): Map<String, Long> =
+        keyCounts("SELECT type, COUNT(*) FROM notifications WHERE created_at >= ? GROUP BY type", ts(boundaryUtc))
+
+    // (total, is_read 합) — CTR 근사 계산용.
+    fun notificationReadApprox(boundaryUtc: LocalDateTime): Pair<Long, Long> =
+        jdbcTemplate.query(
+            "SELECT COUNT(*), COALESCE(SUM(is_read), 0) FROM notifications WHERE created_at >= ?",
+            { rs, _ -> rs.getLong(1) to rs.getLong(2) },
+            ts(boundaryUtc),
+        ).first()
+
+    // 공지 발송 도달 집계(성공/실패/미도달) — 런칭 중 발송된 공지 합산.
+    fun announcementDelivery(boundaryUtc: LocalDateTime): Triple<Long, Long, Long> =
+        jdbcTemplate.query(
+            """
+            SELECT COALESCE(SUM(success_count),0), COALESCE(SUM(failure_count),0), COALESCE(SUM(skipped_count),0)
+            FROM announcements WHERE sent_at >= ?
+            """.trimIndent(),
+            { rs, _ -> Triple(rs.getLong(1), rs.getLong(2), rs.getLong(3)) },
+            ts(boundaryUtc),
+        ).first()
+
+    // ---- 시간대별(KST) ----
+    fun hourlySignups(
+        boundaryUtc: LocalDateTime,
+        boundaryPlus1dUtc: LocalDateTime,
+    ): Map<Int, Long> {
+        val result = linkedMapOf<Int, Long>()
+        jdbcTemplate.query(
+            """
+            SELECT HOUR(created_at + INTERVAL 9 HOUR) AS h, COUNT(*)
+            FROM users WHERE created_at >= ? AND created_at < ?
+            GROUP BY h ORDER BY h
+            """.trimIndent(),
+            { rs, _ -> result[rs.getInt(1)] = rs.getLong(2) },
+            ts(boundaryUtc),
+            ts(boundaryPlus1dUtc),
+        )
+        return result
+    }
+
+    private fun count(
+        sql: String,
+        vararg args: Any,
+    ): Long = jdbcTemplate.queryForObject(sql, Long::class.java, *args) ?: 0L
+
+    private fun keyCounts(
+        sql: String,
+        vararg args: Any,
+    ): Map<String, Long> {
+        val result = linkedMapOf<String, Long>()
+        jdbcTemplate.query(sql, { rs, _ -> result[rs.getString(1)] = rs.getLong(2) }, *args)
+        return result
+    }
+
+    private fun ts(value: LocalDateTime): Timestamp = Timestamp.valueOf(value)
+}

--- a/src/main/kotlin/com/depromeet/piki/metrics/launch/LaunchMetricsService.kt
+++ b/src/main/kotlin/com/depromeet/piki/metrics/launch/LaunchMetricsService.kt
@@ -1,0 +1,81 @@
+package com.depromeet.piki.metrics.launch
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.ZoneOffset
+
+// 런칭데이 리캡 조립. 런칭 경계(KST 자정)를 created_at 저장 기준(UTC)으로 변환해 리포지토리에 넘기고, 집계 결과를
+// 하나의 LaunchRecap 으로 묶는다. 외부 호출 없이 DB 읽기뿐이라 짧은 readOnly 트랜잭션 하나로 충분하다.
+@Service
+class LaunchMetricsService(
+    private val repository: LaunchMetricsRepository,
+) {
+    @Transactional(readOnly = true)
+    fun recap(launchDate: LocalDate): LaunchRecap {
+        val boundaryUtc = launchDate.atStartOfDay(KST).withZoneSameInstant(ZoneOffset.UTC).toLocalDateTime()
+        val boundaryPlus1dUtc =
+            launchDate.plusDays(1).atStartOfDay(KST).withZoneSameInstant(ZoneOffset.UTC).toLocalDateTime()
+
+        val identityCounts = repository.countAfterByIdentityType(boundaryUtc)
+        val (wishUrl, wishImage) = repository.countWishesBySource(boundaryUtc)
+        val (parsedReady, parsedFailed) = repository.countParsing(boundaryUtc)
+        val (notifTotal, notifRead) = repository.notificationReadApprox(boundaryUtc)
+        val (deliverySuccess, deliveryFailure, deliverySkipped) = repository.announcementDelivery(boundaryUtc)
+        val hourly = repository.hourlySignups(boundaryUtc, boundaryPlus1dUtc)
+
+        return LaunchRecap(
+            launchDate = launchDate,
+            signup =
+                LaunchRecap.Signup(
+                    before = repository.countActiveUsersBefore(boundaryUtc),
+                    after = repository.countActiveUsersAfter(boundaryUtc),
+                    afterMembers = identityCounts["MEMBER"] ?: 0L,
+                    afterGuests = identityCounts["GUEST"] ?: 0L,
+                    byProvider = repository.countSignupsByProvider(boundaryUtc),
+                    guestToMemberConversions = repository.countGuestToMemberConversions(boundaryUtc),
+                ),
+            wish =
+                LaunchRecap.Wish(
+                    total = repository.countWishes(boundaryUtc),
+                    fromUrl = wishUrl,
+                    fromImage = wishImage,
+                    parsedReady = parsedReady,
+                    parsedFailed = parsedFailed,
+                ),
+            tournament =
+                LaunchRecap.Tournament(
+                    created = repository.countTournamentsCreated(boundaryUtc),
+                    participants = repository.countTournamentParticipants(boundaryUtc),
+                    itemsAdded = repository.countTournamentItems(boundaryUtc),
+                    completed = repository.countTournamentCompleted(boundaryUtc),
+                    plays = repository.countTournamentPlays(boundaryUtc),
+                ),
+            pushReachableUsers = repository.countPushReachableUsers(),
+            retention =
+                LaunchRecap.Retention(
+                    launchDaySignups = repository.countLaunchDaySignups(boundaryUtc, boundaryPlus1dUtc),
+                    d1Returned = repository.countD1Returned(boundaryUtc, boundaryPlus1dUtc, launchDate.plusDays(1)),
+                    dau = repository.dailyActiveUsers(),
+                ),
+            push =
+                LaunchRecap.Push(
+                    byType = repository.notificationsByType(boundaryUtc),
+                    deliverySuccess = deliverySuccess,
+                    deliveryFailure = deliveryFailure,
+                    deliverySkipped = deliverySkipped,
+                    notificationsTotal = notifTotal,
+                    readApprox = notifRead,
+                ),
+            hourlySignups = (0..23).map { LaunchRecap.HourCount(it, hourly[it] ?: 0L) },
+        )
+    }
+
+    companion object {
+        private val KST: ZoneId = ZoneId.of("Asia/Seoul")
+
+        // 런칭데이 기본값 — date 파라미터로 덮어쓸 수 있다.
+        val DEFAULT_LAUNCH_DATE: LocalDate = LocalDate.of(2026, 6, 20)
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/metrics/launch/LaunchRecap.kt
+++ b/src/main/kotlin/com/depromeet/piki/metrics/launch/LaunchRecap.kt
@@ -1,0 +1,74 @@
+package com.depromeet.piki.metrics.launch
+
+import java.time.LocalDate
+
+// 런칭데이 리캡 화면(admin)의 단일 뷰모델. 모든 수치는 LaunchMetricsRepository 의 DB 집계에서 나오고,
+// 비율·평균 등 파생값만 여기서 계산한다(파생값을 한 곳에 모아 템플릿이 계산을 안 하게 한다).
+data class LaunchRecap(
+    val launchDate: LocalDate,
+    val signup: Signup,
+    val wish: Wish,
+    val tournament: Tournament,
+    val pushReachableUsers: Long,
+    val retention: Retention,
+    val push: Push,
+    val hourlySignups: List<HourCount>,
+) {
+    data class Signup(
+        val before: Long,
+        val after: Long,
+        val afterMembers: Long,
+        val afterGuests: Long,
+        val byProvider: Map<String, Long>,
+        val guestToMemberConversions: Long,
+    )
+
+    data class Wish(
+        val total: Long,
+        val fromUrl: Long,
+        val fromImage: Long,
+        val parsedReady: Long,
+        val parsedFailed: Long,
+    ) {
+        val parseSuccessRate: Int get() = pct(parsedReady, parsedReady + parsedFailed)
+    }
+
+    data class Tournament(
+        val created: Long,
+        val participants: Long,
+        val itemsAdded: Long,
+        val completed: Long,
+        val plays: Long,
+    ) {
+        val avgParticipants: String
+            get() = if (created == 0L) "0" else "%.1f".format(participants.toDouble() / created)
+    }
+
+    data class Retention(
+        val launchDaySignups: Long,
+        val d1Returned: Long,
+        val dau: List<DateCount>,
+    ) {
+        val d1Rate: Int get() = pct(d1Returned, launchDaySignups)
+    }
+
+    // 푸시 히스토리·도달률·근사 클릭률. ctrApprox 는 is_read 기반 근사다(푸시 탭 ∪ 알림센터 열람이 섞임) — UI 에 "근사" 명시.
+    data class Push(
+        val byType: Map<String, Long>,
+        val deliverySuccess: Long,
+        val deliveryFailure: Long,
+        val deliverySkipped: Long,
+        val notificationsTotal: Long,
+        val readApprox: Long,
+    ) {
+        val ctrApproxPct: Int get() = pct(readApprox, notificationsTotal)
+    }
+
+    data class HourCount(val hour: Int, val count: Long)
+
+    data class DateCount(val date: LocalDate, val count: Long)
+
+    companion object {
+        fun pct(numerator: Long, denominator: Long): Int = if (denominator == 0L) 0 else ((numerator * 100) / denominator).toInt()
+    }
+}

--- a/src/main/resources/db/migration/V20260619004710__create_user_daily_activity.sql
+++ b/src/main/resources/db/migration/V20260619004710__create_user_daily_activity.sql
@@ -1,0 +1,10 @@
+-- 런칭데이 리텐션·DAU 측정용 일별 활성 유저 기록. 인증된 요청이 닿을 때 (user_id, 그날 KST) 1행을 남긴다.
+-- 분석 종료 후 DROP 예정(forward-only). FK 없음(컨벤션). 복합 PK 가 유니크 + (user_id) prefix 조회를 겸하고,
+-- 날짜 단위 집계(DAU·리텐션)를 위해 active_date 보조 인덱스를 둔다.
+CREATE TABLE user_daily_activity (
+    user_id     BINARY(16)  NOT NULL,
+    active_date DATE        NOT NULL,
+    created_at  DATETIME(6) NOT NULL,
+    PRIMARY KEY (user_id, active_date),
+    KEY idx_user_daily_activity_active_date (active_date)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/src/main/resources/templates/admin/index.html
+++ b/src/main/resources/templates/admin/index.html
@@ -50,6 +50,10 @@
         <div class="t">공지 발송 →</div>
         <div class="d">전체 공지 작성 · 발송 · 발송 내역</div>
       </a>
+      <a class="card" th:href="@{/admin/metrics/launch}" style="text-decoration:none;color:inherit">
+        <div class="t">런칭데이 리캡 →</div>
+        <div class="d">가입·위시·토너먼트·리텐션·푸시 지표를 런칭 전/후로 한눈에</div>
+      </a>
     </div>
   </div>
 </body>

--- a/src/main/resources/templates/admin/launch-recap.html
+++ b/src/main/resources/templates/admin/launch-recap.html
@@ -1,0 +1,156 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="icon" type="image/x-icon" href="/favicon.ico">
+  <title>런칭데이 리캡 · PiKi 백오피스</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css">
+  <style>
+    :root{--accent:#0EA5E9;--ink:#111827;--muted:#6b7280;--border:#e5e7eb;}
+    *{box-sizing:border-box;} body{margin:0;font-family:"Pretendard Variable",Pretendard,-apple-system,BlinkMacSystemFont,"Apple SD Gothic Neo","Malgun Gothic",system-ui,sans-serif;background:#f7f8fa;color:var(--ink);}
+    .bar{display:flex;align-items:center;gap:12px;padding:14px 24px;background:#fff;border-bottom:1px solid var(--border);}
+    .brand{font-weight:800;font-size:17px;letter-spacing:-.03em;}.brand .dot{color:var(--accent);}
+    .bar a{font-size:13px;color:var(--muted);text-decoration:none;font-weight:600;}
+    .wrap{max-width:880px;margin:0 auto;padding:26px 24px;}
+    h1{font-size:21px;font-weight:800;letter-spacing:-.02em;margin:0 0 6px;} .lede{color:var(--muted);font-size:13.5px;margin:0 0 18px;}
+    .btn{background:var(--accent);color:#fff;border:none;border-radius:10px;padding:9px 15px;font-size:13px;font-weight:700;font-family:inherit;cursor:pointer;}
+    .btn.sm{padding:7px 13px;font-size:12.5px;}
+    input[type=date]{border:1px solid #e3e6ea;border-radius:10px;padding:8px 11px;font-size:13px;font-family:inherit;background:#fbfcfd;}
+    .stats{display:grid;grid-template-columns:repeat(4,1fr);gap:12px;margin-bottom:8px;}
+    .stat{background:#fff;border:1px solid var(--border);border-radius:14px;padding:15px 16px;}
+    .stat .k{font-size:12px;color:var(--muted);font-weight:700;margin-bottom:6px;}
+    .stat .v{font-size:25px;font-weight:800;letter-spacing:-.02em;}
+    .stat .v .up{color:#15a05a;font-size:15px;font-weight:700;}
+    .stat .sub{font-size:11.5px;color:var(--muted);margin-top:3px;}
+    h2{font-size:15px;font-weight:800;margin:22px 0 10px;}
+    .card{background:#fff;border:1px solid var(--border);border-radius:14px;padding:16px 18px;margin-bottom:6px;}
+    .two{display:grid;grid-template-columns:1fr 1fr;gap:14px;}
+    .kv{display:flex;justify-content:space-between;gap:10px;padding:8px 0;border-bottom:1px solid #f1f3f5;font-size:13px;}
+    .kv:last-child{border-bottom:none;} .kv .lab{color:var(--muted);} .kv b{font-weight:700;}
+    .pos{color:#15a05a;} .neg{color:#b42318;}
+    .bar-row{display:flex;align-items:center;gap:8px;font-size:12px;margin:2px 0;}
+    .bar-row .h{width:42px;color:var(--muted);text-align:right;}
+    .bar-row .bv{height:11px;background:var(--accent);border-radius:3px;min-width:2px;}
+    .bar-row .c{color:var(--muted);}
+    .note{font-size:11.5px;color:var(--muted);margin-top:8px;}
+  </style>
+</head>
+<body>
+  <div class="bar"><span class="brand"><img src="/favicon.ico" alt="PiKi" style="width:19px;height:19px;border-radius:5px;vertical-align:-4px;margin-right:6px">PiKi<span class="dot">.</span> 백오피스</span><a th:href="@{/admin}">← 홈</a></div>
+  <div class="wrap">
+    <h1>런칭데이 리캡</h1>
+    <p class="lede">
+      <b th:text="${#temporals.format(launchDate, 'yyyy-MM-dd')}">2026-06-20</b> 00:00(KST) 기준 전/후 지표 · 새로고침할수록 최신.
+    </p>
+    <form method="get" th:action="@{/admin/metrics/launch}" style="display:flex;gap:8px;align-items:center;margin-bottom:18px">
+      <input type="date" name="date" th:value="${launchDate}">
+      <button class="btn sm" type="submit">새로고침</button>
+    </form>
+
+    <!-- 핵심 숫자 -->
+    <div class="stats">
+      <div class="stat">
+        <div class="k">누적 가입자</div>
+        <div class="v" th:text="${#numbers.formatInteger(recap.signup.before + recap.signup.after, 1, 'COMMA')}">0</div>
+        <div class="sub">런칭 전 <b th:text="${#numbers.formatInteger(recap.signup.before,1,'COMMA')}">0</b> · 후 <b class="pos" th:text="'+' + ${#numbers.formatInteger(recap.signup.after,1,'COMMA')}">+0</b></div>
+      </div>
+      <div class="stat">
+        <div class="k">토너먼트 이용자</div>
+        <div class="v" th:text="${#numbers.formatInteger(recap.tournament.participants,1,'COMMA')}">0</div>
+        <div class="sub">런칭 후 참여한 유저</div>
+      </div>
+      <div class="stat">
+        <div class="k">위시 담기</div>
+        <div class="v" th:text="${#numbers.formatInteger(recap.wish.total,1,'COMMA')}">0</div>
+        <div class="sub">런칭 후 담은 아이템</div>
+      </div>
+      <div class="stat">
+        <div class="k">토너먼트 올라간 아이템</div>
+        <div class="v" th:text="${#numbers.formatInteger(recap.tournament.itemsAdded,1,'COMMA')}">0</div>
+        <div class="sub">출전 등록 수</div>
+      </div>
+    </div>
+
+    <!-- 가입 상세 -->
+    <h2>가입 상세 (런칭 후)</h2>
+    <div class="card">
+      <div class="kv"><span class="lab">provider</span>
+        <span>
+          <th:block th:each="e,it : ${recap.signup.byProvider}"><b th:text="${e.key} + ' ' + ${e.value}">KAKAO 0</b><span th:if="${!it.last}"> · </span></th:block>
+          <span th:if="${recap.signup.byProvider.isEmpty()}" class="lab">없음</span>
+        </span>
+      </div>
+      <div class="kv"><span class="lab">유형</span><span>회원 <b th:text="${recap.signup.afterMembers}">0</b> · 게스트 <b th:text="${recap.signup.afterGuests}">0</b></span></div>
+      <div class="kv"><span class="lab">게스트→회원 전환</span><b th:text="${recap.signup.guestToMemberConversions}">0</b></div>
+      <p class="note">전환은 소셜 연결 시각이 가입보다 1분 이상 늦은 경우로 근사 집계.</p>
+    </div>
+
+    <!-- 토너먼트 / 위시 -->
+    <div class="two">
+      <div>
+        <h2>토너먼트</h2>
+        <div class="card">
+          <div class="kv"><span class="lab">생성</span><b th:text="${recap.tournament.created}">0</b></div>
+          <div class="kv"><span class="lab">완료</span><b th:text="${recap.tournament.completed}">0</b></div>
+          <div class="kv"><span class="lab">플레이(픽)</span><b th:text="${#numbers.formatInteger(recap.tournament.plays,1,'COMMA')}">0</b></div>
+          <div class="kv"><span class="lab">평균 참가자</span><b th:text="${recap.tournament.avgParticipants} + '명'">0명</b></div>
+          <p class="note">완료는 참가자별 완료 시각, 플레이는 라운드 픽 수 기준(토너먼트 시작 시각 컬럼 없음).</p>
+        </div>
+      </div>
+      <div>
+        <h2>위시</h2>
+        <div class="card">
+          <div class="kv"><span class="lab">담기 (URL/이미지)</span><span>URL <b th:text="${recap.wish.fromUrl}">0</b> · 이미지 <b th:text="${recap.wish.fromImage}">0</b></span></div>
+          <div class="kv"><span class="lab">파싱 성공/실패</span><span><b class="pos" th:text="${recap.wish.parsedReady}">0</b> / <b class="neg" th:text="${recap.wish.parsedFailed}">0</b></span></div>
+          <div class="kv"><span class="lab">파싱 성공률</span><b th:text="${recap.wish.parseSuccessRate} + '%'">0%</b></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- 리텐션 / DAU -->
+    <h2>리텐션 / DAU</h2>
+    <div class="card">
+      <div class="kv"><span class="lab">D1 재방문</span>
+        <span>런칭날 가입 <b th:text="${recap.retention.launchDaySignups}">0</b> → 다음날 <b class="pos" th:text="${recap.retention.d1Returned}">0</b> (<b th:text="${recap.retention.d1Rate} + '%'">0%</b>)</span>
+      </div>
+      <div style="margin-top:10px">
+        <div class="bar-row" th:each="d : ${recap.retention.dau}">
+          <span class="h" th:text="${#temporals.format(d.date, 'MM-dd')}">06-20</span>
+          <span class="bv" th:style="'width:' + ${d.count * 4 + 2} + 'px'"></span>
+          <span class="c" th:text="${d.count}">0</span>
+        </div>
+        <p class="note" th:if="${recap.retention.dau.isEmpty()}">아직 활동 기록이 없습니다.</p>
+        <p class="note">DAU = 일별 활성 유저(인증 요청 1회 이상). active_date 는 KST 기준.</p>
+      </div>
+    </div>
+
+    <!-- 푸시 -->
+    <h2>푸시</h2>
+    <div class="card">
+      <div class="kv"><span class="lab">발송 이력 (알림 종류별)</span>
+        <span>
+          <th:block th:each="e,it : ${recap.push.byType}"><b th:text="${e.key} + ' ' + ${e.value}">TYPE 0</b><span th:if="${!it.last}"> · </span></th:block>
+          <span th:if="${recap.push.byType.isEmpty()}" class="lab">없음</span>
+        </span>
+      </div>
+      <div class="kv"><span class="lab">공지 도달 (성공/실패/미도달)</span>
+        <span><b class="pos" th:text="${recap.push.deliverySuccess}">0</b> / <b class="neg" th:text="${recap.push.deliveryFailure}">0</b> / <b th:text="${recap.push.deliverySkipped}">0</b></span>
+      </div>
+      <div class="kv"><span class="lab">클릭률 (근사)</span><b th:text="${recap.push.ctrApproxPct} + '%'">0%</b></div>
+      <div class="kv"><span class="lab">푸시 도달 가능 유저</span><b th:text="${#numbers.formatInteger(recap.pushReachableUsers,1,'COMMA')}">0</b></div>
+      <p class="note">클릭률은 is_read 기반 근사다 — 푸시 탭뿐 아니라 알림센터 열람도 포함돼 과대계상될 수 있다(정확 CTR 은 별도 푸시-탭 신호 필요).</p>
+    </div>
+
+    <!-- 시간대별 -->
+    <h2>시간대별 가입 (런칭 당일 · KST)</h2>
+    <div class="card">
+      <div class="bar-row" th:each="h : ${recap.hourlySignups}">
+        <span class="h" th:text="${h.hour} + '시'">0시</span>
+        <span class="bv" th:style="'width:' + ${h.count * 6 + 2} + 'px'"></span>
+        <span class="c" th:text="${h.count}">0</span>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/src/test/kotlin/com/depromeet/piki/metrics/activity/DailyActivityCaptureIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/metrics/activity/DailyActivityCaptureIntegrationTest.kt
@@ -1,0 +1,101 @@
+package com.depromeet.piki.metrics.activity
+
+import com.depromeet.piki.auth.infrastructure.jwt.JwtProvider
+import com.depromeet.piki.support.IntegrationTestSupport
+import com.depromeet.piki.support.uuidToBytes
+import com.depromeet.piki.user.domain.IdentityType
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpHeaders
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.context.WebApplicationContext
+import java.sql.Date
+import java.time.LocalDate
+import java.time.ZoneId
+import java.util.UUID
+import kotlin.test.assertEquals
+
+// Part A — 일별 활동 캡처가 인증 요청에서 실제로 1행을 남기는지(인터셉터·SecurityContext principal·UUID 바인딩·
+// INSERT IGNORE 전체 경로)를 실제 HTTP 흐름 + Testcontainers MySQL 로 검증한다. 각 테스트는 격리된 randomUUID
+// 유저를 써 인메모리 쓰로틀의 클래스 간 누수를 피한다(CLAUDE.md 공유 mutable 상태 규약). user_daily_activity 는
+// FK 가 없어 users 행 없이도 기록되므로, 인증 토큰만으로 충분하다.
+@Transactional
+class DailyActivityCaptureIntegrationTest : IntegrationTestSupport() {
+    @Autowired
+    private lateinit var webApplicationContext: WebApplicationContext
+
+    @Autowired
+    private lateinit var jdbcTemplate: JdbcTemplate
+
+    @Autowired
+    private lateinit var jwtProvider: JwtProvider
+
+    private fun mockMvc() =
+        MockMvcBuilders
+            .webAppContextSetup(webApplicationContext)
+            .apply<DefaultMockMvcBuilder>(springSecurity())
+            .build()
+
+    private fun activityRowCount(userId: UUID): Int =
+        jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM user_daily_activity WHERE user_id = ?",
+            Int::class.java,
+            uuidToBytes(userId),
+        )!!
+
+    @Test
+    fun `인증된 요청은 그 유저의 오늘(KST) 활동을 1행 기록한다`() {
+        val userId = UUID.randomUUID()
+        val token = jwtProvider.generateAccessToken(userId, IdentityType.MEMBER)
+
+        mockMvc()
+            .perform(get("/api/v1/notifications").header(HttpHeaders.AUTHORIZATION, "Bearer $token"))
+            .andExpect(status().isOk)
+
+        assertEquals(1, activityRowCount(userId))
+        val activeDate =
+            jdbcTemplate
+                .queryForObject(
+                    "SELECT active_date FROM user_daily_activity WHERE user_id = ?",
+                    Date::class.java,
+                    uuidToBytes(userId),
+                )!!
+                .toLocalDate()
+        assertEquals(LocalDate.now(ZoneId.of("Asia/Seoul")), activeDate)
+    }
+
+    @Test
+    fun `같은 유저가 같은 날 두 번 요청해도 1행만 남는다`() {
+        val userId = UUID.randomUUID()
+        val token = jwtProvider.generateAccessToken(userId, IdentityType.MEMBER)
+        val mvc = mockMvc()
+
+        repeat(2) {
+            mvc
+                .perform(get("/api/v1/notifications").header(HttpHeaders.AUTHORIZATION, "Bearer $token"))
+                .andExpect(status().isOk)
+        }
+
+        assertEquals(1, activityRowCount(userId))
+    }
+
+    @Test
+    fun `미인증 요청은 활동을 기록하지 않는다`() {
+        // 전체 행 수는 다른 비-@Transactional 통합테스트가 커밋한 활동 때문에 0 이 아닐 수 있으므로,
+        // "미인증 요청이 행을 늘리지 않는다"(before == after)로 단언한다.
+        val before = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM user_daily_activity", Long::class.java)!!
+
+        mockMvc()
+            .perform(get("/api/v1/notifications"))
+            .andExpect(status().isUnauthorized)
+
+        val after = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM user_daily_activity", Long::class.java)!!
+        assertEquals(before, after)
+    }
+}

--- a/src/test/kotlin/com/depromeet/piki/metrics/launch/LaunchMetricsRecapIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/metrics/launch/LaunchMetricsRecapIntegrationTest.kt
@@ -1,0 +1,149 @@
+package com.depromeet.piki.metrics.launch
+
+import com.depromeet.piki.support.IntegrationTestSupport
+import com.depromeet.piki.support.uuidToBytes
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.view
+import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.context.WebApplicationContext
+import java.sql.Date
+import java.sql.Timestamp
+import java.time.LocalDate
+import java.util.UUID
+import kotlin.test.assertEquals
+
+// Part B — 런칭 경계(KST→UTC 변환) 전/후 분리와 신규 user_daily_activity 리텐션 조인을 실데이터 + Testcontainers
+// MySQL 로 검증한다. created_at 은 UTC 저장이라, 경계 6/20 00:00 KST = 6/19 15:00 UTC 를 기준으로 14:00(전)·16:00(후)
+// 유저를 심어 분리가 맞는지 본다. 시딩하지 않은 지표(토너먼트·푸시 등)는 0 으로 떨어져 쿼리 실행 무결성도 함께 확인한다.
+// admin 게이트는 IntegrationTestSupport 의 admin.local-bypass 로 우회된다.
+@Transactional
+class LaunchMetricsRecapIntegrationTest : IntegrationTestSupport() {
+    @Autowired
+    private lateinit var webApplicationContext: WebApplicationContext
+
+    @Autowired
+    private lateinit var jdbcTemplate: JdbcTemplate
+
+    private fun mockMvc() =
+        MockMvcBuilders
+            .webAppContextSetup(webApplicationContext)
+            .apply<DefaultMockMvcBuilder>(springSecurity())
+            .build()
+
+    private val beforeBoundary = "2026-06-19 14:00:00" // < 6/19 15:00 UTC (= 6/20 00:00 KST)
+    private val afterBoundary = "2026-06-19 16:00:00" // 런칭 후 + 런칭 당일 윈도우 내
+
+    private fun insertUser(
+        id: UUID,
+        identityType: String,
+        createdAt: String,
+    ) = jdbcTemplate.update(
+        "INSERT INTO users (id, nickname, identity_type, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+        uuidToBytes(id),
+        id.toString().take(10),
+        identityType,
+        Timestamp.valueOf(createdAt),
+        Timestamp.valueOf(createdAt),
+    )
+
+    @Test
+    fun `런칭 경계 전후 가입자와 리텐션이 정확히 집계되고 미시딩 지표는 0으로 실행된다`() {
+        // 런칭 전 활성 유저 2
+        repeat(2) { insertUser(UUID.randomUUID(), "MEMBER", beforeBoundary) }
+
+        // 런칭 후 유저 3 (회원 2 · 게스트 1)
+        val member1 = UUID.randomUUID()
+        val member2 = UUID.randomUUID()
+        val guest1 = UUID.randomUUID()
+        insertUser(member1, "MEMBER", afterBoundary)
+        insertUser(member2, "MEMBER", afterBoundary)
+        insertUser(guest1, "GUEST", afterBoundary)
+
+        // 소셜 연결(provider) — 가입과 거의 동시각이라 전환(1분 이상 갭) 아님
+        jdbcTemplate.update(
+            "INSERT INTO user_details (user_id, email, provider, social_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
+            uuidToBytes(member1), "a@t.com", "KAKAO", UUID.randomUUID().toString(), Timestamp.valueOf(afterBoundary), Timestamp.valueOf(afterBoundary),
+        )
+        jdbcTemplate.update(
+            "INSERT INTO user_details (user_id, email, provider, social_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
+            uuidToBytes(member2), "b@t.com", "GOOGLE", UUID.randomUUID().toString(), Timestamp.valueOf(afterBoundary), Timestamp.valueOf(afterBoundary),
+        )
+
+        // 위시 — URL 아이템 1 · 이미지(source_url NULL) 아이템 1
+        jdbcTemplate.update(
+            "INSERT INTO items (id, source_url, created_at, updated_at) VALUES (?, ?, ?, ?)",
+            1001L, "https://shop.example/a", Timestamp.valueOf(afterBoundary), Timestamp.valueOf(afterBoundary),
+        )
+        jdbcTemplate.update(
+            "INSERT INTO items (id, created_at, updated_at) VALUES (?, ?, ?)",
+            1002L, Timestamp.valueOf(afterBoundary), Timestamp.valueOf(afterBoundary),
+        )
+        // 파싱 결과 스냅샷 — READY 1(item 1001) · FAILED 1(item 1002). wish 는 이 snapshot 을 가리킨다.
+        jdbcTemplate.update(
+            "INSERT INTO item_snapshots (id, item_id, status, created_at, updated_at) VALUES (2001, 1001, 'READY', ?, ?)",
+            Timestamp.valueOf(afterBoundary), Timestamp.valueOf(afterBoundary),
+        )
+        jdbcTemplate.update(
+            "INSERT INTO item_snapshots (id, item_id, status, created_at, updated_at) VALUES (2002, 1002, 'FAILED', ?, ?)",
+            Timestamp.valueOf(afterBoundary), Timestamp.valueOf(afterBoundary),
+        )
+        // wish 는 item_id 가 아니라 snapshot_id 로 참조(정규화됨)
+        jdbcTemplate.update(
+            "INSERT INTO wishes (user_id, snapshot_id, created_at, updated_at) VALUES (?, 2001, ?, ?)",
+            uuidToBytes(member1), Timestamp.valueOf(afterBoundary), Timestamp.valueOf(afterBoundary),
+        )
+        jdbcTemplate.update(
+            "INSERT INTO wishes (user_id, snapshot_id, created_at, updated_at) VALUES (?, 2002, ?, ?)",
+            uuidToBytes(member1), Timestamp.valueOf(afterBoundary), Timestamp.valueOf(afterBoundary),
+        )
+
+        // 리텐션 — 런칭날 가입자 3명 중 2명이 다음날(6/21 KST) 활동
+        jdbcTemplate.update("INSERT INTO user_daily_activity (user_id, active_date, created_at) VALUES (?, ?, NOW(6))", uuidToBytes(member1), Date.valueOf(LocalDate.of(2026, 6, 21)))
+        jdbcTemplate.update("INSERT INTO user_daily_activity (user_id, active_date, created_at) VALUES (?, ?, NOW(6))", uuidToBytes(member2), Date.valueOf(LocalDate.of(2026, 6, 21)))
+
+        val result =
+            mockMvc()
+                .perform(get("/admin/metrics/launch").param("date", "2026-06-20"))
+                .andExpect(status().isOk)
+                .andExpect(view().name("admin/launch-recap"))
+                .andReturn()
+
+        val recap = result.modelAndView!!.model["recap"] as LaunchRecap
+
+        // 가입 — 경계 전후 분리
+        assertEquals(2, recap.signup.before)
+        assertEquals(3, recap.signup.after)
+        assertEquals(2, recap.signup.afterMembers)
+        assertEquals(1, recap.signup.afterGuests)
+        assertEquals(1L, recap.signup.byProvider["KAKAO"])
+        assertEquals(1L, recap.signup.byProvider["GOOGLE"])
+        assertEquals(0, recap.signup.guestToMemberConversions)
+
+        // 위시
+        assertEquals(2, recap.wish.total)
+        assertEquals(1, recap.wish.fromUrl)
+        assertEquals(1, recap.wish.fromImage)
+        assertEquals(1, recap.wish.parsedReady)
+        assertEquals(1, recap.wish.parsedFailed)
+        assertEquals(50, recap.wish.parseSuccessRate)
+
+        // 리텐션
+        assertEquals(3, recap.retention.launchDaySignups)
+        assertEquals(2, recap.retention.d1Returned)
+        assertEquals(66, recap.retention.d1Rate)
+
+        // 미시딩 지표 — 쿼리 실행 무결성(0)
+        assertEquals(0, recap.tournament.created)
+        assertEquals(0, recap.tournament.itemsAdded)
+        assertEquals(0, recap.pushReachableUsers)
+        assertEquals(0, recap.push.notificationsTotal)
+        assertEquals(0, recap.push.deliverySuccess)
+    }
+}

--- a/src/test/kotlin/com/depromeet/piki/metrics/launch/LaunchRecapTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/metrics/launch/LaunchRecapTest.kt
@@ -1,0 +1,60 @@
+package com.depromeet.piki.metrics.launch
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+// LaunchRecap 의 파생 계산(비율·평균) 분기 — 특히 0 분모 처리를 망라한다. 순수 계산이라 Spring·DB 없이 검증한다.
+class LaunchRecapTest {
+    @Test
+    fun `pct 는 분모가 0이면 0, 아니면 내림 정수 퍼센트를 반환한다`() {
+        assertEquals(0, LaunchRecap.pct(0, 0))
+        assertEquals(0, LaunchRecap.pct(5, 0))
+        assertEquals(50, LaunchRecap.pct(5, 10))
+        assertEquals(33, LaunchRecap.pct(1, 3))
+        assertEquals(100, LaunchRecap.pct(7, 7))
+    }
+
+    @Test
+    fun `위시 파싱 성공률은 성공+실패가 0이면 0이다`() {
+        assertEquals(0, wish(ready = 0, failed = 0).parseSuccessRate)
+        assertEquals(80, wish(ready = 8, failed = 2).parseSuccessRate)
+    }
+
+    @Test
+    fun `토너먼트 평균 참가자는 생성이 0이면 0, 아니면 소수 1자리다`() {
+        assertEquals("0", tournament(created = 0, participants = 0).avgParticipants)
+        assertEquals("3.5", tournament(created = 2, participants = 7).avgParticipants)
+    }
+
+    @Test
+    fun `D1 리텐션율은 런칭날 가입이 0이면 0이다`() {
+        assertEquals(0, retention(signups = 0, returned = 0).d1Rate)
+        assertEquals(44, retention(signups = 100, returned = 44).d1Rate)
+    }
+
+    @Test
+    fun `푸시 CTR 근사는 알림이 0이면 0이다`() {
+        assertEquals(0, push(total = 0, read = 0).ctrApproxPct)
+        assertEquals(31, push(total = 100, read = 31).ctrApproxPct)
+    }
+
+    private fun wish(
+        ready: Long,
+        failed: Long,
+    ) = LaunchRecap.Wish(total = ready + failed, fromUrl = 0, fromImage = 0, parsedReady = ready, parsedFailed = failed)
+
+    private fun tournament(
+        created: Long,
+        participants: Long,
+    ) = LaunchRecap.Tournament(created = created, participants = participants, itemsAdded = 0, completed = 0, plays = 0)
+
+    private fun retention(
+        signups: Long,
+        returned: Long,
+    ) = LaunchRecap.Retention(launchDaySignups = signups, d1Returned = returned, dau = emptyList())
+
+    private fun push(
+        total: Long,
+        read: Long,
+    ) = LaunchRecap.Push(byType = emptyMap(), deliverySuccess = 0, deliveryFailure = 0, deliverySkipped = 0, notificationsTotal = total, readApprox = read)
+}


### PR DESCRIPTION
## Situation

- 6/20 런칭데이에 유입이 몰릴 예정이다. GA(프론트)와 별개로, 백엔드가 런칭 전/후 지표를 모아 팀에 보여주고 싶었다.
- 기존 관측 스택(Grafana·Prometheus·Loki)은 백엔드 개발진만 본다. 기획·디자이너도 보려면 admin 백오피스 화면이 맞다.

## Task

- 가입(전/후·provider·게스트/회원·전환), 위시, 토너먼트, 리텐션, 푸시를 한 admin 페이지에서 본다.
- 핵심 제약: **캡처와 리포팅은 시간축이 다르다.** 내일 안 찍힌 데이터는 못 살리고, 화면은 사후에 만들어도 된다.

## Action

### 설계 결정

| 결정 | 택한 안 | 이유 |
|---|---|---|
| 리포팅 방식 | DB 조회 기반 admin 페이지 | Grafana 는 비개발이 못 봄. 대부분 지표가 기존 `created_at` 으로 사후 도출돼 캡처 없이 만들 수 있고 데이터 손실 0 |
| 리텐션 캡처 | 별도 `user_daily_activity` 테이블 | "로그인/재방문"은 어디에도 안 남아 미리 심어야 함. `users` 컬럼 추가 대신 격리·droppable 한 테이블로(분석 후 DROP) |
| 푸시 CTR | `is_read` 근사 | 정확 CTR 은 푸시-탭 신호(FE 협의)가 필요. 일단 근사 + 화면에 caveat |

### 캡처 (런칭 전 배포 필요)

- 인증 요청의 활성 유저를 KST 일 단위 1행으로 기록한다.
- **best-effort**: 기록 실패해도 요청에 영향 없음.
- **쓰로틀**: 인메모리로 같은 유저의 같은 날 두 번째부터 DB 에 안 닿음(유저당 약 1쓰기/일).
- **멱등**: INSERT IGNORE 로 동시 첫 요청·재시작에도 1행.
- `HandlerInterceptor` 가 SecurityContext principal(UUID)을 읽으므로 미인증·슬랙admin 요청은 자연 제외.

### 리캡 화면

- `GET /admin/metrics/launch` — 런칭 경계(KST 자정) 전/후 집계를 기존 admin 디자인(슬랙-IP 게이트 아래)으로 렌더. 새로고침할수록 "런칭 후" 수치가 커지는 on-demand 집계.
- `created_at` 이 UTC 저장이라 경계(KST)를 UTC 로 변환해 비교한다. 시간대별은 +9h 로 KST 버킷팅.

### 측정의 한계 (화면에 명시)

| 지표 | 한계 | 처리 |
|---|---|---|
| 토너먼트 시작 수 | 상태 전이 시각 컬럼 없음 | 생성·완료(참가자별)·플레이(픽)로 대체 |
| 게스트→회원 전환 | 전환 시각 없음 | 소셜연결과 가입 시각의 갭 1분 이상으로 근사 |
| 푸시 CTR | 탭 신호 없음 | is_read 근사(알림센터 열람도 포함돼 과대계상) |

### 작업 중 발견

- `wishes`·`tournament_items` 가 `item_id` 에서 `snapshot_id` 로 정규화돼 있었다. 위시 소스(URL/이미지) 집계를 snapshot 조인 경유로 정정했다.

## Result

- dev/staging(EC2 로컬 MySQL)·prod(RDS) 어디에 배포하든 공용 DataSource 라 자동으로 그 환경 DB 를 읽고, Flyway 가 테이블도 각 환경에 깐다. 환경 분기 코드 0.
- **blast-radius**: 전역 `HandlerInterceptor` 추가로 모든 인증 요청이 활동 기록을 트리거한다. best-effort·쓰로틀이라 응답·동작 변화는 없고 신규 테이블만 추가된다.
- **후속**: 푸시 CTR 정확화(FE 푸시-탭 신호)는 협의되면 별도 캡처로 교체. 분석 종료 후 `user_daily_activity` 는 DROP 마이그레이션으로 제거.

## 연관 이슈

- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 인증된 사용자의 일일 활동 자동 추적 (KST 기준)
  * 관리자용 런칭데이 대시보드 추가: 가입, 위시, 토너먼트, 리텐션, 푸시 등 주요 지표 한눈에 조회 가능

* **테스트**
  * 일일 활동 기록 통합 테스트 추가
  * 런칭 메트릭 통합 테스트 추가

* **Chores**
  * 일일 활동 데이터 저장 데이터베이스 스키마 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->