### PR TITLE
배포 슬랙 알림이 promotion 머지에서 jq broken pipe 로 누락되던 것 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -587,7 +587,10 @@ jobs:
           SHORT_SHA="${{ needs.resolve.outputs.ref }}"
           SHORT_SHA="${SHORT_SHA:0:7}"
           COMMIT_URL="https://github.com/${{ github.repository }}/commit/${{ needs.resolve.outputs.ref }}"
-          COMMIT_MSG=$(jq -r '(.workflow_run.head_commit.message // .head_commit.message // "")' "$GITHUB_EVENT_PATH" | head -n 1)
+          # jq 안에서 첫 줄을 뽑는다 — `jq | head` 는 head 가 파이프를 닫을 때 jq 가 SIGPIPE(broken pipe)로 죽고,
+          # 이 step 쉘의 pipefail+set -e 가 그걸 실패로 잡아 step 이 exit 2 로 중단된다(슬랙 전송 누락). promotion 머지
+          # (dev→staging·dev→main)처럼 커밋 메시지가 거대하면 jq 출력 도중 head 가 닫혀 재현됐다(#586).
+          COMMIT_MSG=$(jq -r '((.workflow_run.head_commit.message // .head_commit.message // "") | split("\n")[0])' "$GITHUB_EVENT_PATH")
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
           # 배포 대상을 PiKi-Dev / PiKi-Staging / PiKi-Prod 로 브랜딩 + 도메인까지 보여 "어디에 배포됐는지" 명확히.
@@ -619,7 +622,10 @@ jobs:
           SHORT_SHA="${{ needs.resolve.outputs.ref }}"
           SHORT_SHA="${SHORT_SHA:0:7}"
           COMMIT_URL="https://github.com/${{ github.repository }}/commit/${{ needs.resolve.outputs.ref }}"
-          COMMIT_MSG=$(jq -r '(.workflow_run.head_commit.message // .head_commit.message // "")' "$GITHUB_EVENT_PATH" | head -n 1)
+          # jq 안에서 첫 줄을 뽑는다 — `jq | head` 는 head 가 파이프를 닫을 때 jq 가 SIGPIPE(broken pipe)로 죽고,
+          # 이 step 쉘의 pipefail+set -e 가 그걸 실패로 잡아 step 이 exit 2 로 중단된다(슬랙 전송 누락). promotion 머지
+          # (dev→staging·dev→main)처럼 커밋 메시지가 거대하면 jq 출력 도중 head 가 닫혀 재현됐다(#586).
+          COMMIT_MSG=$(jq -r '((.workflow_run.head_commit.message // .head_commit.message // "") | split("\n")[0])' "$GITHUB_EVENT_PATH")
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
           if [ "${{ steps.guard.outcome }}" = "failure" ]; then


### PR DESCRIPTION
## Situation
- `dev→staging` promotion(PR #585, 1.0.1) 배포 후 슬랙 배포 알림이 안 와서 조사했다. 정작 일반 dev 배포는 알림이 정상이었다.
- 원인은 "staging 환경"이 아니라 "커밋 메시지 크기"였다. promotion 머지는 squash 합본 메시지가 거대해, 그때만 슬랙 step이 실패했다.

## Task
- promotion 배포에서만 알림이 누락되는 이유를 진단하고 고친다.
- `continue-on-error`에 가려져 배포 job은 `success`로 보이던 "조용한 실패"를 드러낸다.

## Action
### 진단
- 슬랙 step의 `COMMIT_MSG=$(jq -r '...' | head -n 1)`에서, `head`가 첫 줄을 받고 파이프를 닫으면 `jq`가 SIGPIPE(broken pipe)로 죽는다. step 쉘의 `pipefail`+`set -e`가 이를 실패로 잡아 step이 exit 2로 중단되고, 그 아래 curl(슬랙 전송)은 실행되지 않는다.
- `continue-on-error: true`라 배포 job은 `success`로 통과해 그동안 안 들켰다.
- 거대 커밋에서만 재현된다: 일반 단일 커밋은 jq 출력이 짧아 head가 닫기 전에 다 써져 broken pipe가 안 난다. promotion 머지(수십 커밋 합본 메시지)에서만 터진다. PR #585 배포 run 로그의 `jq: error: writing output failed: Broken pipe` 와 `Process completed with exit code 2`로 확정했다.

### 수정
- `head` 파이프를 제거하고 jq 안에서 첫 줄을 뽑는다 (`... | split("\n")[0]`). 파이프가 없으니 broken pipe 자체가 사라진다.
- `Notify Slack on success`·`Notify Slack on failure` 두 step에 동일 적용.

## Result
- promotion·릴리스 배포(`dev→staging`, `dev→main`)에서 슬랙 알림이 정상 발송된다. 다음 `dev→main`(1.0.x) 릴리스 알림도 같은 거대 커밋이라 이 수정으로 함께 복구된다.
- 일반 dev 배포는 원래 정상이라 동작 변화 없다.

---
## 연관 이슈

- close #586


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * 배포 알림의 신뢰성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->