### PR TITLE
refresh_token 회전 grace 도입으로 동시 갱신 자동 로그아웃 해결

### DIFF
--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/jwt/JwtProperties.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/jwt/JwtProperties.kt
@@ -23,6 +23,11 @@ data class JwtProperties(
     val accessTokenExpiry: Duration,
     @field:DurationMin(seconds = 1, message = "refreshTokenExpiry 는 1초 이상이어야 한다.")
     val refreshTokenExpiry: Duration,
+    // refresh 토큰 회전 직후, 이전 토큰을 이 시간 동안 멱등 유효 처리하는 grace 창 (reuse interval).
+    // Next.js App Router 등에서 한 페이지 진입에 동시 다발 요청이 같은 옛 토큰으로 refresh 를 호출할 때,
+    // 한쪽만 회전 성공하고 나머지가 401 로 튕겨 로그아웃되는 race 를 흡수한다. 창 밖 재사용은 그대로 탐지.
+    @field:DurationMin(seconds = 1, message = "refreshTokenGrace 는 1초 이상이어야 한다.")
+    val refreshTokenGrace: Duration,
 ) {
     companion object {
         // HS256 의 키 최소 길이 (RFC 7518 §3.2: key MUST be at least 256 bits = 32 bytes).

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/jwt/JwtProperties.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/jwt/JwtProperties.kt
@@ -2,6 +2,7 @@ package com.depromeet.piki.auth.infrastructure.jwt
 
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
+import org.hibernate.validator.constraints.time.DurationMax
 import org.hibernate.validator.constraints.time.DurationMin
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.validation.annotation.Validated
@@ -26,7 +27,10 @@ data class JwtProperties(
     // refresh 토큰 회전 직후, 이전 토큰을 이 시간 동안 멱등 유효 처리하는 grace 창 (reuse interval).
     // Next.js App Router 등에서 한 페이지 진입에 동시 다발 요청이 같은 옛 토큰으로 refresh 를 호출할 때,
     // 한쪽만 회전 성공하고 나머지가 401 로 튕겨 로그아웃되는 race 를 흡수한다. 창 밖 재사용은 그대로 탐지.
+    // 상·하한을 모두 강제한다. grace 는 재사용 탐지를 일시 완화하는 보안 동작이라, env 오설정으로 수분·수시간이
+    // 들어오면 탈취 토큰 재사용 허용 구간이 비정상적으로 길어진다. 동시 요청 버스트 흡수엔 수초면 충분하므로 60초 상한.
     @field:DurationMin(seconds = 1, message = "refreshTokenGrace 는 1초 이상이어야 한다.")
+    @field:DurationMax(seconds = 60, message = "refreshTokenGrace 는 60초 이하여야 한다 (재사용 허용 구간 과다 방지).")
     val refreshTokenGrace: Duration,
 ) {
     companion object {

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/redis/RedisRefreshTokenStore.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/redis/RedisRefreshTokenStore.kt
@@ -21,68 +21,103 @@ class RedisRefreshTokenStore(
     ) {
         redisTemplate
             .opsForValue()
-            .set(key(userId), refreshToken, jwtProperties.refreshTokenExpiry.toMillis(), TimeUnit.MILLISECONDS)
+            .set(currentKey(userId), refreshToken, jwtProperties.refreshTokenExpiry.toMillis(), TimeUnit.MILLISECONDS)
     }
 
-    override fun get(userId: UUID): String? = redisTemplate.opsForValue().get(key(userId))
+    override fun get(userId: UUID): String? = redisTemplate.opsForValue().get(currentKey(userId))
 
     override fun delete(userId: UUID) {
-        redisTemplate.delete(key(userId))
+        redisTemplate.delete(listOf(currentKey(userId), graceKey(userId)))
     }
 
-    override fun consumeIfMatches(
+    override fun rotateOrReplay(
         userId: UUID,
-        token: String,
-    ): Boolean {
+        presented: String,
+        candidateRefreshToken: String,
+    ): RefreshOutcome {
         val result =
             redisTemplate.execute(
-                CONSUME_SCRIPT,
-                listOf(key(userId)),
-                token,
-            )
-        // Lua script 반환값 의미:
-        //   1 = 정상 매치 + DEL (다음 R 발급으로 이어짐)
-        //   0 = 키 없음 (이미 소비됐거나 TTL 만료 — 거부)
-        //  -1 = mismatch (재사용 시도) → 살아있던 R 도 같이 DEL (family invalidation). 도난 의심
-        // 0 과 -1 모두 호출자 입장에선 거부 (false) 지만, -1 시점만 도난 감지로 로깅한다.
-        // 향후 사용자 알림 hook 의 사전 단계.
-        if (result == -1L) {
-            // warn 레벨: 시스템 fail 아닌 보안 의심 이벤트. info 보다 가시성 ↑, error 는
-            // alert fatigue 위험 + 시스템 정상이라 의미 안 맞음. PIKI 로그 레벨 정책의
-            // "정상 흐름 아닌 의심 이벤트" 범주.
-            logger.warn("refresh token reuse detected — family invalidated. userId={}", userId)
+                REFRESH_SCRIPT,
+                listOf(currentKey(userId), graceKey(userId)),
+                presented,
+                candidateRefreshToken,
+                jwtProperties.refreshTokenExpiry.toMillis().toString(),
+                jwtProperties.refreshTokenGrace.toMillis().toString(),
+            ) ?: error("refresh Lua script 가 null 을 반환했다 (userId=$userId)")
+
+        // Lua 반환 코드 → 도메인 결과. "P:" 는 grace replay 로 돌려줄 토큰을 접두사 뒤에 싣는다.
+        return when {
+            result == ROTATED -> RefreshOutcome.Rotated
+            result.startsWith(REPLAY_PREFIX) -> RefreshOutcome.Replayed(result.removePrefix(REPLAY_PREFIX))
+            result == EXPIRED -> RefreshOutcome.Expired
+            result == REUSE -> {
+                // warn 레벨: 시스템 fail 아닌 보안 의심 이벤트. info 보다 가시성 ↑, error 는 alert fatigue 위험 +
+                // 시스템 정상이라 의미 안 맞음. PIKI 로그 레벨 정책의 "정상 흐름 아닌 의심 이벤트" 범주.
+                logger.warn("refresh token reuse detected — family invalidated. userId={}", userId)
+                RefreshOutcome.ReuseDetected
+            }
+            else -> error("refresh Lua script 가 예상 못한 값을 반환했다: $result (userId=$userId)")
         }
-        return result == 1L
     }
 
     // 1 유저당 1 refresh token 만 저장하는 설계. 같은 계정 다중 디바이스 로그인 시
     // 나중 로그인이 이전 토큰을 덮어쓰므로 이전 디바이스는 다음 refresh 시점에 강제 로그아웃된다.
     // 다중 디바이스 동시 로그인을 허용하려면 key 에 디바이스 식별자(jti / deviceId)를 추가한다.
-    private fun key(userId: UUID) = "$KEY_PREFIX$userId"
+    private fun currentKey(userId: UUID) = "$KEY_PREFIX$userId"
+
+    // 회전 직후 "옛 토큰|새 토큰" 매핑을 grace TTL 동안 보관 — 동시 요청의 멱등 replay 근거.
+    private fun graceKey(userId: UUID) = "$GRACE_PREFIX$userId"
 
     companion object {
         private const val KEY_PREFIX = "refresh:"
+        private const val GRACE_PREFIX = "refresh:grace:"
 
-        // OAuth 2.0 RFC 6819 / 8252 의 "Refresh Token Rotation + Family Invalidation" 패턴.
-        // 단순 거부에 그치면 공격자가 최신 R 을 먼저 써서 회전시킨 뒤 정상 사용자만 튕기는
-        // 경로가 살아남는다. mismatch (= 재사용 시도) 감지 시 살아있던 R 도 같이 삭제해
-        // 공격자·정상 사용자 모두 끊고 재로그인을 강제한다.
-        // 반환값: 1 = 정상 매치 + DEL, 0 = 키 없음 (이미 소비/만료), -1 = mismatch → family invalidation
-        private val CONSUME_SCRIPT =
-            DefaultRedisScript<Long>().apply {
+        private const val ROTATED = "R"
+        private const val EXPIRED = "0"
+        private const val REUSE = "-1"
+        private const val REPLAY_PREFIX = "P:"
+
+        // OAuth 2.0 RFC 6819 / 8252 의 "Refresh Token Rotation + Family Invalidation" + Auth0 식 reuse interval.
+        //
+        // 토큰 생성은 앱(JwtProvider)이 하므로 "consume → generate → save" 가 본래 다단계라 동시 요청에 race 가 난다.
+        // 그래서 호출자가 candidate(ARGV[2]) 를 미리 만들어 넘기고, 이 스크립트가 회전·grace·replay·무효화 판정을
+        // 통째로 원자 수행한다. Redis 싱글스레드 직렬화 덕에 동시 N개 중 먼저 든 쪽이 회전 승자가 되고 grace 를
+        // 쓰며, 나머지는 같은 스크립트 안에서 승자 토큰을 replay 로 돌려받아 모두 같은 새 토큰으로 수렴한다.
+        //
+        // KEYS[1]=current, KEYS[2]=grace
+        // ARGV[1]=presented(제시 토큰), ARGV[2]=candidate(새 토큰), ARGV[3]=현재토큰 TTL(ms), ARGV[4]=grace TTL(ms)
+        //
+        // grace 값 포맷 "<old>|<new>": JWT 는 base64url(`[A-Za-z0-9_-]`)·점(.)뿐이라 '|' 와 충돌하지 않는다.
+        //
+        // 반환:
+        //   "R"        현재 토큰과 일치 → 회전 (current=candidate, grace="presented|candidate")
+        //   "P:<tok>"  grace 의 old 가 presented 와 일치 → 멱등 replay (이미 발급된 new 를 반환). 회전·무효화 없음
+        //   "0"        현재 토큰 없음 + grace 도 없음 → 만료/이미 소비 → 거부
+        //   "-1"       현재 토큰은 있으나 불일치 + grace 밖 → 재사용 의심 → current·grace 둘 다 DEL (family invalidation)
+        private val REFRESH_SCRIPT =
+            DefaultRedisScript<String>().apply {
                 setScriptText(
                     """
-                    local stored = redis.call('GET', KEYS[1])
-                    if stored == false then return 0 end
-                    if stored ~= ARGV[1] then
-                        redis.call('DEL', KEYS[1])
-                        return -1
+                    local cur = redis.call('GET', KEYS[1])
+                    if cur == ARGV[1] then
+                        redis.call('SET', KEYS[1], ARGV[2], 'PX', ARGV[3])
+                        redis.call('SET', KEYS[2], ARGV[1] .. '|' .. ARGV[2], 'PX', ARGV[4])
+                        return 'R'
                     end
+                    local g = redis.call('GET', KEYS[2])
+                    if g ~= false then
+                        local sep = string.find(g, '|', 1, true)
+                        if sep ~= nil and string.sub(g, 1, sep - 1) == ARGV[1] then
+                            return 'P:' .. string.sub(g, sep + 1)
+                        end
+                    end
+                    if cur == false then return '0' end
                     redis.call('DEL', KEYS[1])
-                    return 1
+                    redis.call('DEL', KEYS[2])
+                    return '-1'
                     """.trimIndent(),
                 )
-                setResultType(Long::class.java)
+                setResultType(String::class.java)
             }
     }
 }

--- a/src/main/kotlin/com/depromeet/piki/auth/infrastructure/redis/RefreshTokenStore.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/infrastructure/redis/RefreshTokenStore.kt
@@ -10,12 +10,36 @@ interface RefreshTokenStore {
 
     fun get(userId: UUID): String?
 
+    // 현재 토큰과 grace 레코드를 함께 지운다 (로그아웃은 grace 창 안의 멱등 replay 도 즉시 끊어야 한다).
     fun delete(userId: UUID)
 
-    // 저장된 토큰과 일치하면 삭제 후 true, 불일치 또는 없으면 false 반환.
-    // GET + 비교 + DEL 을 Lua 스크립트로 원자적으로 수행해 TOCTOU 경쟁 조건을 차단한다.
-    fun consumeIfMatches(
+    // refresh 토큰 회전의 단일 진입점. "GET 현재토큰 → 회전 / grace replay / 거부 / 재사용 무효화" 판정을
+    // 하나의 원자 연산(Redis Lua)으로 수행해 동시 요청 race 를 원천 차단한다.
+    //
+    // - presented: 클라이언트가 제시한 refresh 토큰
+    // - candidateRefreshToken: 호출자가 미리 발급해 둔 새 refresh 토큰 (generate-first). 회전 시 이 값이
+    //   새 현재 토큰이 되고, replay 로 끝나면 버려진다 (jti 랜덤이라 충돌 없음).
+    //
+    // 반환은 sealed RefreshOutcome — 호출자는 when(is) 로 분기한다.
+    fun rotateOrReplay(
         userId: UUID,
-        token: String,
-    ): Boolean
+        presented: String,
+        candidateRefreshToken: String,
+    ): RefreshOutcome
+}
+
+sealed interface RefreshOutcome {
+    // 제시 토큰이 현재 토큰과 일치 → 회전 완료. 호출자가 넘긴 candidate 가 새 현재 토큰이 됐다.
+    data object Rotated : RefreshOutcome
+
+    // grace 창 안에 같은 옛 토큰으로 다시 들어온 동시 요청 → 이미 발급된 토큰을 멱등 반환 (회전·무효화 없음).
+    data class Replayed(
+        val refreshToken: String,
+    ) : RefreshOutcome
+
+    // 저장된 토큰이 없음 (이미 소비됐거나 TTL 만료) → 거부.
+    data object Expired : RefreshOutcome
+
+    // 회전 후·grace 밖에서 옛 토큰 재사용 감지 → family invalidation 수행됨, 거부 (도난 의심).
+    data object ReuseDetected : RefreshOutcome
 }

--- a/src/main/kotlin/com/depromeet/piki/auth/service/AuthService.kt
+++ b/src/main/kotlin/com/depromeet/piki/auth/service/AuthService.kt
@@ -2,6 +2,7 @@ package com.depromeet.piki.auth.service
 
 import com.depromeet.piki.auth.exception.AuthException
 import com.depromeet.piki.auth.infrastructure.jwt.JwtProvider
+import com.depromeet.piki.auth.infrastructure.redis.RefreshOutcome
 import com.depromeet.piki.auth.infrastructure.redis.RefreshTokenStore
 import com.depromeet.piki.auth.service.dto.SignupResult
 import com.depromeet.piki.auth.service.dto.TokenPair
@@ -48,6 +49,9 @@ class AuthService(
     // 갱신 거부는 모두 클라이언트 계약 위반(만료·위조·재사용 토큰)이라 info 로 사유를 구분해 남긴다 —
     // prod 401 디버깅의 핵심: "왜 거부됐나"(파싱 실패/탈퇴/저장 토큰 불일치)를 traceId·userId 와 함께 본다.
     // refresh 토큰 원문은 크리덴셜이라 지문(maskToken)으로만 찍는다.
+    //
+    // generate-first: 후보 토큰쌍을 먼저 만들어 store 에 넘긴다. store 가 회전을 원자 수행하므로,
+    // 동시 요청은 한쪽만 회전하고 나머지는 grace replay 로 같은 토큰으로 수렴한다 (회전 race → 로그아웃 차단).
     fun refresh(refreshToken: String): TokenPair {
         val userId =
             jwtProvider.parseRefreshToken(refreshToken) ?: run {
@@ -59,12 +63,28 @@ class AuthService(
             log.info("토큰 갱신 거부 사유=탈퇴 유저 userId={}", userId)
             throw AuthException.invalidToken()
         }
-        if (!refreshTokenStore.consumeIfMatches(userId, refreshToken)) {
-            log.info("토큰 갱신 거부 사유=저장된 refresh 토큰 불일치(재사용·회전 후) userId={}", userId)
-            throw AuthException.invalidToken()
+
+        val candidateAccess = jwtProvider.generateAccessToken(user.id, user.identityType)
+        val candidateRefresh = jwtProvider.generateRefreshToken(user.id)
+        return when (val outcome = refreshTokenStore.rotateOrReplay(userId, refreshToken, candidateRefresh)) {
+            is RefreshOutcome.Rotated -> {
+                log.info("토큰 갱신 성공 userId={}", userId)
+                TokenPair(accessToken = candidateAccess, refreshToken = candidateRefresh)
+            }
+            is RefreshOutcome.Replayed -> {
+                log.info("토큰 갱신 동시 요청 grace replay userId={}", userId)
+                TokenPair(accessToken = candidateAccess, refreshToken = outcome.refreshToken)
+            }
+            is RefreshOutcome.Expired -> {
+                log.info("토큰 갱신 거부 사유=저장된 refresh 토큰 없음(만료·이미 소비) userId={}", userId)
+                throw AuthException.invalidToken()
+            }
+            is RefreshOutcome.ReuseDetected -> {
+                // store 가 이미 warn(family invalidated) 로 도난 의심을 남겼다. 여기선 거부 사유만 info 로.
+                log.info("토큰 갱신 거부 사유=refresh 토큰 재사용 감지(회전 후·grace 밖) userId={}", userId)
+                throw AuthException.invalidToken()
+            }
         }
-        log.info("토큰 갱신 성공 userId={}", userId)
-        return issueTokenPair(user)
     }
 
     fun logout(userId: UUID) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -71,6 +71,8 @@ jwt:
   # Spring 의 Duration 파싱은 1h / 14d / 30m / PT1H30M 등 다양한 형식 지원.
   access-token-expiry: ${JWT_ACCESS_EXPIRY:15m}
   refresh-token-expiry: ${JWT_REFRESH_EXPIRY:14d}
+  # refresh 회전 후 이전 토큰을 멱등 유효 처리하는 grace 창 (Auth0 reuse_interval 권장치와 동일).
+  refresh-token-grace: ${JWT_REFRESH_GRACE:10s}
 
 auth:
   cookie:

--- a/src/test/kotlin/com/depromeet/piki/auth/controller/AuthTokenStateIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/controller/AuthTokenStateIntegrationTest.kt
@@ -3,6 +3,7 @@ package com.depromeet.piki.auth.controller
 import com.depromeet.piki.auth.infrastructure.jwt.JwtProvider
 import com.depromeet.piki.auth.infrastructure.redis.RefreshTokenStore
 import com.depromeet.piki.support.IntegrationTestSupport
+import com.depromeet.piki.support.StubRefreshTokenStore
 import com.depromeet.piki.support.uuidToBytes
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -18,6 +19,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.web.context.WebApplicationContext
 import tools.jackson.databind.ObjectMapper
 import java.util.UUID
+import kotlin.test.assertEquals
 
 class AuthTokenStateIntegrationTest : IntegrationTestSupport() {
     @Autowired
@@ -31,6 +33,10 @@ class AuthTokenStateIntegrationTest : IntegrationTestSupport() {
 
     @Autowired
     private lateinit var refreshTokenStore: RefreshTokenStore
+
+    // grace TTL 경과를 시뮬레이션하기 위해 stub 의 expireGrace 를 호출한다 (실제 Redis 는 키 TTL 만료가 함).
+    @Autowired
+    private lateinit var stubRefreshTokenStore: StubRefreshTokenStore
 
     @Autowired
     private lateinit var jdbcTemplate: JdbcTemplate
@@ -93,10 +99,9 @@ class AuthTokenStateIntegrationTest : IntegrationTestSupport() {
     }
 
     @Test
-    fun `POST auth token refresh - 재사용된 옛 refreshToken 으로 시도하면 401 + 살아있던 R2 도 무효화 (family invalidation)`() {
-        // OAuth 2.0 RFC 6819 / 8252 의 family invalidation 패턴 검증:
-        // R1 으로 회전해서 R2 가 살아있는 상태에서 R1 을 다시 쓰면 (= 도난 의심) 양쪽 다 끊는다.
-        // 공격자가 옛 R1 을 들고 와도, 정상 사용자가 옛 R1 을 실수로 재시도해도 동일하게 처리된다.
+    fun `POST auth token refresh - grace 창 안에 옛 refreshToken 을 다시 쓰면 200 + 같은 새 토큰을 멱등 반환한다`() {
+        // 동시 다발 refresh race 의 핵심 계약: R1 회전 직후 grace 창 안에 같은 R1 이 다시 들어오면
+        // 401 로 튕기지 않고(=로그아웃 안 됨) 이미 발급된 R2 를 그대로 멱등 반환한다.
         val mockMvc = mockMvc()
         val (accessToken, r1) = createGuest()
         val userId = jwtProvider.parseAccessToken(accessToken)?.userId ?: error("accessToken 파싱 실패")
@@ -119,41 +124,48 @@ class AuthTokenStateIntegrationTest : IntegrationTestSupport() {
                     ).at("/data/refreshToken")
                     .asText()
 
-            // R1 재사용 시도 → 401 + family invalidation 트리거 (살아있던 R2 도 같이 DEL)
-            mockMvc
-                .perform(
-                    post("/api/v1/auth/token/refresh")
-                        .header("X-Client-Type", "app")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(r1Body),
-                ).andExpect(status().isUnauthorized)
+            // grace 창 안 R1 재사용 → 200 + 같은 R2 (멱등 replay). 회전·무효화 없음.
+            val replayedR2 =
+                objectMapper
+                    .readTree(
+                        mockMvc
+                            .perform(
+                                post("/api/v1/auth/token/refresh")
+                                    .header("X-Client-Type", "app")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(r1Body),
+                            ).andExpect(status().isOk)
+                            .andReturn()
+                            .response
+                            .contentAsString,
+                    ).at("/data/refreshToken")
+                    .asText()
+            assertEquals(r2, replayedR2)
 
-            // R2 도 무효화됐는지 확인 — 정상 흐름이면 200 이어야 하지만 family invalidation 으로 401
+            // R2 는 여전히 살아있어 다음 회전에 쓸 수 있다 (family invalidation 안 됨).
             mockMvc
                 .perform(
                     post("/api/v1/auth/token/refresh")
                         .header("X-Client-Type", "app")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(mapOf("refreshToken" to r2))),
-                ).andExpect(status().isUnauthorized)
+                ).andExpect(status().isOk)
         } finally {
             cleanup(userId)
         }
     }
 
     @Test
-    fun `POST auth token refresh - 공격자가 먼저 R1 으로 R2 를 받은 뒤 정상 사용자가 R1 을 시도해도 양쪽 다 무효화된다`() {
-        // 경우 2 시뮬레이션: 공격자가 R1 으로 R2 를 받아 가버리면 정상 사용자가 R1 을 들고와도
-        // family invalidation 이 트리거돼 공격자가 받아간 R2 까지 함께 죽는다.
+    fun `POST auth token refresh - grace 밖에서 옛 refreshToken 을 재사용하면 401 + 살아있던 토큰도 무효화된다`() {
+        // OAuth 2.0 RFC 6819 / 8252 의 family invalidation: grace 창이 지난 뒤 옛 R1 을 다시 쓰면
+        // (= 도난 의심) 양쪽 다 끊는다. grace TTL 경과는 stub.expireGrace 로 시뮬레이션한다.
         val mockMvc = mockMvc()
         val (accessToken, r1) = createGuest()
         val userId = jwtProvider.parseAccessToken(accessToken)?.userId ?: error("accessToken 파싱 실패")
 
         try {
             val r1Body = objectMapper.writeValueAsString(mapOf("refreshToken" to r1))
-
-            // 공격자: R1 으로 R2 를 받아간다.
-            val attackerR2 =
+            val r2 =
                 objectMapper
                     .readTree(
                         mockMvc
@@ -169,7 +181,10 @@ class AuthTokenStateIntegrationTest : IntegrationTestSupport() {
                     ).at("/data/refreshToken")
                     .asText()
 
-            // 정상 사용자: 자기 R1 으로 시도 → 401 + 공격자의 R2 도 무효화
+            // grace 창 만료
+            stubRefreshTokenStore.expireGrace(userId)
+
+            // grace 밖 R1 재사용 → 401 + family invalidation (살아있던 R2 도 같이 DEL)
             mockMvc
                 .perform(
                     post("/api/v1/auth/token/refresh")
@@ -178,13 +193,13 @@ class AuthTokenStateIntegrationTest : IntegrationTestSupport() {
                         .content(r1Body),
                 ).andExpect(status().isUnauthorized)
 
-            // 공격자도 끊긴다
+            // R2 도 무효화됐다 — 정상 흐름이면 200 이어야 하지만 family invalidation 으로 401
             mockMvc
                 .perform(
                     post("/api/v1/auth/token/refresh")
                         .header("X-Client-Type", "app")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(mapOf("refreshToken" to attackerR2))),
+                        .content(objectMapper.writeValueAsString(mapOf("refreshToken" to r2))),
                 ).andExpect(status().isUnauthorized)
         } finally {
             cleanup(userId)

--- a/src/test/kotlin/com/depromeet/piki/auth/controller/RefreshTokenRotationConcurrencyIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/controller/RefreshTokenRotationConcurrencyIntegrationTest.kt
@@ -65,34 +65,40 @@ class RefreshTokenRotationConcurrencyIntegrationTest : IntegrationTestSupport() 
             // 2 단계 래치로 동시 출발 강제 — 한 단계 래치만 쓰면 worker 가 await 도달 전에
             // main 이 countDown 할 수 있어 사실상 순차 실행이 돼 race 재현 신뢰도가 떨어진다.
             val executor = Executors.newFixedThreadPool(2)
-            val workersReady = CountDownLatch(2)
-            val start = CountDownLatch(1)
-            val futures =
-                (0..1).map {
-                    executor.submit<Pair<Int, String>> {
-                        workersReady.countDown()
-                        start.await()
-                        val response =
-                            mockMvc
-                                .perform(
-                                    post("/api/v1/auth/token/refresh")
-                                        .header("X-Client-Type", "app")
-                                        .contentType(MediaType.APPLICATION_JSON)
-                                        .content(body),
-                                ).andReturn()
-                                .response
-                        val refreshed =
-                            response.contentAsString
-                                .takeIf { it.isNotBlank() }
-                                ?.let { objectMapper.readTree(it).at("/data/refreshToken").asText() }
-                                .orEmpty()
-                        response.status to refreshed
-                    }
+            val results =
+                try {
+                    val workersReady = CountDownLatch(2)
+                    val start = CountDownLatch(1)
+                    val futures =
+                        (0..1).map {
+                            executor.submit<Pair<Int, String>> {
+                                workersReady.countDown()
+                                start.await()
+                                val response =
+                                    mockMvc
+                                        .perform(
+                                            post("/api/v1/auth/token/refresh")
+                                                .header("X-Client-Type", "app")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .content(body),
+                                        ).andReturn()
+                                        .response
+                                val refreshed =
+                                    response.contentAsString
+                                        .takeIf { it.isNotBlank() }
+                                        ?.let { objectMapper.readTree(it).at("/data/refreshToken").asText() }
+                                        .orEmpty()
+                                response.status to refreshed
+                            }
+                        }
+                    // await 에 타임아웃을 둬 worker 가 안 뜨면 무기한 대기하지 않게 한다.
+                    assertTrue(workersReady.await(5, TimeUnit.SECONDS), "worker 준비 대기 timeout")
+                    start.countDown()
+                    futures.map { it.get(10, TimeUnit.SECONDS) }
+                } finally {
+                    // 예외·타임아웃에도 스레드풀이 반드시 정리되게 한다 (CI hang·스레드 누수 방지).
+                    executor.shutdownNow()
                 }
-            workersReady.await()
-            start.countDown()
-            val results = futures.map { it.get(10, TimeUnit.SECONDS) }
-            executor.shutdown()
 
             // 두 요청 모두 200 (401·로그아웃 없음)
             assertEquals(setOf(200), results.map { it.first }.toSet())

--- a/src/test/kotlin/com/depromeet/piki/auth/controller/RefreshTokenRotationConcurrencyIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/controller/RefreshTokenRotationConcurrencyIntegrationTest.kt
@@ -18,10 +18,15 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
 
 // 일반 통합 테스트와 달리 @Transactional 을 사용하지 않는다 — 별도 트랜잭션 동시 진행이
 // race 시뮬레이션의 본질이다. 데이터 격리는 매 테스트가 새 게스트 생성으로 보장한다.
-class RefreshTokenFamilyInvalidationConcurrencyIntegrationTest : IntegrationTestSupport() {
+//
+// refresh 회전의 동시성 계약: 같은 옛 토큰으로 동시에 들어온 요청은 한쪽만 회전하고 나머지는 grace
+// replay 로 "같은 새 토큰"에 수렴해야 한다. 과거엔 한쪽 401 + family invalidation 으로 로그아웃됐다(#race).
+class RefreshTokenRotationConcurrencyIntegrationTest : IntegrationTestSupport() {
     @Autowired
     private lateinit var webApplicationContext: WebApplicationContext
 
@@ -38,7 +43,7 @@ class RefreshTokenFamilyInvalidationConcurrencyIntegrationTest : IntegrationTest
     private lateinit var jdbcTemplate: JdbcTemplate
 
     @Test
-    fun `같은 refreshToken 으로 두 요청이 동시에 들어오면 한 쪽 200, 다른 쪽 401 로 family invalidation 트리거된다`() {
+    fun `같은 refreshToken 으로 동시 요청이 들어오면 모두 200 + 같은 새 토큰으로 수렴한다`() {
         val mockMvc =
             MockMvcBuilders
                 .webAppContextSetup(webApplicationContext)
@@ -64,27 +69,39 @@ class RefreshTokenFamilyInvalidationConcurrencyIntegrationTest : IntegrationTest
             val start = CountDownLatch(1)
             val futures =
                 (0..1).map {
-                    executor.submit<Int> {
+                    executor.submit<Pair<Int, String>> {
                         workersReady.countDown()
                         start.await()
-                        mockMvc
-                            .perform(
-                                post("/api/v1/auth/token/refresh")
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .content(body),
-                            ).andReturn()
-                            .response.status
+                        val response =
+                            mockMvc
+                                .perform(
+                                    post("/api/v1/auth/token/refresh")
+                                        .header("X-Client-Type", "app")
+                                        .contentType(MediaType.APPLICATION_JSON)
+                                        .content(body),
+                                ).andReturn()
+                                .response
+                        val refreshed =
+                            response.contentAsString
+                                .takeIf { it.isNotBlank() }
+                                ?.let { objectMapper.readTree(it).at("/data/refreshToken").asText() }
+                                .orEmpty()
+                        response.status to refreshed
                     }
                 }
             workersReady.await()
             start.countDown()
-            val statuses = futures.map { it.get(10, TimeUnit.SECONDS) }.toSet()
+            val results = futures.map { it.get(10, TimeUnit.SECONDS) }
             executor.shutdown()
 
-            // 한 쪽이 R1 매치 통과 + R2 발급 (200), 다른 쪽은 mismatch 로 family invalidation
-            // 트리거 (401). 정상 사용자라면 두 요청이 동시에 가지 않으므로 production 에선
-            // race 영향이 거의 없다.
-            assertEquals(setOf(200, 401), statuses)
+            // 두 요청 모두 200 (401·로그아웃 없음)
+            assertEquals(setOf(200), results.map { it.first }.toSet())
+            // 발급된 refresh 토큰이 동일 토큰으로 수렴 (한쪽 회전, 나머지 grace replay)
+            val refreshed = results.map { it.second }.toSet()
+            assertEquals(1, refreshed.size, "동시 요청이 서로 다른 토큰을 받으면 수렴 실패: $refreshed")
+            // 회전이 실제로 일어나 옛 토큰과는 다르다
+            assertNotEquals(r1, refreshed.first())
+            assertTrue(refreshed.first().isNotBlank())
         } finally {
             refreshTokenStore.delete(userId)
             jdbcTemplate.update("DELETE FROM users WHERE id = ?", uuidToBytes(userId))

--- a/src/test/kotlin/com/depromeet/piki/auth/filter/JwtAuthenticationFilterTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/filter/JwtAuthenticationFilterTest.kt
@@ -24,6 +24,7 @@ class JwtAuthenticationFilterTest {
                 secret = TEST_SECRET,
                 accessTokenExpiry = Duration.ofHours(1),
                 refreshTokenExpiry = Duration.ofDays(14),
+                refreshTokenGrace = Duration.ofSeconds(10),
             ),
         )
     private val withdrawnTokenStore = StubWithdrawnTokenStore()
@@ -118,6 +119,7 @@ class JwtAuthenticationFilterTest {
                     secret = OTHER_SECRET,
                     accessTokenExpiry = Duration.ofHours(1),
                     refreshTokenExpiry = Duration.ofDays(14),
+                refreshTokenGrace = Duration.ofSeconds(10),
                 ),
             )
         val token = otherProvider.generateAccessToken(UUID.randomUUID(), IdentityType.GUEST)

--- a/src/test/kotlin/com/depromeet/piki/auth/infrastructure/jwt/JwtProviderTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/infrastructure/jwt/JwtProviderTest.kt
@@ -14,6 +14,7 @@ class JwtProviderTest {
             secret = TEST_SECRET,
             accessTokenExpiry = Duration.ofHours(1),
             refreshTokenExpiry = Duration.ofDays(14),
+            refreshTokenGrace = Duration.ofSeconds(10),
         )
     private val jwtProvider = JwtProvider(properties)
 
@@ -58,6 +59,7 @@ class JwtProviderTest {
                     secret = TEST_SECRET,
                     accessTokenExpiry = Duration.ofSeconds(-1),
                     refreshTokenExpiry = Duration.ofSeconds(-1),
+                    refreshTokenGrace = Duration.ofSeconds(10),
                 ),
             )
         val token = expiredProvider.generateAccessToken(UUID.randomUUID(), IdentityType.GUEST)
@@ -82,6 +84,7 @@ class JwtProviderTest {
                     secret = "other-secret-key-must-be-at-least-32-chars!",
                     accessTokenExpiry = Duration.ofHours(1),
                     refreshTokenExpiry = Duration.ofDays(14),
+            refreshTokenGrace = Duration.ofSeconds(10),
                 ),
             )
         val token = otherProvider.generateAccessToken(UUID.randomUUID(), IdentityType.GUEST)

--- a/src/test/kotlin/com/depromeet/piki/auth/infrastructure/redis/RedisRefreshTokenStoreIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/infrastructure/redis/RedisRefreshTokenStoreIntegrationTest.kt
@@ -4,8 +4,12 @@ import com.depromeet.piki.support.IntegrationTestSupport
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.redis.core.StringRedisTemplate
 import java.util.UUID
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
@@ -62,5 +66,111 @@ class RedisRefreshTokenStoreIntegrationTest : IntegrationTestSupport() {
         assertNotNull(redisTemplate.opsForValue().get("refresh:$userId"))
 
         store.delete(userId)
+    }
+
+    @Test
+    fun `rotateOrReplay - 현재 토큰과 일치하면 Rotated 이고 새 토큰으로 회전된다`() {
+        val userId = UUID.randomUUID()
+        store.save(userId, "A")
+
+        val outcome = store.rotateOrReplay(userId, presented = "A", candidateRefreshToken = "B")
+
+        assertIs<RefreshOutcome.Rotated>(outcome)
+        assertEquals("B", store.get(userId))
+
+        store.delete(userId)
+    }
+
+    @Test
+    fun `rotateOrReplay - grace 창 안에 옛 토큰으로 다시 오면 Replayed 로 같은 새 토큰을 반환한다`() {
+        val userId = UUID.randomUUID()
+        store.save(userId, "A")
+        store.rotateOrReplay(userId, presented = "A", candidateRefreshToken = "B") // 회전: current=B, grace=A|B
+
+        // 옛 토큰 A 로 동시 재요청 — candidate C 는 버려지고 승자 토큰 B 가 멱등 반환돼야 한다
+        val outcome = store.rotateOrReplay(userId, presented = "A", candidateRefreshToken = "C")
+
+        assertIs<RefreshOutcome.Replayed>(outcome)
+        assertEquals("B", outcome.refreshToken)
+        assertEquals("B", store.get(userId)) // current 는 그대로 B (재회전 없음)
+
+        store.delete(userId)
+    }
+
+    @Test
+    fun `rotateOrReplay - 저장된 토큰이 없으면 Expired 이다`() {
+        val outcome = store.rotateOrReplay(UUID.randomUUID(), presented = "A", candidateRefreshToken = "B")
+
+        assertIs<RefreshOutcome.Expired>(outcome)
+    }
+
+    @Test
+    fun `rotateOrReplay - grace 밖에서 옛 토큰을 재사용하면 ReuseDetected 이고 current 가 무효화된다`() {
+        val userId = UUID.randomUUID()
+        store.save(userId, "A")
+        store.rotateOrReplay(userId, presented = "A", candidateRefreshToken = "B") // current=B, grace=A|B
+
+        // grace TTL 경과 시뮬레이션 — grace 키만 제거 (실시간 10초 대기 회피)
+        redisTemplate.delete("refresh:grace:$userId")
+
+        val outcome = store.rotateOrReplay(userId, presented = "A", candidateRefreshToken = "C")
+
+        assertIs<RefreshOutcome.ReuseDetected>(outcome)
+        assertNull(store.get(userId)) // family invalidation: 살아있던 current(B) 도 삭제
+
+        store.delete(userId)
+    }
+
+    @Test
+    fun `delete 는 grace 키도 함께 지운다`() {
+        val userId = UUID.randomUUID()
+        store.save(userId, "A")
+        store.rotateOrReplay(userId, presented = "A", candidateRefreshToken = "B") // grace=A|B 기록됨
+
+        store.delete(userId)
+
+        assertNull(redisTemplate.opsForValue().get("refresh:grace:$userId"))
+    }
+
+    @Test
+    fun `rotateOrReplay - 같은 옛 토큰 동시 요청은 한 번만 회전하고 모두 같은 새 토큰으로 수렴한다`() {
+        val userId = UUID.randomUUID()
+        store.save(userId, "A")
+
+        val threads = 8
+        val executor = Executors.newFixedThreadPool(threads)
+        val ready = CountDownLatch(threads)
+        val start = CountDownLatch(1)
+        try {
+            val futures =
+                (0 until threads).map { i ->
+                    executor.submit<RefreshOutcome> {
+                        ready.countDown()
+                        start.await()
+                        // 각 스레드가 서로 다른 candidate 를 제시 — 승자의 것만 채택돼야 한다
+                        store.rotateOrReplay(userId, presented = "A", candidateRefreshToken = "cand-$i")
+                    }
+                }
+            ready.await()
+            start.countDown()
+            val outcomes = futures.map { it.get(10, TimeUnit.SECONDS) }
+            executor.shutdown()
+
+            // 정확히 하나만 Rotated, 나머지는 Replayed
+            assertEquals(1, outcomes.count { it is RefreshOutcome.Rotated })
+            assertEquals(threads - 1, outcomes.count { it is RefreshOutcome.Replayed })
+
+            // 모든 요청이 인지한 "새 토큰"이 저장된 current 와 동일하게 수렴
+            val winner = store.get(userId)
+            assertNotNull(winner)
+            val seenTokens =
+                outcomes
+                    .map { if (it is RefreshOutcome.Replayed) it.refreshToken else winner }
+                    .toSet()
+            assertEquals(setOf(winner), seenTokens)
+        } finally {
+            executor.shutdownNow()
+            store.delete(userId)
+        }
     }
 }

--- a/src/test/kotlin/com/depromeet/piki/auth/infrastructure/redis/RedisRefreshTokenStoreIntegrationTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/infrastructure/redis/RedisRefreshTokenStoreIntegrationTest.kt
@@ -122,6 +122,21 @@ class RedisRefreshTokenStoreIntegrationTest : IntegrationTestSupport() {
     }
 
     @Test
+    fun `rotateOrReplay - grace 창 안이어도 current 도 grace 의 옛 토큰도 아닌 토큰은 ReuseDetected 이다`() {
+        val userId = UUID.randomUUID()
+        store.save(userId, "A")
+        store.rotateOrReplay(userId, presented = "A", candidateRefreshToken = "B") // current=B, grace=A|B 살아있음
+
+        // grace 가 살아있어도 A·B 둘 다 아닌 무관 토큰은 replay 가 아니라 재사용 의심으로 처리돼야 한다
+        val outcome = store.rotateOrReplay(userId, presented = "X", candidateRefreshToken = "C")
+
+        assertIs<RefreshOutcome.ReuseDetected>(outcome)
+        assertNull(store.get(userId)) // family invalidation
+
+        store.delete(userId)
+    }
+
+    @Test
     fun `delete 는 grace 키도 함께 지운다`() {
         val userId = UUID.randomUUID()
         store.save(userId, "A")

--- a/src/test/kotlin/com/depromeet/piki/auth/web/TokenCookieWriterTest.kt
+++ b/src/test/kotlin/com/depromeet/piki/auth/web/TokenCookieWriterTest.kt
@@ -17,6 +17,7 @@ class TokenCookieWriterTest {
                 secret = "x".repeat(32),
                 accessTokenExpiry = accessExpiry,
                 refreshTokenExpiry = refreshExpiry,
+                refreshTokenGrace = Duration.ofSeconds(10),
             ),
             AuthCookieProperties(secure = secure),
         )

--- a/src/test/kotlin/com/depromeet/piki/support/StubRefreshTokenStore.kt
+++ b/src/test/kotlin/com/depromeet/piki/support/StubRefreshTokenStore.kt
@@ -1,5 +1,6 @@
 package com.depromeet.piki.support
 
+import com.depromeet.piki.auth.infrastructure.redis.RefreshOutcome
 import com.depromeet.piki.auth.infrastructure.redis.RefreshTokenStore
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
@@ -7,25 +8,57 @@ import java.util.concurrent.ConcurrentHashMap
 class StubRefreshTokenStore : RefreshTokenStore {
     private val store = ConcurrentHashMap<UUID, String>()
 
+    // 회전 직후 옛→새 토큰 매핑 (RedisRefreshTokenStore 의 grace 키 대응). TTL 은 모델링하지 않는다 —
+    // grace 만료(→ ReuseDetected) 검증은 실제 Lua 를 쓰는 RedisRefreshTokenStoreIntegrationTest 가 책임진다.
+    private val grace = ConcurrentHashMap<UUID, Pair<String, String>>()
+
     // default: 정상 저장. 테스트에서 onSave = { _, _ -> throw ... } 로 Redis 장애 시뮬레이션.
     var onSave: (UUID, String) -> Unit = { userId, token -> store[userId] = token }
 
-    override fun save(userId: UUID, refreshToken: String) = onSave(userId, refreshToken)
+    override fun save(
+        userId: UUID,
+        refreshToken: String,
+    ) = onSave(userId, refreshToken)
 
     override fun get(userId: UUID): String? = store[userId]
 
     override fun delete(userId: UUID) {
         store.remove(userId)
+        grace.remove(userId)
     }
 
-    // 매치·불일치 모두 키 삭제 — 불일치는 family invalidation (RedisRefreshTokenStore Lua 스크립트와 동일 의미)
-    override fun consumeIfMatches(userId: UUID, token: String): Boolean {
-        val stored = store.remove(userId) ?: return false
-        return stored == token
+    // 실제 Lua 와 동일 판정. Redis 싱글스레드 직렬화를 @Synchronized 로 모델링해, 동시 요청이 한쪽만 회전하고
+    // 나머지는 grace replay 로 같은 토큰에 수렴하는 것을 stub 에서도 결정적으로 재현한다.
+    @Synchronized
+    override fun rotateOrReplay(
+        userId: UUID,
+        presented: String,
+        candidateRefreshToken: String,
+    ): RefreshOutcome {
+        val cur = store[userId]
+        if (cur == presented) {
+            store[userId] = candidateRefreshToken
+            grace[userId] = presented to candidateRefreshToken
+            return RefreshOutcome.Rotated
+        }
+        grace[userId]?.let { (old, new) ->
+            if (old == presented) return RefreshOutcome.Replayed(new)
+        }
+        cur ?: return RefreshOutcome.Expired
+        store.remove(userId)
+        grace.remove(userId)
+        return RefreshOutcome.ReuseDetected
+    }
+
+    // 테스트에서 grace TTL 경과를 시뮬레이션 — grace 매핑만 제거해, 이후 옛 토큰 재사용이 replay 가 아니라
+    // ReuseDetected(family invalidation) 로 가게 한다. 실제 RedisRefreshTokenStore 에선 grace 키 TTL 만료가 한다.
+    fun expireGrace(userId: UUID) {
+        grace.remove(userId)
     }
 
     fun reset() {
         store.clear()
+        grace.clear()
         onSave = { userId, token -> store[userId] = token }
     }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -49,6 +49,7 @@ jwt:
   secret: ${JWT_SECRET:test-jwt-secret-key-must-be-at-least-32-chars!}
   access-token-expiry: 1h
   refresh-token-expiry: 14d
+  refresh-token-grace: 10s
 
 # S3 업로드는 ImageStorage stub 으로 격리되지만, S3Properties·S3Client 빈 자체는 컨텍스트에 생성되므로
 # 더미 값으로 부팅만 통과시킨다 (S3Properties.init 의 notBlank 검증 충족).


### PR DESCRIPTION
## Situation
- 웹 로그인 후 약 15분(access_token 만료) 뒤 페이지를 새로고침하거나 이동하면 갑자기 `/login` 으로 튕기고 "로그인 정보가 만료됐어요. 다시 로그인해 주세요." toast 가 떴다. PC 브라우저, 앱 웹뷰(iOS/Android) 모두 재현.
- 원인은 Next.js App Router 가 한 페이지 진입에 page request, RSC payload, prefetch 등 동시 다발 요청을 보내고, access_token 만료 시 각 요청이 독립적으로 refresh 를 호출하는 데 있다. (프론트 로그로 확정)

## Task
- 기존 정책은 1유저 1토큰 + rotation + family invalidation 이라, 같은 옛 토큰으로 동시에 들어온 요청 중 한쪽만 회전에 성공하고 나머지는 401 로 거부됐다.
- 더 나쁜 점: 두 번째 요청이 불일치 분기를 타면 방금 발급한 새 토큰까지 family invalidation 으로 지워, 한쪽이 성공해도 결국 로그아웃됐다. 정상적인 동시 갱신을 토큰 도난으로 오인한 셈이다.
- 관건은 동시 갱신(정상)과 실제 재사용(도난)을 구분하는 것. 둘을 가르는 기준은 "회전 직후 짧은 시간 안인가" 라는 시간 창이다 (Auth0 의 reuse interval 과 같은 개념).
- rotation, 재사용 탐지라는 의도된 보안 장치를 약화시키지 않으면서 동시성만 흡수해야 했다.

## Action
### 정책: grace + 멱등 replay
- 회전 직후 짧은 grace 창(기본 10초) 동안 옛 토큰을 멱등 유효 처리한다. 같은 옛 토큰으로 동시에 들어온 요청은 회전을 다시 일으키지 않고 이미 발급된 새 토큰을 그대로 돌려받아, 모든 요청이 같은 토큰으로 수렴한다.
- grace 창 밖의 재사용은 기존대로 family invalidation (도난 탐지 유지). 멀티 디바이스 지원은 이번 범위에서 제외하고 1유저 1토큰 구조를 유지했다.

| 상황 | 처리 | 응답 |
|---|---|---|
| 현재 토큰과 일치 | 회전 (새 토큰 발급) | 200 |
| grace 창 안에 옛 토큰 재요청 | 멱등 replay (같은 새 토큰 반환) | 200 |
| 저장된 토큰 없음 (만료/이미 소비) | 거부 | 401 |
| grace 창 밖 옛 토큰 재사용 | family invalidation | 401 |

### 구현
- refresh 회전을 단일 진입점 `RefreshTokenStore.rotateOrReplay` + sealed `RefreshOutcome`(Rotated / Replayed / Expired / ReuseDetected)로 모델링했다.
- `RedisRefreshTokenStore`: 위 네 갈래 판정을 하나의 Lua 스크립트로 원자 수행한다. Redis 단일 스레드 직렬화 덕에 동시 요청 중 먼저 든 쪽이 회전 승자가 되고 나머지는 같은 스크립트 안에서 승자 토큰을 replay 로 돌려받는다. 토큰 생성은 앱(JwtProvider)이 하므로, 후보 토큰을 미리 만들어 넘기는 generate-first 방식으로 회전과 생성 사이의 race 를 없앴다.
- 로그아웃, 무효화 시 grace 키도 함께 삭제한다 (로그아웃 즉시성, 도난 시 family 전체 차단).
- `JwtProperties.refreshTokenGrace` 추가 (env `JWT_REFRESH_GRACE`, 기본 10s).

### 보안 트레이드오프
- grace 창 안에선 옛 토큰이 새 토큰 패밀리를 만들지 못하고, 이미 발급된 동일 토큰만 멱등 반환한다. 탈취자가 옛 토큰을 그 창 안에 써도 정상 클라이언트와 같은 토큰만 받는다. 창 밖이나 두 번 이상 회전돼 stale 해진 토큰은 그대로 무효화하므로 탐지력은 유지된다.

## Result
- 동시 다발 refresh 가 401 없이 같은 새 토큰으로 수렴해 자동 로그아웃 증상이 사라진다. 프론트가 임시로 둔 200ms 대기, 쿠키 재확인 같은 안전망도 걷어낼 수 있다 (FE 후속).
- 동시성 수렴은 실제 Redis Lua 에 8스레드 동시 호출로 "정확히 1회만 회전 + 나머지 replay + 전부 동일 토큰" 을 검증했다. grace 밖 재사용 무효화는 grace 키를 직접 만료시켜 확인했다 (실시간 10초 대기 회피).
- 기존에 "즉시 재사용 → 401" 을 못박았던 통합 테스트는 새 정책(창 안 replay, 창 밖 invalidation)으로 갱신했다.

---
## 연관 이슈

- close #589


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 토큰 갱신 시 동시 요청 처리 개선: 유예 기간(10초) 내 이전 토큰 재사용 시 동일한 새 토큰을 멱등하게 반환하여 경쟁 조건에서 불필요한 로그아웃 방지

* **보안 개선**
  * 토큰 재사용 감지 추가: 유예 기간 외 이전 토큰 사용 시 감지 및 처리

<!-- end of auto-generated comment: release notes by coderabbit.ai -->