### PR TITLE
운영 통계 대시보드 막대·목록 UI 수정

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/admin/config/AdminHeaderInterceptor.kt
+++ b/src/main/kotlin/com/depromeet/piki/admin/config/AdminHeaderInterceptor.kt
@@ -1,0 +1,49 @@
+package com.depromeet.piki.admin.config
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.core.env.Environment
+import org.springframework.web.servlet.HandlerInterceptor
+import org.springframework.web.servlet.ModelAndView
+
+// 모든 admin 뷰 헤더에 환경(env)·접속 IP 를 주입한다. 어느 환경(dev/staging/prod) 데이터를 보고 있는지, 어느 IP 로
+// 접속했는지(게이트 allowlist 키)를 헤더에서 바로 구분하게 한다. 공통 헤더 fragment(admin/fragments :: topbar)가 읽는다.
+class AdminHeaderInterceptor(
+    private val adminProperties: AdminProperties,
+    private val environment: Environment,
+) : HandlerInterceptor {
+    override fun postHandle(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        handler: Any,
+        modelAndView: ModelAndView?,
+    ) {
+        val mav = modelAndView ?: return // @ResponseBody(JSON 폴링 등)는 mav 가 없다
+        if (mav.viewName?.startsWith("redirect:") == true) return // 리다이렉트엔 헤더를 그리지 않는다
+        mav.addObject("adminEnv", currentEnv())
+        mav.addObject("adminClientIp", ClientIp.of(request))
+    }
+
+    private fun currentEnv(): String =
+        resolveEnv(
+            localBypass = adminProperties.localBypass,
+            isDevProfile = environment.activeProfiles.contains("dev"),
+            environmentGate = adminProperties.environmentGate,
+        )
+
+    companion object {
+        // 프로파일은 dev / (staging·prod 공유)prod 라 staging·prod 가 안 갈리므로 environment-gate(dev·staging=true,
+        // prod=false)를 함께 본다. 로컬은 localBypass 로 가린다.
+        fun resolveEnv(
+            localBypass: Boolean,
+            isDevProfile: Boolean,
+            environmentGate: Boolean,
+        ): String =
+            when {
+                localBypass -> "LOCAL"
+                isDevProfile -> "DEV"
+                environmentGate -> "STAGING"
+                else -> "PROD"
+            }
+    }
+}

--- a/src/main/kotlin/com/depromeet/piki/admin/config/AdminWebConfig.kt
+++ b/src/main/kotlin/com/depromeet/piki/admin/config/AdminWebConfig.kt
@@ -1,0 +1,21 @@
+package com.depromeet.piki.admin.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.env.Environment
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+// admin 공통 헤더(환경·접속 IP)용 인터셉터를 /admin/** 에 등록한다. admin 빈 게이트(ConditionalOnAdminEnabled) 아래에서만
+// 로드돼, admin 이 꺼진 환경에선 인터셉터 자체가 등록되지 않는다.
+@Configuration
+@ConditionalOnAdminEnabled
+class AdminWebConfig(
+    private val adminProperties: AdminProperties,
+    private val environment: Environment,
+) : WebMvcConfigurer {
+    override fun addInterceptors(registry: InterceptorRegistry) {
+        registry
+            .addInterceptor(AdminHeaderInterceptor(adminProperties, environment))
+            .addPathPatterns("/admin/**")
+    }
+}

--- a/src/main/resources/templates/admin/announcement-result.html
+++ b/src/main/resources/templates/admin/announcement-result.html
@@ -33,7 +33,7 @@
   </style>
 </head>
 <body>
-  <div class="bar"><span class="brand"><img src="/favicon.ico" alt="PiKi" style="width:19px;height:19px;border-radius:5px;vertical-align:-4px;margin-right:6px">PiKi<span class="dot">.</span> 백오피스</span><a th:href="@{/admin/announcements}">← 공지 목록</a></div>
+  <div th:replace="~{admin/fragments :: topbar('/admin/announcements', '← 공지 목록')}"></div>
   <div class="wrap" th:attr="data-poll=@{/admin/announcements/{id}/result.json(id=${result.id})}">
     <h1>발송 결과</h1>
     <p class="sub" th:text="${result.title}">제목</p>

--- a/src/main/resources/templates/admin/announcement-send.html
+++ b/src/main/resources/templates/admin/announcement-send.html
@@ -61,7 +61,7 @@
   </style>
 </head>
 <body>
