### PR TITLE
prod EC2 인스턴스 타입을 t4g.small 로 상향

### DIFF
--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -38,7 +38,7 @@ data "aws_ami" "ubuntu_2404_arm64" {
 # -----------------------------------------------------------------------------
 resource "aws_instance" "app" {
   ami                    = var.ec2_ami_id != null ? var.ec2_ami_id : data.aws_ami.ubuntu_2404_arm64[0].id
-  instance_type          = var.ec2_instance_type
+  instance_type          = var.ec2_instance_type_prod
   subnet_id              = aws_subnet.public.id
   availability_zone      = var.azs[0]
   vpc_security_group_ids = [aws_security_group.ec2.id]

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -49,9 +49,20 @@ variable "azs" {
 # ----- EC2 -----
 
 variable "ec2_instance_type" {
-  description = "EC2 인스턴스 타입 (ARM / Graviton)"
+  description = "dev / staging EC2 인스턴스 타입 (ARM / Graviton). prod 는 ec2_instance_type_prod 로 분리."
   type        = string
   default     = "t4g.micro"
+}
+
+variable "ec2_instance_type_prod" {
+  description = <<-EOT
+    운영(prod) EC2 인스턴스 타입 (ARM / Graviton). dev / staging(ec2_instance_type)과
+    분리해 prod 만 독립적으로 사이징한다 — 운영 트래픽/메모리 여유를 위해 small 로 상향.
+    micro(1GiB) → small(2GiB). instance_type 변경은 in-place(stop → 변경 → start)이며
+    AMI 가 고정돼 있어 인스턴스 교체 없이 적용되지만, 적용 중 짧은 다운타임이 발생한다.
+  EOT
+  type        = string
+  default     = "t4g.small"
 }
 
 variable "ec2_ami_id" {


### PR DESCRIPTION
## Situation

- 운영(prod) EC2 가 dev / staging 과 같은 `var.ec2_instance_type`(`t4g.micro`, 메모리 1GiB)을 공유하고 있었다.
- 변수가 하나로 묶여 있어 prod 만 사이징을 올릴 방법이 없었다. 공유 변수를 올리면 dev / staging 까지 불필요하게 따라 올라간다.

## Task

- prod 인스턴스만 한 단계 위(`t4g.small`, 메모리 2GiB)로 올리고, dev / staging 은 `t4g.micro` 그대로 둔다.

## Action

- 운영 전용 변수 `ec2_instance_type_prod`(기본 `t4g.small`)를 신설하고, prod(`aws_instance.app`)만 이 변수를 참조하게 바꿨다.
- dev(`aws_instance.dev_app`) / staging(`aws_instance.staging_app`)은 기존 `ec2_instance_type`(`t4g.micro`)을 그대로 참조한다.
- 전체 플릿이 Graviton / ARM(arm64 AMI 고정)이라 small 은 `t4g.small` 로 둔다.

**대안 비교**

| 방식 | 결과 |
|---|---|
| 공유 `ec2_instance_type` 기본값을 small 로 | dev / staging 까지 같이 올라감 (불필요) |
| prod 전용 변수 분리 (채택) | prod 만 독립 사이징, dev / staging 은 micro 유지 |

## Result

- prod 메모리 1GiB 에서 2GiB 로 확보 (vCPU 는 2개로 동일).
- 이 PR 은 terraform 코드 변경까지다. 실제 `apply` 는 별도로 진행한다.
- **apply 영향**: `instance_type` 변경은 destroy / recreate 가 아니라 in-place(stop, 타입 변경, start)다. AMI 가 고정돼 있어 인스턴스 교체 없이 적용되고 EBS 루트 볼륨 / EIP / 데이터는 보존되지만, 변경 중 prod 약 1-3분 다운타임이 발생한다.
- 검증: `terraform validate` Success, `terraform fmt` 차이 없음 (offline init, 자격증명 / 백엔드 불필요).

---
## 연관 이슈

- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 프로덕션 환경의 EC2 인스턴스 타입 설정을 별도 변수로 분리하여 개발/스테이징 환경과 독립적으로 관리할 수 있도록 개선했습니다.
  * 프로덕션 전용 인스턴스 타입 변수의 기본값을 t4g.small로 설정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->