### PR TITLE
/admin 접근자 슬랙 신원을 access·도메인 로그에 남김

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/admin/access/AdminAccessFilter.kt
+++ b/src/main/kotlin/com/depromeet/piki/admin/access/AdminAccessFilter.kt
@@ -3,9 +3,11 @@ package com.depromeet.piki.admin.access
 import com.depromeet.piki.admin.config.AdminProperties
 import com.depromeet.piki.admin.config.ClientIp
 import com.depromeet.piki.admin.config.ConditionalOnAdminEnabled
+import com.depromeet.piki.common.logging.LoggingKeys
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.MDC
 import org.springframework.core.Ordered
 import org.springframework.core.annotation.Order
 import org.springframework.stereotype.Component
@@ -39,7 +41,18 @@ class AdminAccessFilter(
         if (AdminSession.boundIp(session) != ip) return deny(response)
         if (!allowlistService.isAllowed(ip)) return deny(response)
         allowlistService.refresh(ip) // sliding
-        filterChain.doFilter(request, response)
+        // 신원 확립 — 슬랙 actor(표시명)를 이 요청에 싣는다. MDC 는 요청 내내 떠 있어 도메인 로그에 "누가"가 찍히고,
+        // attribute 는 AccessLogFilter(바깥)가 access log 한 줄에 재주입한다(userId 와 동일 흐름). hasIdentity 가
+        // non-blank 를 보장하나 타입상 nullable 이라 Elvis 로 방어한다(여기 닿으면 사실상 non-null).
+        val actor = AdminSession.slackName(session) ?: return deny(response)
+        MDC.put(LoggingKeys.ADMIN_ACTOR, actor)
+        request.setAttribute(LoggingKeys.ADMIN_ACTOR, actor)
+        try {
+            filterChain.doFilter(request, response)
+        } finally {
+            // 이 요청 범위로만 MDC 를 빌렸다 돌려준다(스레드 재사용 시 누수 방지). attribute 는 같은 요청 객체라 자연 소멸.
+            MDC.remove(LoggingKeys.ADMIN_ACTOR)
+        }
     }
 
     // /admin 과 /admin/** 만 게이트. /admin-assets·/admin-access 는 다른 prefix 라 제외(공개 진입·정적).

--- a/src/main/kotlin/com/depromeet/piki/common/logging/LoggingKeys.kt
+++ b/src/main/kotlin/com/depromeet/piki/common/logging/LoggingKeys.kt
@@ -10,4 +10,11 @@ package com.depromeet.piki.common.logging
 // 식별자라 마스킹 없이 그대로 싣는다(역추적은 DB join 이라는 별도 권한 경계를 거친다).
 object LoggingKeys {
     const val USER_ID = "userId"
+
+    // /admin 백오피스 요청의 슬랙 actor(표시명). AdminAccessFilter 가 세션 신원에서 꺼내 요청 내내 MDC 에 얹어
+    // 도메인 로그에 찍히게 하고, request attribute 로도 심어 AccessLogFilter 가 access log 한 줄에 재주입한다
+    // (userId 와 같은 흐름 — JwtAuthenticationFilter↔AccessLogFilter). userId(UUID 가명 식별자)와 의미가 달라
+    // 슬롯을 재사용하지 않고 별도 키로 둔다. prod ECS JSON 은 MDC 를 필드로 자동 출력하므로 별도 설정 없이
+    // adminActor 필드로 뜬다(평문 콘솔 패턴엔 명시 안 함 — 비-admin 요청까지 빈 슬롯이 붙는 노이즈를 피한다).
+    const val ADMIN_ACTOR = "adminActor"
 }

--- a/src/main/kotlin/com/depromeet/piki/common/web/AccessLogFilter.kt
+++ b/src/main/kotlin/com/depromeet/piki/common/web/AccessLogFilter.kt
@@ -22,6 +22,8 @@ import org.springframework.web.filter.OncePerRequestFilter
 // userId: 이 필터 finally 시점엔 JwtAuthenticationFilter(더 안쪽)가 자기 finally 에서 MDC userId 를 이미 지운 뒤다.
 // 그래서 JwtAuthenticationFilter 가 함께 심어둔 request attribute 에서 읽어, 이 로그 한 줄 동안만 MDC 에 얹는다 —
 // 콘솔 패턴 [user=...]·ECS userId 필드가 access log 에도 도메인 로그와 똑같이 찍힌다.