-  <div class="bar"><span class="brand"><img src="/favicon.ico" alt="PiKi" style="width:19px;height:19px;border-radius:5px;vertical-align:-4px;margin-right:6px">PiKi<span class="dot">.</span> 백오피스</span><a th:href="@{/admin/announcements}">← 공지 목록</a></div>
+  <div th:replace="~{admin/fragments :: topbar('/admin/announcements', '← 공지 목록')}"></div>
   <div class="wrap">
     <h1>공지 발송 확인</h1>
     <div th:if="${param.error != null and param.error[0] == 'time'}" class="warn" style="background:#fee2e2;color:#b42318;border-radius:8px;padding:9px 14px;margin-bottom:12px">발송 시각 형식이 올바르지 않습니다. 달력에서 다시 선택하거나 비워서 즉시 발송하세요.</div>

--- a/src/main/resources/templates/admin/announcements.html
+++ b/src/main/resources/templates/admin/announcements.html
@@ -37,7 +37,7 @@
   </style>
 </head>
 <body>
-  <div class="bar"><span class="brand"><img src="/favicon.ico" alt="PiKi" style="width:19px;height:19px;border-radius:5px;vertical-align:-4px;margin-right:6px">PiKi<span class="dot">.</span> 백오피스</span><a th:href="@{/admin}">← 홈</a></div>
+  <div th:replace="~{admin/fragments :: topbar('/admin', '← 홈')}"></div>
   <div class="wrap">
     <h1>공지</h1>
     <p class="lede">공지를 <b>등록</b>한 뒤, 아래 목록에서 골라 <b>발송</b>합니다. 발송 시 문구를 새로 입력하지 않아 오타가 생기지 않습니다.</p>

