### PR TITLE
dev→staging→prod 승격 워크플로 + 자동 semver 버저닝

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,11 @@ on:
     branches: [dev, staging, main]
     types: [completed]
   workflow_dispatch:
+    inputs:
+      version:
+        description: "prod 릴리즈 semver 태그 (예: v1.0.1). 비우면 release-<sha7> 로 폴백. Promote 워크플로가 채운다."
+        required: false
+        type: string
 
 jobs:
   # 트리거 브랜치 → 배포 환경(dev/prod)·도메인·nginx conf 를 한 곳에서 결정한다.
@@ -687,8 +692,14 @@ jobs:
       - name: Create GitHub Release (auto notes)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Promote 워크플로가 prod 승격 시 채우는 semver 태그. 직접 dispatch·push 경로엔 비어 있어 SHA 로 폴백.
+          VERSION: ${{ inputs.version }}
         run: |
-          TAG="release-$(echo '${{ needs.resolve.outputs.ref }}' | cut -c1-7)"
+          if [ -n "$VERSION" ]; then
+            TAG="$VERSION"
+          else
+            TAG="release-$(echo '${{ needs.resolve.outputs.ref }}' | cut -c1-7)"
+          fi
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "release $TAG 이미 존재 — skip"
           else

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -4,6 +4,9 @@ name: Promote
 # 코드는 PR 로 dev 에만 들어오고(squash), 이 워크플로가 "이미 CI 통과·배포된 동일 커밋"을 다음 환경으로
 # 앞으로만(fast-forward) 옮긴다. ff 전용이라 세 브랜치 SHA 가 항상 정렬되고, squash·분기 사고를 구조적으로 막는다.
 #
+# prod 승격 시 선택한 단위(patch/minor/major)로 다음 semver 버전을 계산해 deploy 로 넘긴다. 실제 태그·릴리즈는
+# deploy 의 release job 이 "배포 성공 후" 만든다(안 뜬 버전에 태그를 안 박기 위해).
+#
 # staging·main 에는 직접 커밋하지 않는 것이 전제다 (직접 커밋이 들어가면 ff 가 깨져 이 워크플로가 에러로 멈춘다).
 on:
   workflow_dispatch:
@@ -15,6 +18,15 @@ on:
         options:
           - staging
           - prod
+      bump:
+        description: "prod 버전 증가 단위 (staging 은 무시). 최신 vX.Y.Z 에서 bump, 태그 없으면 v1.0.0 baseline."
+        required: false
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
 
 # ref 업데이트(contents) + deploy 워크플로 dispatch(actions) 권한.
 permissions:
@@ -39,6 +51,33 @@ jobs:
             echo "source=staging" >> "$GITHUB_OUTPUT"
             echo "target=main"    >> "$GITHUB_OUTPUT"
           fi
+
+      # prod 승격에만 필요 — 태그를 읽어 다음 버전 계산.
+      - name: Checkout (태그 조회용)
+        if: ${{ inputs.target == 'prod' }}
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: 다음 prod 버전 계산
+        id: ver
+        if: ${{ inputs.target == 'prod' }}
+        env:
+          BUMP: ${{ inputs.bump }}
+        run: |
+          # 최신 semver 태그. 없으면 v1.0.0 을 "이미 출시된 baseline" 으로 보고 거기서 bump (첫 릴리즈는 v1.0.1~).
+          LATEST=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -1)
+          BASE="${LATEST#v}"
+          [ -z "$BASE" ] && BASE="1.0.0"
+          IFS=. read -r MA MI PA <<< "$BASE"
+          case "$BUMP" in
+            major) MA=$((MA + 1)); MI=0; PA=0 ;;
+            minor) MI=$((MI + 1)); PA=0 ;;
+            *)     PA=$((PA + 1)) ;;
+          esac
+          VER="v${MA}.${MI}.${PA}"
+          echo "version=$VER" >> "$GITHUB_OUTPUT"
+          echo "::notice::다음 prod 버전 $VER (latest=${LATEST:-none}, bump=$BUMP)"
 
       - name: Fast-forward 승격
         id: ff
@@ -71,12 +110,18 @@ jobs:
         if: ${{ steps.ff.outputs.skipped == 'false' }}
         env:
           GH_TOKEN: ${{ github.token }}
-          DST: ${{ steps.plan.outputs.target }}
+          TARGET: ${{ inputs.target }}
+          VERSION: ${{ steps.ver.outputs.version }}
         run: |
           # GITHUB_TOKEN 으로 한 ref 업데이트는 CI(on: push)를 자동 트리거하지 않는다(Actions recursion 방지).
           # ff 라 대상 SHA 는 dev 에서 이미 CI 를 통과한 동일 커밋이므로, CI 재실행 없이 배포만 직접 dispatch 한다.