+// adminActor(슬랙명)도 동일 패턴 — AdminAccessFilter(더 안쪽)가 자기 finally 에서 MDC 를 지우므로, 함께 심어둔
+// attribute 에서 읽어 이 access log 한 줄에 재주입한다. /admin 요청은 "누가" 가 access·도메인 로그 양쪽에 찍힌다.
 @Component
 @Order(Ordered.HIGHEST_PRECEDENCE + 3)
 class AccessLogFilter : OncePerRequestFilter() {
@@ -40,11 +42,13 @@ class AccessLogFilter : OncePerRequestFilter() {
         } finally {
             val latencyMs = (System.nanoTime() - startNanos) / 1_000_000
             (request.getAttribute(LoggingKeys.USER_ID) as? String)?.let { MDC.put(LoggingKeys.USER_ID, it) }
+            (request.getAttribute(LoggingKeys.ADMIN_ACTOR) as? String)?.let { MDC.put(LoggingKeys.ADMIN_ACTOR, it) }
             try {
                 log.info("{} {} -> {} ({}ms)", request.method, request.requestURI, response.status, latencyMs)
             } finally {
-                // 미인증 요청이면 위에서 put 을 안 했어도 remove 는 무해(no-op). 이 한 줄 로그 범위로만 MDC 를 빌렸다 돌려준다.
+                // 미인증·비-admin 요청이면 위에서 put 을 안 했어도 remove 는 무해(no-op). 이 한 줄 로그 범위로만 MDC 를 빌렸다 돌려준다.
                 MDC.remove(LoggingKeys.USER_ID)
+                MDC.remove(LoggingKeys.ADMIN_ACTOR)
             }
         }
     }

--- a/src/test/kotlin/com/depromeet/piki/common/web/AccessLogFilterTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/common/web/AccessLogFilterTest.kt
@@ -1,0 +1,63 @@
+package com.depromeet.piki.common.web
+
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
+import com.depromeet.piki.common.logging.LoggingKeys
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
+import org.springframework.mock.web.MockFilterChain
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+// AccessLogFilter 의 로깅 contract 단위 검증 — access log 한 줄에 actor(adminActor)·userId 가 요청 attribute 로부터
+// MDC 로 재주입되는지 본다. 통합 경로로는 표현이 어려운 별도 분류다: 공유 컨텍스트가 admin.local-bypass=true 라
+// /admin 게이트(actor 를 심는 AdminAccessFilter)가 우회되고, 그 AdminAllowlistService 는 내부 컴포넌트라 stub 으로
+// 게이트를 통과시킬 수도 없으며(모킹 금지), access log 의 MDC 는 HTTP 응답 필드가 아니라 단언할 표면이 없다.
+// 그래서 의존성 없는 이 필터를 직접 호출 + Logback ListAppender 로 로그 이벤트의 MDC 를 캡처해 검증한다(Spring·DB 없음).
+class AccessLogFilterTest {
+    private val filter = AccessLogFilter()
+    private val logger = LoggerFactory.getLogger(AccessLogFilter::class.java) as Logger
+    private val appender =
+        ListAppender<ILoggingEvent>().apply {
+            start()
+            logger.addAppender(this)
+        }
+
+    @AfterEach
+    fun tearDown() {
+        logger.detachAppender(appender)
+    }
+
+    @Test
+    fun `adminActor attribute 가 있으면 access log 의 MDC 에 슬랙명이 실린다`() {
+        val request = MockHttpServletRequest("GET", "/admin/metrics")
+        request.setAttribute(LoggingKeys.ADMIN_ACTOR, "theo")
+
+        filter.doFilter(request, MockHttpServletResponse(), MockFilterChain())
+
+        assertEquals("theo", appender.list.single().mdcPropertyMap[LoggingKeys.ADMIN_ACTOR])
+    }
+
+    @Test
+    fun `adminActor attribute 가 없으면 MDC 에 adminActor 가 없다`() {
+        val request = MockHttpServletRequest("GET", "/api/v1/users/me")
+
+        filter.doFilter(request, MockHttpServletResponse(), MockFilterChain())
+
+        assertNull(appender.list.single().mdcPropertyMap[LoggingKeys.ADMIN_ACTOR])
+    }
+
+    @Test
+    fun `userId attribute 도 같은 방식으로 access log MDC 에 실린다 (기존 contract 회귀 가드)`() {
+        val request = MockHttpServletRequest("GET", "/api/v1/users/me")
+        request.setAttribute(LoggingKeys.USER_ID, "11111111-2222-3333-4444-555555555555")
+
+        filter.doFilter(request, MockHttpServletResponse(), MockFilterChain())
+
+        assertEquals("11111111-2222-3333-4444-555555555555", appender.list.single().mdcPropertyMap[LoggingKeys.USER_ID])
+    }
+}