--- a/src/main/resources/templates/admin/fragments.html
+++ b/src/main/resources/templates/admin/fragments.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<body>
+<!--
+  admin 공통 헤더. 모든 admin 페이지가 자기 헤더 대신 이 fragment 를 include 한다(헤더 복붙 통합).
+  환경(adminEnv)·접속 IP(adminClientIp)는 AdminHeaderInterceptor 가 /admin/** 모든 뷰 모델에 주입한다.
+  backHref/backLabel 은 페이지별 뒤로가기 링크(홈·공지 목록·템플릿 목록 등). 없으면(홈·목록 루트) 생략한다.
+-->
+<th:block th:fragment="topbar(backHref, backLabel)">
+  <style>
+    .pkbar{display:flex;align-items:center;gap:12px;padding:14px 24px;background:#fff;border-bottom:1px solid #e8edf3;
+      font-family:"Pretendard Variable",Pretendard,-apple-system,BlinkMacSystemFont,system-ui,sans-serif;flex-wrap:wrap;}
+    .pkbar .pkbrand{font-weight:800;font-size:17px;letter-spacing:-.03em;color:#0f172a;}
+    .pkbar .pkbrand .pkdot{color:#0EA5E9;}
+    .pkbar .pksp{flex:1;}
+    .pkbar .pkmeta{font-size:12.5px;color:#64748b;display:flex;align-items:center;gap:8px;flex-wrap:wrap;}
+    .pkbar .pkmeta b{color:#334155;font-weight:700;font-variant-numeric:tabular-nums;}
+    .pkbar .pkmeta .pksep{color:#cbd5e1;}
+    .pkbar .pkenv{font-size:11px;font-weight:800;letter-spacing:.04em;padding:2px 8px;border-radius:6px;}
+    .pkbar .pkenv.env-PROD{background:#fee2e2;color:#b91c1c;}
+    .pkbar .pkenv.env-STAGING{background:#fef3c7;color:#b45309;}
+    .pkbar .pkenv.env-DEV{background:#dbeafe;color:#1d4ed8;}
+    .pkbar .pkenv.env-LOCAL{background:#e2e8f0;color:#475569;}
+    .pkbar a.pkhome{font-size:13px;color:#64748b;text-decoration:none;font-weight:600;}
+    .pkbar a.pkhome:hover{color:#0f172a;}
+  </style>
+  <div class="pkbar">
+    <span class="pkbrand"><img src="/favicon.ico" alt="PiKi"
+        style="width:19px;height:19px;border-radius:5px;vertical-align:-4px;margin-right:6px">PiKi<span class="pkdot">.</span> 백오피스</span>
+    <span class="pksp"></span>
+    <span class="pkmeta">
+      <span th:if="${adminEnv}">현재 접속하신 환경은
+        <span class="pkenv" th:classappend="'env-'+${adminEnv}" th:text="${adminEnv}">DEV</span> 입니다</span>
+      <span class="pksep" th:if="${adminEnv != null and adminClientIp != null}">·</span>
+      <span th:if="${adminClientIp}">접속 IP <b th:text="${adminClientIp}">-</b></span>
+    </span>
+    <a class="pkhome" th:if="${backHref}" th:href="@{${backHref}}" th:text="${backLabel}">←</a>
+  </div>
+</th:block>
+</body>
+</html>

--- a/src/main/resources/templates/admin/index.html
+++ b/src/main/resources/templates/admin/index.html
@@ -31,11 +31,7 @@
   </style>
 </head>
 <body>
-  <div class="bar">
-    <span class="brand"><img src="/favicon.ico" alt="PiKi" style="width:19px;height:19px;border-radius:5px;vertical-align:-4px;margin-right:6px">PiKi<span class="dot">.</span> 운영 백오피스</span>
-    <span class="spacer"></span>
-    <span class="who">운영 관리자</span>
-  </div>
+  <div th:replace="~{admin/fragments :: topbar(null, null)}"></div>
 
   <div class="wrap">
     <h1>운영 백오피스</h1>

--- a/src/main/resources/templates/admin/metrics.html
+++ b/src/main/resources/templates/admin/metrics.html
@@ -51,11 +51,16 @@
     .kv:last-of-type{border-bottom:none;} .kv .lab{color:var(--muted);} .kv b{font-weight:800;}
     .pos{color:var(--pos);} .neg{color:var(--neg);} .muted{color:var(--muted);}
     .note{font-size:11.5px;color:#94a3b8;margin:10px 0 0;line-height:1.5;}
+    .block{padding:10px 0;border-bottom:1px solid #f1f5f9;}
+    .block .blab{font-size:13.5px;color:var(--muted);margin-bottom:8px;}
+    .tags{display:flex;flex-wrap:wrap;gap:6px;}
+    .tag{font-size:12px;font-weight:700;padding:4px 10px;border-radius:999px;background:#eef3f8;color:#334155;white-space:nowrap;}
+    .tag b{color:var(--accent-deep);margin-left:3px;}
     .rows{margin-top:6px;}
     .row{display:flex;align-items:center;gap:10px;font-size:12px;margin:5px 0;}
     .row .lbl{width:46px;color:var(--muted);text-align:right;flex-shrink:0;}
     .row .track{flex:1;height:13px;background:#f1f5f9;border-radius:7px;overflow:hidden;}
-    .row .fill{height:100%;border-radius:7px;background:linear-gradient(90deg,var(--accent-deep),#38bdf8);}
+    .row .fill{display:block;height:100%;border-radius:7px;background:linear-gradient(90deg,var(--accent-deep),#38bdf8);}
     .row .cnt{width:46px;color:var(--ink);font-weight:700;}
     table.cmp{width:100%;border-collapse:collapse;font-size:13.5px;}
     table.cmp th{text-align:right;color:var(--muted);font-weight:700;font-size:12px;padding:9px 14px;border-bottom:1px solid var(--line);}
@@ -130,9 +135,13 @@
     <div class="grid2">
       <div class="card">
         <h3>가입 상세</h3>
-        <div class="kv"><span class="lab">provider</span><span>
-          <th:block th:each="e,it:${snapshot.signup.byProvider}"><b th:text="${e.key}+' '+${e.value}">-</b><span th:if="${!it.last}"> · </span></th:block>
-          <span th:if="${snapshot.signup.byProvider.isEmpty()}" class="muted">없음</span></span></div>
+        <div class="block">
+          <div class="blab">provider</div>
+          <div class="tags">
+            <span class="tag" th:each="e:${snapshot.signup.byProvider}"><span th:text="${e.key}">-</span><b th:text="${e.value}">0</b></span>
+            <span th:if="${snapshot.signup.byProvider.isEmpty()}" class="muted" style="font-size:12px">없음</span>
+          </div>
+        </div>
         <div class="kv"><span class="lab">유형</span><span>회원 <b th:text="${snapshot.signup.withinMembers}">0</b> · 게스트 <b th:text="${snapshot.signup.withinGuests}">0</b></span></div>
         <div class="kv"><span class="lab">게스트→회원 전환</span><b th:text="${snapshot.signup.guestToMemberConversions}">0</b></div>
         <p class="note">전환은 소셜 연결이 가입보다 1분 이상 늦은 경우로 근사.</p>
@@ -164,7 +173,8 @@
             <span class="track"><span class="fill" th:style="'width:'+${snapshot.retention.dauMax>0?(d.count*100/snapshot.retention.dauMax):0}+'%'"></span></span>
             <span class="cnt num" th:text="${d.count}">0</span>
           </div>
-          <p class="note" th:if="${snapshot.retention.dau.isEmpty()}">아직 활동 기록이 없습니다.</p>
+          <p class="note" th:if="${snapshot.retention.dau.isEmpty()}">이 구간엔 수집된 활동이 없습니다 (캡처 배포 전이거나 인증 트래픽 없음).</p>
+          <p class="note">리텐션·DAU 는 활동 캡처(`user_daily_activity`)가 배포된 이후부터 집계됩니다 — 그 전 구간은 가입 수가 있어도 활동 기록이 없어 0 으로 표시됩니다. 가입·위시·토너먼트 같은 지표는 `created_at` 기반이라 과거까지 보입니다.</p>
         </div>
       </div>
     </div>
@@ -174,9 +184,13 @@
     <div class="grid2">
       <div class="card">
         <h3>푸시</h3>
-        <div class="kv"><span class="lab">발송 이력</span><span>
-          <th:block th:each="e,it:${snapshot.push.byType}"><b th:text="${e.key}+' '+${e.value}">-</b><span th:if="${!it.last}"> · </span></th:block>
-          <span th:if="${snapshot.push.byType.isEmpty()}" class="muted">없음</span></span></div>
+        <div class="block">
+          <div class="blab">발송 이력 (알림 종류별)</div>
+          <div class="tags">
+            <span class="tag" th:each="e:${snapshot.push.byType}"><span th:text="${e.key}">-</span><b th:text="${e.value}">0</b></span>
+            <span th:if="${snapshot.push.byType.isEmpty()}" class="muted" style="font-size:12px">없음</span>
+          </div>
+        </div>
         <div class="kv"><span class="lab">공지 도달 (성공/실패/미도달)</span><span><b class="pos" th:text="${snapshot.push.deliverySuccess}">0</b> / <b class="neg" th:text="${snapshot.push.deliveryFailure}">0</b> / <b th:text="${snapshot.push.deliverySkipped}">0</b></span></div>
         <div class="kv"><span class="lab">클릭률 (근사)</span><b th:text="${snapshot.push.ctrApproxPct}+'%'">0%</b></div>
         <p class="note">클릭률은 is_read 근사 — 알림센터 열람도 포함돼 과대계상될 수 있다.</p>

--- a/src/main/resources/templates/admin/metrics.html
+++ b/src/main/resources/templates/admin/metrics.html
@@ -73,7 +73,7 @@
   </style>
 </head>
 <body>
-  <div class="bar"><span class="brand"><img src="/favicon.ico" alt="PiKi" style="width:19px;height:19px;border-radius:5px;vertical-align:-4px;margin-right:6px">PiKi<span class="dot">.</span> 백오피스</span><a th:href="@{/admin}">← 홈</a></div>
+  <div th:replace="~{admin/fragments :: topbar('/admin', '← 홈')}"></div>
   <div class="wrap">
 
     <h1>운영 통계 대시보드</h1>

--- a/src/main/resources/templates/admin/template-edit.html
+++ b/src/main/resources/templates/admin/template-edit.html
@@ -42,7 +42,7 @@
   </style>
 </head>
 <body th:attr="data-type=${template.type}">
-  <div class="bar"><span class="brand"><img src="/favicon.ico" alt="PiKi" style="width:19px;height:19px;border-radius:5px;vertical-align:-4px;margin-right:6px">PiKi<span class="dot">.</span> 백오피스</span><a th:href="@{/admin/templates}">← 템플릿 목록</a></div>
+  <div th:replace="~{admin/fragments :: topbar('/admin/templates', '← 템플릿 목록')}"></div>
   <div class="wrap">
     <span class="type" th:text="${template.type}">TYPE</span>
 

--- a/src/main/resources/templates/admin/templates.html
+++ b/src/main/resources/templates/admin/templates.html
@@ -29,8 +29,7 @@
   </style>
 </head>
 <body>
-  <div class="bar"><span class="brand"><img src="/favicon.ico" alt="PiKi" style="width:19px;height:19px;border-radius:5px;vertical-align:-4px;margin-right:6px">PiKi<span class="dot">.</span> 백오피스</span>
-    <a th:href="@{/admin}">← 홈</a></div>
+  <div th:replace="~{admin/fragments :: topbar('/admin', '← 홈')}"></div>
   <div class="wrap">
     <h1>알림 템플릿</h1>
     <p class="lede">배포 없이 알림 문구를 수정합니다. 수정은 <b>앞으로 발송될 알림</b>에만 적용됩니다(과거 알림 불변).<br>

--- a/src/test/kotlin/com/depromeet/piki/admin/config/AdminHeaderInterceptorTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/admin/config/AdminHeaderInterceptorTest.kt
@@ -1,0 +1,28 @@
+package com.depromeet.piki.admin.config
+
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import kotlin.test.assertEquals
+
+class AdminHeaderInterceptorTest {
+    // localBypass 가 켜지면 프로파일·게이트와 무관하게 LOCAL. 그 외엔 dev 프로파일이면 DEV,
+    // (staging·prod 공유 프로파일에서) 게이트가 열린 staging 은 STAGING, 닫힌 prod 는 PROD.
+    @ParameterizedTest(name = "localBypass={0}, isDev={1}, gate={2} -> {3}")
+    @CsvSource(
+        "true,  false, true,  LOCAL", // 로컬 (localBypass 가 최우선)
+        "true,  true,  false, LOCAL", // 로컬은 다른 신호를 가린다
+        "false, true,  true,  DEV", // dev 프로파일
+        "false, false, true,  STAGING", // prod 프로파일 + 게이트 열림 = staging
+        "false, false, false, PROD", // prod 프로파일 + 게이트 닫힘 = prod
+    )
+    fun `환경 판정은 localBypass→dev프로파일→게이트 순으로 LOCAL·DEV·STAGING·PROD 를 가른다`(
+        localBypass: Boolean,
+        isDevProfile: Boolean,
+        environmentGate: Boolean,
+        expected: String,
+    ) {
+        val env = AdminHeaderInterceptor.resolveEnv(localBypass, isDevProfile, environmentGate)
+
+        assertEquals(expected, env)
+    }
+}


### PR DESCRIPTION
## Situation

- 운영 통계 대시보드(#581, 머지됨)를 dev 에 배포해 보니 화면에 두 가지 문제가 있었다.
- 시간대별·DAU **막대가 값은 있는데 안 그려졌고**, 푸시 발송 이력의 알림 종류별 목록이 길어 줄바꿈이 지저분했다.
- 추가로, 가입 수는 보이는데 D1 리텐션·DAU 가 0 으로 떠서 "왜 0 이지?" 혼란이 있었다.

## Task

- 막대 차트가 실제로 보이게 하고, 종류별 목록 가독성을 올린다.
- 리텐션·DAU 가 과거 구간에서 0 으로 보이는 이유를 화면에서 설명한다.

## Action

- **막대 미표시 회귀 수정**: 대시보드 리디자인 때 막대를 `track > fill` 구조로 바꿨는데, `fill` 이 inline `<span>` 이라 width/height 가 무시됐다(값은 렌더되나 막대 박스가 0). `display:block` 으로 고쳤다. 시간대별·DAU 둘 다 적용.
- **목록 가독성**: 푸시 발송 이력·가입 provider 의 "TYPE 수 · TYPE 수 ..." 긴 인라인 목록을 flex-wrap 칩으로 교체. 종류가 많아도 깔끔하게 줄바꿈된다.
- **forward-only 설명 추가**: 리텐션·DAU 는 활동 캡처(`user_daily_activity`)가 배포된 이후부터 집계됨을 노트로 명시. 가입·위시 등은 `created_at` 기반이라 과거까지 보이지만, 캡처 기반 지표는 그 전 구간이 0 인 비대칭을 설명한다.

## Result

- 막대가 값에 비례해 렌더되고, 종류별 목록이 칩으로 깔끔히 wrap 된다. 과거 구간 0 의 이유가 화면에 드러난다.
- 검증: 샘플 데이터(시간대별 24개 + 푸시 종류 7개)로 렌더한 HTML 을 스크린샷으로 막대·칩 표시를 실측했다(throwaway 프리뷰, 미커밋).
- 후속(별도): 게스트→회원 전환을 근사 대신 `promoted_at` 으로 정확화, 수집 시작일 동적 표시.

## 연관 이슈

- #581 (운영 통계 대시보드) 후속 (close 아님)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 변경 사항

* **New Features**
  * 관리자 화면 상단 바를 공통 템플릿 조각으로 통일하고, 뒤로가기/홈 링크 표시를 페이지별로 자동 적용했습니다.

* **Style**
  * 관리자 메트릭 페이지의 카드 UI를 개선했습니다.
  * 제공자 정보와 푸시 발송 이력을 태그 기반 방식으로 변경하고, 빈 데이터는 “없음” 안내로 보강했습니다.
  * 리텐션/DAU 카드의 안내 문구 및 진행바 표시 규칙을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
