### PR TITLE
JVM GC 를 G1 으로 명시 (Serial Full GC 18초 STW 방지)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,14 +48,18 @@ jobs:
           #   prod 2×768=1536 < 1.8G RAM, dev/staging 2×400=800 < 906M RAM 안에 들어가 swap thrash 를 막는다.
           # 힙(-Xmx)은 컨테이너 RAM 안에 비힙(metaspace·thread stack·code cache·direct buffer) 여유를 남겨 잡는다.
           # 값은 시작점 — 검증 배포에서 부팅 피크·overlap RAM 을 실측해 확정한다.
+          # GC 는 -XX:+UseG1GC 를 명시한다(환경 공통). JVM 은 컨테이너 메모리 한도를 가용 메모리로 인식하는데, G1 자동
+          #   선택 기준(2 CPU + 1792MB)에 못 미쳐 Serial GC 로 떨어진다(prod 256m 실측 확인 — Copy + MarkSweepCompact).
+          #   Serial Full GC 는 단일 스레드 stop-the-world 라 힙이 클수록 1회 pause 가 길어져(prod 실측 평균 18s/회) 힙만
+          #   키우면 오히려 악화된다. G1 으로 병렬·증분 회수를 강제해 STW 를 짧게 가져간다.
           if [ "$BRANCH" = "main" ]; then
             echo "mem_limit=768m" >> "$GITHUB_OUTPUT"
             echo "mem_swap=1536m" >> "$GITHUB_OUTPUT"
-            echo "jvm_opts=-Xmx512m -Xms64m -XX:+ExitOnOutOfMemoryError" >> "$GITHUB_OUTPUT"
+            echo "jvm_opts=-Xmx512m -Xms64m -XX:+UseG1GC -XX:+ExitOnOutOfMemoryError" >> "$GITHUB_OUTPUT"
           else
             echo "mem_limit=400m" >> "$GITHUB_OUTPUT"
             echo "mem_swap=800m" >> "$GITHUB_OUTPUT"
-            echo "jvm_opts=-Xmx256m -Xms64m -XX:+ExitOnOutOfMemoryError" >> "$GITHUB_OUTPUT"
+            echo "jvm_opts=-Xmx256m -Xms64m -XX:+UseG1GC -XX:+ExitOnOutOfMemoryError" >> "$GITHUB_OUTPUT"
           fi
           echo "ref=$REF" >> "$GITHUB_OUTPUT"
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Situation
- prod 힙이 87% 까지 올라가는 걸 Grafana 에서 보고 GC 상태를 실측했더니, prod 가 **Serial GC**(Copy + MarkSweepCompact)로 돌고 있었다.
- Full GC 가 11회에 총 200초, **평균 18초/회 stop-the-world**. Full GC 가 돌 때마다 앱이 18초간 멈춘다 (prod 에선 사실상 짧은 다운).
- 원인: JVM 은 컨테이너 메모리 한도(cgroup)를 가용 메모리로 인식하는데, G1 자동 선택 기준(2 CPU + 1792MB)에 못 미쳐 Serial 로 떨어진다.

## Task
- GC 를 G1 으로 명시해 Full GC 의 긴 STW 를 없앤다.
- #598(힙 256→512m)만으로는 부족하다. Serial Full GC 는 힙이 클수록 1회 STW 가 길어져, 힙만 키우면 오히려 악화되기 때문.

## Action
- deploy.yml 의 `jvm_opts` 에 `-XX:+UseG1GC` 를 **환경 공통**으로 추가했다 (prod + dev/staging 양 분기).
- **환경 공통으로 켠 이유**: dev/staging 에서 "G1 부팅·헬스체크 통과 + 256m/400m cgroup 에서 정상 동작" 을 먼저 검증하고 prod 까지 같은 GC 로 올린다. prod 첫 적용을 무검증으로 두지 않는다.

| GC | 동작 | 큰 힙에서 |
|---|---|---|
| Serial (현행, 자동 선택) | 단일 스레드 mark-sweep-compact STW | 힙↑ → 1회 STW↑ (역효과) |
| G1 (이 PR) | 병렬·증분 회수 | STW 짧게 유지 |

## Result
- GC 가 G1 으로 강제돼 Full GC 의 18초 STW 가 수백 ms 수준으로 줄 것으로 기대된다 (적용 후 Grafana `jvm_gc_pause` 로 실측 확정).
- **적용 순서**: 이 PR 과 #598(힙 512m)이 함께 prod 에 가야 효과가 온전하다. dev→staging 에서 G1 정상 동작 확인 후 dev→main 릴리스(prod 무중단 blue-green).
- **주의**: dev/staging 은 256m/400m cgroup 이라 G1 native 오버헤드로 빡빡할 수 있다. 배포 헬스체크로 드러나며, 무중단이라 실패해도 기존 컨테이너가 유지(롤백)된다.

---
## 연관 이슈

- 