### PR DESCRIPTION
## Situation
- /admin 백오피스는 슬랙 grant 로 발급된 세션이 곧 신원이다. 누가 들어왔는지 정보가 세션 안에 있는데도 로그엔 안 남았다.
- prod 로그에서 `GET /admin/metrics -> 200` 을 봐도 누가 봤는지 알 수 없었다. admin 요청은 JWT userId 가 없어 access log 의 user 슬롯이 늘 비어 있었다.

## Task
- /admin 요청에 슬랙 사용자명을 실어, access log 와 그 요청 중 도메인 로그 양쪽에서 누가 접근했는지 추적 가능하게 한다.

## Action
- AdminAccessFilter 가 게이트 통과 후 세션의 슬랙 user_name 을 꺼내 MDC 와 request attribute 에 싣는다. MDC 는 요청 내내 떠 있어 도메인 로그에 찍히고, attribute 는 바깥 AccessLogFilter 가 access log 한 줄에 재주입한다. 기존 JWT userId 와 똑같은 흐름이라 새 메커니즘이 아니다.
- userId 슬롯을 재사용하지 않고 별도 키(adminActor)로 뒀다. userId 는 UUID 가명 식별자라, 거기에 슬랙명을 섞으면 userId 로 거는 grep 과 대시보드 쿼리의 의미가 깨진다.
- 평문 콘솔 패턴(application.yml)은 안 건드렸다. prod 는 ECS JSON 으로 MDC 를 필드로 자동 출력하므로 adminActor 가 자동 필드화된다. 콘솔 패턴에 박으면 비-admin 요청까지 빈 슬롯이 붙어 노이즈만 는다.
- 식별자는 user_name(표시명)을 쓴다. 슬랙이 함께 주는 user_id(불변 ID)도 세션에 있지만, 사람이 읽는 이름이 목적에 맞다. 한글 이름도 안 깨진다: 슬랙 본문을 UTF-8 로 디코딩(parseForm)해 세션에 정상 String 으로 저장돼 있고, 출력 charset 도 UTF-8(JDK 25 file.encoding 기본)이다.

## Result
- prod 로그에서 /admin 요청은 access 로그와 그 요청의 도메인 로그 양쪽에 adminActor=슬랙명 필드가 붙는다. Grafana, Loki 에서 누가 어떤 admin 페이지를 언제 봤는지 필터하고 검색할 수 있다.
- AccessLogFilter 는 전역 필터(모든 요청)지만, 추가 코드가 null-guard 라 비-admin 요청은 동작이 안 바뀐다(attribute 없으면 no-op).
- 검증 한계: actor 를 심는 AdminAccessFilter 경로는 자동 테스트가 없다. 공유 통합 컨텍스트가 admin.local-bypass=true 라 그 게이트가 우회되고, allowlist 서비스는 내부 컴포넌트라 모킹 금지 정책상 게이트 통과를 강제할 수 없다. 대신 소비측(access log 한 줄에 실리는지)을 필터 단위테스트로 덮었다.
- 후속: 표시명 대신 불변 user_id 까지 남기려면 adminActorId 필드를 더하면 된다. 이번엔 이름만 싣는다.

---
## 연관 이슈

- 