-          gh workflow run deploy.yml --ref "$DST"
-          echo "::notice::deploy.yml dispatch → $DST (배포는 Deploy 워크플로에서 진행)"
+          if [ "$TARGET" = "prod" ]; then
+            gh workflow run deploy.yml --ref main -f version="$VERSION"
+            echo "::notice::deploy.yml dispatch → main (version=$VERSION)"
+          else
+            gh workflow run deploy.yml --ref staging
+            echo "::notice::deploy.yml dispatch → staging"
+          fi
 
       - name: 요약
         if: ${{ always() }}
@@ -86,12 +131,16 @@ jobs:
           DST: ${{ steps.plan.outputs.target }}
           SHA: ${{ steps.ff.outputs.sha }}
           SKIPPED: ${{ steps.ff.outputs.skipped }}
+          VERSION: ${{ steps.ver.outputs.version }}
         run: |
           {
             echo "### Promote: $TARGET_INPUT"
             echo ""
             echo "- 경로: \`$SRC\` → \`$DST\`"
             echo "- 커밋: \`$SHA\`"
+            if [ "$TARGET_INPUT" = "prod" ]; then
+              echo "- 버전: \`$VERSION\` (배포 성공 시 deploy 가 태그·릴리즈 생성)"
+            fi
             if [ "$SKIPPED" = "true" ]; then
               echo "- 결과: 변경 없음(이미 동일) — 배포 생략"
             else

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,0 +1,100 @@
+name: Promote
+
+# 환경 승격(promotion): dev → staging → main(prod).
+# 코드는 PR 로 dev 에만 들어오고(squash), 이 워크플로가 "이미 CI 통과·배포된 동일 커밋"을 다음 환경으로
+# 앞으로만(fast-forward) 옮긴다. ff 전용이라 세 브랜치 SHA 가 항상 정렬되고, squash·분기 사고를 구조적으로 막는다.
+#
+# staging·main 에는 직접 커밋하지 않는 것이 전제다 (직접 커밋이 들어가면 ff 가 깨져 이 워크플로가 에러로 멈춘다).
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "승격 대상 환경 (staging = dev→staging, prod = staging→main)"
+        required: true
+        type: choice
+        options:
+          - staging
+          - prod
+
+# ref 업데이트(contents) + deploy 워크플로 dispatch(actions) 권한.
+permissions:
+  contents: write
+  actions: write
+
+concurrency:
+  group: promote-${{ inputs.target }}
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 승격 경로 결정
+        id: plan
+        run: |
+          if [ "${{ inputs.target }}" = "staging" ]; then
+            echo "source=dev"     >> "$GITHUB_OUTPUT"
+            echo "target=staging" >> "$GITHUB_OUTPUT"
+          else
+            echo "source=staging" >> "$GITHUB_OUTPUT"
+            echo "target=main"    >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Fast-forward 승격
+        id: ff
+        env:
+          GH_TOKEN: ${{ github.token }}
+          R: ${{ github.repository }}
+          SRC: ${{ steps.plan.outputs.source }}
+          DST: ${{ steps.plan.outputs.target }}
+        run: |
+          SRC_SHA=$(gh api "repos/$R/git/refs/heads/$SRC" --jq '.object.sha')
+          DST_SHA=$(gh api "repos/$R/git/refs/heads/$DST" --jq '.object.sha')
+          echo "promote $SRC($SRC_SHA) → $DST($DST_SHA)"
+          echo "sha=$SRC_SHA" >> "$GITHUB_OUTPUT"
+
+          if [ "$SRC_SHA" = "$DST_SHA" ]; then
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::$DST 는 이미 $SRC 와 동일 — 승격할 변경 없음, 배포 생략"
+            exit 0
+          fi
+
+          # force 없이 PATCH → fast-forward 만 허용. 분기(non-ff)면 422 로 실패해 안전하게 멈춘다.
+          if ! gh api -X PATCH "repos/$R/git/refs/heads/$DST" -f "sha=$SRC_SHA"; then
+            echo "::error::$SRC → $DST fast-forward 불가. $DST 가 $SRC 에서 분기됨(직접 커밋·hotfix 의심) 또는 branch protection 이 ref 업데이트를 막음."
+            exit 1
+          fi
+          echo "skipped=false" >> "$GITHUB_OUTPUT"
+          echo "::notice::$SRC → $DST 승격 완료 ($SRC_SHA)"
+
+      - name: 대상 환경 배포 dispatch
+        if: ${{ steps.ff.outputs.skipped == 'false' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DST: ${{ steps.plan.outputs.target }}
+        run: |
+          # GITHUB_TOKEN 으로 한 ref 업데이트는 CI(on: push)를 자동 트리거하지 않는다(Actions recursion 방지).
+          # ff 라 대상 SHA 는 dev 에서 이미 CI 를 통과한 동일 커밋이므로, CI 재실행 없이 배포만 직접 dispatch 한다.
+          gh workflow run deploy.yml --ref "$DST"
+          echo "::notice::deploy.yml dispatch → $DST (배포는 Deploy 워크플로에서 진행)"
+
+      - name: 요약
+        if: ${{ always() }}
+        env:
+          TARGET_INPUT: ${{ inputs.target }}
+          SRC: ${{ steps.plan.outputs.source }}
+          DST: ${{ steps.plan.outputs.target }}
+          SHA: ${{ steps.ff.outputs.sha }}
+          SKIPPED: ${{ steps.ff.outputs.skipped }}
+        run: |
+          {
+            echo "### Promote: $TARGET_INPUT"
+            echo ""
+            echo "- 경로: \`$SRC\` → \`$DST\`"
+            echo "- 커밋: \`$SHA\`"
+            if [ "$SKIPPED" = "true" ]; then
+              echo "- 결과: 변경 없음(이미 동일) — 배포 생략"
+            else
+              echo "- 결과: fast-forward 승격 + 배포 dispatch"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
+# PIKI Server
 
+PIKI 백엔드 서버.
+
+## 버전
+
+![version](https://img.shields.io/github/v/release/depromeet/PIKI-Server?label=version&color=blue)
+
+최신 변경사항은 [릴리즈 노트](https://github.com/depromeet/PIKI-Server/releases/latest)에서 확인할 수 있습니다.
+
+모든 prod 배포는 `Promote` 워크플로로 `dev` → `staging` → `prod` 승격되며, prod 승격 시 선택한 단위(patch/minor/major)로 semver 태그(`vX.Y.Z`)와 릴리즈가 자동 생성됩니다. (`v1.0.0` 출시 완료, 이후 `v1.0.1`부터)


### PR DESCRIPTION
## Situation
- 배포는 "브랜치 = 환경" 모델이다: `dev` push → dev, `staging` push → staging, `main` push → prod.
- 코드는 PR 로 `dev` 에만 들어오고(squash), staging·prod 로의 승격은 사람이 손으로 머지해 왔다.
- 릴리즈 버전 관리도 없었다. 태그가 커밋 SHA(`release-<sha7>`) 라 "버전이 올라간다" 는 개념 자체가 없었다.

## Task
- dev → staging → prod 승격을 한 번에·안전하게, 그리고 prod 승격 시 semver 버전을 자동 부여.
- 함정들:
  - dev 는 squash 머지라 새 SHA 가 쌓인다. 승격까지 squash·merge-commit 으로 하면 환경 브랜치마다 또 다른 SHA 가 생겨 세 브랜치가 영구히 어긋난다.
  - GitHub Actions 의 기본 `GITHUB_TOKEN` push 는 다른 워크플로(CI `on: push`)를 자동 트리거하지 않는다.
  - 태그·릴리즈가 ff 모델·"배포 성공 후 생성" 조건과 충돌하면 안 된다.
  - 이 레포는 PR 제목의 type prefix 가 불규칙이라 conventional-commits 자동 bump 가 불안정하다.

## Action
### 승격: fast-forward 전용, 원클릭
- `workflow_dispatch` 버튼(`target` = staging | prod). force 없는 ref PATCH(분기면 422 로 멈춤)로 ff 승격 후, `deploy.yml` 을 대상 브랜치로 직접 dispatch.
- 직접 dispatch 이유: `GITHUB_TOKEN` push 가 CI 를 안 깨우고, ff 라 대상 SHA 는 dev 에서 이미 CI 통과한 동일 커밋이라 CI 재실행이 낭비. 이미 같은 SHA 면 no-op.
- 전제: staging·main 직접 커밋 금지 (들어가면 ff 가 깨져 워크플로가 에러로 멈춘다).

### 버저닝: promote 시 수동 bump
- prod 승격에 `bump` 입력(patch | minor | major). 최신 `vX.Y.Z` 태그에서 bump, 태그가 없으면 `v1.0.0` 을 출시 baseline 으로 보고 첫 릴리즈는 `v1.0.1`부터.
- conventional-commits 자동 판별 대신 사람이 고른다(커밋 제목 불규칙 때문에 오판 위험).
- 계산한 버전을 deploy 로 넘기고, `deploy.yml` 의 release job 이 **배포 성공 후** 그 semver 태그로 릴리즈를 만든다(version 없으면 기존 SHA 폴백). "태그 = 실제 라이브된 버전" 속성을 유지.

### README: 동적 표기(커밋 0)
- shields.io 버전 배지(최신 릴리즈 자동 반영) + 릴리즈 노트 링크. 변경 요약은 자동 생성 릴리즈 노트가 담당한다.
- README 에 매 릴리즈 커밋하지 않아 ff 모델을 깨지 않는다(정적으로 박으면 main 에 매번 커밋 → ff 충돌이라 동적으로 택함).

## Result
- staging·prod 승격이 Actions 버튼 한 번. prod 는 patch/minor/major 만 고르면 버전 태그·릴리즈가 자동 생성된다.
- 주의(배포 전 확인): staging·main 의 branch protection 이 `GITHUB_TOKEN`(contents: write)의 ff ref 업데이트를 허용해야 한다. require PR / status check / restrict push 가 걸려 있으면 PATCH 가 막혀 워크플로가 **에러로 멈춘다**(조용히 틀리지 않음). 그 경우 Actions 예외 허용 또는 PAT 필요.
- 후속(옵션): prod 승인 게이트, staging soak 시간.

---
## 연관 이슈

- 
